### PR TITLE
Update docs to reflect chidori-js as sole JS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,13 +355,14 @@ See [`examples/`](./examples):
 
 ## ✅ JavaScript Conformance (Test262)
 
-Chidori runs agents in an embedded QuickJS runtime. To check that runtime
-against the same yardstick Bun and Node use, we run [**Test262**](https://github.com/tc39/test262) —
-the official TC39 ECMAScript conformance suite.
+Chidori executes agent code on its **embedded pure-Rust JavaScript engine**
+(`crates/chidori-js`, oxc parser → bytecode → stack VM, zero `unsafe`, no C) —
+the only JS engine in the tree. To check that engine against the same yardstick
+Bun and Node use, we run [**Test262**](https://github.com/tc39/test262) — the
+official TC39 ECMAScript conformance suite.
 
 ```bash
-# Vendor the suite (shallow clone of tc39/test262) and run language + built-ins.
-# First run clones ~56k files; subsequent runs reuse the checkout.
+# Vendor the pinned suite (shallow clone of tc39/test262) and run language + built-ins.
 scripts/test262.sh
 
 # Run a subset:
@@ -375,15 +376,25 @@ scripts/test262.sh --json target/test262-report.json --verbose
 The runner prints a pass/fail/skip summary:
 
 ```
-Test262 (chidori/QuickJS bare context)
-  pass 39178  fail 202  skip 7885  =>  99.49% of executed
+Test262 (chidori pure-Rust engine, bare context)
+  pass 38271  fail 1503  skip 7517  =>  96.22% of executed
 ```
 
 It drives the **bare ECMAScript context** (no `chidori` host object), so the
 number is pure language conformance — directly comparable to how Bun and Node
-report it. Modules and dynamic `import()` run by default; features the engine
-does not implement (and that Bun/Node also skip) are reported as `skip`, never
-hidden.
+report it. The percentage is `pass / (pass + fail)` over *executed* tests; the
+skip count is reported alongside so the denominator is never hidden. Features
+the engine intentionally does not implement — `Intl`, `Temporal`,
+`Atomics`/`SharedArrayBuffer`, `WeakRef`/`FinalizationRegistry`, `ShadowRealm`,
+decorators, iterator helpers (the same kinds of things Bun/Node skip) — are
+reported as `skip`, never hidden.
+
+Because `chidori-js` has no fallback engine, conformance is **load-bearing**: a
+language regression directly breaks real agents. CI gates every engine change
+against a committed per-test baseline
+(`crates/test262-runner/test262-expectations.json`) at a pinned suite commit,
+plus a nightly run — see
+[`.github/workflows/test262.yml`](./.github/workflows/test262.yml).
 
 You can also run the runner directly (after `cargo build --release -p test262-runner`):
 
@@ -391,142 +402,24 @@ You can also run the runner directly (after `cargo build --release -p test262-ru
 target/release/test262-runner --test262 vendor/test262 --help
 ```
 
-See [`docs/conformance.md`](./docs/conformance.md) for how it works, the honest
-skip policy, and the remaining engine-level gaps.
+### Remaining gaps
 
-### In-tree pure-Rust engine (experimental)
+The residual failures, by area (top clusters of the 1,503 total):
 
-Alongside the embedded QuickJS runtime, the tree ships an **independent,
-pure-Rust JavaScript engine** (`crates/chidori-js`) — oxc parser → bytecode →
-stack VM, with deterministic-replay durable execution and **no C and no
-`boa_engine`**. It is selectable with `--engine rust`:
+| count | area | nature |
+|--:|---|---|
+| 303 | `language/expressions` | class element corners, dynamic-`import()` semantics, `yield*` delegation ordering |
+| 222 | `language/statements` | remaining class element corners, `for-of` iterator-close |
+| 136 | `built-ins/Array` | species/proxy interplay, length-boundary semantics |
+| 98 | `built-ins/RegExp` | lone-surrogate matching (needs UTF-16 strings); `v`-flag; `prototype` long tail |
+| 96 | `built-ins/TypedArray` | resizable-`ArrayBuffer` / out-of-bounds tracking |
+| 59 | `built-ins/String` | `normalize`, Unicode/surrogate edge cases |
+| 52 | `built-ins/Promise` | spec-detailed async ordering combinations |
+| 51 | `language/module-code` | TLA ordering, cyclic-graph corner cases |
+| 23 | `language/arguments-object` | mapped-arguments index/parameter aliasing |
 
-```bash
-target/release/test262-runner --test262 vendor/test262 --engine rust
-```
-
-It is younger than the QuickJS path (which scores **99.5%** above), but already
-runs the full language + built-ins suite. Each test executes on its own
-worker thread with a wall-clock timeout and cooperative cancellation, so the
-whole suite completes in **~5 minutes** instead of hanging on pathological cases.
-
-**Latest run: `84.65%` of executed — 32,775 pass / 5,944 fail / 8,546 skip.**
-(Language **86.9%**, Built-ins **80.9%**.)
-
-#### Language — 80.1% (17,686 / 22,089 executed)
-
-| Category | Pass | Fail | Skip | Pass-rate |
-|---|--:|--:|--:|:--|
-| `expressions` | 8,380 | 2,143 | 515 | ████████░░ 80% |
-| `statements` | 7,283 | 1,828 | 226 | ████████░░ 80% |
-| `literals` | 411 | 40 | 83 | █████████░ 91% |
-| `arguments-object` | 206 | 57 | 0 | ████████░░ 78% |
-| `function-code` | 159 | 58 | 0 | ███████░░░ 73% |
-| `block-scope` | 143 | 2 | 0 | ██████████ 99% |
-| `types` | 99 | 12 | 2 | █████████░ 89% |
-| `white-space` | 62 | 5 | 0 | █████████░ 93% |
-| `computed-property-names` | 40 | 8 | 0 | ████████░░ 83% |
-| `destructuring` | 15 | 4 | 0 | ████████░░ 79% |
-| `rest-parameters` | 10 | 1 | 0 | █████████░ 91% |
-| `directive-prologue` | 40 | 22 | 0 | ██████░░░░ 65% |
-| `global-code` | 27 | 15 | 0 | ██████░░░░ 64% |
-| `identifier-resolution` | 8 | 6 | 0 | ██████░░░░ 57% |
-| `eval-code` | 142 | 200 | 5 | ████░░░░░░ 42% |
-| lexical & syntax¹ | 660 | 0 | 1 | ██████████ 100% |
-| `module-code` / `export` / `import` / `source-text` | 1 | 2 | 727 | _modules not yet supported_ |
-
-¹ `asi`, `comments`, `identifiers`, `keywords`, `line-terminators`,
-`punctuators`, `reserved-words`, `future-reserved-words`, `statementList`.
-
-#### Built-ins — 76.6% (12,745 / 16,630 executed)
-
-**Core objects & primitives**
-
-| Category | Pass | Fail | Skip | Pass-rate |
-|---|--:|--:|--:|:--|
-| `Object` | 3,042 | 361 | 8 | █████████░ 89% |
-| `Array` | 2,148 | 822 | 111 | ███████░░░ 72% |
-| `String` | 1,050 | 163 | 10 | █████████░ 87% |
-| `RegExp` | 834 | 692 | 353 | █████░░░░░ 55% |
-| `Date` | 561 | 22 | 11 | ██████████ 96% |
-| `Function` | 341 | 155 | 13 | ███████░░░ 69% |
-| `Number` | 322 | 17 | 1 | ██████████ 95% |
-| `Math` | 302 | 25 | 0 | █████████░ 92% |
-| `JSON` | 115 | 27 | 23 | ████████░░ 81% |
-| `BigInt` | 75 | 1 | 1 | ██████████ 99% |
-| `Symbol` | 68 | 9 | 21 | █████████░ 88% |
-| `NativeErrors` | 76 | 12 | 6 | █████████░ 86% |
-| `Boolean` | 49 | 1 | 1 | ██████████ 98% |
-| `Error` | 38 | 17 | 38 | ███████░░░ 69% |
-| `AggregateError` | 21 | 3 | 1 | █████████░ 88% |
-
-**Collections & iterators**
-
-| Category | Pass | Fail | Skip | Pass-rate |
-|---|--:|--:|--:|:--|
-| `Set` | 332 | 49 | 2 | █████████░ 87% |
-| `Map` | 144 | 25 | 35 | █████████░ 85% |
-| `WeakSet` | 78 | 6 | 1 | █████████░ 93% |
-| `WeakMap` | 92 | 9 | 40 | █████████░ 91% |
-| `ArrayIteratorPrototype` | 23 | 4 | 0 | █████████░ 85% |
-| `MapIteratorPrototype` | 10 | 1 | 0 | █████████░ 91% |
-| `SetIteratorPrototype` | 10 | 1 | 0 | █████████░ 91% |
-| `GeneratorPrototype` | 29 | 32 | 0 | █████░░░░░ 48% |
-| `GeneratorFunction` | 7 | 14 | 2 | ███░░░░░░░ 33% |
-| `StringIteratorPrototype` | 5 | 2 | 0 | ███████░░░ 71% |
-| `RegExpStringIteratorPrototype` | 4 | 13 | 0 | ██░░░░░░░░ 24% |
-| `Iterator` | 5 | 0 | 509 | _mostly helper proposals (skipped)_ |
-
-**Typed arrays & binary data**
-
-| Category | Pass | Fail | Skip | Pass-rate |
-|---|--:|--:|--:|:--|
-| `TypedArray` | 957 | 474 | 15 | ███████░░░ 67% |
-| `TypedArrayConstructors` | 496 | 164 | 78 | ████████░░ 75% |
-| `DataView` | 406 | 104 | 51 | ████████░░ 80% |
-| `ArrayBuffer` | 67 | 115 | 39 | ████░░░░░░ 37% |
-
-`TypedArrayConstructors` includes `Int8Array`…`Float64Array` plus the
-`BigInt64Array`/`BigUint64Array` pair, which pass **100%**.
-
-**Async, reflection & meta**
-
-| Category | Pass | Fail | Skip | Pass-rate |
-|---|--:|--:|--:|:--|
-| `Reflect` | 143 | 10 | 0 | █████████░ 93% |
-| `Proxy` | 193 | 80 | 38 | ███████░░░ 71% |
-| `Promise` | 392 | 247 | 38 | ██████░░░░ 61% |
-| `AsyncFunction` | 9 | 8 | 1 | █████░░░░░ 53% |
-| `AsyncGeneratorPrototype` | 17 | 31 | 0 | ████░░░░░░ 35% |
-| `AsyncGeneratorFunction` | 7 | 14 | 2 | ███░░░░░░░ 33% |
-| `AsyncFromSyncIteratorPrototype` | 9 | 29 | 0 | ██░░░░░░░░ 24% |
-| `AsyncIteratorPrototype` | 0 | 4 | 9 | ░░░░░░░░░░ 0% |
-
-**Globals, coercion & URI**
-
-| Category | Pass | Fail | Skip | Pass-rate |
-|---|--:|--:|--:|:--|
-| `parseFloat` / `isNaN` / `isFinite` | 84 | 0 | 0 | ██████████ 100% |
-| `parseInt` | 53 | 2 | 0 | █████████░ 96% |
-| `global` | 27 | 2 | 0 | █████████░ 93% |
-| `eval` | 9 | 1 | 0 | █████████░ 90% |
-| `encodeURI` / `encodeURIComponent` | 46 | 16 | 0 | ███████░░░ 74% |
-| `decodeURI` / `decodeURIComponent` | 107 | 4 | 0 | ██████████ 96% |
-| `NaN` / `Infinity` / `undefined` (value props) | 7 | 13 | 0 | ████░░░░░░ 35% |
-| `ThrowTypeError` | 0 | 13 | 1 | ░░░░░░░░░░ 0% |
-
-**Not yet implemented** (reported as `skip`, never hidden): ES modules
-(`import`/`export`), `Temporal`, `Intl`, `Atomics` / `SharedArrayBuffer`,
-`WeakRef` / `FinalizationRegistry` (intentionally unsupported under the
-deterministic-replay contract), `ShadowRealm`, and the
-`DisposableStack` / `SuppressedError` proposals.
-
-**Reading the table.** Strong areas (≥ 85%) include `Object`, `String`, `Date`,
-`Number`, `Math`, `BigInt`, `Set`/`Map`/`WeakMap`/`WeakSet`, `Reflect`, and the
-typed-array constructors. The biggest open gaps are `RegExp` (Unicode property
-escapes `\p{}` need Unicode tables), `ArrayBuffer` (resizable buffers), and the
-async-iterator/generator surfaces — see the long-tail list in
-[`docs/pure-rust-js-engine-plan.md`](./docs/pure-rust-js-engine-plan.md).
+See [`docs/conformance.md`](./docs/conformance.md) for the measurement
+methodology, the honest skip policy, the CI gate, and the full breakdown.
 
 ## 🏗 Architecture
 
@@ -539,7 +432,7 @@ async-iterator/generator surfaces — see the long-tail list in
 │               Rust Core Runtime                      │
 │                                                      │
 │  ┌─────────────┐ ┌──────────────┐ ┌──────────────┐  │
-│  │ TypeScript  │ │ Host Function│ │  Snapshot /  │  │
+│  │ TypeScript  │ │ Host Function│ │  Call log /  │  │
 │  │  Runtime    │ │ Registry     │ │   Replay     │  │
 │  └─────────────┘ └──────────────┘ └──────────────┘  │
 │  ┌─────────────┐ ┌──────────────┐ ┌──────────────┐  │
@@ -551,7 +444,7 @@ async-iterator/generator surfaces — see the long-tail list in
 
 - **TypeScript runtime** transpiles `.ts` agents and exposes a deterministic `chidori` host API.
 - **Host functions** are the only way agents touch the outside world.
-- **Snapshot/checkpoint engine** records host calls and persists runtime metadata for resume.
+- **Call-log / replay engine** records every host call and replays the journal for deterministic, zero-LLM-call resume.
 - **LLM providers** (Anthropic, OpenAI, LiteLLM-compatible) are swappable via `reqwest`.
 - **Template engine** uses `minijinja` for Jinja2 prompt templates.
 - **HTTP server** (`axum`) powers the `serve` command and session API.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ RUN_ID=$(ls -t examples/agents/.chidori/runs | head -1)
 ### Human-In-The-Loop Demo
 
 This demo shows the session API pausing on `chidori.input(...)` and resuming
-from the persisted VM state.
+from the persisted call log.
 
 Start the server:
 
@@ -188,8 +188,8 @@ The completed response includes:
 ```
 
 That flow is the core Chidori loop: TypeScript code runs until a durable host
-operation pauses, Chidori persists the run, and resume continues from the saved
-state.
+operation pauses, Chidori persists the run, and resume re-executes the agent
+against the persisted call log to continue from where it paused.
 
 ## 🧩 Core Concepts
 
@@ -206,7 +206,7 @@ An agent is a `.ts` file that exports an async `agent(input, chidori)` function.
 | `chidori.http(url, options)` | Make an HTTP request |
 | `chidori.memory(action, ...)` | Persistent storage (key-value + vector) |
 | `chidori.log(msg, data)` | Structured logging |
-| `chidori.env(name)` | Read environment variables |
+| `chidori.checkpoint(label, meta)` | Record an explicit call-log marker for trace/replay |
 | `chidori.retry(fn, options)` | Retry with backoff |
 | `chidori.tryCall(fn)` | Capture errors without raising |
 
@@ -253,7 +253,7 @@ Exposes:
 - `GET  /sessions` — list all sessions
 - `GET  /sessions/{id}` — get session result
 - `GET  /sessions/{id}/checkpoint` — get the call log and snapshot manifest metadata
-- `GET  /sessions/{id}/snapshot` — inspect snapshot manifest metadata without raw VM bytes
+- `GET  /sessions/{id}/snapshot` — inspect the durable journal-scaffold manifest metadata (no VM image — resume is call-log replay)
 - `POST /sessions/{id}/resume` — resume a paused `input()` or approval session
 - `POST /sessions/{id}/replay` — replay from a session's checkpoint
 - `POST /sessions/{id}/cancel` — cancel a running or stored session
@@ -471,7 +471,11 @@ chidori/
 │   │   └── openai.rs       # OpenAI-compatible (incl. LiteLLM)
 │   └── tools/
 │       └── mod.rs          # Tool discovery + JSON schema generation
+├── crates/
+│   ├── chidori-js/         # Pure-Rust JS engine (oxc → bytecode → VM), the only engine
+│   └── test262-runner/     # Test262 conformance harness + baseline gate
 ├── sdk/
+│   ├── typescript/         # TypeScript SDK (zero-dependency HTTP client)
 │   └── python/chidori/     # Python SDK (pure stdlib, no deps)
 ├── examples/
 │   ├── agents/             # Example .ts agents

--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -279,21 +279,30 @@ Both SDKs are zero-dependency and mirror each other. Gaps:
 ### Examples and docs — the doc-drift list
 
 Examples (~20 agents plus `examples/record-replay/`) remain in good shape.
-The docs are the main debt: a body of them still describes the QuickJS era.
-Concretely:
+The docs *were* the main debt: a body of them still described the QuickJS era.
+**Update (2026-06-12): this list is now resolved** — see recommendation 6.
+The original items, for the record:
 
-- `README.md` (~lines 358–410): says agents run on "an embedded QuickJS
+- ~~`README.md` (~lines 358–410): says agents run on "an embedded QuickJS
   runtime", cites the dead 99.5 % QuickJS number, and describes
-  `chidori-js` as the "younger" alternative path.
-- `docs/sandbox-model.md`: frames the rust engine as opt-in via a
-  `rust-engine` cargo feature (removed in #39).
-- `docs/rust-engine-quickjs-removal-gaps.md` and
+  `chidori-js` as the "younger" alternative path.~~ Rewritten: `chidori-js`
+  is now described as the sole engine at 96.22 %, with no QuickJS framing,
+  no `--engine rust` example, and a current cluster-table of remaining gaps.
+- ~~`docs/sandbox-model.md`: frames the rust engine as opt-in via a
+  `rust-engine` cargo feature (removed in #39).~~ Preamble rewritten; the
+  `CHIDORI_JS_ENGINE`/`rust-engine`/"default QuickJS path" framing, the
+  `exec*` capability references, and the stale "~91 %" number are gone.
+- ~~`docs/rust-engine-quickjs-removal-gaps.md` and
   `docs/pure-rust-js-engine-plan.md`: the migration they track is done;
-  they should be marked historical (their "decision: default stays QuickJS"
-  sections actively contradict the tree).
-- `scripts/conformance.sh`: still advertises `ENGINE=rust|quickjs`.
-- SDK READMEs (above), and `crates/chidori-js/src/lib.rs` ~420 ("rust
-  engine path yet").
+  they should be marked historical.~~ Both now carry a "historical —
+  superseded" banner up top.
+- ~~`scripts/conformance.sh`: still advertises `ENGINE=rust|quickjs`.~~
+  Already gone — the script wraps `test262-runner --state` with no engine knob.
+- ~~SDK READMEs (above), and `crates/chidori-js/src/lib.rs` ~420 ("rust
+  engine path yet").~~ Both SDK READMEs no longer claim resume is "gated on
+  the QuickJS serializer"; the `lib.rs` string already read "not supported in
+  single-file entrypoints". The stale "QuickJS path / `--features rust-engine`"
+  comments in `src/runtime/engine.rs` were corrected too.
 
 ---
 
@@ -329,9 +338,15 @@ Concretely:
    ready-made untrusted profile is the next step.
 4. ~~Run Test262 in CI~~ — **done** (#41). Add TypeScript SDK tests next.
 5. **Automate SDK publishing** to npm/PyPI, or remove the registry badges.
-6. **Pay down the doc drift** (the list above): README engine section, SDK
+6. ~~**Pay down the doc drift** (the list above): README engine section, SDK
    READMEs, sandbox-model preamble, archive the two migration docs, the
-   conformance.sh `ENGINE` knob.
+   conformance.sh `ENGINE` knob.~~ — **done**: the README engine/conformance
+   section now describes `chidori-js` as the sole engine at 96.22 % (no QuickJS,
+   no `--engine rust`); `docs/sandbox-model.md`'s preamble drops the
+   `CHIDORI_JS_ENGINE`/`rust-engine` framing and the `exec*` references; the two
+   migration docs carry a "historical — superseded" banner; both SDK READMEs no
+   longer claim resume is "gated on the QuickJS serializer"; and the stale
+   QuickJS-path comments in `src/runtime/engine.rs` are corrected.
 7. Longer-term, as adoption demands: per-VM memory accounting, value
    checkpointing for long journals (P6), a broader `node:` allowlist
    (`path`, `events`, `url` are cheap wins), more native providers or

--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -3,8 +3,11 @@
 *An in-depth review of the repository: what works, what is limited, and what
 is incomplete. Originally taken 2026-06-10 at commit `f93c2cd` ("runtime");
 updated 2026-06-11 after the QuickJS removal (#39), the CI fixes (#40), the
-Test262 CI gate (#41), and the conformance work in #42 and the
-derived-constructor rework on this branch.*
+Test262 CI gate (#41), the conformance work in #42, and the
+derived-constructor / arguments / restricted-property / explicit-resource
+rework in #43; the parallel Test262 runner (#44) and the workspace policy
+gate (#45). Doc-drift pass on 2026-06-12 (this branch). All of #39–#45 are
+merged into the branch history.*
 
 ## Scope and method
 
@@ -56,7 +59,7 @@ Test262 runs in CI against a committed per-test baseline (PRs touching the
 engine, pushes to `main`, and a nightly schedule), so the number can no
 longer rot silently. Conformance is **96.22 %** of executed tests at the
 pinned suite commit (38,271 pass / 1,503 fail / 7,517 skip), after the
-engine work on this branch — the derived-constructor construction model,
+engine work in #43 — the derived-constructor construction model,
 a correctness batch (arguments object, function-name bindings, restricted
 properties, `__proto__` literals, `delete` semantics), and a full
 implementation of explicit resource management (`using`/`await using`) —
@@ -90,7 +93,7 @@ build; new passes print a baseline-refresh hint.
   the *durability contract* rejects it), `with`-scope reference/closure
   semantics, spec-order member writes, `export default` self-reference
   fixes.
-- **This branch**: the spec construction model for derived classes —
+- **#43** (first batch): the spec construction model for derived classes —
   `super()` now performs a real `Construct(parent, args, new.target)` so
   `class A extends Array` (or `Map`, `Error`, …) produces a genuine exotic
   instance; `this` is in TDZ until `super()` returns (ReferenceError before,
@@ -103,7 +106,7 @@ build; new passes print a baseline-refresh hint.
   `extends null` and `extends Symbol` behave per spec. This cleared 144
   baseline failures (1,911 → 1,767) with zero regressions across the full
   suite — the bulk of what had been a ~300-test `class` cluster.
-- **Also on this branch** (a second batch, −194 failures → 1,571): named
+- **#43** (a second batch, −194 failures → 1,571): named
   function expressions and classes bind their own names per spec (immutable,
   TDZ for class heritage); the `arguments` object is a real exotic
   Arguments object (length/callee/@@iterator/tag) instead of a plain array;
@@ -113,7 +116,7 @@ build; new passes print a baseline-refresh hint.
   identifiers follows the spec (strict SyntaxError, binding/global
   configurability); %Object.prototype% is an immutable-prototype exotic
   object; eval-created globals are deletable, script-level ones are not.
-- **Explicit resource management** (a third batch, −68 → 1,503): `using` /
+- **#43 — explicit resource management** (a third batch, −68 → 1,503): `using` /
   `await using` declarations now dispose per spec — resources recorded
   before the binding initializes, disposed in reverse on EVERY exit path
   (throw/return/break/continue included) via a finally-style landing pad,
@@ -128,9 +131,12 @@ build; new passes print a baseline-refresh hint.
 | 303 | `language/expressions` | class element corners, dynamic-`import()` semantics, `yield*` delegation ordering |
 | 222 | `language/statements` | remaining class element corners, `for-of` iterator-close |
 | 136 | `built-ins/Array` | species/proxy interplay, length-boundary semantics |
-| 98 | `built-ins/RegExp` | lone-surrogate matching (needs UTF-16 strings), `v`-flag |
-| 96 | `built-ins/TypedArray` | resizable-`ArrayBuffer` out-of-bounds tracking |
+| 98 | `built-ins/RegExp` | lone-surrogate matching (needs UTF-16 strings); `v`-flag; `prototype` long tail |
+| 96 | `built-ins/TypedArray` | resizable-`ArrayBuffer` / out-of-bounds tracking |
+| 59 | `built-ins/String` | `normalize`, Unicode/surrogate edge cases |
 | 52 | `built-ins/Promise` | spec-detailed async ordering combinations |
+| 51 | `language/module-code` | TLA ordering, cyclic-graph corner cases |
+| 23 | `language/arguments-object` | mapped-arguments index/parameter aliasing |
 
 **Intentionally unsupported** (consistent with the deterministic replay
 contract, skipped honestly in the runner): `Intl`, `Temporal`,
@@ -182,7 +188,11 @@ The `execJs` / `execPython` / `execWasm` / `exec_expr` sandboxes are
 **removed**, along with their WASM interpreter blobs and the hand-rolled
 WASI shim. This deleted both a feature (polyglot snippet execution) and an
 attack/maintenance surface; agents now execute TypeScript only. Anyone
-relying on `chidori.execPython(...)` has no replacement.
+relying on `chidori.execPython(...)` has no replacement. (The
+`execJs`/`execPython`/`execWasm` JS *stubs* still exist in
+`crates/chidori-js/src/lib.rs`, but they are inert — the host backend
+rejects the effect with `chidori.<name> is not supported on the rust engine`,
+so there is no path back to snippet execution.)
 
 ### LLM providers
 

--- a/docs/pure-rust-js-engine-plan.md
+++ b/docs/pure-rust-js-engine-plan.md
@@ -1,13 +1,20 @@
 # Pure-Rust JS Engine + Replay-Based Durable Execution — Implementation Plan
 
-Status: **implemented (v1)** · Owner: TBD · Last updated: 2026-05-31
+> **⚠️ Historical — superseded.** This plan tracked building the pure-Rust engine
+> *alongside* QuickJS behind a `rust-engine` cargo feature. That migration is
+> **complete**: QuickJS was removed in #39, the feature flag is gone, and
+> `chidori-js` is now the **only** JS engine in the tree (the default and only
+> path). The "default OFF / QuickJS untouched" framing below is historical. For
+> the current engine and conformance story see
+> [`docs/conformance.md`](./conformance.md).
+
+Status: **implemented · migration complete** · Last updated: 2026-05-31
 
 ## Implementation status
 
-The engine and replay runtime are built in `crates/chidori-js` and integrated
-behind the `rust-engine` cargo feature (default OFF — the QuickJS/C path is
-untouched, verified by the existing suite passing 100% and the default build
-producing zero errors).
+The engine and replay runtime are built in `crates/chidori-js`. It began behind
+a `rust-engine` cargo feature (default OFF, alongside the QuickJS/C path); as of
+#39 that feature is removed and `chidori-js` is the sole engine.
 
 | Phase | Scope | Status |
 | --- | --- | --- |

--- a/docs/rust-engine-quickjs-removal-gaps.md
+++ b/docs/rust-engine-quickjs-removal-gaps.md
@@ -1,5 +1,13 @@
 # Removing QuickJS: gaps to close first
 
+> **⚠️ Historical — superseded.** The migration this document tracks is
+> **complete**: QuickJS was removed in #39 and `chidori-js` is now the only JS
+> engine in the tree. The "G5 conformance bar still pending" and "default stays
+> QuickJS" framing below describes the in-progress state and **no longer reflects
+> the codebase**. Kept for historical context only. For the current state see
+> [`docs/conformance.md`](./conformance.md) and
+> [`docs/fable_review.md`](./fable_review.md).
+
 **Status:** G1, G2, G3, G4, G6 **closed**; only G5 (conformance bar) remains.
 **Goal:** make the pure-Rust `chidori-js` engine the *only* engine and delete the
 QuickJS/C path entirely.

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -1,9 +1,8 @@
 # Sandbox model of the chidori-js runtime
 
 > **Status:** Implemented, with documented gaps (see [Current gaps](#current-gaps)).
-> **Target engine:** the pure-Rust `chidori-js` engine (`CHIDORI_JS_ENGINE=rust`,
-> `rust-engine` feature). The default QuickJS path has its own isolation story and
-> is out of scope here.
+> **Target engine:** the pure-Rust `chidori-js` engine — the only JS engine in
+> the tree (the QuickJS/C path was removed in #39).
 > **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md),
 > [`docs/captured-effects-vfs-crypto-timers.md`](./captured-effects-vfs-crypto-timers.md),
 > [`docs/conformance.md`](./conformance.md).
@@ -28,7 +27,7 @@ cannot corrupt memory, escape into host code, or reach a capability it was not
 given.
 
 What it is **not**: a containment boundary for the powerful effects the host
-*does* inject (`execPython`, `execWasm`, `http`, `workspace.*`). Those are real
+*does* inject (`http`, `workspace.*`). Those are real
 capabilities; whether granting them is "safe" depends entirely on whether the
 agent code is trusted. There is also no process/OS isolation — the engine runs
 in-process with the host.
@@ -55,7 +54,7 @@ remaining distance.
 | Hang the host with an infinite loop | ✅ Yes — opcode budget |
 | OOM the host (string / heap growth) | ✅ Yes — string cap + memory ceiling |
 | Crash the host with a panic | ✅ Yes — `catch_unwind` boundary |
-| Abuse an injected powerful effect (`execPython`, `http`, `workspace`) | ⚠️ Only if the host gates it — see [gaps](#current-gaps) |
+| Abuse an injected powerful effect (`http`, `workspace`) | ⚠️ Only if the host gates it — see [gaps](#current-gaps) |
 | Starve co-tenant agents / exceed a precise per-agent memory quota | ⚠️ Coarse only — see [gaps](#current-gaps) |
 | Break out of the process / OS | ❌ No process or OS isolation |
 
@@ -76,8 +75,10 @@ stack VM with `Rc<RefCell>` reference counting. Two properties make it a sandbox
    I/O exists **only** because the host installs it:
    - `Engine::install_chidori_effects` (`crates/chidori-js/src/lib.rs`) wires the
      async `chidori.*` effect surface (`log`, `tool`, `prompt`, `input`, `http`,
-     `memory`, `template`, `checkpoint`, `callAgent`, `execJs`/`execPython`/
-     `execWasm`, `workspace.*`).
+     `memory`, `template`, `checkpoint`, `callAgent`, `workspace.*`). The
+     `execJs`/`execPython`/`execWasm` JS stubs remain defined but are inert — the
+     host backend rejects the effect (`… is not supported on the rust engine`)
+     since the snippet sandboxes were removed in #39.
    - `Engine::install_sync_natives` wires the synchronous `__chidori_*` natives the
      `node:` shims call (crypto hashing/HMAC, captured randomness, the VFS).
 
@@ -87,8 +88,9 @@ stack VM with `Rc<RefCell>` reference counting. Two properties make it a sandbox
 
 The production wiring lives in `src/runtime/rust_engine.rs::run_module`, which
 builds a fresh engine per run, installs the captured-effect natives + determinism
-prelude, forwards `chidori.*` to the shared `HostBindingBackend` (the same durable
-host machinery the QuickJS path uses), then runs the agent's entrypoint.
+prelude, forwards `chidori.*` to the shared `HostBindingBackend` (the durable
+host machinery — call log, replay, policy, MCP, OTEL), then runs the agent's
+entrypoint.
 
 ## Filesystem isolation (`node:fs` → VFS)
 
@@ -238,7 +240,7 @@ resource-precision gaps.
    accumulate leaked bytes across runs; the baseline-relative memory cap is robust
    to this within a run but not across many runs on a reused thread.
 
-7. **Engine maturity.** The pure-Rust engine is at ~91% Test262 (see
+7. **Engine maturity.** The pure-Rust engine is at 96.22% Test262 (see
    [`docs/conformance.md`](./conformance.md)); spec deviations are not
    memory-unsafe but can produce surprising behavior or, in edge cases, perturb
    determinism/replay. This is a correctness-maturity caveat, not a containment
@@ -248,8 +250,8 @@ resource-precision gaps.
 
 If you intend to run code you do not trust on this engine today:
 
-1. Gate or disable `execPython`/`execJs`/`execWasm`/`workspace.*` (gap 1) — do not
-   install those effects, or add a deny-by-default policy check.
+1. Gate or disable `workspace.*` (gap 1) with a deny-by-default policy check (the
+   `exec*` snippet sandboxes were already removed in #39).
 2. Lower `CHIDORI_JS_OP_BUDGET` and `CHIDORI_JS_MEM_CAP_MB` to fit the workload, and
    enable `CHIDORI_JS_DEADLINE_MS` (acceptable because untrusted code should not be
    making slow trusted host calls).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -53,9 +53,10 @@ for evt in client.stream({"document": "hi"}):
 
 Snapshot-aware checkpoints include the replay call log plus optional manifest
 metadata. Durable resume is exposed through `client.resume(session_id,
-response)` for paused sessions. Today it resumes through persisted
-host-promise metadata and replay/scaffold recovery; direct live VM continuation
-from the server-side snapshot is still gated on the QuickJS serializer.
+response)` for paused sessions, recovering through persisted host-promise
+metadata and the replay journal. Replay **is** the resume mechanism by design —
+the QuickJS live-VM snapshot path was removed in #39, not merely deferred, so
+the manifest carries journal/scaffold metadata rather than serialized VM bytes.
 
 Mirrors the TypeScript SDK (`sdk/typescript/`) method-for-method. See the
 top-level `examples/sdk_demo.py` for a longer walkthrough and the server's

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -74,11 +74,12 @@ hashes, pending host operation, and snapshot file name. Clients can use it to
 display durable-resume state or diagnose why resume is blocked without handling
 the raw `runtime.snapshot` VM bytes.
 
-`client.replay(checkpoint)` still uses the call log for deterministic replay.
-Durable resume is exposed through `client.resume(sessionId, response)` for
-paused sessions. Today it resumes through persisted host-promise metadata and
-replay/scaffold recovery; direct live VM continuation from the server-side
-snapshot is still gated on the QuickJS serializer.
+`client.replay(checkpoint)` uses the call log for deterministic replay. Durable
+resume is exposed through `client.resume(sessionId, response)` for paused
+sessions, recovering through persisted host-promise metadata and the replay
+journal. Replay **is** the resume mechanism by design — the QuickJS live-VM
+snapshot path was removed in #39, not merely deferred, so the manifest carries
+journal/scaffold metadata rather than serialized VM bytes.
 
 Use `client.getSnapshotManifest(sessionId)` when a UI needs only snapshot
 metadata. The endpoint never returns the binary VM snapshot.

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -54,20 +54,21 @@ pub struct RunResult {
 
 /// Persist a resume scaffold for a run on the pure-Rust engine (G2).
 ///
-/// Unlike the QuickJS path, the rust live path's durability is the
-/// `RuntimeContext` call log, not a VM image: resume re-executes the agent from
-/// the top and feeds each host effect its recorded result via the call-log
-/// replay (`try_replay`), blocking again at the pending frontier. So there is no
-/// VM blob to store — we persist a manifest (`InitialTypeScriptStateScaffold`
-/// kind) plus the call log, pending operation, host-promise table, capabilities,
-/// and VFS, which is exactly what the server's call-log replay resume path
-/// consumes.
+/// The engine's durability is the `RuntimeContext` call log, not a VM image:
+/// resume re-executes the agent from the top and feeds each host effect its
+/// recorded result via the call-log replay (`try_replay`), blocking again at the
+/// pending frontier. So there is no VM blob to store — we persist a manifest
+/// (`InitialTypeScriptStateScaffold` kind) plus the call log, pending operation,
+/// host-promise table, capabilities, and VFS, which is exactly what the server's
+/// call-log replay resume path consumes.
 ///
-/// The ABI token is `chidori-quickjs` on purpose: the server's resume gate
-/// validates the manifest ABI against `SnapshotAbi::current("chidori-quickjs")`,
-/// and the existing QuickJS *scaffold* fallback uses the same token and resumes
-/// the same engine-agnostic way (call-log replay, not a VM image). Reusing it
-/// keeps the rust manifest acceptable to the unchanged resume gate.
+/// The ABI token is `chidori-quickjs` for backward compatibility: the server's
+/// resume gate validates the manifest ABI against
+/// `SnapshotAbi::current("chidori-quickjs")` — the token the durable format has
+/// always used (it predates the QuickJS removal in #39, and the scaffold has
+/// always resumed engine-agnostically via call-log replay, never a VM image).
+/// Keeping the name leaves the manifest acceptable to the unchanged resume gate
+/// and lets artifacts written before the removal still load.
 fn persist_rust_journal_scaffold(
     base: &Path,
     run_id: &str,
@@ -100,7 +101,7 @@ fn persist_rust_journal_scaffold(
     // The rust engine has no VM image to serialize; resume is call-log replay.
     // We still write a non-empty blob — the durable code bundle the journal keys
     // reference — so `SnapshotStore::load()` round-trips and the on-disk shape
-    // matches the QuickJS scaffold (manifest + blob + checkpoint + pending).
+    // matches the established scaffold shape (manifest + blob + checkpoint + pending).
     let blob = chidori_js::replay::DurableBlob {
         bundle: source.to_string(),
         effects: Vec::new(),
@@ -410,14 +411,14 @@ impl Engine {
             let source = std::fs::read_to_string(path)
                 .with_context(|| format!("Failed to read {}", path.display()))?;
 
-            // Route to the pure-Rust engine when selected (CHIDORI_JS_ENGINE=rust).
-            // Host effects still flow through host_core/RuntimeContext, so the
-            // durable call log and the host-call span tree behave identically;
-            // this path additionally emits JS-level function spans when tracing
-            // is on. Only compiled with `--features rust-engine`.
-            // Build the same runtime host backend the QuickJS path uses, so
-            // every `chidori.*` effect routes through identical durable
-            // machinery (call log, replay, policy, MCP, OTEL).
+            // Run the agent on the pure-Rust `chidori-js` engine — the only JS
+            // engine in the tree (the QuickJS/C path was removed in #39).
+            // Host effects flow through host_core/RuntimeContext, so the durable
+            // call log and the host-call span tree behave identically; this path
+            // additionally emits JS-level function spans when tracing is on.
+            // Build the runtime host backend so every `chidori.*` effect routes
+            // through identical durable machinery (call log, replay, policy,
+            // MCP, OTEL).
             let mut seeded = PolicyCache::default();
             for (target, args) in &self.approvals {
                 seeded.approve(target, args);
@@ -435,8 +436,7 @@ impl Engine {
             );
             // Persist a durable journal scaffold before the run and at each
             // host-operation safepoint, so a pause/crash has a resumable
-            // artifact on disk (G2). Mirrors the QuickJS safepoint wiring
-            // below, but stores the rust engine's journal-shaped manifest.
+            // artifact on disk (G2). Stores the engine's journal-shaped manifest.
             if let Some(ref base) = self.persist_base {
                 let safepoint_base = base.clone();
                 let safepoint_run_id = run_id.clone();
@@ -481,7 +481,7 @@ impl Engine {
             // the `PAUSE_MARKER` sentinel from the host effect — which the
             // rust engine throws as a JS error and bubbles up here as `Err`.
             // We surface that as a paused `RunResult` so the resume flow has
-            // something to resume, mirroring the QuickJS arm. The check runs
+            // something to resume. The check runs
             // on `Ok` too in case the agent caught the sentinel and returned.
             let surface_pause = |ctx: &RuntimeContext| -> Option<RunResult> {
                 if let Some(pending) = ctx.take_pending_input() {
@@ -1804,8 +1804,8 @@ def agent(value):
     /// `node:` captured effects (crypto + fs) run on the active engine and a
     /// record→replay round-trip reproduces identical output — including the
     /// captured randomness, which is journaled as a `crypto.random` call so a
-    /// resumed run draws the exact same bytes. Runs under whichever engine
-    /// `CHIDORI_JS_ENGINE` selects, so it guards both the QuickJS and rust paths.
+    /// resumed run draws the exact same bytes. Runs on the pure-Rust
+    /// `chidori-js` engine (the only engine in the tree).
     #[test]
     fn engine_node_builtins_crypto_fs_record_replay_parity() {
         let dir = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Summary

This PR updates documentation and comments throughout the codebase to reflect that `chidori-js` is now the only JavaScript engine in the tree following the removal of QuickJS in #39. The changes clarify the current architecture and remove stale references to the QuickJS path, the `rust-engine` feature flag, and the `CHIDORI_JS_ENGINE` environment variable.

## Key Changes

- **README.md conformance section**: Rewrote the Test262 section to describe `chidori-js` as the sole pure-Rust engine (96.22% pass rate) rather than framing it as an experimental alternative. Removed references to QuickJS's 99.5% score and the `--engine rust` selection mechanism. Added a table of remaining gaps by area instead of detailed per-category breakdowns.

- **docs/sandbox-model.md**: Updated the preamble to remove `CHIDORI_JS_ENGINE=rust` and `rust-engine` feature framing. Removed references to `execPython` and `execWasm` capabilities (removed in #39), noting they remain as inert JS stubs. Clarified that the engine uses the shared `HostBindingBackend` durable machinery.

- **docs/pure-rust-js-engine-plan.md** and **docs/rust-engine-quickjs-removal-gaps.md**: Added "Historical — superseded" banners at the top explaining that the migration is complete and QuickJS has been removed. These documents are retained for historical context only.

- **SDK READMEs** (TypeScript and Python): Clarified that durable resume uses call-log replay as the primary mechanism (not gated on QuickJS serialization). Removed the framing that live-VM snapshot continuation is "still gated on the QuickJS serializer" — it was removed entirely in #39, not deferred.

- **src/runtime/engine.rs**: Updated comments to remove references to "the QuickJS path" and clarify that `chidori-js` is the only engine. Simplified explanations of the ABI token reuse and durable scaffold format, removing QuickJS-specific context. Corrected the comment about safepoint wiring to drop the QuickJS comparison.

- **Architecture diagram** (README.md): Changed "Snapshot / Replay" label to "Call log / Replay" to more accurately reflect the journal-based durability model.

## Implementation Details

- All changes are documentation and comment updates; no functional code changes.
- The conformance section now reports the current pure-Rust engine metrics (38,271 pass / 1,503 fail / 7,517 skip = 96.22%) with a concise table of remaining gaps by area.
- Historical migration documents are preserved with clear banners directing readers to current documentation.
- Comments in `src/runtime/engine.rs` now accurately describe the engine-agnostic call-log replay mechanism without QuickJS-specific framing.

https://claude.ai/code/session_012Y2MEdQkK7zqjL6ann3f5Y