### PR TITLE
Add per-session policy profiles and supervised approval flow

### DIFF
--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -6,7 +6,9 @@ updated 2026-06-11 after the QuickJS removal (#39), the CI fixes (#40), the
 Test262 CI gate (#41), the conformance work in #42, and the
 derived-constructor / arguments / restricted-property / explicit-resource
 rework in #43; the parallel Test262 runner (#44) and the workspace policy
-gate (#45). Doc-drift pass on 2026-06-12 (this branch). All of #39–#45 are
+gate (#45). Doc-drift pass on 2026-06-12 (#46), followed by the secret
+broker (#47) and the node-shim batch + built-in `untrusted` policy profile
+(#48); a `--untrusted` CLI flag landed on this branch. All of #39–#48 are
 merged into the branch history.*
 
 ## Scope and method
@@ -219,8 +221,11 @@ The real gaps, restated post-#39:
    `read` / `write` / `delete` / `manifest`) pass through the policy gate, so a
    restrictive profile can deny or gate disk writes while allowing reads. The
    `exec*` family is gone. What remains is the *default decision*: the fallback
-   is still `AlwaysAllow`, so deny-by-default for untrusted profiles is opt-in
-   (`"default": "never_allow"` + allow rules) rather than automatic.
+   is still `AlwaysAllow`. Deny-by-default is now a one-switch opt-in — the
+   built-in `untrusted` profile (#48), selectable via
+   `CHIDORI_POLICY_PROFILE=untrusted` or the `--untrusted` flag on
+   `chidori run` / `chidori serve` (the flag wins over all `CHIDORI_POLICY*`
+   env vars) — but it is still opt-in, not automatic.
 2. **Memory accounting is process-wide, not per-VM** (`src/mem_guard.rs`):
    under concurrent agents one run's allocations can be attributed to
    another; enforcement is polled, so brief overshoot is possible.
@@ -343,11 +348,15 @@ The original items, for the record:
 3. ~~Gate the remaining powerful effects (`workspace.*`) through the policy
    layer~~ — **done**: every `workspace.*` action now routes through
    `enforce_policy` (targets `workspace:list` / `read` / `write` / `delete` /
-   `manifest`), joining `http`. The remaining follow-up is making
-   **deny-by-default** the actual default for untrusted profiles — today the
-   fallback decision is still `AlwaysAllow`, so untrusted callers must opt in
-   with `"default": "never_allow"` plus explicit allow rules. Shipping a
-   ready-made untrusted profile is the next step.
+   `manifest`), joining `http`. ~~Shipping a ready-made untrusted profile is
+   the next step.~~ — **done** (#48 + this branch): the built-in `untrusted`
+   profile (deny-by-default fallback, read-only workspace allowlist) ships
+   behind `CHIDORI_POLICY_PROFILE=untrusted` and an `--untrusted` flag on
+   `chidori run` / `chidori serve`; the flag takes precedence over all
+   `CHIDORI_POLICY*` env vars, with CLI integration tests covering denial,
+   the read-only allowlist, and flag-over-env precedence. The default
+   profile remains `AlwaysAllow` — making `untrusted` automatic for
+   untrusted callers is the remaining (design-level) follow-up.
 4. ~~Run Test262 in CI~~ — **done** (#41). Add TypeScript SDK tests next.
 5. **Automate SDK publishing** to npm/PyPI, or remove the registry badges.
 6. ~~**Pay down the doc drift** (the list above): README engine section, SDK

--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -225,7 +225,10 @@ The real gaps, restated post-#39:
    built-in `untrusted` profile (#48), selectable via
    `CHIDORI_POLICY_PROFILE=untrusted` or the `--untrusted` flag on
    `chidori run` / `chidori serve` (the flag wins over all `CHIDORI_POLICY*`
-   env vars) — but it is still opt-in, not automatic.
+   env vars) — but it is still opt-in, not automatic. A `supervised`
+   sibling (ask-by-default, settled through the server's `/approve` flow)
+   and per-session profile selection over the HTTP API (stricter-wins
+   layering on the server policy) landed on this branch.
 2. **Memory accounting is process-wide, not per-VM** (`src/mem_guard.rs`):
    under concurrent agents one run's allocations can be attributed to
    another; enforcement is polled, so brief overshoot is possible.
@@ -354,7 +357,15 @@ The original items, for the record:
    behind `CHIDORI_POLICY_PROFILE=untrusted` and an `--untrusted` flag on
    `chidori run` / `chidori serve`; the flag takes precedence over all
    `CHIDORI_POLICY*` env vars, with CLI integration tests covering denial,
-   the read-only allowlist, and flag-over-env precedence. The default
+   the read-only allowlist, and flag-over-env precedence. Two follow-ups
+   from this review also landed on this branch: a **`supervised`** profile
+   (same allowlist, `AskBefore` fallback — gated calls suspend as
+   `awaiting_approval` and settle through `/approve` instead of failing)
+   and **per-session policy selection** over the HTTP API (`policy_profile`
+   on `POST /sessions` / `/sessions/stream`, persisted on the session and
+   re-applied across resume/approve/replay, exposed in both SDKs). Session
+   profiles layer on the server policy with stricter-wins semantics, so a
+   caller can tighten but never relax the operator's policy. The default
    profile remains `AlwaysAllow` — making `untrusted` automatic for
    untrusted callers is the remaining (design-level) follow-up.
 4. ~~Run Test262 in CI~~ — **done** (#41). Add TypeScript SDK tests next.

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -203,8 +203,9 @@ resource-precision gaps.
    deny or require approval for disk writes while still allowing reads. The
    remaining gap is the *default*: the fallback decision is still `AlwaysAllow`, so
    out of the box nothing is denied. Deny-by-default is now one switch away — the
-   built-in [`untrusted` profile](#the-untrusted-policy-profile-deny-by-default)
-   (`CHIDORI_POLICY_PROFILE=untrusted`) — but it is opt-in, not automatic.
+   built-in [`untrusted` profile](#the-untrusted-policy-profile-deny-by-default),
+   selectable as `chidori run --untrusted` / `chidori serve --untrusted` or via
+   `CHIDORI_POLICY_PROFILE=untrusted` — but it is opt-in, not automatic.
    *Remaining fix:* make it the default for untrusted runs.
 
 2. **The memory ceiling is process-wide, not per-VM.** The `CountingAllocator`
@@ -255,11 +256,19 @@ effect is `AlwaysAllow`, so out of the box nothing is denied; deny-by-default is
 something you turn on.
 
 The **`untrusted`** profile is a ready-made, deny-by-default policy you can select
-by name — no hand-written JSON. Enable it with a single environment variable:
+by name — no hand-written JSON. Enable it with a CLI flag (on `run` and `serve`)
+or an environment variable:
 
 ```sh
-CHIDORI_POLICY_PROFILE=untrusted chidori run agent.ts
+chidori run --untrusted agent.ts                       # CLI flag
+chidori serve --untrusted agent.ts                     # also on serve
+CHIDORI_POLICY_PROFILE=untrusted chidori run agent.ts  # env-var equivalent
 ```
+
+The flag is the operator's last word: `--untrusted` takes precedence over **all**
+`CHIDORI_POLICY*` env vars (including a permissive `CHIDORI_POLICY_FILE` /
+`CHIDORI_POLICY`), so a wrapper script can guarantee confinement regardless of
+ambient configuration.
 
 Semantics:
 
@@ -275,9 +284,9 @@ The fallback governs exactly the powerful surface, because the *pure* effects
 (`log`, `template`, `memory`, `prompt`, …) never call `enforce_policy` and so run
 regardless of the profile — they have no ambient authority to abuse.
 
-Selection order in `PolicyConfig::from_env` is `CHIDORI_POLICY_FILE` →
-`CHIDORI_POLICY` (inline JSON) → `CHIDORI_POLICY_PROFILE` (a built-in name) →
-default. The **default profile is unchanged** (`AlwaysAllow` fallback, no rules):
+Selection order is the `--untrusted` flag first, then `PolicyConfig::from_env`:
+`CHIDORI_POLICY_FILE` → `CHIDORI_POLICY` (inline JSON) → `CHIDORI_POLICY_PROFILE`
+(a built-in name) → default. The **default profile is unchanged** (`AlwaysAllow` fallback, no rules):
 the `untrusted` profile is purely opt-in. To customize further, copy the profile's
 shape into your own `CHIDORI_POLICY` JSON (rules + `"default": "never_allow"`), or
 add `AskBefore` rules to surface an approval prompt instead of a hard refusal.
@@ -286,9 +295,9 @@ add `AskBefore` rules to surface an approval prompt instead of a hard refusal.
 
 If you intend to run code you do not trust on this engine today:
 
-1. Select the deny-by-default policy: `CHIDORI_POLICY_PROFILE=untrusted` (above).
-   This denies `http` and `workspace` mutations while leaving read-only workspace
-   introspection available.
+1. Select the deny-by-default policy: `chidori run --untrusted` (or
+   `CHIDORI_POLICY_PROFILE=untrusted`, above). This denies `http` and `workspace`
+   mutations while leaving read-only workspace introspection available.
 2. Lower `CHIDORI_JS_OP_BUDGET` and `CHIDORI_JS_MEM_CAP_MB` to fit the workload, and
    enable `CHIDORI_JS_DEADLINE_MS` (acceptable because untrusted code should not be
    making slow trusted host calls).

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -288,8 +288,50 @@ Selection order is the `--untrusted` flag first, then `PolicyConfig::from_env`:
 `CHIDORI_POLICY_FILE` → `CHIDORI_POLICY` (inline JSON) → `CHIDORI_POLICY_PROFILE`
 (a built-in name) → default. The **default profile is unchanged** (`AlwaysAllow` fallback, no rules):
 the `untrusted` profile is purely opt-in. To customize further, copy the profile's
-shape into your own `CHIDORI_POLICY` JSON (rules + `"default": "never_allow"`), or
-add `AskBefore` rules to surface an approval prompt instead of a hard refusal.
+shape into your own `CHIDORI_POLICY` JSON (rules + `"default": "never_allow"`).
+
+### The `supervised` profile (ask-by-default)
+
+The **`supervised`** profile is the approval-flow sibling of `untrusted`: the same
+read-only workspace allowlist, but the fallback is `AskBefore` instead of
+`NeverAllow`. Under the server, a gated call suspends the run — the session
+transitions to `awaitingapproval` with a `pending_approval` carrying the
+`(target, args)` being asked about — and `POST /sessions/:id/approve` with
+`{"decision": "allow"}` or `{"decision": "deny"}` settles it. Approvals are
+remembered per `(target, args)` for the rest of the session, so the agent does not
+re-ask for an identical call. On the bare CLI (where nothing can answer the
+prompt) the gated call errors instead, unless `CHIDORI_POLICY_AUTO_APPROVE=1`.
+
+Select it anywhere a profile name is accepted: `CHIDORI_POLICY_PROFILE=supervised`
+or a session's `policy_profile` field (below).
+
+### Per-session profiles over the HTTP API
+
+A multi-tenant server can mix trusted and untrusted callers without restarting or
+re-configuring: `POST /sessions` and `POST /sessions/stream` accept an optional
+`policy_profile` field (alias `policyProfile`) naming a built-in profile.
+
+```sh
+curl -X POST localhost:8080/sessions \
+  -d '{"input": {}, "policy_profile": "untrusted"}'
+```
+
+Semantics:
+
+- **Stricter-wins layering.** The session profile is layered on the server
+  policy and, for every gated call, the *stricter* of the two decisions applies
+  (`never_allow` > `ask_before` > `always_allow`). A caller-selected profile can
+  therefore tighten what the operator's policy allows but can never relax it —
+  selecting a profile is not an escalation path even on a hardened server.
+- **Sticky for the session's lifetime.** The profile name is persisted on the
+  session and re-applied on every re-run: `input()` resume, approval replay, and
+  `/replay`. It is reported back in the session JSON as `policy_profile`.
+- **Validated up front.** An unknown profile name is a `400` at creation; a
+  stored name that no longer resolves (e.g. after a version change) fails closed
+  to `untrusted` rather than silently running under the looser server policy.
+
+Both SDKs expose this: `client.run(input, { policyProfile: "untrusted" })` in
+TypeScript, `client.run(input, policy_profile="untrusted")` in Python.
 
 ## How to harden for untrusted code
 

--- a/sdk/python/chidori/client.py
+++ b/sdk/python/chidori/client.py
@@ -127,15 +127,25 @@ class AgentClient:
         """Check server health."""
         return self._get("/health")
 
-    def run(self, input: dict) -> Session:
+    def run(self, input: dict, policy_profile: str | None = None) -> Session:
         """Create a new session and run the agent with the given input.
 
         Returns a Session with the output, status, and call log. If the
         agent called `input()`, the returned Session will have
         status == "paused" and a populated `pending_prompt` — use
         `client.resume(session.id, response)` to continue.
+
+        `policy_profile` optionally names a built-in policy profile
+        ("untrusted" or "supervised") applied to every run of this session.
+        It is layered on the server policy with stricter-wins semantics —
+        it can tighten what the operator allows, never relax it. Under
+        "supervised", gated calls pause the session as "awaitingapproval";
+        approve or deny them via the server's /approve endpoint.
         """
-        data = self._post("/sessions", {"input": input})
+        body: dict[str, Any] = {"input": input}
+        if policy_profile is not None:
+            body["policy_profile"] = policy_profile
+        data = self._post("/sessions", body)
         return Session(
             id=data["id"],
             status=data["status"],

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -47,7 +47,20 @@ export type Json =
   | { [key: string]: Json };
 
 /** Server-side session status. */
-export type SessionStatus = "running" | "completed" | "failed" | "paused";
+export type SessionStatus =
+  | "running"
+  | "completed"
+  | "failed"
+  | "paused"
+  | "cancelled"
+  | "awaitingapproval";
+
+/**
+ * Built-in policy profiles selectable per session. Layered on the server
+ * policy with stricter-wins semantics: a profile can tighten what the
+ * operator's policy allows, never relax it.
+ */
+export type PolicyProfile = "untrusted" | "supervised";
 
 /** A single host function call recorded during an agent run. */
 export interface CallRecord {
@@ -262,9 +275,22 @@ export class AgentClient {
     return (await this.getJSON("/health")) as Json;
   }
 
-  /** Create a new session and run the agent with the given input. */
-  async run(input: Json): Promise<Session> {
-    const data = await this.postJSON("/sessions", { input });
+  /**
+   * Create a new session and run the agent with the given input.
+   *
+   * `options.policyProfile` optionally names a built-in policy profile
+   * ("untrusted" or "supervised") applied to every run of this session.
+   * It is layered on the server policy with stricter-wins semantics — it
+   * can tighten what the operator allows, never relax it. Under
+   * "supervised", gated calls pause the session as "awaitingapproval";
+   * approve or deny them via the server's /approve endpoint.
+   */
+  async run(input: Json, options?: { policyProfile?: PolicyProfile }): Promise<Session> {
+    const body: Record<string, unknown> = { input };
+    if (options?.policyProfile) {
+      body.policy_profile = options.policyProfile;
+    }
+    const data = await this.postJSON("/sessions", body);
     return this.sessionFrom(data, input);
   }
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -73,6 +73,7 @@ async fn create_thread(
         pending_prompt: None,
         pending_approval: None,
         approvals: Vec::new(),
+        policy_profile: None,
         created_at: chrono::Utc::now(),
     };
     if let Err(e) = state.store.put(&session) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,13 @@ enum Commands {
         /// When set, --trace is ignored (the call log is implicit in the stream).
         #[arg(long)]
         stream: bool,
+
+        /// Run under the built-in deny-by-default `untrusted` policy profile:
+        /// gated effects (http, workspace mutations) are refused unless
+        /// allowlisted. Equivalent to CHIDORI_POLICY_PROFILE=untrusted, but
+        /// takes precedence over all CHIDORI_POLICY* env vars.
+        #[arg(long)]
+        untrusted: bool,
     },
 
     /// Validate a TypeScript agent file without running it
@@ -147,6 +154,13 @@ enum Commands {
         /// Print host function calls to stderr during execution
         #[arg(short, long)]
         verbose: bool,
+
+        /// Serve under the built-in deny-by-default `untrusted` policy profile:
+        /// gated effects (http, workspace mutations) are refused unless
+        /// allowlisted. Equivalent to CHIDORI_POLICY_PROFILE=untrusted, but
+        /// takes precedence over all CHIDORI_POLICY* env vars.
+        #[arg(long)]
+        untrusted: bool,
     },
 }
 
@@ -163,11 +177,12 @@ fn main() {
             verbose,
             tools,
             stream,
+            untrusted,
         } => {
             let result = if stream {
-                cmd_run_stream(&file, &input, verbose, &tools)
+                cmd_run_stream(&file, &input, verbose, &tools, untrusted)
             } else {
-                cmd_run(&file, &input, trace, verbose, &tools)
+                cmd_run(&file, &input, trace, verbose, &tools, untrusted)
             };
             (result, false)
         }
@@ -184,7 +199,8 @@ fn main() {
             file,
             port,
             verbose,
-        } => (cmd_serve(&file, port, verbose), false),
+            untrusted,
+        } => (cmd_serve(&file, port, verbose, untrusted), false),
     };
 
     // Flush any buffered OTLP spans before the process exits. No-op when
@@ -351,16 +367,16 @@ fn cmd_demo() -> Result<()> {
                 .collect::<Vec<_>>();
             let tool_dirs = tools.iter().map(PathBuf::from).collect::<Vec<_>>();
             if *stream {
-                cmd_run_stream(&file, &inputs, false, &tool_dirs)
+                cmd_run_stream(&file, &inputs, false, &tool_dirs, false)
             } else {
-                cmd_run(&file, &inputs, *trace, false, &tool_dirs)
+                cmd_run(&file, &inputs, *trace, false, &tool_dirs, false)
             }
         }
         DemoAction::Serve { file, port } => {
             if !confirm_start_server(*port)? {
                 return Ok(());
             }
-            cmd_serve(&PathBuf::from(file), *port, false)
+            cmd_serve(&PathBuf::from(file), *port, false, false)
         }
     }
 }
@@ -417,12 +433,25 @@ fn has_llm_provider() -> bool {
         || std::env::var_os("LITELLM_API_URL").is_some()
 }
 
+/// Resolve the permission policy for a CLI invocation. `--untrusted` selects
+/// the built-in deny-by-default profile and wins over every CHIDORI_POLICY*
+/// env var (an explicit flag beats ambient configuration); otherwise the
+/// usual env-driven resolution applies.
+fn cli_policy(untrusted: bool) -> Arc<policy::PolicyConfig> {
+    if untrusted {
+        Arc::new(policy::builtin_profile("untrusted").expect("built-in untrusted profile exists"))
+    } else {
+        policy::PolicyConfig::from_env()
+    }
+}
+
 fn cmd_run(
     file: &PathBuf,
     inputs: &[String],
     trace: bool,
     verbose: bool,
     extra_tool_dirs: &[PathBuf],
+    untrusted: bool,
 ) -> Result<()> {
     // Set up tracing.
     if verbose {
@@ -456,6 +485,7 @@ fn cmd_run(
 
     let engine = Engine::new(providers, template_engine, tokio_rt)
         .with_tools(tools)
+        .with_policy(cli_policy(untrusted))
         .with_persist_base(base_dir.join(".chidori").join("runs"));
 
     // Run the agent.
@@ -498,6 +528,7 @@ fn cmd_run_stream(
     inputs: &[String],
     verbose: bool,
     extra_tool_dirs: &[PathBuf],
+    untrusted: bool,
 ) -> Result<()> {
     use tokio::sync::mpsc;
 
@@ -525,7 +556,9 @@ fn cmd_run_stream(
     let tools =
         Arc::new(ToolRegistry::load_from_dirs(&tool_dirs).unwrap_or_else(|_| ToolRegistry::new()));
 
-    let engine = Engine::new(providers, template_engine, tokio_rt).with_tools(tools);
+    let engine = Engine::new(providers, template_engine, tokio_rt)
+        .with_tools(tools)
+        .with_policy(cli_policy(untrusted));
 
     let (event_tx, event_rx) = mpsc::unbounded_channel::<crate::runtime::context::RuntimeEvent>();
 
@@ -889,7 +922,7 @@ fn cmd_stats(dir: Option<&std::path::Path>) -> Result<()> {
     Ok(())
 }
 
-fn cmd_serve(file: &PathBuf, port: u16, verbose: bool) -> Result<()> {
+fn cmd_serve(file: &PathBuf, port: u16, verbose: bool, untrusted: bool) -> Result<()> {
     if verbose {
         tracing_subscriber::fmt()
             .with_env_filter("info")
@@ -923,6 +956,7 @@ fn cmd_serve(file: &PathBuf, port: u16, verbose: bool) -> Result<()> {
         template_engine,
         file.clone(),
         port,
+        cli_policy(untrusted),
     ))?;
 
     Ok(())

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -33,6 +33,17 @@ impl Default for Decision {
     }
 }
 
+impl Decision {
+    /// Total order by restrictiveness: AlwaysAllow < AskBefore < NeverAllow.
+    fn strictness(self) -> u8 {
+        match self {
+            Decision::AlwaysAllow => 0,
+            Decision::AskBefore => 1,
+            Decision::NeverAllow => 2,
+        }
+    }
+}
+
 /// A single rule. `target` is "tool:<name>" / "http" / "workspace:<action>"
 /// (where `<action>` is `list` / `read` / `write` / `delete` / `manifest`) /
 /// "*". `match_args` is an optional JSON subset that must be contained in the
@@ -55,6 +66,13 @@ pub struct PolicyConfig {
     /// Fallback when no rule matches.
     #[serde(default)]
     pub default: Decision,
+    /// An additional policy layered on top of this one: the effective decision
+    /// for a call is the *stricter* of the two. Set via [`restricted_by`]
+    /// (e.g. a per-session profile on the server) so a caller-selected policy
+    /// can only tighten, never relax, the operator's policy. Never serialized:
+    /// the overlay is reconstructed from its profile name on every run.
+    #[serde(skip)]
+    pub overlay: Option<Arc<PolicyConfig>>,
 }
 
 impl PolicyConfig {
@@ -91,8 +109,24 @@ impl PolicyConfig {
 
     /// Resolve a call against the policy. `target` is the normalized target
     /// string (see PolicyRule.target). Rules are tried in order; the first
-    /// matching rule wins. Wildcard "*" always matches target.
+    /// matching rule wins. Wildcard "*" always matches target. When an
+    /// overlay is present, the stricter of the two resolutions wins.
     pub fn decide(&self, target: &str, args: &Value) -> (Decision, Option<String>) {
+        let base = self.decide_local(target, args);
+        match &self.overlay {
+            None => base,
+            Some(overlay) => {
+                let layered = overlay.decide(target, args);
+                if layered.0.strictness() > base.0.strictness() {
+                    layered
+                } else {
+                    base
+                }
+            }
+        }
+    }
+
+    fn decide_local(&self, target: &str, args: &Value) -> (Decision, Option<String>) {
         for rule in &self.rules {
             if rule.target != target && rule.target != "*" {
                 continue;
@@ -106,20 +140,39 @@ impl PolicyConfig {
         }
         (self.default, None)
     }
+
+    /// Layer `profile` on top of this policy: every decision becomes the
+    /// stricter of the two. This is the per-session selection mechanism — a
+    /// caller-picked profile can deny or gate what the operator's policy
+    /// allows, but can never allow what the operator denies.
+    pub fn restricted_by(&self, profile: Arc<PolicyConfig>) -> PolicyConfig {
+        let mut base = self.clone();
+        base.overlay = Some(match base.overlay.take() {
+            None => profile,
+            Some(existing) => Arc::new(existing.restricted_by(profile)),
+        });
+        base
+    }
 }
 
-/// Names of the built-in profiles selectable via `CHIDORI_POLICY_PROFILE`.
-pub const BUILTIN_PROFILES: &[&str] = &["untrusted"];
+/// Names of the built-in profiles selectable via `CHIDORI_POLICY_PROFILE`,
+/// the `--untrusted` CLI flag, or a session's `policy_profile` field.
+pub const BUILTIN_PROFILES: &[&str] = &["untrusted", "supervised"];
 
 /// Build a ready-made [`PolicyConfig`] by name, or `None` for an unknown name.
 ///
-/// The only profile today is `"untrusted"`: deny-by-default with a minimal
-/// allowlist of pure, side-effect-free host effects. It is opt-in (via
-/// `CHIDORI_POLICY_PROFILE=untrusted`) and never affects the default profile,
-/// which keeps the historical `AlwaysAllow` fallback.
+/// * `"untrusted"` — deny-by-default: gated effects are hard-refused unless
+///   on the read-only workspace allowlist.
+/// * `"supervised"` — ask-by-default: the same allowlist, but unmatched gated
+///   effects pause the run for operator approval (the server's
+///   `awaiting_approval` / `/approve` flow) instead of failing outright.
+///
+/// Both are opt-in and never affect the default profile, which keeps the
+/// historical `AlwaysAllow` fallback.
 pub fn builtin_profile(name: &str) -> Option<PolicyConfig> {
     match name {
         "untrusted" => Some(untrusted_profile()),
+        "supervised" => Some(supervised_profile()),
         _ => None,
     }
 }
@@ -140,20 +193,38 @@ pub fn builtin_profile(name: &str) -> Option<PolicyConfig> {
 /// Denied (by the fallback): `http` (network egress) and `workspace:write` /
 /// `workspace:delete` (disk mutation within the root).
 fn untrusted_profile() -> PolicyConfig {
+    PolicyConfig {
+        rules: read_only_workspace_allowlist(),
+        default: Decision::NeverAllow,
+        overlay: None,
+    }
+}
+
+/// Ask-by-default profile: identical allowlist to `untrusted`, but unmatched
+/// gated effects resolve to `AskBefore` — under the server's pause flow the
+/// run suspends as `awaiting_approval` and the operator decides per call
+/// (approvals are remembered per (target, args) for the session). On the bare
+/// CLI, where nothing can answer the prompt, the call errors instead.
+fn supervised_profile() -> PolicyConfig {
+    PolicyConfig {
+        rules: read_only_workspace_allowlist(),
+        default: Decision::AskBefore,
+        overlay: None,
+    }
+}
+
+fn read_only_workspace_allowlist() -> Vec<PolicyRule> {
     let allow_read_only = |target: &str| PolicyRule {
         target: target.to_string(),
         decision: Decision::AlwaysAllow,
         match_args: None,
         reason: Some("read-only workspace introspection".to_string()),
     };
-    PolicyConfig {
-        rules: vec![
-            allow_read_only("workspace:list"),
-            allow_read_only("workspace:read"),
-            allow_read_only("workspace:manifest"),
-        ],
-        default: Decision::NeverAllow,
-    }
+    vec![
+        allow_read_only("workspace:list"),
+        allow_read_only("workspace:read"),
+        allow_read_only("workspace:manifest"),
+    ]
 }
 
 /// True when `args` contains all keys/values in `pattern` (shallow for scalars,
@@ -238,6 +309,76 @@ mod tests {
                 "{target} should be allowed"
             );
         }
+    }
+
+    #[test]
+    fn supervised_profile_asks_by_default_and_allows_read_only() {
+        let cfg = builtin_profile("supervised").expect("supervised profile exists");
+        assert_eq!(cfg.default, Decision::AskBefore);
+
+        let (decision, _) = cfg.decide("http", &json!({ "url": "https://example.com" }));
+        assert_eq!(decision, Decision::AskBefore);
+        let (decision, _) = cfg.decide("workspace:write", &json!({ "path": "a.txt" }));
+        assert_eq!(decision, Decision::AskBefore);
+        for target in ["workspace:list", "workspace:read", "workspace:manifest"] {
+            let (decision, _) = cfg.decide(target, &json!({}));
+            assert_eq!(
+                decision,
+                Decision::AlwaysAllow,
+                "{target} should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn overlay_tightens_a_permissive_base() {
+        let base = PolicyConfig::default(); // AlwaysAllow fallback
+        let layered = base.restricted_by(Arc::new(builtin_profile("untrusted").unwrap()));
+
+        let (decision, _) = layered.decide("http", &json!({}));
+        assert_eq!(decision, Decision::NeverAllow);
+        let (decision, _) = layered.decide("workspace:write", &json!({}));
+        assert_eq!(decision, Decision::NeverAllow);
+        // Allowed on both sides stays allowed.
+        let (decision, _) = layered.decide("workspace:read", &json!({}));
+        assert_eq!(decision, Decision::AlwaysAllow);
+    }
+
+    #[test]
+    fn overlay_cannot_relax_a_restrictive_base() {
+        // Operator policy denies http outright; a session-selected supervised
+        // profile (AskBefore) must not downgrade that to a mere prompt.
+        let base = PolicyConfig {
+            rules: vec![PolicyRule {
+                target: "http".to_string(),
+                decision: Decision::NeverAllow,
+                match_args: None,
+                reason: Some("operator denies egress".to_string()),
+            }],
+            default: Decision::AlwaysAllow,
+            overlay: None,
+        };
+        let layered = base.restricted_by(Arc::new(builtin_profile("supervised").unwrap()));
+
+        let (decision, reason) = layered.decide("http", &json!({}));
+        assert_eq!(decision, Decision::NeverAllow);
+        assert_eq!(reason.as_deref(), Some("operator denies egress"));
+        // Targets the base allows fall to the overlay's AskBefore.
+        let (decision, _) = layered.decide("workspace:write", &json!({}));
+        assert_eq!(decision, Decision::AskBefore);
+    }
+
+    #[test]
+    fn overlay_stacks_recursively() {
+        let base = PolicyConfig::default();
+        let layered = base
+            .restricted_by(Arc::new(builtin_profile("supervised").unwrap()))
+            .restricted_by(Arc::new(builtin_profile("untrusted").unwrap()));
+        // The strictest of all layers wins.
+        let (decision, _) = layered.decide("http", &json!({}));
+        assert_eq!(decision, Decision::NeverAllow);
+        let (decision, _) = layered.decide("workspace:read", &json!({}));
+        assert_eq!(decision, Decision::AlwaysAllow);
     }
 
     #[test]

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1008,6 +1008,7 @@ mod tests {
                 reason: Some("test approval".to_string()),
             }],
             default: crate::policy::Decision::AlwaysAllow,
+            overlay: None,
         });
 
         let engine = Engine::new(

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -883,6 +883,7 @@ mod tests {
                 reason: Some("test approval".to_string()),
             }],
             default: Decision::AlwaysAllow,
+            overlay: None,
         }));
 
         let request = NativeAgentRequest {
@@ -1102,6 +1103,7 @@ mod tests {
                 reason: Some("write tool requires approval".to_string()),
             }],
             default: Decision::AlwaysAllow,
+            overlay: None,
         }));
 
         let request = NativeAgentRequest {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -128,6 +128,7 @@ pub async fn run_once(recipe: &Recipe, deps: &SchedulerDeps) -> Result<String> {
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: Utc::now(),
         };
         Ok((id, session))

--- a/src/server.rs
+++ b/src/server.rs
@@ -325,6 +325,7 @@ pub async fn serve(
     template_engine: Arc<TemplateEngine>,
     agent_path: PathBuf,
     port: u16,
+    policy: Arc<PolicyConfig>,
 ) -> anyhow::Result<()> {
     // Configurable concurrency cap. Default 8 is low enough to keep one
     // LLM provider from being flooded and high enough that a small agent
@@ -340,9 +341,9 @@ pub async fn serve(
         .and_then(|v| v.parse().ok())
         .unwrap_or(30_000);
 
-    // Load the permission policy, MCP servers, recipes, and session store
-    // up front so startup errors happen before we bind the listener.
-    let policy = PolicyConfig::from_env();
+    // Load the MCP servers, recipes, and session store up front so startup
+    // errors happen before we bind the listener. The permission policy is
+    // resolved by the caller (CLI flag or CHIDORI_POLICY* env vars).
     let mcp = Arc::new(McpManager::new());
     let mcp_cfg = McpServersConfig::load_from_env().unwrap_or_default();
     let mcp_tools = mcp.start_from_config(&mcp_cfg).await.unwrap_or_else(|e| {

--- a/src/server.rs
+++ b/src/server.rs
@@ -78,6 +78,7 @@ fn session_view(s: &StoredSession) -> Value {
         "pending_seq": s.pending_seq,
         "pending_prompt": s.pending_prompt,
         "pending_approval": s.pending_approval,
+        "policy_profile": s.policy_profile,
     })
 }
 
@@ -584,7 +585,11 @@ async fn health() -> impl IntoResponse {
 /// wired up: MCP tools merged into the ToolRegistry, permission policy, and
 /// MCP manager. Every server handler that spawns an agent goes through here
 /// so the config surface stays in one place.
-fn build_engine(app: &AppState) -> Engine {
+/// Build an engine for one run of a session. `policy_profile` is the
+/// session's stored profile (if any), layered on the server policy — passing
+/// it here (rather than only at create time) keeps the tightened policy in
+/// force across resume/approve/replay re-runs of the same session.
+fn build_engine(app: &AppState, policy_profile: Option<&str>) -> Engine {
     let rt = Arc::new(tokio::runtime::Runtime::new().unwrap());
     // Reuse the app's provider registry so a replay-based resume sees the same
     // providers as the live-VM resume path (which drives `state.providers`
@@ -604,7 +609,7 @@ fn build_engine(app: &AppState) -> Engine {
     }
     Engine::new(providers, app.template_engine.clone(), rt)
         .with_tools(Arc::new(registry))
-        .with_policy(app.policy.clone())
+        .with_policy(session_policy(app, policy_profile))
         .with_mcp(app.mcp.clone())
         .with_persist_base(app.run_base.clone())
 }
@@ -613,7 +618,7 @@ fn build_engine(app: &AppState) -> Engine {
 /// the current thread (already inside spawn_blocking) and returns the output
 /// JSON. Any error is bubbled as an anyhow::Error.
 fn run_agent_sync(app: &AppState, inputs: Value) -> anyhow::Result<Value> {
-    let engine = build_engine(app);
+    let engine = build_engine(app, None);
     let result = engine.run(&app.agent_path, &inputs)?;
     Ok(result.output)
 }
@@ -687,6 +692,47 @@ struct CreateSessionRequest {
     /// agent is used.
     #[serde(default)]
     agent: Option<String>,
+    /// Optional: a built-in policy profile name ("untrusted" or "supervised")
+    /// applied to every run of this session, layered on the server policy
+    /// with stricter-wins semantics — it can only tighten, never relax, what
+    /// the operator configured. Lets a multi-tenant front-end mix trusted
+    /// and untrusted callers on one server.
+    #[serde(default, alias = "policyProfile")]
+    policy_profile: Option<String>,
+}
+
+/// Validate a client-supplied policy profile name at session creation.
+fn validate_policy_profile(requested: Option<&str>) -> Result<(), (StatusCode, String)> {
+    match requested {
+        None => Ok(()),
+        Some(name) if crate::policy::builtin_profile(name).is_some() => Ok(()),
+        Some(name) => Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "unknown policy profile '{}' (known: {})",
+                name,
+                crate::policy::BUILTIN_PROFILES.join(", ")
+            ),
+        )),
+    }
+}
+
+/// Resolve the effective policy for a session: the server policy, optionally
+/// tightened by the session's profile. A stored profile name that no longer
+/// resolves (e.g. after a downgrade) fails closed to `untrusted` rather than
+/// silently running under the looser server policy.
+fn session_policy(app: &AppState, profile: Option<&str>) -> Arc<PolicyConfig> {
+    let Some(name) = profile else {
+        return app.policy.clone();
+    };
+    let profile_cfg = crate::policy::builtin_profile(name).unwrap_or_else(|| {
+        tracing::warn!(
+            "session policy profile '{}' is unknown; failing closed to 'untrusted'",
+            name
+        );
+        crate::policy::builtin_profile("untrusted").expect("untrusted profile exists")
+    });
+    Arc::new(app.policy.restricted_by(Arc::new(profile_cfg)))
 }
 
 /// Resolve an optional per-session agent override against the server's
@@ -788,6 +834,10 @@ async fn create_session(
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let input = body.input.clone();
     let replay_from = body.replay_from.clone();
+    if let Err((status, msg)) = validate_policy_profile(body.policy_profile.as_deref()) {
+        return (status, Json(json!({"error": msg}))).into_response();
+    }
+    let policy_profile = body.policy_profile.clone();
     // Resolve an optional per-session agent override before spawning
     // the blocking worker — cheaper to reject here than to take a
     // concurrency permit for an invalid request.
@@ -803,7 +853,7 @@ async fn create_session(
     let app_state = state.clone();
 
     let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state);
+        let engine = build_engine(&app_state, body.policy_profile.as_deref());
         match replay_from {
             Some(log) => engine.run_replay_pausable(&effective_agent_path, &body.input, log),
             None => engine.run_pausable(&effective_agent_path, &body.input),
@@ -852,6 +902,7 @@ async fn create_session(
                 pending_prompt,
                 pending_approval,
                 approvals: Vec::new(),
+                policy_profile: policy_profile.clone(),
                 created_at: chrono::Utc::now(),
             }
         }
@@ -867,6 +918,7 @@ async fn create_session(
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile,
             created_at: chrono::Utc::now(),
         },
     };
@@ -1009,10 +1061,11 @@ async fn replay_session(State(state): State<AppState>, Path(id): Path<String>) -
     let input_clone = input.clone();
     let approvals = original.approvals.clone();
     let vfs = load_persisted_vfs(&state.run_base, original.run_id.as_deref());
+    let policy_profile = original.policy_profile.clone();
     let app_state = state.clone();
 
     let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state).with_approvals(approvals);
+        let engine = build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
         engine.run_with_replay_host_promises_and_vfs(
             &app_state.agent_path,
             &input_clone,
@@ -1039,6 +1092,7 @@ async fn replay_session(State(state): State<AppState>, Path(id): Path<String>) -
                 pending_prompt: None,
                 pending_approval: None,
                 approvals: original.approvals.clone(),
+                policy_profile: original.policy_profile.clone(),
                 created_at: chrono::Utc::now(),
             };
             if let Some(err) = store_or_500(&state, &session) {
@@ -1154,6 +1208,11 @@ async fn stream_session(
         Err(resp) => return resp,
     };
 
+    if let Err((status, msg)) = validate_policy_profile(body.policy_profile.as_deref()) {
+        return (status, Json(json!({"error": msg}))).into_response();
+    }
+    let policy_profile = body.policy_profile.clone();
+
     let session_id = body
         .session_id
         .as_deref()
@@ -1194,6 +1253,7 @@ async fn stream_session(
         pending_prompt: None,
         pending_approval: None,
         approvals: Vec::new(),
+        policy_profile: policy_profile.clone(),
         created_at: chrono::Utc::now(),
     };
     let _ = state.session_store.put(&running_session);
@@ -1206,7 +1266,7 @@ async fn stream_session(
     // agent run. Dropping it at the end of the closure releases the slot.
     tokio::task::spawn_blocking(move || {
         let _run_permit = permit;
-        let engine = build_engine(&app_state);
+        let engine = build_engine(&app_state, policy_profile.as_deref());
 
         let result = engine.run_streaming(&agent_path, &input, event_tx);
         let final_event = match result {
@@ -1239,6 +1299,7 @@ async fn stream_session(
                     pending_prompt: None,
                     pending_approval: None,
                     approvals: Vec::new(),
+                    policy_profile: policy_profile.clone(),
                     created_at: chrono::Utc::now(),
                 };
                 let _ = app_state.session_store.put(&completed_session);
@@ -1279,6 +1340,7 @@ async fn stream_session(
                     pending_prompt: None,
                     pending_approval: None,
                     approvals: Vec::new(),
+                    policy_profile: policy_profile.clone(),
                     created_at: chrono::Utc::now(),
                 });
                 json!({
@@ -1370,6 +1432,7 @@ async fn cancel_session(
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         },
         Ok(None) => {
@@ -1517,10 +1580,11 @@ async fn resume_session(
     let approvals = original.approvals.clone();
     let vfs = load_persisted_vfs(&state.run_base, original.run_id.as_deref());
     let resume_run_id = original.run_id.clone();
+    let policy_profile = original.policy_profile.clone();
     let app_state = state.clone();
 
     let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state).with_approvals(approvals);
+        let engine = build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
         // Continue under the original run id (when known) so the resumed run
         // keeps its persisted run directory and stays a single durable run,
         // matching the live-VM resume path. Falls back to a fresh id only when
@@ -1707,9 +1771,10 @@ async fn approve_session(
     let call_log = original.call_log.clone();
     let resume_run_id = original.run_id.clone();
     let vfs = load_persisted_vfs(&state.run_base, original.run_id.as_deref());
+    let policy_profile = original.policy_profile.clone();
     let app_state = state.clone();
     let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state).with_approvals(approvals);
+        let engine = build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
         // Replay the recorded call log (so any host calls the agent made before
         // the policy block — e.g. a prior `input()` — return their recorded
         // results instead of pausing again) with the approval seeded in the
@@ -1814,7 +1879,7 @@ async fn handle_event(
     let app_state = state.clone();
 
     let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state);
+        let engine = build_engine(&app_state, None);
         engine.run(&app_state.agent_path, &input)
     })
     .await
@@ -1931,6 +1996,7 @@ mod tests {
                 pending_prompt: None,
                 pending_approval: None,
                 approvals: Vec::new(),
+                policy_profile: None,
                 created_at: chrono::Utc::now(),
             })
             .unwrap();
@@ -2203,6 +2269,7 @@ mod tests {
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -2266,6 +2333,7 @@ mod tests {
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
         state.session_store.put(&session).unwrap();
@@ -2331,6 +2399,7 @@ mod tests {
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
         state.session_store.put(&session).unwrap();
@@ -2400,6 +2469,7 @@ mod tests {
             pending_prompt: None,
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
         state.session_store.put(&session).unwrap();
@@ -2485,6 +2555,7 @@ mod tests {
             pending_prompt: Some("continue?".to_string()),
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
         state.session_store.put(&session).unwrap();
@@ -2582,6 +2653,7 @@ mod tests {
             pending_prompt: Some("continue?".to_string()),
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
         state.session_store.put(&session).unwrap();
@@ -2684,6 +2756,7 @@ mod tests {
             pending_prompt: Some("continue?".to_string()),
             pending_approval: None,
             approvals: Vec::new(),
+            policy_profile: None,
             created_at: chrono::Utc::now(),
         };
         state.session_store.put(&session).unwrap();
@@ -3108,6 +3181,119 @@ mod tests {
             }
             other => panic!("expected rejected host promise, got {other:?}"),
         }
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    fn policy_test_project(name: &str, agent_source: &str) -> (PathBuf, AppState) {
+        let temp_dir = std::env::temp_dir().join(format!("{name}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let agent_path = temp_dir.join("agent.ts");
+        std::fs::write(&agent_path, agent_source).unwrap();
+        let run_base = temp_dir.join(".chidori").join("runs");
+        let state = test_state(run_base, agent_path);
+        (temp_dir, state)
+    }
+
+    fn create_request(policy_profile: Option<&str>) -> CreateSessionRequest {
+        CreateSessionRequest {
+            input: json!({}),
+            session_id: None,
+            attempt_number: None,
+            replay_from: None,
+            agent: None,
+            policy_profile: policy_profile.map(ToOwned::to_owned),
+        }
+    }
+
+    const HTTP_AGENT: &str = r#"
+        export async function agent(input, chidori) {
+            const res = await chidori.http({ url: "https://example.invalid/" });
+            return { res };
+        }
+    "#;
+
+    #[tokio::test]
+    async fn create_session_rejects_unknown_policy_profile() {
+        let (temp_dir, state) = policy_test_project("chidori-server-policy-unknown", HTTP_AGENT);
+
+        let (status, body) = response_json(
+            create_session(State(state), Json(create_request(Some("nonsense")))).await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("unknown policy profile 'nonsense'") && error.contains("untrusted"),
+            "expected an unknown-profile error listing the builtins, got: {error}"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn untrusted_session_denies_gated_effects_despite_permissive_server_policy() {
+        let (temp_dir, state) = policy_test_project("chidori-server-policy-untrusted", HTTP_AGENT);
+        // The server policy is the permissive default (AlwaysAllow); the
+        // session profile must tighten it, not the other way around.
+
+        let (status, body) = response_json(
+            create_session(State(state), Json(create_request(Some("untrusted")))).await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["status"], json!("failed"));
+        assert_eq!(body["policy_profile"], json!("untrusted"));
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("policy: `http` denied"),
+            "expected the http call to be denied, got: {error}"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn supervised_session_pauses_for_approval_then_operator_denies() {
+        let (temp_dir, state) = policy_test_project("chidori-server-policy-supervised", HTTP_AGENT);
+
+        let (status, body) = response_json(
+            create_session(
+                State(state.clone()),
+                Json(create_request(Some("supervised"))),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["status"], json!("awaitingapproval"));
+        assert_eq!(body["policy_profile"], json!("supervised"));
+        assert_eq!(body["pending_approval"]["target"], json!("http"));
+        let id = body["id"].as_str().unwrap().to_string();
+
+        // Operator denies: the session fails without the call executing.
+        let (status, body) = response_json(
+            approve_session(
+                State(state),
+                Path(id),
+                Json(ApproveRequest {
+                    decision: "deny".to_string(),
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("failed"));
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("denied by operator"),
+            "expected an operator-denied error, got: {error}"
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -52,6 +52,12 @@ pub struct StoredSession {
     /// have to ask twice for the same (target, args) within a session.
     #[serde(default)]
     pub approvals: Vec<(String, Value)>,
+    /// Built-in policy profile selected at session creation (e.g. "untrusted",
+    /// "supervised"). Layered on the server policy with stricter-wins
+    /// semantics on every run of this session, including resume/approve
+    /// replays — it can tighten the server policy but never relax it.
+    #[serde(default)]
+    pub policy_profile: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/tests/cli_typescript.rs
+++ b/tests/cli_typescript.rs
@@ -491,6 +491,51 @@ fn cli_untrusted_profile_allows_read_only_workspace() {
 }
 
 #[test]
+fn cli_untrusted_flag_overrides_permissive_policy_env() {
+    let dir = temp_project("untrusted-flag-precedence");
+    let workspace = dir.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.workspace.write("out.txt", "data");
+                return { ok: true };
+            }
+        "#,
+    )
+    .unwrap();
+
+    // --untrusted must win over an explicitly permissive CHIDORI_POLICY:
+    // the flag is the operator's last word, env vars are ambient config.
+    let permissive = r#"{ "default": "always_allow", "rules": [] }"#;
+    let output = run_chidori_with_str_env(
+        &[
+            "run",
+            agent.to_str().unwrap(),
+            "--untrusted",
+            "--input",
+            r#"{}"#,
+        ],
+        &dir,
+        &[
+            ("CHIDORI_POLICY", permissive),
+            ("CHIDORI_WORKSPACE_ROOT", workspace.to_str().unwrap()),
+        ],
+    );
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("workspace:write") && stderr.contains("denied"),
+        "expected --untrusted to deny workspace:write despite permissive env policy, got stderr:\n{stderr}"
+    );
+    assert!(!workspace.join("out.txt").exists());
+
+    fs::remove_dir_all(dir).ok();
+}
+
+#[test]
 fn cli_stream_accepts_multiline_typed_agent_signature() {
     let dir = temp_project("stream-multiline-types");
     let agent = dir.join("agent.ts");


### PR DESCRIPTION
## Summary

This PR introduces per-session policy profiles and a new `supervised` policy profile that enables operator approval workflows. Sessions can now be created with an optional `policy_profile` field that layers a built-in profile on the server's policy using stricter-wins semantics, allowing multi-tenant servers to mix trusted and untrusted callers without reconfiguration.

## Key Changes

- **New `supervised` policy profile**: Ask-by-default fallback (instead of deny-by-default) that pauses runs for operator approval via the existing `/approve` endpoint. Identical allowlist to `untrusted` but enables interactive gating rather than hard refusal.

- **Policy overlay mechanism**: Added `overlay` field to `PolicyConfig` that implements stricter-wins layering — when multiple policies are stacked, the most restrictive decision applies. This ensures caller-selected profiles can only tighten, never relax, the operator's policy.

- **Per-session profile selection**: `POST /sessions` and `POST /sessions/stream` now accept optional `policy_profile` field (alias `policyProfile`). Profiles are validated at creation, persisted on the session, and re-applied on every re-run (resume, approve, replay).

- **CLI `--untrusted` flag**: Added `--untrusted` flag to `chidori run` and `chidori serve` commands. Takes precedence over all `CHIDORI_POLICY*` environment variables, giving operators a way to guarantee confinement regardless of ambient configuration.

- **Policy resolution refactoring**: Moved policy loading from `serve()` to the caller (CLI), allowing the server to accept a pre-resolved policy. Session-specific profiles are resolved at engine build time for each run.

- **SDK updates**: TypeScript and Python SDKs now expose `policyProfile` / `policy_profile` parameter in `run()` methods with documentation on stricter-wins semantics.

## Implementation Details

- Policy decisions now check both base and overlay policies, selecting the stricter result via a `strictness()` ordering: `AlwaysAllow` (0) < `AskBefore` (1) < `NeverAllow` (2).

- Unknown profile names are rejected with `400 Bad Request` at session creation; stored profile names that no longer resolve (e.g., after downgrade) fail closed to `untrusted` rather than silently running under the looser server policy.

- The `build_engine()` function now accepts an optional `policy_profile` parameter, applied consistently across all run paths: initial creation, resume, approve, replay, and streaming.

- Session storage schema updated to include `policy_profile` field; all test fixtures updated accordingly.

- Comprehensive test coverage added for profile validation, overlay stacking, and CLI flag precedence.

https://claude.ai/code/session_01HRGMMrPzmtHjZqYWg8BkAY