### PR TITLE
Route workspace effects through policy enforcement gate

### DIFF
--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -202,10 +202,13 @@ Still **capability-confinement, not OS isolation** (`docs/sandbox-model.md`
 — note that doc still describes the rust engine as opt-in; see doc drift).
 The real gaps, restated post-#39:
 
-1. **`http` is the only effect routed through `enforce_policy`**;
-   `workspace.*` effects appear unconditional. The list of ungated powerful
-   effects shrank (the `exec*` family is gone), but deny-by-default routing
-   through the policy gate has still not landed.
+1. **Powerful effects now route through `enforce_policy`, but the default is
+   still allow.** `http` and every `workspace.*` action (`workspace:list` /
+   `read` / `write` / `delete` / `manifest`) pass through the policy gate, so a
+   restrictive profile can deny or gate disk writes while allowing reads. The
+   `exec*` family is gone. What remains is the *default decision*: the fallback
+   is still `AlwaysAllow`, so deny-by-default for untrusted profiles is opt-in
+   (`"default": "never_allow"` + allow rules) rather than automatic.
 2. **Memory accounting is process-wide, not per-VM** (`src/mem_guard.rs`):
    under concurrent agents one run's allocations can be attributed to
    another; enforcement is polled, so brief overshoot is possible.
@@ -316,9 +319,14 @@ Concretely:
    permanent quality bar, not a gate. Keep picking off the cluster table
    above (Array species, RegExp `v`-flag/UTF-16, resizable ArrayBuffer,
    Promise ordering are the next four).
-3. **Gate the remaining powerful effects** (`workspace.*`) through the
-   policy layer, deny-by-default for untrusted profiles — still the most
-   security-relevant single change, and smaller now that `exec*` is gone.
+3. ~~Gate the remaining powerful effects (`workspace.*`) through the policy
+   layer~~ — **done**: every `workspace.*` action now routes through
+   `enforce_policy` (targets `workspace:list` / `read` / `write` / `delete` /
+   `manifest`), joining `http`. The remaining follow-up is making
+   **deny-by-default** the actual default for untrusted profiles — today the
+   fallback decision is still `AlwaysAllow`, so untrusted callers must opt in
+   with `"default": "never_allow"` plus explicit allow rules. Shipping a
+   ready-made untrusted profile is the next step.
 4. ~~Run Test262 in CI~~ — **done** (#41). Add TypeScript SDK tests next.
 5. **Automate SDK publishing** to npm/PyPI, or remove the registry badges.
 6. **Pay down the doc drift** (the list above): README engine section, SDK

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -191,15 +191,19 @@ These are the known limitations as of this writing. None of them are
 memory-safety holes (the engine is safe Rust); they are confinement and
 resource-precision gaps.
 
-1. **Injected powerful effects are mostly ungated.** `execPython` spawns a Python
-   interpreter, `execWasm` runs Wasmer (fuel + memory-page capped), `http` makes
-   real outbound network requests, and `workspace.*` does real disk I/O within a
-   sanitized root. Of these, only `http` passes through the policy enforcement gate
-   (`enforce_policy`); `execPython`/`execJs`/`execWasm`/`workspace.*` appear to run
-   unconditionally once installed. For **trusted** agent code this is by design;
-   for **untrusted** code these are escape hatches (subprocess, network egress,
-   disk-in-root). *Fix:* route every powerful effect through the same policy gate
-   `http` uses, defaulting to deny for an untrusted profile.
+1. **Not every powerful effect is gated yet.** The remaining powerful effects are
+   `http` (real outbound network requests) and `workspace.*` (real disk I/O within
+   a sanitized root); the `exec*` snippet sandboxes were removed in #39. Both `http`
+   and every `workspace.*` action now pass through the policy enforcement gate
+   (`enforce_policy`): `http` against the `http` target, and workspace actions
+   against `workspace:list` / `workspace:read` / `workspace:write` /
+   `workspace:delete` / `workspace:manifest`. A restrictive profile can therefore
+   deny or require approval for disk writes while still allowing reads. The
+   remaining gap is the *default*: the fallback decision is still `AlwaysAllow`, so
+   an untrusted profile must opt in to deny-by-default (`"default": "never_allow"`
+   plus explicit allow rules) rather than getting it automatically. *Fix:* ship a
+   ready-made deny-by-default untrusted profile and make it the default for
+   untrusted runs.
 
 2. **The memory ceiling is process-wide, not per-VM.** The `CountingAllocator`
    counter is global; the watchdog caps *baseline-relative* growth

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -32,9 +32,10 @@ impl Default for Decision {
     }
 }
 
-/// A single rule. `target` is "tool:<name>" / "shell" / "http" / "exec" /
-/// "write_file" / "*". `match_args` is an optional JSON subset that must be
-/// contained in the call args for the rule to apply.
+/// A single rule. `target` is "tool:<name>" / "http" / "workspace:<action>"
+/// (where `<action>` is `list` / `read` / `write` / `delete` / `manifest`) /
+/// "*". `match_args` is an optional JSON subset that must be contained in the
+/// call args for the rule to apply.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyRule {
     pub target: String,

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -91,6 +91,13 @@ impl HostBindingBackend {
         args: serde_json::Value,
         live: impl FnOnce() -> std::result::Result<serde_json::Value, String>,
     ) -> std::result::Result<serde_json::Value, String> {
+        // Route every workspace effect through the policy gate before it runs,
+        // the same way `http` and `tool:` calls are gated. With the default
+        // AlwaysAllow policy this is a no-op; a restrictive profile can now
+        // deny or gate `workspace:write` / `workspace:delete` (or any action)
+        // by target. Enforcing before recording means a denied or paused call
+        // never lands in the journal.
+        self.enforce_policy(&format!("workspace:{action}"), &args)?;
         let call_args = serde_json::json!({
             "action": action,
             "args": args,

--- a/tests/cli_typescript.rs
+++ b/tests/cli_typescript.rs
@@ -43,6 +43,15 @@ fn run_chidori_with_env(args: &[&str], cwd: &Path, envs: &[(&str, &Path)]) -> Ou
     command.output().unwrap()
 }
 
+fn run_chidori_with_str_env(args: &[&str], cwd: &Path, envs: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(chidori_bin());
+    command.args(args).current_dir(cwd);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().unwrap()
+}
+
 fn assert_success(output: &Output) {
     assert!(
         output.status.success(),
@@ -310,6 +319,102 @@ fn cli_stream_workspace_binding_writes_real_disk_manifest() {
             && event["output"]["content"] == "export default {};"
             && event["output"]["files"][0]["path"] == "agent.ts"
     }));
+
+    fs::remove_dir_all(dir).ok();
+}
+
+#[test]
+fn cli_workspace_write_denied_by_policy_is_blocked() {
+    let dir = temp_project("workspace-policy-deny");
+    let workspace = dir.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.workspace.write("secret.ts", "export default {};");
+                return { ok: true };
+            }
+        "#,
+    )
+    .unwrap();
+
+    // A restrictive profile that denies workspace writes. Before workspace
+    // effects were routed through the policy gate, this rule had no effect and
+    // the write went through unconditionally.
+    let policy = r#"{
+        "default": "always_allow",
+        "rules": [
+            { "target": "workspace:write", "decision": "never_allow", "reason": "read-only profile" }
+        ]
+    }"#;
+
+    let output = run_chidori_with_str_env(
+        &["run", agent.to_str().unwrap(), "--input", r#"{}"#],
+        &dir,
+        &[
+            ("CHIDORI_WORKSPACE_ROOT", workspace.to_str().unwrap()),
+            ("CHIDORI_POLICY", policy),
+        ],
+    );
+
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("workspace:write") && stderr.contains("denied"),
+        "expected a workspace:write policy denial, got stderr:\n{stderr}"
+    );
+    // The deny must happen before the effect runs: no file on disk.
+    assert!(
+        !workspace.join("secret.ts").exists(),
+        "denied workspace.write must not have touched the disk"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
+#[test]
+fn cli_workspace_read_allowed_while_write_denied() {
+    let dir = temp_project("workspace-policy-read-ok");
+    let workspace = dir.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    // Seed a file the agent is allowed to read.
+    fs::write(workspace.join("seed.txt"), "hello").unwrap();
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                return { content: await chidori.workspace.read("seed.txt") };
+            }
+        "#,
+    )
+    .unwrap();
+
+    // Deny only writes; reads fall through to the AlwaysAllow default.
+    let policy = r#"{
+        "default": "always_allow",
+        "rules": [
+            { "target": "workspace:write", "decision": "never_allow" }
+        ]
+    }"#;
+
+    let output = run_chidori_with_str_env(
+        &["run", agent.to_str().unwrap(), "--input", r#"{}"#],
+        &dir,
+        &[
+            ("CHIDORI_WORKSPACE_ROOT", workspace.to_str().unwrap()),
+            ("CHIDORI_POLICY", policy),
+        ],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello"),
+        "expected the allowed workspace.read to return its content, got:\n{stdout}"
+    );
 
     fs::remove_dir_all(dir).ok();
 }


### PR DESCRIPTION
## Summary
This PR gates all `workspace.*` effects (list, read, write, delete, manifest) through the policy enforcement layer, matching the existing behavior for `http` calls. This allows restrictive security profiles to deny or require approval for disk operations while still permitting reads.

## Key Changes

- **Policy enforcement for workspace actions**: Added `enforce_policy` call in `HostBindingBackend::workspace_call` to route all workspace effects through the policy gate before execution, using targets like `workspace:read`, `workspace:write`, etc.

- **Test helper function**: Added `run_chidori_with_str_env` to support passing string-based environment variables (in addition to the existing `run_chidori_with_env` that uses `Path`), enabling cleaner test setup for policy configuration.

- **New test cases**:
  - `cli_workspace_write_denied_by_policy_is_blocked`: Verifies that a policy denying `workspace:write` prevents disk writes and returns an error
  - `cli_workspace_read_allowed_while_write_denied`: Confirms that selective policies work correctly (reads allowed, writes denied)

- **Documentation updates**: Updated `docs/fable_review.md` and `docs/sandbox-model.md` to reflect that workspace effects now route through the policy gate, clarifying the remaining gap (default decision is still `AlwaysAllow` rather than deny-by-default for untrusted profiles).

- **Policy rule documentation**: Updated comments in `src/policy.rs` to document the new `workspace:<action>` target format.

## Implementation Details

The enforcement happens before the effect executes, ensuring denied calls never reach the journal or disk. With the default `AlwaysAllow` policy this is transparent; restrictive profiles can now selectively gate or deny workspace operations by target while allowing others (e.g., deny writes but allow reads).

https://claude.ai/code/session_01WQTMcTGxXPVjCRtjZyGmBd