### PR TITLE
Renaming queries -> triggers across SDK layer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,1 @@
-/nix/store/wpnij05f1bvqdfkysmfm5ynzzh1ym8h7-pre-commit-config.json
+/nix/store/7fj83l2m2qs3k1f64ciz80qnd0g7sxhh-pre-commit-config.json

--- a/toolchain/chidori/package_python/chidori/_chidori.pyi
+++ b/toolchain/chidori/package_python/chidori/_chidori.pyi
@@ -15,13 +15,48 @@ class Chidori:
     def list_change_events(self, callback: object) -> None: ...
     def poll_local_code_node_execution(self) -> None: ...
     def ack_local_code_node_execution(self, branch: int, counter: int) -> None: ...
-    def respond_local_code_node_execution(self, branch: int, counter: int, node_name: str, response: Optional[object]) -> None: ...
+    def respond_local_code_node_execution(
+        self, branch: int, counter: int, node_name: str, response: Optional[object]
+    ) -> None: ...
 
 class GraphBuilder:
-    def custom_node(self, name: str, queries: List[Optional[str]], output_tables: List[str], output: str, node_type_name: str) -> None: ...
-    def deno_code_node(self, name: str, queries: List[Optional[str]], output_tables: List[str], output: str, code: str, is_template: bool) -> None: ...
-    def vector_memory_node(self, name: str, queries: List[Optional[str]], output_tables: List[str], output: str, template: str, action: str, embedding_model: str, db_vendor: str, collection_name: str) -> None: ...
-    def prompt_node(self, name: str, queries: List[Optional[str]], output_tables: List[str], template: str, model: str) -> None: ...
+    def custom_node(
+        self,
+        name: str,
+        triggers: List[Optional[str]],
+        output_tables: List[str],
+        output: str,
+        node_type_name: str,
+    ) -> None: ...
+    def deno_code_node(
+        self,
+        name: str,
+        triggers: List[Optional[str]],
+        output_tables: List[str],
+        output: str,
+        code: str,
+        is_template: bool,
+    ) -> None: ...
+    def vector_memory_node(
+        self,
+        name: str,
+        triggers: List[Optional[str]],
+        output_tables: List[str],
+        output: str,
+        template: str,
+        action: str,
+        embedding_model: str,
+        db_vendor: str,
+        collection_name: str,
+    ) -> None: ...
+    def prompt_node(
+        self,
+        name: str,
+        triggers: List[Optional[str]],
+        output_tables: List[str],
+        template: str,
+        model: str,
+    ) -> None: ...
     def commit(self, c: Chidori, branch: int) -> None: ...
     def serialize_yaml(self) -> str: ...
 

--- a/toolchain/chidori/src/translations/python.rs
+++ b/toolchain/chidori/src/translations/python.rs
@@ -742,12 +742,12 @@ impl PyGraphBuilder {
     }
 
     // https://github.com/PyO3/pyo3/issues/525
-    #[pyo3(signature = (name=String::new(), queries=vec!["None".to_string()], output_tables=vec![], output=String::from("{}"), node_type_name=String::new()))]
+    #[pyo3(signature = (name=String::new(), triggers=vec!["None".to_string()], output_tables=vec![], output=String::from("{}"), node_type_name=String::new()))]
     fn custom_node<'a>(
         mut self_: PyRefMut<'_, Self>,
         py: Python<'a>,
         name: String,
-        queries: Option<Vec<String>>,
+        triggers: Option<Vec<String>>,
         output_tables: Vec<String>,
         output: String,
         node_type_name: String,
@@ -757,7 +757,7 @@ impl PyGraphBuilder {
             let mut graph_builder = g.lock().await;
             let nh = graph_builder.custom_node(CustomNodeCreateOpts {
                 name,
-                queries,
+                triggers,
                 output_tables: Some(output_tables),
                 output: Some(output),
                 node_type_name,
@@ -766,12 +766,12 @@ impl PyGraphBuilder {
         })
     }
 
-    #[pyo3(signature = (name=String::new(), queries=vec!["None".to_string()], output_tables=None, output=None, code=String::new(), is_template=None))]
+    #[pyo3(signature = (name=String::new(), triggers=vec!["None".to_string()], output_tables=None, output=None, code=String::new(), is_template=None))]
     fn deno_code_node<'a>(
         mut self_: PyRefMut<'_, Self>,
         py: Python<'a>,
         name: String,
-        queries: Option<Vec<String>>,
+        triggers: Option<Vec<String>>,
         output_tables: Option<Vec<String>>,
         output: Option<String>,
         code: String,
@@ -782,7 +782,7 @@ impl PyGraphBuilder {
             let mut graph_builder = g.lock().await;
             let nh = graph_builder.deno_code_node(DenoCodeNodeCreateOpts {
                 name,
-                queries,
+                triggers,
                 output_tables,
                 output,
                 code,
@@ -793,12 +793,12 @@ impl PyGraphBuilder {
     }
 
 
-    #[pyo3(signature = (name=String::new(), queries=vec!["None".to_string()], output_tables=vec![], output=String::from("{}"), template=String::new(), action="WRITE".to_string(), embedding_model="TEXT_EMBEDDING_ADA_002".to_string(), db_vendor="QDRANT".to_string(), collection_name=String::new()))]
+    #[pyo3(signature = (name=String::new(), triggers=vec!["None".to_string()], output_tables=vec![], output=String::from("{}"), template=String::new(), action="WRITE".to_string(), embedding_model="TEXT_EMBEDDING_ADA_002".to_string(), db_vendor="QDRANT".to_string(), collection_name=String::new()))]
     fn vector_memory_node<'a>(
         mut self_: PyRefMut<'_, Self>,
         py: Python<'a>,
         name: String,
-        queries: Option<Vec<String>>,
+        triggers: Option<Vec<String>>,
         output_tables: Vec<String>,
         output: String,
         template: String,
@@ -812,7 +812,7 @@ impl PyGraphBuilder {
             let mut graph_builder = g.lock().await;
             let nh = graph_builder.vector_memory_node(VectorMemoryNodeCreateOpts {
                 name,
-                queries,
+                triggers,
                 output_tables: Some(output_tables),
                 output: Some(output),
                 template: Some(template),
@@ -858,12 +858,12 @@ impl PyGraphBuilder {
 
     // TODO: nodes that are added should return a clean definition of what their addition looks like
     // TODO: adding a node should also display any errors
-    #[pyo3(signature = (name=String::new(), queries=vec!["None".to_string()], output_tables=None, template=String::new(), model=None))]
+    #[pyo3(signature = (name=String::new(), triggers=vec!["None".to_string()], output_tables=None, template=String::new(), model=None))]
     fn prompt_node<'a>(
         mut self_: PyRefMut<'_, Self>,
         py: Python<'a>,
         name: String,
-        queries: Option<Vec<String>>,
+        triggers: Option<Vec<String>>,
         output_tables: Option<Vec<String>>,
         template: String,
         model: Option<String>
@@ -873,7 +873,7 @@ impl PyGraphBuilder {
             let mut graph_builder = g.lock().await;
             let nh = graph_builder.prompt_node(PromptNodeCreateOpts {
                 name,
-                queries,
+                triggers,
                 output_tables,
                 template,
                 model,

--- a/toolchain/chidori/src/translations/rust.rs
+++ b/toolchain/chidori/src/translations/rust.rs
@@ -342,14 +342,14 @@ impl Chidori {
 }
 
 
-fn default_queries() -> Option<Vec<String>> {
+fn default_triggers() -> Option<Vec<String>> {
     Some(vec!["None".to_string()])
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct PromptNodeCreateOpts {
     pub name: String,
-    pub queries: Option<Vec<String>>,
+    pub triggers: Option<Vec<String>>,
     pub output_tables: Option<Vec<String>>,
     pub template: String,
     pub model: Option<String>
@@ -359,7 +359,7 @@ impl Default for PromptNodeCreateOpts {
     fn default() -> Self {
         PromptNodeCreateOpts {
             name: "".to_string(),
-            queries: default_queries(),
+            triggers: default_triggers(),
             output_tables: None,
             template: "".to_string(),
             model: Some("GPT_3_5_TURBO".to_string()),
@@ -369,7 +369,7 @@ impl Default for PromptNodeCreateOpts {
 impl PromptNodeCreateOpts {
     pub fn merge(&mut self, other: PromptNodeCreateOpts) {
         self.name = other.name;
-        self.queries = other.queries.or(self.queries.take());
+        self.triggers = other.triggers.or(self.triggers.take());
         self.output_tables = other.output_tables.or(self.output_tables.take());
         self.template = other.template;
         self.model = other.model.or(self.model.take());
@@ -381,7 +381,7 @@ impl PromptNodeCreateOpts {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct CustomNodeCreateOpts {
     pub name: String,
-    pub queries: Option<Vec<String>>,
+    pub triggers: Option<Vec<String>>,
     pub output_tables: Option<Vec<String>>,
     pub output: Option<String>,
     pub node_type_name: String
@@ -392,7 +392,7 @@ impl Default for CustomNodeCreateOpts {
     fn default() -> Self {
         CustomNodeCreateOpts {
             name: "".to_string(),
-            queries: default_queries(),
+            triggers: default_triggers(),
             output_tables: None,
             output: None,
             node_type_name: "".to_string(),
@@ -402,7 +402,7 @@ impl Default for CustomNodeCreateOpts {
 impl CustomNodeCreateOpts {
     pub fn merge(&mut self, other: CustomNodeCreateOpts) {
         self.name = other.name;
-        self.queries = other.queries.or(self.queries.take());
+        self.triggers = other.triggers.or(self.triggers.take());
         self.output_tables = other.output_tables.or(self.output_tables.take());
         self.output = other.output.or(self.output.take());
         self.node_type_name = other.node_type_name;
@@ -414,7 +414,7 @@ impl CustomNodeCreateOpts {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct DenoCodeNodeCreateOpts {
     pub name: String,
-    pub queries: Option<Vec<String>>,
+    pub triggers: Option<Vec<String>>,
     pub output_tables: Option<Vec<String>>,
     pub output: Option<String>,
     pub code: String,
@@ -425,7 +425,7 @@ impl Default for DenoCodeNodeCreateOpts {
     fn default() -> Self {
         DenoCodeNodeCreateOpts {
             name: "".to_string(),
-            queries: default_queries(),
+            triggers: default_triggers(),
             output_tables: None,
             output: None,
             code: "".to_string(),
@@ -437,7 +437,7 @@ impl Default for DenoCodeNodeCreateOpts {
 impl DenoCodeNodeCreateOpts {
     pub fn merge(&mut self, other: DenoCodeNodeCreateOpts) {
         self.name = other.name;
-        self.queries = other.queries.or(self.queries.take());
+        self.triggers = other.triggers.or(self.triggers.take());
         self.output_tables = other.output_tables.or(self.output_tables.take());
         self.output = other.output.or(self.output.take());
         self.code = other.code;
@@ -448,7 +448,7 @@ impl DenoCodeNodeCreateOpts {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct VectorMemoryNodeCreateOpts {
     pub name: String,
-    pub queries: Option<Vec<String>>,
+    pub triggers: Option<Vec<String>>,
     pub output_tables: Option<Vec<String>>,
     pub output: Option<String>,
     pub template: Option<String>, // TODO: default is the contents of the query
@@ -463,7 +463,7 @@ impl Default for VectorMemoryNodeCreateOpts {
     fn default() -> Self {
         VectorMemoryNodeCreateOpts {
             name: "".to_string(),
-            queries: None,
+            triggers: None,
             output_tables: None,
             output: None,
             template: None,
@@ -479,7 +479,7 @@ impl Default for VectorMemoryNodeCreateOpts {
 impl VectorMemoryNodeCreateOpts {
     pub fn merge(&mut self, other: VectorMemoryNodeCreateOpts) {
         self.name = other.name;
-        self.queries = other.queries.or(self.queries.take());
+        self.triggers = other.triggers.or(self.triggers.take());
         self.output_tables = other.output_tables.or(self.output_tables.take());
         self.output = other.output.or(self.output.take());
         self.template = other.template.or(self.template.take());
@@ -490,9 +490,9 @@ impl VectorMemoryNodeCreateOpts {
     }
 }
 
-fn remap_queries(queries: Option<Vec<String>>) -> Vec<Option<String>> {
-    let queries: Vec<Option<String>> = if let Some(queries) = queries {
-        queries.into_iter().map(|q| {
+fn remap_triggers(triggers: Option<Vec<String>>) -> Vec<Option<String>> {
+    let triggers: Vec<Option<String>> = if let Some(triggers) = triggers {
+        triggers.into_iter().map(|q| {
             if q == "None".to_string() {
                 None
             } else {
@@ -502,7 +502,7 @@ fn remap_queries(queries: Option<Vec<String>>) -> Vec<Option<String>> {
     } else {
         vec![]
     };
-    queries
+    triggers
 }
 
 #[derive(Clone)]
@@ -521,7 +521,7 @@ impl GraphBuilder {
         def.merge(arg);
         let node = create_prompt_node(
             def.name.clone(),
-            remap_queries(def.queries),
+            remap_triggers(def.triggers),
             def.template,
             def.model.unwrap_or("GPT_3_5_TURBO".to_string()),
             def.output_tables.unwrap_or(vec![]))?;
@@ -534,7 +534,7 @@ impl GraphBuilder {
         def.merge(arg);
         let node = create_custom_node(
             def.name.clone(),
-            remap_queries(def.queries.clone()),
+            remap_triggers(def.triggers.clone()),
             def.output.unwrap_or("{}".to_string()),
             def.node_type_name,
             def.output_tables.unwrap_or(vec![])
@@ -549,7 +549,7 @@ impl GraphBuilder {
         def.merge(arg);
         let node = create_code_node(
             def.name.clone(),
-            remap_queries(def.queries.clone()),
+            remap_triggers(def.triggers.clone()),
             def.output.unwrap_or("{}".to_string()),
             SourceNodeType::Code("DENO".to_string(), def.code, def.is_template.unwrap_or(false)),
             def.output_tables.unwrap_or(vec![])
@@ -564,7 +564,7 @@ impl GraphBuilder {
         def.merge(arg);
         let node = create_vector_memory_node(
             def.name.clone(),
-            remap_queries(def.queries.clone()),
+            remap_triggers(def.triggers.clone()),
             def.output.unwrap_or("{}".to_string()),
             def.action.unwrap_or("READ".to_string()),
             def.embedding_model.unwrap_or("TEXT_EMBEDDING_ADA_002".to_string()),
@@ -676,11 +676,11 @@ impl NodeHandle {
     }
 
     pub fn run_when(&mut self, graph_builder: &mut GraphBuilder, other_node: &NodeHandle) -> anyhow::Result<bool> {
-        let queries = &mut self.node.core.as_mut().unwrap().queries;
+        let triggers = &mut self.node.core.as_mut().unwrap().queries; // queries->triggers Note: On next pass, change ItemCore defintion in ProtoBufs
 
         // Remove null query if it is the only one present
-        if queries.len() == 1 && queries[0].query.is_none() {
-            queries.remove(0);
+        if triggers.len() == 1 && triggers[0].query.is_none() {
+            triggers.remove(0);
         }
 
         let q = construct_query_from_output_type(
@@ -688,7 +688,7 @@ impl NodeHandle {
             &other_node.get_name(),
             &other_node.get_output_type()
         ).unwrap();
-        queries.push(Query { query: Some(q)});
+        triggers.push(Query { query: Some(q)});
         graph_builder.clean_graph.merge_file(&File { nodes: vec![self.node.clone()], ..Default::default() })?;
         Ok(true)
     }

--- a/toolchain/chidori/tests/nodejs/chidori.test.js
+++ b/toolchain/chidori/tests/nodejs/chidori.test.js
@@ -23,7 +23,7 @@ test('start server', async () => {
     });
     g.denoCodeNode({
         name: "CodeNode",
-        queries: ["query Q { InspirationalQuote { promptResult } }"],
+        triggers: ["query Q { InspirationalQuote { promptResult } }"],
         code: `return {"output": "Here is your quote for " + \`{{InspirationalQuote.promptResult}}\` }`,
         output: `type CodeNode { output: String }`,
         is_template: true

--- a/toolchain/chidori/tests/python/test_chidori.py
+++ b/toolchain/chidori/tests/python/test_chidori.py
@@ -12,19 +12,16 @@ async def test_simple_agent():
         name="InspirationalQuote",
         code="""
             return {"promptResult": "placeholder for openai call" }
-            """
+            """,
     )
     pn = await g.deno_code_node(
         name="CodeNode",
-        queries=["""SELECT promptResult FROM InspirationalQuote"""],
+        triggers=["""SELECT promptResult FROM InspirationalQuote"""],
         code="""
             return {"output": "Here is your quote for "+ new Date() + {{InspirationalQuote.promptResult}} }
             """,
-        is_template=True
+        is_template=True,
     )
     # await g.commit(client, 0)
     # await client.play(0, 0)
     assert 1 == 1
-
-
-


### PR DESCRIPTION
Two notes:

1) I've run `cargo test` from the chidori directory (it did catch an issue for me; I hadn't changed protobufs ItemCore to use 
queries on this pass), BUT I haven't run the tests/chidori.test.js or tests/test_chidori.py files yet

2) It appears that nodejs implementation simply forwards the arguments to prompt_graph_core? So I may need to change Core to change the 
node implementation

