### PR TITLE
Add chidori.signal(): multiplayer runtime signals with a durable mailbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ An agent is a `.ts` file that exports an async `agent(input, chidori)` function.
 | `chidori.callAgent(path, input)` | Call a sub-agent |
 | `chidori.parallel(fns)` | Run functions concurrently |
 | `chidori.input(msg, options)` | Human-in-the-loop — pauses execution |
+| `chidori.signal(name, options)` | Multiplayer — pause at a named listen point until an outside party (human or agent) delivers `{ name, payload, from }`; drains a durable mailbox if one is queued |
+| `chidori.pollSignal(name)` | Non-blocking signal check — consume a queued signal of this name or resolve to `null` |
 | `chidori.http(url, options)` | Make an HTTP request |
 | `chidori.memory(action, ...)` | Persistent storage (key-value + vector) |
 | `chidori.log(msg, data)` | Structured logging |
@@ -278,6 +280,7 @@ Exposes:
 - `GET  /sessions/{id}/checkpoint` — get the call log and snapshot manifest metadata
 - `GET  /sessions/{id}/snapshot` — inspect the durable journal-scaffold manifest metadata (no VM image — resume is call-log replay)
 - `POST /sessions/{id}/resume` — resume a paused `input()` or approval session
+- `POST /sessions/{id}/signal` — deliver a signal `{ name, payload?, from? }`: resolves+resumes a run paused-waiting on that name (200), else enqueues into the durable mailbox (202), or 409 for a terminal run
 - `POST /sessions/{id}/replay` — replay from a session's checkpoint
 - `POST /sessions/{id}/cancel` — cancel a running or stored session
 - `POST /sessions/stream` — run a session with SSE call and prompt progress events

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@ runtime, CLI, server, and tool work should target `.ts` agents and tools.
 | Language-neutral host core | Done |
 | Call-log replay | Done |
 | Human input and policy approval pause/resume | Done through live VM resume with replay fallback |
+| Multiplayer signals (`chidori.signal` / `pollSignal`, `POST /sessions/{id}/signal`) | Done — Phase 1 + `pollSignal` (`docs/signals.md`); `signalAny` / `timeoutMs` / live in-memory delivery are future work |
 | TypeScript tool discovery | Done |
 | TypeScript and Python SDK parity | Done |
 | Snapshot manifests, policy/source validation, host promise records | Done |
@@ -46,6 +47,11 @@ completion audit lives in
 
 - [x] `chidori.prompt()`
 - [x] `chidori.input()`
+- [x] `chidori.signal()` / `chidori.pollSignal()` — multiplayer named signals:
+      blocking listen point, durable per-run mailbox, `POST /sessions/{id}/signal`
+      delivery (resolve+resume / enqueue / 409), deterministic replay (Phase 1 +
+      `pollSignal` of `docs/signals.md`; `signalAny` / `timeoutMs` / live in-memory
+      delivery are future work).
 - [x] `chidori.callAgent()`
 - [x] `chidori.tool()`
 - [x] `chidori.parallel()`

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -154,6 +154,33 @@ impl Engine {
             });
         let d = dispatch.clone();
         self.vm
+            .define_method(&chidori, "signal", 2, move |vm, _t, args| {
+                let name = args
+                    .first()
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                let opts = args
+                    .get(1)
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                forward_effect(
+                    vm,
+                    &d,
+                    "signal",
+                    serde_json::json!({ "name": name, "opts": opts }),
+                )
+            });
+        let d = dispatch.clone();
+        self.vm
+            .define_method(&chidori, "pollSignal", 1, move |vm, _t, args| {
+                let name = args
+                    .first()
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                forward_effect(vm, &d, "poll_signal", serde_json::json!({ "name": name }))
+            });
+        let d = dispatch.clone();
+        self.vm
             .define_method(&chidori, "checkpoint", 2, move |vm, _t, args| {
                 let label = args
                     .first()

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,8 +1,15 @@
 # Runtime Signals — Multiplayer Agents — Design Doc & Implementation Plan
 
-> **Status:** Draft for review.
-> **Target engine:** pure-Rust JS engine (`CHIDORI_JS_ENGINE=rust`, `rust-engine`
-> feature). The default QuickJS path is untouched.
+> **Status:** Implemented. Phase 1 plus `pollSignal` have shipped: the named
+> **blocking** `chidori.signal(name)`, the durable **per-run mailbox**, the
+> `POST /sessions/{id}/signal` **delivery endpoint** (resolve+resume, enqueue, or
+> 409), and **deterministic replay** of the whole multiplayer session.
+> `signalAny`, `timeoutMs`, and live zero-latency in-memory delivery to a running
+> task (the Phase 2/3 remainder) are **future work**. The same-name tie-break is
+> pinned to **pending-pause-wins-with-newest**.
+> **Engine:** chidori-js (the pure-Rust JS engine) is now the only runtime — there
+> is no `CHIDORI_JS_ENGINE=rust` selector, no `rust-engine` cargo feature gate to
+> opt in, and no separate QuickJS path to keep untouched.
 > **Related:** [`docs/branching-execution.md`](./branching-execution.md),
 > [`docs/captured-effects-vfs-crypto-timers.md`](./captured-effects-vfs-crypto-timers.md),
 > [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md).
@@ -530,7 +537,7 @@ pick among them.
 
 ## 14. Implementation plan (phased)
 
-**Phase 1 — Named blocking signal + durable mailbox + paused-run delivery (deterministic)**
+**Phase 1 — Named blocking signal + durable mailbox + paused-run delivery (deterministic)** *(shipped)*
 1. `src/runtime/engine.rs` (~425–451): **fix the rust-engine arm of `run_with_context`**
    to surface pauses via `take_pending_input()` / `take_pending_signal()` →
    `RunResult{paused}` (prerequisite; also fixes rust-engine `input()` pausing).
@@ -560,7 +567,7 @@ Tests (`--features rust-engine`):
   chidori.signal("review")`, a second terminal (or peer agent) POSTs the review; streams
   to tael (`CHIDORI_JS_ENGINE=rust`).
 
-**Phase 2 — Non-blocking poll + fan-in/select + sender identity in trace**
+**Phase 2 — Non-blocking poll + fan-in/select + sender identity in trace** *(partially shipped: `pollSignal` done; `signalAny` / `timeoutMs` / `from`-as-span-attribute are future)*
 - `chidori.pollSignal` (records value *or* null at the seq → deterministic),
   `chidori.signalAny([names])` (pauses on a name *set*; result says which fired; match key
   `{names:[...]}`). `from` stamped as an OTEL span attribute in `RunSpan::stream_record`.
@@ -568,7 +575,7 @@ Tests (`--features rust-engine`):
 - Tests: poll returns null then a value deterministically; select fires on first matching
   name; `from` appears in the streamed span.
 
-**Phase 3 — Live in-memory delivery to running tasks**
+**Phase 3 — Live in-memory delivery to running tasks** *(future)*
 - `ActiveSession.signal_tx` (analogous to `cancel_tx`); streaming worker `select!`s on
   `signal_rx`, write-through to `inbox.json`, in-process fast resume trigger (skip the
   HTTP `/resume` round-trip). Determinism unchanged (it is still a deterministic resume

--- a/examples/multiplayer-review/README.md
+++ b/examples/multiplayer-review/README.md
@@ -1,0 +1,177 @@
+# Multiplayer review — signals, the durable mailbox, deterministic replay
+
+A runnable example of **`chidori.signal` / `chidori.pollSignal`** (see
+[`docs/signals.md`](../../docs/signals.md)): one agent run stays open to
+**multiple participants** — humans *and* other agents — who push information
+into it mid-flight, while the whole session stays **deterministically
+replayable**.
+
+The agent ([`policy_doc.ts`](./policy_doc.ts)) turns a brief into a policy
+document. Three participants collaborate on **one live run**:
+
+- a **human editor** (Mara) reviews drafts and asks for changes,
+- a **compliance-checker agent** pushes an approve/changes verdict,
+- a **human lead** (Sam) re-scopes the doc mid-run.
+
+None of these are agent-initiated `input()` questions. The reviewers **push** a
+`review` signal when they have it; the lead **steers** with a `steer` signal
+whenever he wants. The agent only consumes those pushes at the points it
+declares safe:
+
+```ts
+// BLOCKS — nothing to do until a review lands; the run idles cheaply on disk.
+const review = await chidori.signal<Review>("review");
+
+// NON-BLOCKING — steering is optional; check the mailbox, move on if empty.
+const steer = await chidori.pollSignal<Steer>("steer");
+```
+
+`writeDraft`/`revise` are local helpers so the example runs offline with no LLM
+provider; swap them for `chidori.prompt(...)` to get real model spans.
+
+## Serve the agent
+
+```bash
+cargo run -- serve examples/multiplayer-review/policy_doc.ts --port 8080
+# or, with the prebuilt binary:
+./target/debug/chidori serve examples/multiplayer-review/policy_doc.ts --port 8080
+```
+
+Create a run (it drafts, then **pauses** at `signal("review")`):
+
+```bash
+curl -s -H 'Content-Type: application/json' \
+  -XPOST localhost:8080/sessions \
+  -d '{"input":{"topic":"data-retention policy"}}'
+# -> { "id": "<RUN>", "status": "paused", "pending_signal_name": "review", ... }
+```
+
+Grab the id into `$RUN`. A session view of a signal pause carries
+`pending_signal_name: "review"` (it is `null` for a plain `input()` pause), so a
+caller knows *which* named signal to deliver.
+
+## Deliver signals (multiplayer)
+
+> The endpoint requires `Content-Type: application/json`. `curl -d` defaults to
+> form-encoding, so the header is mandatory.
+
+**The lead steers — while the agent is mid-flight and not yet listening.** The
+run is paused on `review`, not `steer`, so this lands in the **durable mailbox**
+and is consumed at the next `pollSignal("steer")`. The endpoint returns
+`202 Accepted` with the assigned `delivery_seq`:
+
+```bash
+curl -s -H 'Content-Type: application/json' \
+  -XPOST localhost:8080/sessions/$RUN/signal \
+  -d '{
+    "name": "steer",
+    "payload": { "priority": "high", "scope": "EU + UK only" },
+    "from": { "kind": "human", "id": "sam" }
+  }'
+# 202 -> { "id": "<RUN>", "status": "queued", "name": "steer", "delivery_seq": 1 }
+```
+
+**The compliance agent delivers a "changes" verdict.** The run *is* paused
+waiting on `review`, so this **resolves the pause and resumes** the run — which
+revises (draining Sam's queued `steer` at the `pollSignal`) and pauses again on
+the next `review`. The endpoint returns `200 OK` with the advanced session view:
+
+```bash
+curl -s -H 'Content-Type: application/json' \
+  -XPOST localhost:8080/sessions/$RUN/signal \
+  -d '{
+    "name": "review",
+    "payload": { "decision": "changes", "notes": "Tighten the data-retention section." },
+    "from": { "kind": "agent", "id": "compliance-bot" }
+  }'
+# 200 -> { "status": "paused", "pending_signal_name": "review", ... }
+```
+
+**The human editor approves.** The agent publishes and the run completes:
+
+```bash
+curl -s -H 'Content-Type: application/json' \
+  -XPOST localhost:8080/sessions/$RUN/signal \
+  -d '{
+    "name": "review",
+    "payload": { "decision": "approve", "notes": "LGTM" },
+    "from": { "kind": "human", "id": "mara" }
+  }'
+# 200 -> status "completed", output:
+# { "status": "published", "rounds": 2,
+#   "approvedBy": { "kind": "human", "id": "mara" }, "draft": "..." }
+```
+
+Delivering to a **completed / failed / cancelled** run returns `409 Conflict`
+(no inbox write); an empty `name` is `400`; an unknown session is `404`.
+
+### From the SDKs instead of curl
+
+```python
+from chidori import AgentClient, Session, SignalQueued
+client = AgentClient("http://localhost:8080")
+paused = client.run({"topic": "data-retention policy"})           # status "paused"
+queued = client.signal(paused.id, "steer", {"priority": "high"})  # SignalQueued (202)
+done   = client.signal(paused.id, "review",
+                       {"decision": "approve", "notes": "LGTM"},
+                       from_={"kind": "human", "id": "mara"})       # Session (200)
+```
+
+```ts
+import { AgentClient, isSignalQueued } from "chidori";
+const client = new AgentClient("http://localhost:8080");
+const res = await client.signal(run, { name: "review", payload: { decision: "approve", notes: "LGTM" } });
+if (isSignalQueued(res)) console.log("queued at", res.delivery_seq);
+else console.log(res.status, res.output);
+```
+
+## What the trace shows
+
+Each signal is a recorded host call, so the multiplayer session is one ordered
+trace with every participant attributed by `from`:
+
+```bash
+RUN_DIR=examples/multiplayer-review/.chidori/runs
+RUN_ID=$(ls -t "$RUN_DIR" | head -1)
+cargo run -- trace "$RUN_ID" --dir examples/multiplayer-review
+```
+
+```
+Calls: 10
+  #1   log          writing draft
+  #2   log          draft round 1 ready
+  #3   signal       {"name":"review"}     <- idled here; resolved by compliance-bot (changes)
+  #4   log          review received
+  #5   poll_signal  {"name":"steer"}      <- drained Sam's queued steer (delivery_seq 1)
+  #6   log          scope changed mid-run
+  #7   log          revising draft
+  #8   log          draft round 2 ready
+  #9   signal       {"name":"review"}     <- resolved by mara (approve)
+  #10  log          review received
+```
+
+The `signal` and `poll_signal` calls freeze `{payload, from}` into the call log,
+so *who reviewed each draft* and *when the lead re-scoped* are a durable audit,
+not lost in a chat channel.
+
+## It replays deterministically
+
+```bash
+cargo run -- resume examples/multiplayer-review/policy_doc.ts "$RUN_ID" \
+  --dir examples/multiplayer-review
+```
+
+`resume` (any replay) reproduces the **identical** run: the compliance verdict,
+Sam's steering, and Mara's approval are replayed from their recorded
+`CallRecord`s — no human is re-contacted and the compliance agent is not re-run.
+The inbox is a live-only convenience; the call log is the source of truth, so a
+replay with an empty mailbox still reproduces every consumed signal.
+
+## Notes
+
+- chidori-js (the pure-Rust JS engine) is the only runtime; no engine env var or
+  cargo feature is needed.
+- Phase 1 + `pollSignal` are shipped: a blocking named signal, a durable per-run
+  mailbox, the `/signal` delivery endpoint, and deterministic replay. `signalAny`,
+  `timeoutMs`, and zero-latency in-memory delivery to a running task are future
+  work (see [`docs/signals.md`](../../docs/signals.md) §14).

--- a/examples/multiplayer-review/policy_doc.ts
+++ b/examples/multiplayer-review/policy_doc.ts
@@ -1,0 +1,98 @@
+import type { Chidori, Signal } from "chidori";
+
+/**
+ * Multiplayer policy-doc drafting agent (docs/signals.md §7).
+ *
+ * Three participants collaborate on ONE live run:
+ *   - a human editor (e.g. Mara) reviews drafts and asks for changes,
+ *   - a compliance-checker agent pushes an approve/changes verdict,
+ *   - a human lead (e.g. Sam) re-scopes the doc mid-run.
+ *
+ * None of these are agent-initiated `input()` questions. The reviewers PUSH a
+ * `review` signal when they have it; the lead STEERS with a `steer` signal
+ * whenever he wants. The agent only consumes those pushes at the points it
+ * declares safe:
+ *   - `chidori.signal("review")` BLOCKS — nothing to do until a review lands;
+ *     the run idles cheaply on disk and resumes when a review is delivered (or
+ *     was already queued in the durable mailbox).
+ *   - `chidori.pollSignal("steer")` is NON-BLOCKING — steering is optional; the
+ *     agent checks the mailbox and moves on if it is empty.
+ *
+ * Every signal is recorded in the call log, so the whole multiplayer session
+ * replays deterministically (`chidori resume <run-id>`): the reviews, the
+ * verdict, and the steering are replayed from their recorded CallRecords with
+ * no human re-contacted and no compliance agent re-run.
+ *
+ * Deliver signals with:
+ *   POST /sessions/{id}/signal  { name, payload, from }
+ * (see the README for full curl examples).
+ *
+ * `writeDraft`/`revise` are kept as local helpers so the example is runnable
+ * offline with no LLM provider; swap them for `chidori.prompt(...)` calls to
+ * get real model spans in the trace.
+ */
+
+type Brief = { topic?: string; audience?: string; priority?: string; scope?: string };
+type Review = { decision: "approve" | "changes"; notes: string };
+type Steer = { priority?: string; scope?: string };
+
+export async function agent(input: Brief, chidori: Chidori) {
+  let brief: Brief = {
+    topic: input.topic ?? "data-retention policy",
+    audience: input.audience ?? "all staff",
+  };
+
+  let draft = await writeDraft(chidori, brief); // "expensive": stands in for LLM + retrieval
+  let round = 0;
+
+  while (true) {
+    round++;
+    await chidori.log(`draft round ${round} ready`, { words: draft.length });
+
+    // Open this run to reviewers. The compliance agent AND the human editor both
+    // send a "review" signal; whichever lands first (or is already queued in the
+    // mailbox) is consumed here. `from` tells us who reviewed.
+    const review: Signal<Review> = await chidori.signal<Review>("review");
+    await chidori.log("review received", {
+      from: review.from,
+      decision: review.payload.decision,
+    });
+
+    if (review.payload.decision === "approve") {
+      return {
+        status: "published",
+        rounds: round,
+        approvedBy: review.from,
+        draft,
+      };
+    }
+
+    // A reviewer asked for changes — revise and loop. Before revising,
+    // opportunistically pick up any steering the lead pushed (non-blocking;
+    // null if none waiting).
+    const steer = await chidori.pollSignal<Steer>("steer");
+    if (steer) {
+      await chidori.log("scope changed mid-run", { from: steer.from, ...steer.payload });
+      brief = { ...brief, ...steer.payload }; // re-scope without restarting
+    }
+
+    draft = await revise(chidori, draft, review.payload.notes, brief);
+  }
+}
+
+/** Stand-in for the expensive drafting step (LLM + retrieval). Local + offline. */
+async function writeDraft(chidori: Chidori, brief: Brief): Promise<string> {
+  await chidori.log("writing draft", { topic: brief.topic, scope: brief.scope });
+  return `# ${brief.topic} (for ${brief.audience})\n\nInitial draft body.`;
+}
+
+/** Stand-in for the revision step. Appends the reviewer's notes to the draft. */
+async function revise(
+  chidori: Chidori,
+  draft: string,
+  notes: string,
+  brief: Brief,
+): Promise<string> {
+  await chidori.log("revising draft", { notes, scope: brief.scope });
+  return `${draft}\n\n## Revision\nAddressed: ${notes}`;
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -41,6 +41,23 @@ if paused.status == "paused":
     print("prompt:", paused.pending_prompt)
     final = client.resume(paused.id, "yes")
 
+# Multiplayer signals (when the agent calls `chidori.signal` / `pollSignal`):
+# deliver {name, payload?, from?} to a run. A run paused-waiting on this name
+# resolves + resumes (returns a Session); otherwise the signal is enqueued into
+# the durable mailbox (returns a SignalQueued with the assigned delivery_seq).
+from chidori import Session, SignalQueued
+paused = client.run({"topic": "data-retention policy"})
+print("awaiting signal:", paused.pending_signal_name)  # -> "review"
+result = client.signal(
+    paused.id, "review",
+    payload={"decision": "approve", "notes": "LGTM"},
+    from_={"kind": "human", "id": "mara"},
+)
+if isinstance(result, SignalQueued):
+    print("queued at delivery_seq", result.delivery_seq)  # 202
+else:
+    print(result.status, result.output)  # 200 — resumed Session
+
 # Live streaming: yields host calls, prompt stream events, then `done`
 for evt in client.stream({"document": "hi"}):
     if evt["type"] == "call":

--- a/sdk/python/chidori/__init__.py
+++ b/sdk/python/chidori/__init__.py
@@ -17,6 +17,6 @@ Usage:
     replayed = client.replay(checkpoint)
 """
 
-from chidori.client import AgentClient, Session, Checkpoint
+from chidori.client import AgentClient, Session, Checkpoint, SignalQueued
 
-__all__ = ["AgentClient", "Session", "Checkpoint"]
+__all__ = ["AgentClient", "Session", "Checkpoint", "SignalQueued"]

--- a/sdk/python/chidori/client.py
+++ b/sdk/python/chidori/client.py
@@ -49,6 +49,20 @@ class Checkpoint:
 
 
 @dataclass
+class SignalQueued:
+    """Returned by `AgentClient.signal` when the run was not paused-waiting on
+    this name (it was running, or paused on something else), so the signal was
+    enqueued into the durable mailbox to be drained at the next matching listen
+    point. Mirrors the server's 202 Accepted body.
+    """
+
+    id: str
+    name: str
+    delivery_seq: int
+    status: str = "queued"
+
+
+@dataclass
 class Session:
     """A single agent execution session with its result and call log."""
 
@@ -63,6 +77,10 @@ class Session:
     # to the human and later call `client.resume(session.id, response)`.
     pending_seq: int | None = None
     pending_prompt: str | None = None
+    # When the run is `paused` at a `chidori.signal(name)` listen point, the
+    # name it is waiting on (so the caller can deliver via `client.signal`).
+    # None for plain `input()` pauses and non-signal states.
+    pending_signal_name: str | None = None
     snapshot_manifest: dict | None = None
     _client: AgentClient | None = field(default=None, repr=False)
 
@@ -154,6 +172,7 @@ class AgentClient:
             error=data.get("error"),
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
+            pending_signal_name=data.get("pending_signal_name"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -180,6 +199,7 @@ class AgentClient:
             error=data.get("error"),
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
+            pending_signal_name=data.get("pending_signal_name"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -199,6 +219,50 @@ class AgentClient:
             error=data.get("error"),
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
+            pending_signal_name=data.get("pending_signal_name"),
+            snapshot_manifest=data.get("snapshot_manifest"),
+            _client=self,
+        )
+
+    def signal(
+        self,
+        session_id: str,
+        name: str,
+        payload: Any = None,
+        from_: Any = None,
+    ) -> Session | SignalQueued:
+        """Deliver a signal `{name, payload?, from?}` to a run
+        (`POST /sessions/{id}/signal`).
+
+        Two outcomes:
+          * the run was paused-waiting on this exact name → the pause resolves
+            and the run resumes; returns the advanced `Session` (200), now
+            `completed` or re-`paused`.
+          * the run was running or paused on something else → the signal is
+            enqueued into the durable mailbox; returns a `SignalQueued`
+            descriptor (202) carrying the assigned `delivery_seq`.
+
+        Raises on 400 (empty name), 404 (unknown session), or 409 (terminal run).
+        """
+        status, data = self._post_with_status(
+            f"/sessions/{session_id}/signal",
+            {"name": name, "payload": payload, "from": from_},
+        )
+        if status == 202 or data.get("status") == "queued":
+            return SignalQueued(
+                id=data["id"],
+                name=data.get("name", name),
+                delivery_seq=data["delivery_seq"],
+            )
+        return Session(
+            id=data["id"],
+            status=data["status"],
+            input=data.get("input", {}),
+            output=data.get("output"),
+            error=data.get("error"),
+            pending_seq=data.get("pending_seq"),
+            pending_prompt=data.get("pending_prompt"),
+            pending_signal_name=data.get("pending_signal_name"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -214,6 +278,7 @@ class AgentClient:
             error=data.get("error"),
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
+            pending_signal_name=data.get("pending_signal_name"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -342,6 +407,9 @@ class AgentClient:
             raise RuntimeError(f"HTTP {e.code}: {body}") from e
 
     def _post(self, path: str, body: dict) -> dict:
+        return self._post_with_status(path, body)[1]
+
+    def _post_with_status(self, path: str, body: dict) -> tuple[int, dict]:
         url = self.base_url + path
         data = json.dumps(body).encode()
         req = urllib.request.Request(
@@ -349,7 +417,7 @@ class AgentClient:
         )
         try:
             with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read())
+                return resp.status, json.loads(resp.read())
         except urllib.error.HTTPError as e:
             body = e.read().decode()
             raise RuntimeError(f"HTTP {e.code}: {body}") from e

--- a/sdk/python/tests/fixtures/signal_review.ts
+++ b/sdk/python/tests/fixtures/signal_review.ts
@@ -1,0 +1,16 @@
+export async function agent(input, chidori) {
+  // A trivial "draft" so the run reaches a named listen point without needing
+  // an LLM. The interesting part is the signal pause.
+  const draft = `draft for ${input.topic ?? "untitled"}`;
+  await chidori.log("draft ready", { topic: input.topic ?? "untitled" });
+
+  // Pause until a `review` signal is delivered (or one is already queued).
+  const review = await chidori.signal("review");
+
+  return {
+    topic: input.topic ?? "untitled",
+    draft,
+    decision: review.payload?.decision ?? null,
+    reviewedBy: review.from,
+  };
+}

--- a/sdk/python/tests/test_session_api.py
+++ b/sdk/python/tests/test_session_api.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 # The SDK lives alongside this test file.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from chidori import AgentClient, Checkpoint  # noqa: E402
+from chidori import AgentClient, Checkpoint, Session, SignalQueued  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Paths + defaults
@@ -378,6 +378,79 @@ class PauseResumeTests(_MockLlmTestCase):
         resumed = self.client.resume(paused.id, "no thanks")
         self.assertEqual(resumed.status, "completed")
         self.assertFalse(resumed.output["approved"])
+
+
+# ---------------------------------------------------------------------------
+# Signal delivery via POST /sessions/{id}/signal
+# ---------------------------------------------------------------------------
+
+
+class SignalTests(_MockLlmTestCase):
+    agent = FIXTURES / "signal_review.ts"
+
+    def test_run_pauses_on_signal_with_pending_name(self):
+        paused = self.client.run({"topic": "data-retention"})
+        self.assertEqual(paused.status, "paused")
+        # A signal pause surfaces the awaited name (not a plain input prompt).
+        self.assertEqual(paused.pending_signal_name, "review")
+
+    def test_signal_resolves_pause_and_resumes(self):
+        paused = self.client.run({"topic": "data-retention"})
+        self.assertEqual(paused.status, "paused")
+
+        result = self.client.signal(
+            paused.id,
+            "review",
+            payload={"decision": "approve", "notes": "lgtm"},
+            from_={"kind": "human", "id": "mara"},
+        )
+        # Paused-waiting-on-this-name → resolves + resumes → a Session.
+        self.assertIsInstance(result, Session)
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.output["decision"], "approve")
+        self.assertEqual(result.output["reviewedBy"], {"kind": "human", "id": "mara"})
+
+    def test_signal_with_other_name_is_queued(self):
+        paused = self.client.run({"topic": "data-retention"})
+        self.assertEqual(paused.status, "paused")
+
+        # The run is paused on "review", not "steer" → enqueued into the mailbox.
+        queued = self.client.signal(
+            paused.id,
+            "steer",
+            payload={"priority": "high"},
+            from_={"kind": "human", "id": "sam"},
+        )
+        self.assertIsInstance(queued, SignalQueued)
+        self.assertEqual(queued.status, "queued")
+        self.assertEqual(queued.name, "steer")
+        self.assertIsInstance(queued.delivery_seq, int)
+
+        # The run stays paused-waiting-on-review; delivering it still resumes.
+        self.assertEqual(self.client.get_session(paused.id).status, "paused")
+        resumed = self.client.signal(
+            paused.id,
+            "review",
+            payload={"decision": "changes", "notes": "tighten"},
+            from_={"kind": "agent", "id": "compliance-bot"},
+        )
+        self.assertIsInstance(resumed, Session)
+        self.assertEqual(resumed.status, "completed")
+        self.assertEqual(resumed.output["decision"], "changes")
+
+    def test_signal_to_completed_run_is_409(self):
+        paused = self.client.run({"topic": "data-retention"})
+        done = self.client.signal(
+            paused.id,
+            "review",
+            payload={"decision": "approve", "notes": "ok"},
+            from_={"kind": "human", "id": "mara"},
+        )
+        self.assertEqual(done.status, "completed")
+        # A terminal run rejects further delivery with 409 (no inbox write).
+        with self.assertRaises(RuntimeError) as ctx:
+            self.client.signal(done.id, "review", payload={"decision": "approve"})
+        self.assertIn("409", str(ctx.exception))
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -26,7 +26,7 @@ import type { Chidori, ToolDefinition } from "chidori";
 ## Usage
 
 ```ts
-import { AgentClient, Checkpoint } from "chidori";
+import { AgentClient, Checkpoint, isSignalQueued } from "chidori";
 
 const client = new AgentClient("http://localhost:8080");
 
@@ -61,6 +61,21 @@ for await (const evt of client.stream({ document: "hi" })) {
 if (session.status === "paused") {
   const resumed = await client.resume(session.id, "yes");
   console.log(resumed.output);
+}
+
+// Multiplayer signals (from chidori.signal / pollSignal): deliver
+// { name, payload?, from? } to a run.
+const result = await client.signal(session.id, {
+  name: "review",
+  payload: { decision: "approve", notes: "LGTM" },
+  from: { kind: "human", id: "mara" },
+});
+if (isSignalQueued(result)) {
+  // run wasn't paused-waiting on this name → enqueued in the durable mailbox (202)
+  console.log("queued at delivery_seq", result.delivery_seq);
+} else {
+  // run was paused-waiting on this name → resolved + resumed (200)
+  console.log(result.status, result.output);
 }
 ```
 

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -125,6 +125,34 @@ export interface InputOptions {
   choices?: string[];
 }
 
+/**
+ * Who delivered a signal. `kind` distinguishes a human participant from a peer
+ * agent; `id` is the participant identity; `runId` is set when an agent sends
+ * (its own run id), so agent-to-agent coordination is attributable in the trace.
+ */
+export interface SignalSender {
+  kind: "human" | "agent";
+  id: string;
+  runId?: string;
+}
+
+/**
+ * A named message delivered into a run mid-flight (`docs/signals.md` §6.1). The
+ * inverse of `input()`: an outside party (human or agent) pushes
+ * `{ name, payload, from }` at an agent-declared listen point. Every signal is
+ * recorded in the call log, so the multiplayer session replays deterministically.
+ */
+export interface Signal<T = AgentJson> {
+  name: string;
+  payload: T;
+  from: SignalSender;
+}
+
+export interface SignalOptions {
+  /** Phase 2 (future): resolve to a timeout sentinel instead of waiting forever. */
+  timeoutMs?: number;
+}
+
 export interface ParallelOptions {
   concurrency?: number;
 }
@@ -214,6 +242,19 @@ export interface Chidori {
   context(seed?: { system?: string; tools?: string[] }): Context;
   prompt(text: string, options?: PromptOptions): Promise<string>;
   input(message: string, options?: InputOptions): Promise<string>;
+  /**
+   * Pause at a named listen point until a matching signal is delivered (or one
+   * is already queued in the durable mailbox), then resolve to
+   * `{ name, payload, from }`. The inverse of `input()`: the run idles cheaply
+   * on disk and an outside party delivers via `POST /sessions/{id}/signal`.
+   */
+  signal<T = AgentJson>(name: string, options?: SignalOptions): Promise<Signal<T>>;
+  /**
+   * Non-blocking: consume a queued signal of this name if present, else resolve
+   * to `null`. Records the result (value or null) at this seq so replay is
+   * deterministic.
+   */
+  pollSignal<T = AgentJson>(name: string): Promise<Signal<T> | null>;
   callAgent<TInput extends AgentJson = JsonObject, TOutput extends AgentJson = AgentJson>(
     path: string,
     input?: TInput,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -4,6 +4,8 @@
  * dependencies; uses the global `fetch` available in Node 18+ and browsers.
  */
 
+import type { SignalSender } from "./agent.js";
+
 export type {
   AgentFunction,
   AgentJson,
@@ -25,6 +27,9 @@ export type {
   RandomPolicy,
   RetryOptions,
   RuntimePolicyConfig,
+  Signal,
+  SignalOptions,
+  SignalSender,
   ToolDefinition,
   ToolFunction,
   TryCallResult,
@@ -188,6 +193,41 @@ export class Checkpoint {
   }
 }
 
+/**
+ * Returned by `client.signal` when the run was not paused-waiting on this name
+ * (it was running, or paused on something else), so the signal was enqueued
+ * into the durable mailbox to be drained at the next matching listen point.
+ * Mirrors the server's 202 Accepted body.
+ */
+export interface SignalQueued {
+  /** Session id the signal was delivered to. */
+  id: string;
+  status: "queued";
+  /** The signal name, echoed back. */
+  name: string;
+  /** Monotonic per-run sequence freezing global arrival order across senders. */
+  delivery_seq: number;
+}
+
+/** A signal delivery request body for `client.signal`. */
+export interface SignalDelivery {
+  /** Required, non-empty: the listen-point name the agent awaits. */
+  name: string;
+  /** Any JSON payload (default null). */
+  payload?: Json;
+  /** Sender provenance recorded in the trace (default null). */
+  from?: SignalSender | Json;
+}
+
+/**
+ * Type guard distinguishing the two `client.signal` outcomes: a resumed
+ * `Session` (the run was paused-waiting on this name) vs a `SignalQueued`
+ * descriptor (the signal was enqueued for a later listen point).
+ */
+export function isSignalQueued(result: Session | SignalQueued): result is SignalQueued {
+  return (result as SignalQueued).status === "queued";
+}
+
 /** One execution of an agent — result + call log + status. */
 export class Session {
   constructor(
@@ -200,6 +240,12 @@ export class Session {
     public pendingPrompt: string | null = null,
     private readonly client: AgentClient | null = null,
     public snapshotManifest: SnapshotManifest | null = null,
+    /**
+     * When the run is `paused` at a `chidori.signal(name)` listen point, the
+     * name it is waiting on (so a caller can deliver via `client.signal`).
+     * `null` for plain `input()` pauses and non-signal states.
+     */
+    public pendingSignalName: string | null = null,
   ) {}
 
   get ok(): boolean {
@@ -318,6 +364,38 @@ export class AgentClient {
     return this.sessionFrom(data, (data.input as Json | undefined) ?? null);
   }
 
+  /**
+   * Deliver a signal `{ name, payload?, from? }` to a run
+   * (`POST /sessions/{id}/signal`).
+   *
+   * Two outcomes, distinguished by `isSignalQueued`:
+   *   * the run was paused-waiting on this exact name → it resolves the pause
+   *     and resumes; this returns the advanced `Session` (200), now `completed`
+   *     or re-`paused`.
+   *   * the run was running or paused on something else → the signal is enqueued
+   *     into the durable mailbox; this returns a `SignalQueued` descriptor (202)
+   *     carrying the assigned `delivery_seq`.
+   *
+   * Throws on 400 (empty name), 404 (unknown session), or 409 (terminal run).
+   */
+  async signal(
+    sessionId: string,
+    delivery: SignalDelivery,
+  ): Promise<Session | SignalQueued> {
+    const { status, data } = await this.postJSONWithStatus(
+      `/sessions/${sessionId}/signal`,
+      {
+        name: delivery.name,
+        payload: delivery.payload ?? null,
+        from: delivery.from ?? null,
+      },
+    );
+    if (status === 202 || (data as { status?: string }).status === "queued") {
+      return data as unknown as SignalQueued;
+    }
+    return this.sessionFrom(data, (data.input as Json | undefined) ?? null);
+  }
+
   /** Fetch an existing session by id. */
   async getSession(id: string): Promise<Session> {
     const data = (await this.getJSON(`/sessions/${id}`)) as Record<string, unknown>;
@@ -398,6 +476,7 @@ export class AgentClient {
       (data.pending_prompt as string | undefined) ?? null,
       this,
       (data.snapshot_manifest as SnapshotManifest | undefined) ?? null,
+      (data.pending_signal_name as string | undefined) ?? null,
     );
   }
 
@@ -408,13 +487,20 @@ export class AgentClient {
   }
 
   private async postJSON(path: string, body: unknown): Promise<Record<string, unknown>> {
+    return (await this.postJSONWithStatus(path, body)).data;
+  }
+
+  private async postJSONWithStatus(
+    path: string,
+    body: unknown,
+  ): Promise<{ status: number; data: Record<string, unknown> }> {
     const resp = await fetch(this.baseUrl + path, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
     if (!resp.ok) throw await httpError(resp);
-    return (await resp.json()) as Record<string, unknown>;
+    return { status: resp.status, data: (await resp.json()) as Record<string, unknown> };
   }
 }
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -71,6 +71,7 @@ async fn create_thread(
         error: None,
         pending_seq: None,
         pending_prompt: None,
+        pending_signal_name: None,
         pending_approval: None,
         approvals: Vec::new(),
         policy_profile: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,6 +491,25 @@ fn cmd_run(
     // Run the agent.
     let result = engine.run(file, &input_value)?;
 
+    // A `chidori.signal(name)` listen point with an empty mailbox pauses the run
+    // (there is no stdin fallback for signals, unlike `input()`). The engine has
+    // already persisted the durable pause scaffold under `.chidori/runs/<run_id>`;
+    // tell the user the run is awaiting a signal and how to deliver one rather
+    // than printing a bare `null` output. See `docs/signals.md`.
+    if let Some(signal) = &result.paused_signal {
+        eprintln!(
+            "Run {} paused, awaiting signal '{}'.",
+            result.run_id, signal.name
+        );
+        eprintln!(
+            "Deliver it with: POST /sessions/{{id}}/signal \
+             {{\"name\":\"{}\",\"payload\":...,\"from\":...}} \
+             (or resume the run server-side).",
+            signal.name
+        );
+        return Ok(());
+    }
+
     // Print the output.
     let output_str = serde_json::to_string_pretty(&result.output)?;
     println!("{output_str}");

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -10,7 +10,8 @@ use crate::runtime::capability::{Capability, CapabilityLedger};
 use crate::runtime::otel::RunSpan;
 use crate::runtime::snapshot::{
     HostOperationId, HostPromiseRecord, HostPromiseTable, PendingHostOperation,
-    PendingHostOperationKind, HOST_PROMISE_TABLE_FILE, PENDING_HOST_OPERATION_FILE,
+    PendingHostOperationKind, QueuedSignal, HOST_PROMISE_TABLE_FILE, PENDING_HOST_OPERATION_FILE,
+    SIGNAL_INBOX_FILE,
 };
 use crate::runtime::vfs::Vfs;
 
@@ -126,6 +127,14 @@ struct RuntimeContextInner {
     pub pending_input: Option<PendingInput>,
     /// Set by the permission policy when an AskBefore rule needs approval.
     pub pending_approval: Option<PendingApproval>,
+    /// Set by `signal()` when pausing at a listen point with an empty mailbox.
+    /// The engine reads this after eval unwinds to surface a signal pause.
+    pub pending_signal: Option<PendingSignal>,
+    /// Durable per-run signal mailbox, loaded at run/resume start (threaded the
+    /// same way `vfs` is). `take_queued_signal(name)` drains the lowest-
+    /// `delivery_seq` matching entry and immediately re-persists the shrunken
+    /// inbox so a crash can't double-deliver (see `docs/signals.md` §8.4/§10).
+    pub signal_inbox: Vec<QueuedSignal>,
     /// Durable host-promise bookkeeping. This is snapshot-serializable Rust
     /// state; the QuickJS fork will bind these ids to real JS promises.
     #[allow(dead_code)]
@@ -213,6 +222,18 @@ pub struct PendingInput {
     pub prompt: String,
 }
 
+/// Set by `execute_signal` when a `chidori.signal(name)` listen point has no
+/// matching mailbox entry and must pause. The engine reads this after eval
+/// unwinds to distinguish a signal pause (surfaced as `RunResult.paused_signal`)
+/// from a real error, mirroring [`PendingInput`]. The pending host operation's
+/// match key is `{ "name": name }`; `id` is its host-promise id.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PendingSignal {
+    pub seq: u64,
+    pub name: String,
+    pub id: HostOperationId,
+}
+
 /// Set by the policy enforcer when a call needs user approval but the
 /// engine is running in Pause mode (server context). The engine catches the
 /// pause sentinel, takes this value, and returns it in `RunResult` so the
@@ -263,6 +284,8 @@ impl RuntimeContext {
                 input_mode: InputMode::Stdin,
                 pending_input: None,
                 pending_approval: None,
+                pending_signal: None,
+                signal_inbox: Vec::new(),
                 host_promises: HostPromiseTable::new(),
                 event_sender: None,
                 emit_call_events: true,
@@ -299,6 +322,22 @@ impl RuntimeContext {
         host_promises: Vec<HostPromiseRecord>,
         vfs: Vfs,
     ) -> Self {
+        Self::with_replay_host_promises_vfs_and_signals(replay_log, host_promises, vfs, Vec::new())
+    }
+
+    /// As `with_replay_host_promises_and_vfs`, but also threads an initial signal
+    /// mailbox (`docs/signals.md` §8.4) loaded from the run's durable
+    /// `signals/inbox.json`, the same way `vfs` is restored. A signal that was
+    /// enqueued before the agent reached a matching `chidori.signal(name)` listen
+    /// point is drained from this inbox on (re)run. The existing constructor
+    /// variants delegate here with an empty inbox so their signatures stay
+    /// unchanged.
+    pub fn with_replay_host_promises_vfs_and_signals(
+        replay_log: Vec<CallRecord>,
+        host_promises: Vec<HostPromiseRecord>,
+        vfs: Vfs,
+        signal_inbox: Vec<QueuedSignal>,
+    ) -> Self {
         Self {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: AgentConfig::default(),
@@ -310,6 +349,8 @@ impl RuntimeContext {
                 input_mode: InputMode::Stdin,
                 pending_input: None,
                 pending_approval: None,
+                pending_signal: None,
+                signal_inbox,
                 host_promises: HostPromiseTable::from_records(host_promises),
                 event_sender: None,
                 emit_call_events: true,
@@ -343,6 +384,8 @@ impl RuntimeContext {
                 input_mode: InputMode::Stdin,
                 pending_input: None,
                 pending_approval: None,
+                pending_signal: None,
+                signal_inbox: Vec::new(),
                 host_promises: HostPromiseTable::new(),
                 event_sender: None,
                 emit_call_events: true,
@@ -805,6 +848,48 @@ impl RuntimeContext {
         self.inner.lock().unwrap().pending_approval.take()
     }
 
+    pub fn set_pending_signal(&self, pending: PendingSignal) {
+        self.inner.lock().unwrap().pending_signal = Some(pending);
+    }
+
+    pub fn take_pending_signal(&self) -> Option<PendingSignal> {
+        self.inner.lock().unwrap().pending_signal.take()
+    }
+
+    /// Replace the in-memory signal mailbox. Used by the
+    /// `with_replay_..._and_signals` constructors and resume paths that load the
+    /// durable inbox from disk before agent code runs.
+    pub fn set_signal_inbox(&self, inbox: Vec<QueuedSignal>) {
+        self.inner.lock().unwrap().signal_inbox = inbox;
+    }
+
+    /// A clone of the current signal mailbox, for inspection/tests.
+    pub fn signal_inbox(&self) -> Vec<QueuedSignal> {
+        self.inner.lock().unwrap().signal_inbox.clone()
+    }
+
+    /// Drain the lowest-`delivery_seq` queued signal whose name matches `name`,
+    /// removing it from the in-memory mailbox and — if persistence is enabled —
+    /// immediately re-persisting the shrunken inbox to `SIGNAL_INBOX_FILE` in the
+    /// SAME critical section as consumption. This is the determinism guarantee
+    /// from `docs/signals.md` §8.4/§10: a crash between consumption and the
+    /// recorded `CallRecord` must not leave the signal in the inbox for a second
+    /// delivery — on restart the recorded result wins and the inbox is never
+    /// re-drained for that seq. Returns `None` when no matching entry exists.
+    pub fn take_queued_signal(&self, name: &str) -> Option<QueuedSignal> {
+        let mut inner = self.inner.lock().unwrap();
+        let idx = inner
+            .signal_inbox
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.name == name)
+            .min_by_key(|(_, s)| s.delivery_seq)
+            .map(|(i, _)| i)?;
+        let signal = inner.signal_inbox.remove(idx);
+        persist_signal_inbox(&inner);
+        Some(signal)
+    }
+
     #[allow(dead_code)]
     pub fn create_host_promise(
         &self,
@@ -993,6 +1078,34 @@ fn persist_host_promises(inner: &RuntimeContextInner) {
             }
         }
     }
+}
+
+/// Persist the in-memory signal mailbox to `SIGNAL_INBOX_FILE` under the run's
+/// persist dir. The inbox lives in a `signals/` subdirectory, so the parent dir
+/// is created first. No-op when persistence is disabled.
+fn persist_signal_inbox(inner: &RuntimeContextInner) {
+    let Some(dir) = inner.persist_dir.as_ref() else {
+        return;
+    };
+    let inbox_path = dir.join(SIGNAL_INBOX_FILE);
+    if let Some(parent) = inbox_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_vec_pretty(&inner.signal_inbox) {
+        let _ = std::fs::write(inbox_path, json);
+    }
+}
+
+/// Load the durable signal mailbox from a run directory. Returns an empty vec
+/// when the file is absent or unreadable (a fresh run with no queued signals).
+/// Used by resume/run paths to thread the inbox into a context the same way the
+/// VFS is restored.
+pub fn load_signal_inbox(run_dir: &std::path::Path) -> Vec<QueuedSignal> {
+    let path = run_dir.join(SIGNAL_INBOX_FILE);
+    let Ok(bytes) = std::fs::read(path) else {
+        return Vec::new();
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
 }
 
 fn default_workspace_root() -> Option<PathBuf> {

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -348,6 +348,55 @@ impl Engine {
         self.run_with_context(path, inputs, ctx)
     }
 
+    /// As `run_replay_pausable_with_host_promises_and_vfs`, but also threads the
+    /// durable signal mailbox (`signals/inbox.json`) into the resumed run so a
+    /// re-run that reaches a `chidori.signal(name)`/`pollSignal(name)` listen
+    /// point drains any queued entries instead of pausing. See `docs/signals.md`
+    /// §9 (the resume worker loads the inbox).
+    pub fn run_replay_pausable_with_host_promises_vfs_and_signals(
+        &self,
+        path: &Path,
+        inputs: &Value,
+        replay_log: Vec<CallRecord>,
+        host_promises: Vec<HostPromiseRecord>,
+        vfs: crate::runtime::vfs::Vfs,
+        signal_inbox: Vec<crate::runtime::snapshot::QueuedSignal>,
+    ) -> Result<RunResult> {
+        let ctx = RuntimeContext::with_replay_host_promises_vfs_and_signals(
+            replay_log,
+            host_promises,
+            vfs,
+            signal_inbox,
+        );
+        ctx.set_input_mode(InputMode::Pause);
+        self.run_with_context(path, inputs, ctx)
+    }
+
+    /// As above, preserving the original run id (so the resumed run keeps its
+    /// persisted run directory) AND threading the signal mailbox. This is the
+    /// method the server's resume/signal-delivery paths use.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_replay_pausable_with_host_promises_vfs_signals_preserving_run_id(
+        &self,
+        path: &Path,
+        inputs: &Value,
+        replay_log: Vec<CallRecord>,
+        host_promises: Vec<HostPromiseRecord>,
+        vfs: crate::runtime::vfs::Vfs,
+        signal_inbox: Vec<crate::runtime::snapshot::QueuedSignal>,
+        run_id: String,
+    ) -> Result<RunResult> {
+        let ctx = RuntimeContext::with_replay_host_promises_vfs_and_signals(
+            replay_log,
+            host_promises,
+            vfs,
+            signal_inbox,
+        );
+        ctx.set_run_id(run_id);
+        ctx.set_input_mode(InputMode::Pause);
+        self.run_with_context(path, inputs, ctx)
+    }
+
     /// Resume/replay an interactive streaming run with persisted host-promise
     /// state. Used by embedders that mirror the server session interaction
     /// without routing through HTTP.

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -10,7 +10,7 @@ use crate::providers::ProviderRegistry;
 use crate::runtime::call_log::{CallLog, CallRecord};
 use crate::runtime::context::{
     HostOperationCompletionSafepoint, HostOperationSafepoint, InputMode, PendingApproval,
-    PendingInput, RuntimeContext, RuntimeEvent,
+    PendingInput, PendingSignal, RuntimeContext, RuntimeEvent,
 };
 use crate::runtime::snapshot::{
     HostPromiseRecord, RuntimePolicy, SnapshotAbi, SnapshotManifest, SnapshotStore,
@@ -50,6 +50,13 @@ pub struct RunResult {
     /// mode. The caller should render an approval UI and, on approve, re-run
     /// the agent with the approval added to `Engine::with_approvals`.
     pub paused_approval: Option<PendingApproval>,
+    /// Set when the agent called `chidori.signal(name)` at a listen point with
+    /// an empty mailbox in Pause mode. The caller should treat the run as
+    /// suspended on the named listen point and later resume by delivering a
+    /// matching signal (replaying the call log with a completed `Signal` host
+    /// op at `pending.seq`). Distinct from `paused` so the server knows *which*
+    /// named op is waiting. See `docs/signals.md`.
+    pub paused_signal: Option<PendingSignal>,
 }
 
 /// Persist a resume scaffold for a run on the pure-Rust engine (G2).
@@ -497,6 +504,7 @@ impl Engine {
                         run_id: ctx.run_id(),
                         paused: Some(pending),
                         paused_approval: None,
+                        paused_signal: None,
                     });
                 }
                 if let Some(approval) = ctx.take_pending_approval() {
@@ -512,6 +520,26 @@ impl Engine {
                         run_id: ctx.run_id(),
                         paused: None,
                         paused_approval: Some(approval),
+                        paused_signal: None,
+                    });
+                }
+                // A `chidori.signal(name)` listen point with an empty mailbox
+                // sets `pending_signal` and bails with `PAUSE_MARKER`, exactly
+                // like `input` — surface it as a paused run, not a failure.
+                if let Some(signal) = ctx.take_pending_signal() {
+                    if let Some(ref base) = self.persist_base {
+                        let _ = persist_rust_journal_scaffold(
+                            base, &run_id, path, &source, &policy, ctx,
+                        );
+                    }
+                    emit_otel(ctx, None);
+                    return Some(RunResult {
+                        output: Value::Null,
+                        call_log: ctx.call_log(),
+                        run_id: ctx.run_id(),
+                        paused: None,
+                        paused_approval: None,
+                        paused_signal: Some(signal),
                     });
                 }
                 None
@@ -550,6 +578,7 @@ impl Engine {
                         run_id: ctx.run_id(),
                         paused: None,
                         paused_approval: None,
+                        paused_signal: None,
                     })
                 }
                 Err(e) => {
@@ -1865,6 +1894,96 @@ def agent(value):
             .run_with_replay(&path, &serde_json::json!({ "msg": "hello" }), replay_log)
             .unwrap();
         assert_eq!(replayed.output, out);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// An agent awaiting `chidori.signal("review")` with an empty mailbox pauses
+    /// (surfaced as `RunResult.paused_signal`, not a failure). Delivering the
+    /// signal — via a completed `Signal` host promise plus the synthetic
+    /// `signal` CallRecord, the durable resume shape from `docs/signals.md` §9 —
+    /// completes the run with the delivered payload, and a full re-run from the
+    /// recorded call_log reproduces identical output.
+    #[test]
+    fn engine_pauses_and_resumes_typescript_signal() {
+        let dir =
+            std::env::temp_dir().join(format!("chidori-engine-ts-signal-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    const review = await chidori.signal("review");
+                    return { decision: review.payload.decision, by: review.from.id };
+                }
+            "#,
+        )
+        .unwrap();
+
+        let engine = || {
+            Engine::new(
+                Arc::new(ProviderRegistry::new()),
+                Arc::new(TemplateEngine::new(&dir)),
+                Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            )
+        };
+
+        // Empty mailbox → pauses on the named listen point.
+        let paused = engine()
+            .run_pausable(&path, &serde_json::json!({}))
+            .unwrap();
+        assert!(paused.paused.is_none());
+        assert!(paused.paused_approval.is_none());
+        let pending = paused.paused_signal.expect("expected a signal pause");
+        assert_eq!(pending.name, "review");
+        assert_eq!(pending.seq, 1);
+        assert!(paused.call_log.into_records().is_empty());
+
+        // Deliver the signal: a completed Signal host promise (match key
+        // {name}) carrying the {name,payload,from} result. `replay_completed_
+        // host_operation` injects the synthetic `signal` CallRecord on resume.
+        let delivered = serde_json::json!({
+            "name": "review",
+            "payload": { "decision": "approve" },
+            "from": { "kind": "human", "id": "mara" },
+        });
+        let host_promises = vec![crate::runtime::snapshot::HostPromiseRecord {
+            operation: crate::runtime::snapshot::PendingHostOperation::new(
+                crate::runtime::snapshot::HostOperationId(1),
+                pending.seq,
+                crate::runtime::snapshot::PendingHostOperationKind::Signal,
+                serde_json::json!({ "name": "review" }),
+            ),
+            state: crate::runtime::snapshot::HostPromiseState::Resolved {
+                value: delivered.clone(),
+                completed_at: chrono::Utc::now(),
+            },
+        }];
+        let resumed = engine()
+            .run_replay_pausable_with_host_promises(
+                &path,
+                &serde_json::json!({}),
+                Vec::new(),
+                host_promises,
+            )
+            .unwrap();
+        assert!(resumed.paused_signal.is_none());
+        assert_eq!(
+            resumed.output,
+            serde_json::json!({ "decision": "approve", "by": "mara" })
+        );
+        let records = resumed.call_log.into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "signal");
+        assert_eq!(records[0].result, delivered);
+
+        // Full re-run from the recorded call_log reproduces identical output
+        // without any mailbox or delivery.
+        let rerun = engine()
+            .run_with_replay(&path, &serde_json::json!({}), records.clone())
+            .unwrap();
+        assert_eq!(rerun.output, resumed.output);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/runtime/host_core.rs
+++ b/src/runtime/host_core.rs
@@ -7,7 +7,9 @@ use crate::providers::{
     CacheTtl, ContentBlock, LlmRequest, LlmResponse, ProviderRegistry, TokenSink, ToolCall,
 };
 use crate::runtime::call_log::{CallRecord, TokenUsage};
-use crate::runtime::context::{InputMode, PendingInput, RuntimeContext, PAUSE_MARKER};
+use crate::runtime::context::{
+    InputMode, PendingInput, PendingSignal, RuntimeContext, PAUSE_MARKER,
+};
 use crate::runtime::memory::execute_memory_action;
 use crate::runtime::snapshot::{HostPromiseState, PendingHostOperationKind};
 use crate::runtime::template::TemplateEngine;
@@ -194,6 +196,7 @@ fn host_operation_kind(function: &str) -> Option<PendingHostOperationKind> {
         "memory" => Some(PendingHostOperationKind::Memory),
         "checkpoint" => Some(PendingHostOperationKind::Checkpoint),
         "log" => Some(PendingHostOperationKind::Log),
+        "signal" | "poll_signal" => Some(PendingHostOperationKind::Signal),
         _ => None,
     }
 }
@@ -254,6 +257,151 @@ pub fn execute_input(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
             Err(anyhow::anyhow!("{PAUSE_MARKER}: {prompt}"))
         }
     }
+}
+
+/// Pull the required `name` string from a signal binding's args
+/// (`{ "name": <string>, "opts": <json|null> }`), with a clear host-side error
+/// when it is missing or not a string. Shared by `execute_signal` /
+/// `execute_poll_signal`.
+fn signal_name(function: &str, args: &Value) -> Result<String> {
+    args.get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("chidori.{function} requires a string name"))
+}
+
+/// `chidori.signal(name, opts)` — the blocking, named, externally-deliverable
+/// flavor of `input`, fronted by a durable per-run mailbox. See
+/// `docs/signals.md` §5/§8.3. Order:
+///   1. replay short-circuit (`try_replay_checked`) — a recorded result wins,
+///      so a replay never reads the inbox;
+///   2. completed-host-op check (`(seq, Signal, {name})`) — a delivered-via-
+///      resume signal that post-dates the journal;
+///   3. mailbox drain (`take_queued_signal`) — consume a pre-arrived signal
+///      WITHOUT pausing, recording the `{name,payload,from}` result;
+///   4. otherwise PAUSE: set `PendingSignal` and bail with `PAUSE_MARKER` (the
+///      pause *type* is distinguished from `input` by which pending slot is set).
+/// The durable match key is `{ "name": name }` only — the payload is unknown at
+/// pause time and rides in the result.
+pub fn execute_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
+    let name = signal_name("signal", args)?;
+    let match_args = json!({ "name": name });
+    let seq = ctx.next_seq();
+
+    if let Some(record) = ctx
+        .try_replay_checked(seq, "signal")
+        .map_err(|err| anyhow::anyhow!(err))?
+    {
+        return Ok(record.result);
+    }
+
+    if let Some(result) = replay_completed_host_operation(
+        ctx,
+        seq,
+        "signal",
+        PendingHostOperationKind::Signal,
+        &match_args,
+    )? {
+        return Ok(result);
+    }
+
+    let host_operation = ctx.begin_host_operation_with_function(
+        seq,
+        PendingHostOperationKind::Signal,
+        Some("signal".to_string()),
+        match_args.clone(),
+    );
+    ctx.run_host_operation_safepoint(host_operation)?;
+
+    if let Some(queued) = ctx.take_queued_signal(&name) {
+        let result = json!({
+            "name": queued.name,
+            "payload": queued.payload,
+            "from": queued.from,
+        });
+        ctx.resolve_host_operation(host_operation, result.clone())?;
+        ctx.record_call(CallRecord {
+            seq,
+            parent_seq: None,
+            function: "signal".to_string(),
+            args: match_args,
+            result: result.clone(),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        });
+        ctx.run_host_operation_completion_safepoint(host_operation)?;
+        return Ok(result);
+    }
+
+    ctx.set_pending_signal(PendingSignal {
+        seq,
+        name: name.clone(),
+        id: host_operation,
+    });
+    Err(anyhow::anyhow!("{PAUSE_MARKER}: signal {name}"))
+}
+
+/// `chidori.pollSignal(name)` — non-blocking signal consumption (`docs/signals.md`
+/// §6.1). Same replay/completed-host-op checks as `execute_signal` (function
+/// name `"poll_signal"`, kind `Signal`, match key `{name}`), then a single
+/// mailbox drain: records the `{name,payload,from}` object if a matching signal
+/// is queued, or JSON `null` if not. The result is ALWAYS recorded at this seq —
+/// so a poll that found nothing replays as `null` deterministically — and it
+/// never pauses.
+pub fn execute_poll_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
+    let name = signal_name("pollSignal", args)?;
+    let match_args = json!({ "name": name });
+    let seq = ctx.next_seq();
+
+    if let Some(record) = ctx
+        .try_replay_checked(seq, "poll_signal")
+        .map_err(|err| anyhow::anyhow!(err))?
+    {
+        return Ok(record.result);
+    }
+
+    if let Some(result) = replay_completed_host_operation(
+        ctx,
+        seq,
+        "poll_signal",
+        PendingHostOperationKind::Signal,
+        &match_args,
+    )? {
+        return Ok(result);
+    }
+
+    let host_operation = ctx.begin_host_operation_with_function(
+        seq,
+        PendingHostOperationKind::Signal,
+        Some("poll_signal".to_string()),
+        match_args.clone(),
+    );
+    ctx.run_host_operation_safepoint(host_operation)?;
+
+    let result = match ctx.take_queued_signal(&name) {
+        Some(queued) => json!({
+            "name": queued.name,
+            "payload": queued.payload,
+            "from": queued.from,
+        }),
+        None => Value::Null,
+    };
+    ctx.resolve_host_operation(host_operation, result.clone())?;
+    ctx.record_call(CallRecord {
+        seq,
+        parent_seq: None,
+        function: "poll_signal".to_string(),
+        args: match_args,
+        result: result.clone(),
+        duration_ms: 0,
+        token_usage: None,
+        timestamp: Utc::now(),
+        error: None,
+    });
+    ctx.run_host_operation_completion_safepoint(host_operation)?;
+    Ok(result)
 }
 
 /// Whether (and how long) a prompt request should mark cacheable prefix
@@ -907,7 +1055,7 @@ mod tests {
         HostOperationCompletionSafepoint, HostOperationSafepoint, RuntimeContext,
     };
     use crate::runtime::snapshot::{
-        HostOperationId, HostPromiseRecord, HostPromiseState, PendingHostOperation,
+        HostOperationId, HostPromiseRecord, HostPromiseState, PendingHostOperation, QueuedSignal,
         PENDING_HOST_OPERATION_FILE,
     };
 
@@ -1814,5 +1962,220 @@ mod tests {
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].kind, PendingHostOperationKind::Input);
         assert_eq!(pending[0].args, json!({ "prompt": "Approve?" }));
+    }
+
+    fn queued_signal(name: &str, payload: Value, from: Value, delivery_seq: u64) -> QueuedSignal {
+        QueuedSignal {
+            name: name.to_string(),
+            payload,
+            from,
+            delivery_seq,
+            enqueued_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn signal_pauses_when_inbox_empty() {
+        let ctx = RuntimeContext::new();
+
+        let err = execute_signal(&ctx, &json!({ "name": "review", "opts": null })).unwrap_err();
+
+        assert!(err.to_string().contains(PAUSE_MARKER));
+        // The pending host op carries kind Signal and the name-only match key.
+        let pending = ctx.pending_host_operations();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].kind, PendingHostOperationKind::Signal);
+        assert_eq!(pending[0].args, json!({ "name": "review" }));
+        // The pause slot is set so the engine surfaces a signal pause.
+        let pending_signal = ctx.take_pending_signal().expect("pending signal set");
+        assert_eq!(pending_signal.name, "review");
+        assert_eq!(pending_signal.seq, 1);
+        // No call was recorded — the run is suspended, not completed.
+        assert!(ctx.call_log().into_records().is_empty());
+    }
+
+    #[test]
+    fn signal_consumes_queued_without_pausing() {
+        let ctx = RuntimeContext::new();
+        ctx.set_signal_inbox(vec![queued_signal(
+            "review",
+            json!({ "decision": "approve" }),
+            json!({ "kind": "human", "id": "mara" }),
+            7,
+        )]);
+
+        let result = execute_signal(&ctx, &json!({ "name": "review", "opts": null })).unwrap();
+
+        assert_eq!(
+            result,
+            json!({
+                "name": "review",
+                "payload": { "decision": "approve" },
+                "from": { "kind": "human", "id": "mara" },
+            })
+        );
+        // The inbox is drained and a completed call is recorded with the value.
+        assert!(ctx.signal_inbox().is_empty());
+        let records = ctx.call_log().into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "signal");
+        assert_eq!(records[0].args, json!({ "name": "review" }));
+        assert_eq!(records[0].result, result);
+        assert!(ctx.take_pending_signal().is_none());
+    }
+
+    #[test]
+    fn signal_replay_returns_recorded_value_without_touching_inbox() {
+        // Record a signal consumption.
+        let recorded = vec![CallRecord {
+            seq: 1,
+            parent_seq: None,
+            function: "signal".to_string(),
+            args: json!({ "name": "review" }),
+            result: json!({
+                "name": "review",
+                "payload": { "decision": "approve" },
+                "from": { "kind": "human", "id": "mara" },
+            }),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        }];
+        // Replay context with a DIFFERENT same-name signal sitting in the inbox.
+        // The recorded value must win and the inbox must stay undrained.
+        let ctx = RuntimeContext::with_replay(recorded);
+        ctx.set_signal_inbox(vec![queued_signal(
+            "review",
+            json!({ "decision": "changes" }),
+            json!({ "kind": "agent", "id": "bot" }),
+            99,
+        )]);
+
+        let result = execute_signal(&ctx, &json!({ "name": "review", "opts": null })).unwrap();
+
+        assert_eq!(
+            result,
+            json!({
+                "name": "review",
+                "payload": { "decision": "approve" },
+                "from": { "kind": "human", "id": "mara" },
+            })
+        );
+        // The inbox was never read on replay.
+        assert_eq!(ctx.signal_inbox().len(), 1);
+        assert_eq!(
+            ctx.signal_inbox()[0].payload,
+            json!({ "decision": "changes" })
+        );
+    }
+
+    #[test]
+    fn signal_consumes_same_name_in_delivery_seq_order() {
+        let ctx = RuntimeContext::new();
+        // Two same-name signals enqueued out of delivery_seq order.
+        ctx.set_signal_inbox(vec![
+            queued_signal("review", json!("second"), json!({ "id": "b" }), 20),
+            queued_signal("review", json!("first"), json!({ "id": "a" }), 10),
+        ]);
+
+        let first = execute_signal(&ctx, &json!({ "name": "review", "opts": null })).unwrap();
+        assert_eq!(first["payload"], json!("first"));
+        assert_eq!(ctx.signal_inbox().len(), 1);
+
+        let second = execute_signal(&ctx, &json!({ "name": "review", "opts": null })).unwrap();
+        assert_eq!(second["payload"], json!("second"));
+        assert!(ctx.signal_inbox().is_empty());
+
+        let records = ctx.call_log().into_records();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].result["payload"], json!("first"));
+        assert_eq!(records[1].result["payload"], json!("second"));
+    }
+
+    #[test]
+    fn poll_signal_records_null_when_empty_and_value_when_queued() {
+        // Empty inbox → records null, never pauses.
+        let ctx = RuntimeContext::new();
+        let empty = execute_poll_signal(&ctx, &json!({ "name": "steer" })).unwrap();
+        assert_eq!(empty, Value::Null);
+        let records = ctx.call_log().into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "poll_signal");
+        assert_eq!(records[0].result, Value::Null);
+
+        // Queued → records the value object.
+        let ctx2 = RuntimeContext::new();
+        ctx2.set_signal_inbox(vec![queued_signal(
+            "steer",
+            json!({ "priority": "high" }),
+            json!({ "kind": "human", "id": "sam" }),
+            3,
+        )]);
+        let value = execute_poll_signal(&ctx2, &json!({ "name": "steer" })).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "name": "steer",
+                "payload": { "priority": "high" },
+                "from": { "kind": "human", "id": "sam" },
+            })
+        );
+        assert!(ctx2.signal_inbox().is_empty());
+    }
+
+    #[test]
+    fn poll_signal_replays_null_and_value_deterministically() {
+        // A recorded null poll replays as null without consulting the inbox.
+        let null_record = vec![CallRecord {
+            seq: 1,
+            parent_seq: None,
+            function: "poll_signal".to_string(),
+            args: json!({ "name": "steer" }),
+            result: Value::Null,
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        }];
+        let ctx = RuntimeContext::with_replay(null_record);
+        // Even with a queued same-name signal, the recorded null wins.
+        ctx.set_signal_inbox(vec![queued_signal(
+            "steer",
+            json!({ "priority": "high" }),
+            json!({ "id": "sam" }),
+            5,
+        )]);
+        let replayed_null = execute_poll_signal(&ctx, &json!({ "name": "steer" })).unwrap();
+        assert_eq!(replayed_null, Value::Null);
+        assert_eq!(ctx.signal_inbox().len(), 1);
+
+        // A recorded value poll replays the value.
+        let value = json!({
+            "name": "steer",
+            "payload": { "priority": "high" },
+            "from": { "id": "sam" },
+        });
+        let value_record = vec![CallRecord {
+            seq: 1,
+            parent_seq: None,
+            function: "poll_signal".to_string(),
+            args: json!({ "name": "steer" }),
+            result: value.clone(),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        }];
+        let ctx2 = RuntimeContext::with_replay(value_record);
+        let replayed_value = execute_poll_signal(&ctx2, &json!({ "name": "steer" })).unwrap();
+        assert_eq!(replayed_value, value);
+    }
+
+    #[test]
+    fn signal_requires_string_name() {
+        let ctx = RuntimeContext::new();
+        let err = execute_signal(&ctx, &json!({ "name": 42, "opts": null })).unwrap_err();
+        assert!(err.to_string().contains("requires a string name"));
     }
 }

--- a/src/runtime/snapshot.rs
+++ b/src/runtime/snapshot.rs
@@ -16,6 +16,12 @@ pub const SNAPSHOT_MANIFEST_FILE: &str = "runtime.snapshot.json";
 pub const SNAPSHOT_BLOB_FILE: &str = "runtime.snapshot";
 pub const PENDING_HOST_OPERATION_FILE: &str = "pending.json";
 pub const HOST_PROMISE_TABLE_FILE: &str = "host_promises.json";
+/// Durable per-run signal mailbox. Lives in a `signals/` subdirectory of the
+/// run directory (unlike the flat `pending.json`/`host_promises.json`), so
+/// writers must create the parent dir before writing. Holds the ordered
+/// `Vec<QueuedSignal>` absorbing signals that arrive before the agent reaches a
+/// matching `chidori.signal(name)` listen point.
+pub const SIGNAL_INBOX_FILE: &str = "signals/inbox.json";
 pub const BRANCHES_DIR: &str = "branches";
 pub const PARALLEL_BRANCH_MANIFEST_FILE: &str = "manifest.json";
 pub const TYPESCRIPT_RUNTIME_ABI_VERSION: u32 = 1;
@@ -239,6 +245,11 @@ pub enum PendingHostOperationKind {
     /// timers that must survive suspend → restore (see
     /// `docs/captured-effects-vfs-crypto-timers.md`).
     Timer,
+    /// A `chidori.signal(name)` / `chidori.pollSignal(name)` listen point. The
+    /// match key (the pending op's `args`) is `{ "name": <string> }` only; the
+    /// delivered `{ name, payload, from }` rides in the resolved result. See
+    /// `docs/signals.md`.
+    Signal,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -462,6 +473,21 @@ fn completed_args_match(recorded: &Value, rebuilt: &Value) -> bool {
         value
     };
     strip(recorded) == strip(rebuilt)
+}
+
+/// One signal sitting in the durable per-run mailbox (`signals/inbox.json`),
+/// absorbed before the agent reached a matching `chidori.signal(name)` listen
+/// point. `delivery_seq` is a monotonic counter assigned by the delivery
+/// endpoint, freezing global arrival order across all senders so same-name
+/// signals are consumed lowest-first and that choice replays deterministically.
+/// `from` stays an opaque JSON value carrying `{ kind, id, runId? }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueuedSignal {
+    pub name: String,
+    pub payload: Value,
+    pub from: Value,
+    pub delivery_seq: u64,
+    pub enqueued_at: DateTime<Utc>,
 }
 
 pub const DEFAULT_BRANCH_SEQUENCE_RANGE_WIDTH: u64 = 10_000;

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -545,6 +545,20 @@ impl HostBindingBackend {
         Ok(result.as_str().unwrap_or("").to_string())
     }
 
+    fn signal(&self, a: &serde_json::Value) -> std::result::Result<serde_json::Value, String> {
+        let HostBindingBackend::Runtime { runtime_ctx, .. } = self else {
+            return Err("chidori.signal requires the runtime host backend".to_string());
+        };
+        host_core::execute_signal(runtime_ctx, a).map_err(|err| err.to_string())
+    }
+
+    fn poll_signal(&self, a: &serde_json::Value) -> std::result::Result<serde_json::Value, String> {
+        let HostBindingBackend::Runtime { runtime_ctx, .. } = self else {
+            return Err("chidori.pollSignal requires the runtime host backend".to_string());
+        };
+        host_core::execute_poll_signal(runtime_ctx, a).map_err(|err| err.to_string())
+    }
+
     fn enforce_policy(
         &self,
         target: &str,
@@ -797,6 +811,8 @@ impl HostBindingBackend {
                     .to_string();
                 self.input(prompt).map(serde_json::Value::String)
             }
+            "signal" => self.signal(a),
+            "poll_signal" => self.poll_signal(a),
             "checkpoint" => {
                 let args = serde_json::json!({
                     "label": a.get("label").cloned().unwrap_or(serde_json::Value::Null),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -126,6 +126,7 @@ pub async fn run_once(recipe: &Recipe, deps: &SchedulerDeps) -> Result<String> {
             error: None,
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,6 +54,26 @@ struct AppState {
     run_semaphore: Arc<Semaphore>,
     acquire_timeout: std::time::Duration,
     active_sessions: Arc<StdMutex<HashMap<String, ActiveSession>>>,
+    /// Per-run advisory locks serializing `signals/inbox.json` read-modify-write
+    /// (enqueue and the delivery routing decision). A paused run is not a live
+    /// task in Phase 1, but the endpoint can still race itself across concurrent
+    /// deliveries; this in-process mutex (keyed by run id) makes each delivery's
+    /// inbox mutation atomic, matching how the server already serializes per-run
+    /// state. See `docs/signals.md` §11.
+    signal_inbox_locks: Arc<StdMutex<HashMap<String, Arc<StdMutex<()>>>>>,
+}
+
+impl AppState {
+    /// Resolve (creating on first use) the per-run inbox lock for `run_id`. The
+    /// caller `.lock()`s the returned `Arc` and holds the guard for the duration
+    /// of an enqueue / routing decision.
+    fn signal_inbox_lock(&self, run_id: &str) -> Arc<StdMutex<()>> {
+        let mut locks = self.signal_inbox_locks.lock().unwrap();
+        locks
+            .entry(run_id.to_string())
+            .or_insert_with(|| Arc::new(StdMutex::new(())))
+            .clone()
+    }
 }
 
 const PROMPT_TOOL_PAUSE_FILE: &str = "prompt_tool_pause.json";
@@ -77,6 +97,7 @@ fn session_view(s: &StoredSession) -> Value {
         "call_count": s.call_log.len(),
         "pending_seq": s.pending_seq,
         "pending_prompt": s.pending_prompt,
+        "pending_signal_name": s.pending_signal_name,
         "pending_approval": s.pending_approval,
         "policy_profile": s.policy_profile,
     })
@@ -300,6 +321,65 @@ fn load_persisted_vfs(run_base: &FsPath, run_id: Option<&str>) -> crate::runtime
     }
 }
 
+/// Load a run's durable signal mailbox (`signals/inbox.json`) so a resumed run
+/// can drain queued signals at later listen points (doc §9, sibling of
+/// `load_persisted_vfs`). Empty when the run has no inbox file yet.
+fn load_persisted_signal_inbox(
+    run_base: &FsPath,
+    run_id: Option<&str>,
+) -> Vec<crate::runtime::snapshot::QueuedSignal> {
+    let Some(run_id) = run_id else {
+        return Vec::new();
+    };
+    crate::runtime::context::load_signal_inbox(&run_base.join(run_id))
+}
+
+/// Append a signal to a run's durable mailbox under a per-run advisory lock,
+/// assigning it the next `delivery_seq` (`max(existing)+1`, starting at 1) so
+/// global arrival order across senders is frozen and same-name signals are
+/// consumed lowest-first (doc §8.4/§10/§11). The lock is the same per-run mutex
+/// the server uses to serialize inbox read-modify-write while a run is paused or
+/// running (doc §11: "guard `inbox.json` read-modify-write with a per-run
+/// advisory ... lock"). Creates the `signals/` directory if absent.
+fn enqueue_signal_to_inbox(
+    state: &AppState,
+    run_id: &str,
+    name: &str,
+    payload: Value,
+    from: Value,
+) -> anyhow::Result<crate::runtime::snapshot::QueuedSignal> {
+    use crate::runtime::snapshot::{QueuedSignal, SIGNAL_INBOX_FILE};
+
+    let lock = state.signal_inbox_lock(run_id);
+    let _guard = lock.lock().unwrap();
+    let run_dir = state.run_base.join(run_id);
+    let inbox_path = run_dir.join(SIGNAL_INBOX_FILE);
+    let mut inbox: Vec<QueuedSignal> = if inbox_path.exists() {
+        serde_json::from_slice(&std::fs::read(&inbox_path)?).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let next_delivery_seq = inbox
+        .iter()
+        .map(|s| s.delivery_seq)
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1);
+    let queued = QueuedSignal {
+        name: name.to_string(),
+        payload,
+        from,
+        delivery_seq: next_delivery_seq,
+        enqueued_at: chrono::Utc::now(),
+    };
+    inbox.push(queued.clone());
+    if let Some(parent) = inbox_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&inbox_path, serde_json::to_vec_pretty(&inbox)?)?;
+    Ok(queued)
+}
+
 #[allow(dead_code)]
 fn resolve_persisted_pending_host_operation(
     run_base: &FsPath,
@@ -392,6 +472,7 @@ pub async fn serve(
         run_semaphore: Arc::new(Semaphore::new(max_concurrent)),
         acquire_timeout: std::time::Duration::from_millis(acquire_timeout_ms),
         active_sessions: Arc::new(StdMutex::new(HashMap::new())),
+        signal_inbox_locks: Arc::new(StdMutex::new(HashMap::new())),
     };
 
     let auth_required = std::env::var("CHIDORI_API_KEY").is_ok();
@@ -417,6 +498,7 @@ pub async fn serve(
         .route("/sessions/{id}/snapshot", get(get_snapshot_manifest))
         .route("/sessions/{id}/replay", post(replay_session))
         .route("/sessions/{id}/resume", post(resume_session))
+        .route("/sessions/{id}/signal", post(signal_session))
         .route("/sessions/{id}/approve", post(approve_session))
         .route("/sessions/{id}/cancel", post(cancel_session))
         .route("/sessions/stream", post(stream_session))
@@ -467,6 +549,7 @@ pub async fn serve(
     eprintln!("              GET  /sessions/{{id}}/snapshot   → snapshot manifest");
     eprintln!("              POST /sessions/{{id}}/replay     → replay from checkpoint");
     eprintln!("              POST /sessions/{{id}}/resume     → resume paused input() call");
+    eprintln!("              POST /sessions/{{id}}/signal     → deliver a signal to a run");
     eprintln!("              POST /sessions/{{id}}/cancel     → cancel running session");
     eprintln!("              POST /sessions/stream            → run with SSE events");
     eprintln!("  Health:     GET  /health");
@@ -864,32 +947,53 @@ async fn create_session(
 
     let session = match result {
         Ok(run_result) => {
-            let (status, pending_seq, pending_prompt, pending_approval, output) =
-                if let Some(pending) = run_result.paused {
-                    (
-                        SessionStatus::Paused,
-                        Some(pending.seq),
-                        Some(pending.prompt),
-                        None,
-                        None,
-                    )
-                } else if let Some(appr) = run_result.paused_approval {
-                    (
-                        SessionStatus::AwaitingApproval,
-                        None,
-                        None,
-                        Some(appr),
-                        None,
-                    )
-                } else {
-                    (
-                        SessionStatus::Completed,
-                        None,
-                        None,
-                        None,
-                        Some(run_result.output),
-                    )
-                };
+            let (
+                status,
+                pending_seq,
+                pending_prompt,
+                pending_signal_name,
+                pending_approval,
+                output,
+            ) = if let Some(pending) = run_result.paused {
+                (
+                    SessionStatus::Paused,
+                    Some(pending.seq),
+                    Some(pending.prompt),
+                    None,
+                    None,
+                    None,
+                )
+            } else if let Some(signal) = run_result.paused_signal {
+                // A `chidori.signal(name)` listen point with an empty mailbox.
+                // Reuse `Paused`; `pending_signal_name` (not the status) marks it
+                // as a signal pause so the delivery endpoint can match the name.
+                (
+                    SessionStatus::Paused,
+                    Some(signal.seq),
+                    None,
+                    Some(signal.name),
+                    None,
+                    None,
+                )
+            } else if let Some(appr) = run_result.paused_approval {
+                (
+                    SessionStatus::AwaitingApproval,
+                    None,
+                    None,
+                    None,
+                    Some(appr),
+                    None,
+                )
+            } else {
+                (
+                    SessionStatus::Completed,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(run_result.output),
+                )
+            };
             StoredSession {
                 id: id.clone(),
                 run_id: Some(run_result.run_id),
@@ -900,6 +1004,7 @@ async fn create_session(
                 error: None,
                 pending_seq,
                 pending_prompt,
+                pending_signal_name,
                 pending_approval,
                 approvals: Vec::new(),
                 policy_profile: policy_profile.clone(),
@@ -916,6 +1021,7 @@ async fn create_session(
             error: Some(e.to_string()),
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile,
@@ -1090,6 +1196,7 @@ async fn replay_session(State(state): State<AppState>, Path(id): Path<String>) -
                 error: None,
                 pending_seq: None,
                 pending_prompt: None,
+                pending_signal_name: None,
                 pending_approval: None,
                 approvals: original.approvals.clone(),
                 policy_profile: original.policy_profile.clone(),
@@ -1251,6 +1358,7 @@ async fn stream_session(
         error: None,
         pending_seq: None,
         pending_prompt: None,
+        pending_signal_name: None,
         pending_approval: None,
         approvals: Vec::new(),
         policy_profile: policy_profile.clone(),
@@ -1297,6 +1405,7 @@ async fn stream_session(
                     error: error.clone(),
                     pending_seq: None,
                     pending_prompt: None,
+                    pending_signal_name: None,
                     pending_approval: None,
                     approvals: Vec::new(),
                     policy_profile: policy_profile.clone(),
@@ -1338,6 +1447,7 @@ async fn stream_session(
                     error: Some(error.clone()),
                     pending_seq: None,
                     pending_prompt: None,
+                    pending_signal_name: None,
                     pending_approval: None,
                     approvals: Vec::new(),
                     policy_profile: policy_profile.clone(),
@@ -1430,6 +1540,7 @@ async fn cancel_session(
             error: Some(reason.clone()),
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -1474,6 +1585,126 @@ async fn cancel_session(
         "reason": reason,
     }))
     .into_response()
+}
+
+/// Shared tail of `resume_session` and `signal_session` (doc §9: "factor its
+/// shared tail into `complete_pending_and_resume(...)`"). The caller has already
+/// (1) resolved the persisted pending host operation and (2) appended the
+/// synthetic resume `CallRecord` (an `input` record for resume, a `signal`
+/// record for signal delivery) at the pending seq into `call_log`. This helper
+/// performs the common re-run: load the host-promise table, VFS, and signal
+/// mailbox; replay-run the agent (preserving the run id and per-session policy
+/// profile + approvals); and map the outcome back onto `original`, surfacing a
+/// fresh input/signal/approval pause or completion. Returns the HTTP `Response`.
+///
+/// Threading the signal inbox here is what lets a resumed run that reaches a
+/// *second* `signal(name)`/`pollSignal(name)` listen point drain a queued entry
+/// instead of pausing (doc §9, §3 of the stage spec).
+async fn complete_pending_and_resume(
+    state: &AppState,
+    original: StoredSession,
+    call_log: Vec<CallRecord>,
+) -> Response {
+    let input = original.input.clone();
+    let host_promises =
+        match load_persisted_host_promises(&state.run_base, original.run_id.as_deref()) {
+            Ok(host_promises) => host_promises,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": e.to_string()})),
+                )
+                    .into_response();
+            }
+        };
+    let approvals = original.approvals.clone();
+    let vfs = load_persisted_vfs(&state.run_base, original.run_id.as_deref());
+    let signal_inbox = load_persisted_signal_inbox(&state.run_base, original.run_id.as_deref());
+    let resume_run_id = original.run_id.clone();
+    let policy_profile = original.policy_profile.clone();
+    let app_state = state.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        let engine = build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
+        // Continue under the original run id (when known) so the resumed run
+        // keeps its persisted run directory and stays a single durable run,
+        // matching the live-VM resume path. Falls back to a fresh id only when
+        // the session never recorded one.
+        match resume_run_id {
+            Some(run_id) => engine
+                .run_replay_pausable_with_host_promises_vfs_signals_preserving_run_id(
+                    &app_state.agent_path,
+                    &input,
+                    call_log,
+                    host_promises,
+                    vfs,
+                    signal_inbox,
+                    run_id,
+                ),
+            None => engine.run_replay_pausable_with_host_promises_vfs_and_signals(
+                &app_state.agent_path,
+                &input,
+                call_log,
+                host_promises,
+                vfs,
+                signal_inbox,
+            ),
+        }
+    })
+    .await
+    .unwrap();
+
+    let mut session = original;
+    match result {
+        Ok(run_result) => {
+            session.run_id = Some(run_result.run_id);
+            session.call_log = run_result.call_log.into_records();
+            if let Some(pending) = run_result.paused {
+                session.status = SessionStatus::Paused;
+                session.pending_seq = Some(pending.seq);
+                session.pending_prompt = Some(pending.prompt.clone());
+                session.pending_signal_name = None;
+                session.pending_approval = None;
+            } else if let Some(signal) = run_result.paused_signal {
+                // Re-run reached a NEW signal listen point with an empty mailbox.
+                // Persist it exactly like an input pause (the pending op + host
+                // promise table + shrunken inbox were already written to disk by
+                // the runtime safepoints); surface the awaited name in the view.
+                session.status = SessionStatus::Paused;
+                session.pending_seq = Some(signal.seq);
+                session.pending_prompt = None;
+                session.pending_signal_name = Some(signal.name);
+                session.pending_approval = None;
+            } else if let Some(appr) = run_result.paused_approval {
+                session.status = SessionStatus::AwaitingApproval;
+                session.pending_seq = None;
+                session.pending_prompt = None;
+                session.pending_signal_name = None;
+                session.pending_approval = Some(appr);
+            } else {
+                session.status = SessionStatus::Completed;
+                session.output = Some(run_result.output.clone());
+                session.pending_seq = None;
+                session.pending_prompt = None;
+                session.pending_signal_name = None;
+                session.pending_approval = None;
+            }
+            if let Some(err) = store_or_500(state, &session) {
+                return err;
+            }
+            (StatusCode::OK, Json(session_view(&session))).into_response()
+        }
+        Err(e) => {
+            session.status = SessionStatus::Failed;
+            session.error = Some(e.to_string());
+            let _ = state.session_store.put(&session);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response()
+        }
+    }
 }
 
 /// POST /sessions/:id/resume — supply a response to the agent's pending
@@ -1564,92 +1795,197 @@ async fn resume_session(
         error: None,
     });
 
-    let input = original.input.clone();
-    let input_clone = input.clone();
-    let host_promises =
-        match load_persisted_host_promises(&state.run_base, original.run_id.as_deref()) {
-            Ok(host_promises) => host_promises,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": e.to_string()})),
-                )
-                    .into_response();
-            }
-        };
-    let approvals = original.approvals.clone();
-    let vfs = load_persisted_vfs(&state.run_base, original.run_id.as_deref());
-    let resume_run_id = original.run_id.clone();
-    let policy_profile = original.policy_profile.clone();
-    let app_state = state.clone();
+    complete_pending_and_resume(&state, original, call_log).await
+}
 
-    let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
-        // Continue under the original run id (when known) so the resumed run
-        // keeps its persisted run directory and stays a single durable run,
-        // matching the live-VM resume path. Falls back to a fresh id only when
-        // the session never recorded one.
-        match resume_run_id {
-            Some(run_id) => engine
-                .run_replay_pausable_with_host_promises_and_vfs_preserving_run_id(
-                    &app_state.agent_path,
-                    &input_clone,
-                    call_log,
-                    host_promises,
-                    vfs,
-                    run_id,
-                ),
-            None => engine.run_replay_pausable_with_host_promises_and_vfs(
-                &app_state.agent_path,
-                &input_clone,
-                call_log,
-                host_promises,
-                vfs,
-            ),
-        }
-    })
-    .await
-    .unwrap();
+/// POST /sessions/:id/signal — deliver a signal `{ name, payload, from }` to a
+/// run (`docs/signals.md` §9). `name` is a required string; `payload` is any
+/// JSON (default null); `from` is an optional provenance object (default null).
+///
+/// Routing by run state (doc §9 table):
+///   * Paused waiting on THIS name → resolve the pending `Signal` op with
+///     `{name,payload,from}`, inject a synthetic `signal` CallRecord, and resume
+///     via `complete_pending_and_resume` (the same machinery `/resume` uses).
+///   * Paused on a different name / on input / on approval, or Running → enqueue
+///     into `signals/inbox.json` (drained at the next matching listen point),
+///     202 Accepted.
+///   * Completed / Failed / Cancelled → 409 Conflict, NO inbox write (an orphan
+///     inbox would mislead a later replay).
+#[derive(Deserialize)]
+struct SignalRequest {
+    name: String,
+    #[serde(default)]
+    payload: Value,
+    #[serde(default)]
+    from: Value,
+}
 
-    let mut session = original;
-    match result {
-        Ok(run_result) => {
-            session.run_id = Some(run_result.run_id);
-            if let Some(pending) = run_result.paused {
-                session.status = SessionStatus::Paused;
-                session.call_log = run_result.call_log.into_records();
-                session.pending_seq = Some(pending.seq);
-                session.pending_prompt = Some(pending.prompt.clone());
-                session.pending_approval = None;
-            } else if let Some(appr) = run_result.paused_approval {
-                session.status = SessionStatus::AwaitingApproval;
-                session.call_log = run_result.call_log.into_records();
-                session.pending_seq = None;
-                session.pending_prompt = None;
-                session.pending_approval = Some(appr);
-            } else {
-                session.status = SessionStatus::Completed;
-                session.output = Some(run_result.output.clone());
-                session.call_log = run_result.call_log.into_records();
-                session.pending_seq = None;
-                session.pending_prompt = None;
-                session.pending_approval = None;
-            }
-            if let Some(err) = store_or_500(&state, &session) {
-                return err;
-            }
-            (StatusCode::OK, Json(session_view(&session))).into_response()
+async fn signal_session(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<SignalRequest>,
+) -> Response {
+    if body.name.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "signal requires a non-empty `name`"})),
+        )
+            .into_response();
+    }
+
+    let original = match state.session_store.get(&id) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "Session not found"})),
+            )
+                .into_response();
         }
         Err(e) => {
-            session.status = SessionStatus::Failed;
-            session.error = Some(e.to_string());
-            let _ = state.session_store.put(&session);
-            (
+            return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": e.to_string()})),
             )
-                .into_response()
+                .into_response();
         }
+    };
+
+    // Terminal runs reject delivery with no inbox write.
+    if matches!(
+        original.status,
+        SessionStatus::Completed | SessionStatus::Failed | SessionStatus::Cancelled
+    ) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": format!("session is {:?}; cannot accept signals", original.status),
+            })),
+        )
+            .into_response();
+    }
+
+    // Paused waiting on THIS exact name: resolve the pending pause with the
+    // newly arrived signal and resume. Tie-break (doc §11, pinned decision):
+    // "pending-pause-wins-with-newest" — when the run is paused on name X and a
+    // same-name entry is ALSO already queued in the inbox, the pending pause
+    // resolves with THIS just-delivered signal; the older queued entry stays in
+    // the inbox (threaded into the resumed run by `complete_pending_and_resume`)
+    // for the next `signal(name)` listen point.
+    let waiting_on_this_name = original.status == SessionStatus::Paused
+        && original.pending_signal_name.as_deref() == Some(body.name.as_str());
+
+    if waiting_on_this_name {
+        let Some(seq) = original.pending_seq else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "Signal-paused session has no pending seq"})),
+            )
+                .into_response();
+        };
+
+        if let Err(err) = validate_snapshot_manifest_for_resume(
+            &state.run_base,
+            original.run_id.as_deref(),
+            &state.agent_path,
+        ) {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({"error": err.to_string()})),
+            )
+                .into_response();
+        }
+
+        // The recorded signal result freezes `{name,payload,from}` (doc §8.3) —
+        // the match key on disk is `{name}` only.
+        let value = json!({
+            "name": body.name,
+            "payload": body.payload,
+            "from": body.from,
+        });
+
+        // Serialize against concurrent deliveries to the same run while we
+        // resolve the pending op + mutate the inbox-adjacent durable state.
+        let lock = state.signal_inbox_lock(original.run_id.as_deref().unwrap_or(&id));
+        let _guard = lock.lock().unwrap();
+
+        let completed = complete_persisted_pending_host_operation(
+            &state.run_base,
+            original.run_id.as_deref(),
+            Some((seq, PendingHostOperationKind::Signal)),
+            HostPromiseCompletion::Resolved(value.clone()),
+        );
+        match completed {
+            // The pending op matched a `Signal` at this seq: inject the synthetic
+            // `signal` record and resume (reusing the resume tail).
+            Ok(Some(_)) => {
+                drop(_guard);
+                let mut call_log = original.call_log.clone();
+                call_log.push(CallRecord {
+                    seq,
+                    parent_seq: None,
+                    function: "signal".to_string(),
+                    args: json!({ "name": body.name }),
+                    result: value,
+                    duration_ms: 0,
+                    token_usage: None,
+                    timestamp: chrono::Utc::now(),
+                    error: None,
+                });
+                complete_pending_and_resume(&state, original, call_log).await
+            }
+            // No matching pending op on disk (e.g. nothing persisted). Fall back
+            // to enqueueing so the signal is not lost.
+            Ok(None) => {
+                drop(_guard);
+                enqueue_and_respond(&state, &original, &id, body)
+            }
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": err.to_string()})),
+            )
+                .into_response(),
+        }
+    } else {
+        // Paused on a different name / input / approval, or Running: enqueue.
+        enqueue_and_respond(&state, &original, &id, body)
+    }
+}
+
+/// Enqueue a delivered signal into the run's durable mailbox and return a
+/// 202 Accepted body describing the assigned `delivery_seq`. Shared by the
+/// "paused-on-other / running" branch and the pending-op-missing fallback.
+fn enqueue_and_respond(
+    state: &AppState,
+    original: &StoredSession,
+    id: &str,
+    body: SignalRequest,
+) -> Response {
+    let run_id = match original.run_id.as_deref() {
+        Some(run_id) => run_id,
+        None => {
+            // No run directory yet (e.g. a Running session that hasn't recorded
+            // a run id). Key the mailbox by session id so it is still durable and
+            // is picked up once the run threads its inbox.
+            id
+        }
+    };
+    match enqueue_signal_to_inbox(state, run_id, &body.name, body.payload, body.from) {
+        Ok(queued) => (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "id": id,
+                "status": "queued",
+                "name": queued.name,
+                "delivery_seq": queued.delivery_seq,
+            })),
+        )
+            .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": err.to_string()})),
+        )
+            .into_response(),
     }
 }
 
@@ -1771,6 +2107,9 @@ async fn approve_session(
     let call_log = original.call_log.clone();
     let resume_run_id = original.run_id.clone();
     let vfs = load_persisted_vfs(&state.run_base, original.run_id.as_deref());
+    // Thread the signal mailbox so an approved run that reaches a `signal(name)`
+    // listen point drains a queued entry instead of pausing (doc §9, §3).
+    let signal_inbox = load_persisted_signal_inbox(&state.run_base, original.run_id.as_deref());
     let policy_profile = original.policy_profile.clone();
     let app_state = state.clone();
     let result = tokio::task::spawn_blocking(move || {
@@ -1785,20 +2124,22 @@ async fn approve_session(
         // the resumed run keeps its persisted directory.
         match resume_run_id {
             Some(run_id) => engine
-                .run_replay_pausable_with_host_promises_and_vfs_preserving_run_id(
+                .run_replay_pausable_with_host_promises_vfs_signals_preserving_run_id(
                     &app_state.agent_path,
                     &input,
                     call_log,
                     Vec::new(),
                     vfs,
+                    signal_inbox,
                     run_id,
                 ),
-            None => engine.run_replay_pausable_with_host_promises_and_vfs(
+            None => engine.run_replay_pausable_with_host_promises_vfs_and_signals(
                 &app_state.agent_path,
                 &input,
                 call_log,
                 Vec::new(),
                 vfs,
+                signal_inbox,
             ),
         }
     })
@@ -1813,6 +2154,12 @@ async fn approve_session(
                 session.status = SessionStatus::Paused;
                 session.pending_seq = Some(pending.seq);
                 session.pending_prompt = Some(pending.prompt);
+                session.pending_signal_name = None;
+            } else if let Some(signal) = run_result.paused_signal {
+                session.status = SessionStatus::Paused;
+                session.pending_seq = Some(signal.seq);
+                session.pending_prompt = None;
+                session.pending_signal_name = Some(signal.name);
             } else if let Some(appr) = run_result.paused_approval {
                 session.status = SessionStatus::AwaitingApproval;
                 session.pending_approval = Some(appr);
@@ -1944,6 +2291,7 @@ mod tests {
             run_semaphore: Arc::new(Semaphore::new(1)),
             acquire_timeout: std::time::Duration::from_millis(1),
             active_sessions: Arc::new(StdMutex::new(HashMap::new())),
+            signal_inbox_locks: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -1994,6 +2342,7 @@ mod tests {
                 error: None,
                 pending_seq: None,
                 pending_prompt: None,
+                pending_signal_name: None,
                 pending_approval: None,
                 approvals: Vec::new(),
                 policy_profile: None,
@@ -2273,6 +2622,7 @@ mod tests {
             error: None,
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2337,6 +2687,7 @@ mod tests {
             error: None,
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2403,6 +2754,7 @@ mod tests {
             error: None,
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2473,6 +2825,7 @@ mod tests {
             error: None,
             pending_seq: None,
             pending_prompt: None,
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2559,6 +2912,7 @@ mod tests {
             error: None,
             pending_seq: Some(2),
             pending_prompt: Some("continue?".to_string()),
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2657,6 +3011,7 @@ mod tests {
             error: None,
             pending_seq: Some(2),
             pending_prompt: Some("continue?".to_string()),
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2760,6 +3115,7 @@ mod tests {
             error: None,
             pending_seq: Some(2),
             pending_prompt: Some("continue?".to_string()),
+            pending_signal_name: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -3300,6 +3656,523 @@ mod tests {
             error.contains("denied by operator"),
             "expected an operator-denied error, got: {error}"
         );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Signal delivery (`docs/signals.md` §9–§11) — Stage 2.
+    // -----------------------------------------------------------------------
+
+    /// Build a state whose run_base is the agent's `.chidori/runs` dir (so a run
+    /// pausing on a signal persists into the same tree the delivery endpoint
+    /// reads), with a generous acquire timeout for the real engine runs.
+    fn signal_test_state(temp_dir: &FsPath, agent_path: PathBuf) -> AppState {
+        let run_base = temp_dir.join(".chidori").join("runs");
+        std::fs::create_dir_all(&run_base).unwrap();
+        let mut state = test_state(run_base, agent_path);
+        state.run_semaphore = Arc::new(Semaphore::new(4));
+        state.acquire_timeout = std::time::Duration::from_secs(30);
+        state
+    }
+
+    fn write_agent(temp_dir: &FsPath, source: &str) -> PathBuf {
+        std::fs::create_dir_all(temp_dir).unwrap();
+        let agent_path = temp_dir.join("agent.ts");
+        std::fs::write(&agent_path, source).unwrap();
+        agent_path
+    }
+
+    async fn create_paused_session(state: &AppState, id: &str, input: Value) -> Value {
+        let (_status, body) = response_json(
+            create_session(
+                State(state.clone()),
+                Json(
+                    serde_json::from_value(json!({
+                        "input": input,
+                        "session_id": id,
+                    }))
+                    .unwrap(),
+                ),
+            )
+            .await,
+        )
+        .await;
+        body
+    }
+
+    /// Signal delivered to a run paused waiting on THIS name resolves the pause
+    /// and resumes to completion; the final output and the session view reflect
+    /// the delivered payload.
+    #[tokio::test]
+    async fn signal_to_paused_waiting_this_name_resolves_and_resumes() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-resolve-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const review = await chidori.signal("review");
+                    return { decision: review.payload.decision, by: review.from.id };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "s-signal-1", json!({})).await;
+        assert_eq!(created["status"], json!("paused"));
+        assert_eq!(created["pending_signal_name"], json!("review"));
+
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("s-signal-1".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "approve" }),
+                    from: json!({ "kind": "human", "id": "mara" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(
+            body["output"],
+            json!({ "decision": "approve", "by": "mara" })
+        );
+
+        let stored = state.session_store.get("s-signal-1").unwrap().unwrap();
+        assert_eq!(stored.status, SessionStatus::Completed);
+        assert_eq!(stored.pending_signal_name, None);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Signal delivered to a run paused on `input()` (a different pause) is
+    /// enqueued; the run stays paused; after the input is resumed, the agent's
+    /// later `signal(name)` drains the queued entry without pausing again.
+    #[tokio::test]
+    async fn signal_to_input_paused_enqueues_then_drains_after_resume() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-enqueue-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const name = await chidori.input("who?");
+                    const review = await chidori.signal("review");
+                    return { name, decision: review.payload.decision };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "s-signal-2", json!({})).await;
+        assert_eq!(created["status"], json!("paused"));
+        // This is an input() pause, not a signal pause.
+        assert_eq!(created["pending_signal_name"], Value::Null);
+        let run_id = created["run_id"].as_str().unwrap().to_string();
+
+        // Deliver a "review" signal while paused on input → must enqueue.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("s-signal-2".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "changes" }),
+                    from: json!({ "id": "bot" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["status"], json!("queued"));
+        assert_eq!(body["delivery_seq"], json!(1));
+
+        // inbox.json exists with the entry, and the run is still paused.
+        let inbox = load_persisted_signal_inbox(&state.run_base, Some(&run_id));
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].name, "review");
+        let still_paused = state.session_store.get("s-signal-2").unwrap().unwrap();
+        assert_eq!(still_paused.status, SessionStatus::Paused);
+
+        // Resume the input(); the later signal() drains the queued entry.
+        let (status, body) = response_json(
+            resume_session(
+                State(state.clone()),
+                Path("s-signal-2".to_string()),
+                Json(ResumeRequest {
+                    response: "ada".to_string(),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(
+            body["output"],
+            json!({ "name": "ada", "decision": "changes" })
+        );
+
+        // Inbox was drained to empty by consumption.
+        let drained = load_persisted_signal_inbox(&state.run_base, Some(&run_id));
+        assert!(
+            drained.is_empty(),
+            "inbox should be drained, got {drained:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Signal delivered to a completed run → 409 Conflict and NO inbox file.
+    #[tokio::test]
+    async fn signal_to_completed_run_conflicts_with_no_inbox() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-409-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent() { return { ok: true }; }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "s-signal-3", json!({})).await;
+        assert_eq!(created["status"], json!("completed"));
+        let run_id = created["run_id"].as_str().unwrap().to_string();
+
+        let (status, _body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("s-signal-3".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: Value::Null,
+                    from: Value::Null,
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+
+        let inbox_path = state
+            .run_base
+            .join(&run_id)
+            .join(crate::runtime::snapshot::SIGNAL_INBOX_FILE);
+        assert!(
+            !inbox_path.exists(),
+            "completed run must not have an inbox written"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Determinism: enqueue-before-listen and pause-then-deliver produce the
+    /// identical recorded `signal` CallRecord and final output. Both paths use
+    /// the same agent body and deliver the same `{name,payload,from}`; only the
+    /// arrival timing differs (queued-then-drained vs pending-pause-resolved).
+    #[tokio::test]
+    async fn signal_enqueue_before_listen_matches_pause_then_deliver() {
+        let payload = json!({ "decision": "approve" });
+        let from = json!({ "kind": "human", "id": "mara" });
+
+        // Path A: pause-then-deliver. The agent reaches `signal("review")` with
+        // an empty mailbox, pauses, and the delivery resolves the pending pause.
+        let source_a = r#"
+            export async function agent(input, chidori) {
+                const review = await chidori.signal("review");
+                return { decision: review.payload.decision, by: review.from.id };
+            }
+        "#;
+        let dir_a =
+            std::env::temp_dir().join(format!("chidori-signal-det-a-{}", uuid::Uuid::new_v4()));
+        let agent_a = write_agent(&dir_a, source_a);
+        let state_a = signal_test_state(&dir_a, agent_a);
+        create_paused_session(&state_a, "a", json!({})).await;
+        response_json(
+            signal_session(
+                State(state_a.clone()),
+                Path("a".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: payload.clone(),
+                    from: from.clone(),
+                }),
+            )
+            .await,
+        )
+        .await;
+        let stored_a = state_a.session_store.get("a").unwrap().unwrap();
+
+        // Path B: enqueue-before-listen. The agent first pauses on `input()`; we
+        // deliver "review" while it is paused (so the signal is ENQUEUED, never a
+        // pending-pause), then resume the input(). When the agent reaches
+        // `signal("review")` it drains the queued entry WITHOUT pausing. The
+        // recorded signal value must be identical to Path A.
+        let source_b = r#"
+            export async function agent(input, chidori) {
+                await chidori.input("gate");
+                const review = await chidori.signal("review");
+                return { decision: review.payload.decision, by: review.from.id };
+            }
+        "#;
+        let dir_b =
+            std::env::temp_dir().join(format!("chidori-signal-det-b-{}", uuid::Uuid::new_v4()));
+        let agent_b = write_agent(&dir_b, source_b);
+        let state_b = signal_test_state(&dir_b, agent_b);
+        create_paused_session(&state_b, "b", json!({})).await;
+        // Deliver while paused on input → enqueued.
+        let (qstatus, _) = response_json(
+            signal_session(
+                State(state_b.clone()),
+                Path("b".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: payload.clone(),
+                    from: from.clone(),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(qstatus, StatusCode::ACCEPTED);
+        // Resume the input(); the later signal() drains the queued entry.
+        response_json(
+            resume_session(
+                State(state_b.clone()),
+                Path("b".to_string()),
+                Json(ResumeRequest {
+                    response: "go".to_string(),
+                }),
+            )
+            .await,
+        )
+        .await;
+        let stored_b = state_b.session_store.get("b").unwrap().unwrap();
+
+        // Identical recorded signal CallRecord (result + match-key args) and
+        // identical final output, regardless of arrival timing.
+        let sig_a = stored_a
+            .call_log
+            .iter()
+            .find(|r| r.function == "signal")
+            .unwrap();
+        let sig_b = stored_b
+            .call_log
+            .iter()
+            .find(|r| r.function == "signal")
+            .unwrap();
+        assert_eq!(sig_a.result, sig_b.result);
+        assert_eq!(sig_a.args, sig_b.args);
+        assert_eq!(stored_a.output, stored_b.output);
+
+        let _ = std::fs::remove_dir_all(dir_a);
+        let _ = std::fs::remove_dir_all(dir_b);
+    }
+
+    /// Tie-break (`docs/signals.md` §11, pinned "pending-pause-wins-with-newest"):
+    /// a queued same-name entry already in the inbox PLUS a pending pause on that
+    /// name PLUS a new delivery → the pause resolves with the NEW payload, and
+    /// the older queued entry survives for a later listen point.
+    #[tokio::test]
+    async fn signal_tie_break_pending_pause_wins_with_newest() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-tiebreak-{}", uuid::Uuid::new_v4()));
+        // Two sequential review listen points: the first consumes the new
+        // delivery (pause wins), the second drains the older queued entry.
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const first = await chidori.signal("review");
+                    const second = await chidori.signal("review");
+                    return { first: first.payload.tag, second: second.payload.tag };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "tie", json!({})).await;
+        let run_id = created["run_id"].as_str().unwrap().to_string();
+        assert_eq!(created["pending_signal_name"], json!("review"));
+
+        // Pre-seed an OLDER queued same-name entry directly into the inbox while
+        // the run is paused on the first `review`.
+        enqueue_signal_to_inbox(
+            &state,
+            &run_id,
+            "review",
+            json!({ "tag": "old-queued" }),
+            json!({ "id": "queued-sender" }),
+        )
+        .unwrap();
+
+        // Deliver a NEW review: the pending pause must resolve with THIS one.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("tie".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "tag": "new-delivered" }),
+                    from: json!({ "id": "live-sender" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        // First listen point got the NEW payload; second drained the OLD queued.
+        assert_eq!(
+            body["output"],
+            json!({ "first": "new-delivered", "second": "old-queued" })
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// End-to-end: an agent with two sequential `signal("review")` calls; two
+    /// deliveries; both recorded in order with their delivered payloads.
+    #[tokio::test]
+    async fn signal_two_sequential_listen_points_record_in_order() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-two-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const a = await chidori.signal("review");
+                    const b = await chidori.signal("review");
+                    return { a: a.payload.round, b: b.payload.round };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        create_paused_session(&state, "two", json!({})).await;
+
+        // First delivery resolves the first listen point; the run re-pauses on
+        // the second `review`.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("two".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "round": 1 }),
+                    from: json!({ "id": "r1" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("paused"));
+        assert_eq!(body["pending_signal_name"], json!("review"));
+
+        // Second delivery resolves the second listen point → completion.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("two".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "round": 2 }),
+                    from: json!({ "id": "r2" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(body["output"], json!({ "a": 1, "b": 2 }));
+
+        // Both signal records present, in seq order, with their payloads.
+        let stored = state.session_store.get("two").unwrap().unwrap();
+        let signals: Vec<_> = stored
+            .call_log
+            .iter()
+            .filter(|r| r.function == "signal")
+            .collect();
+        assert_eq!(signals.len(), 2);
+        assert!(signals[0].seq < signals[1].seq);
+        assert_eq!(signals[0].result["payload"], json!({ "round": 1 }));
+        assert_eq!(signals[1].result["payload"], json!({ "round": 2 }));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Pure replay (`/sessions/{id}/replay`) must NOT consume the inbox: a replay
+    /// with a non-empty inbox leaves the inbox file unchanged and reproduces the
+    /// identical output (the recorded `signal` call short-circuits before the
+    /// mailbox drain — the determinism contract, `docs/signals.md` §10).
+    #[tokio::test]
+    async fn replay_does_not_consume_inbox() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-replay-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const review = await chidori.signal("review");
+                    return { decision: review.payload.decision };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        // Drive a run to completion via a delivered signal.
+        let created = create_paused_session(&state, "replay-src", json!({})).await;
+        let run_id = created["run_id"].as_str().unwrap().to_string();
+        response_json(
+            signal_session(
+                State(state.clone()),
+                Path("replay-src".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "approve" }),
+                    from: json!({ "id": "x" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        let completed = state.session_store.get("replay-src").unwrap().unwrap();
+        assert_eq!(completed.status, SessionStatus::Completed);
+
+        // Seed a non-empty inbox under the run dir; replay must ignore it.
+        enqueue_signal_to_inbox(
+            &state,
+            &run_id,
+            "review",
+            json!({ "decision": "SHOULD-NOT-BE-USED" }),
+            json!({ "id": "ghost" }),
+        )
+        .unwrap();
+        let inbox_before = load_persisted_signal_inbox(&state.run_base, Some(&run_id));
+        assert_eq!(inbox_before.len(), 1);
+
+        let (status, body) = response_json(
+            replay_session(State(state.clone()), Path("replay-src".to_string())).await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        // Replay reproduces the recorded decision, not the ghost inbox entry.
+        assert_eq!(body["output"], json!({ "decision": "approve" }));
+
+        // Inbox file is untouched by replay.
+        let inbox_after = load_persisted_signal_inbox(&state.run_base, Some(&run_id));
+        assert_eq!(inbox_after, inbox_before);
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -43,6 +43,13 @@ pub struct StoredSession {
     pub error: Option<String>,
     pub pending_seq: Option<u64>,
     pub pending_prompt: Option<String>,
+    /// Set when status == Paused on a `chidori.signal(name)` listen point.
+    /// Carries the listen-point name so the view advertises which signal the
+    /// run is awaiting and the delivery endpoint can match `body.name` against
+    /// it. A signal pause reuses `SessionStatus::Paused`; this field (not the
+    /// status) distinguishes it from an `input()` pause. See `docs/signals.md`.
+    #[serde(default)]
+    pub pending_signal_name: Option<String>,
     /// Set when status == AwaitingApproval. Carries the (target, args)
     /// the policy is asking about so the UI can render a prompt.
     #[serde(default)]


### PR DESCRIPTION
Implements runtime signals per `docs/signals.md` — Phase 1 plus `pollSignal`. A running agent can now declare named listen points where external participants (humans or other agents) push information mid-run, while the whole session stays deterministically replayable.

## Agent API

```ts
const review = await chidori.signal<Review>("review");   // pause until delivered (or drain the mailbox)
const steer  = await chidori.pollSignal("steer");        // non-blocking: queued signal or null
```

Both resolve to `{ name, payload, from }`; every consumption is recorded in the call log, so replay returns the identical value without touching the inbox or the endpoint.

## Delivery

`POST /sessions/{id}/signal` with `{ name, payload?, from? }`:
- **Paused on this name** → resolves the pending host op and resumes (shares a `complete_pending_and_resume` tail with `/resume`), returning the advanced session view (200).
- **Paused on something else / still running** → durably enqueued into the per-run `signals/inbox.json` mailbox (monotonic `delivery_seq`, per-run lock), returning 202 `{ status: "queued", delivery_seq }`; drained at the next matching listen point.
- **Terminal run** → 409, no inbox write.

Session views expose `pending_signal_name` so callers can see which listen point a paused run is waiting on. Same-name tie-break is pinned (and tested) as pending-pause-wins-with-newest per §11 of the design doc.

## Determinism

The durable match key is `(seq, Signal, {name})`; payload/`from` live in the recorded result. Replay and the completed-host-op check short-circuit before the mailbox is ever consulted, and mailbox consumption persists the shrunken inbox in the same critical section that records the call — tests pin that enqueue-before-listen vs pause-then-deliver produce identical call logs, and that `/replay` never consumes the inbox.

## Also in this PR

- `RunResult.paused_signal` pause surfacing (sibling of input/approval pauses); `chidori run` reports "awaiting signal '<name>'".
- TypeScript + Python SDK: `client.signal(...)` returning the resumed `Session` or a `SignalQueued` descriptor, `Signal`/`SignalSender` agent types, `pending_signal_name` on session views.
- `examples/multiplayer-review/` — the design doc's §7 policy-doc agent (blocking `signal("review")` + non-blocking `pollSignal("steer")`) with a runnable curl walkthrough; verified end-to-end manually.
- `docs/signals.md` marked implemented (Phase 1 + `pollSignal` shipped; `signalAny`/`timeoutMs`/live in-memory delivery remain future work); README/TODO updated.

## Verification

- `cargo fmt --check` clean; `cargo test --workspace` green (211 lib + 15 bin + integration suites; 18 new signal tests across host_core, engine, and server).
- `sdk/typescript`: `npm run typecheck` + `npm run build` green; Python SDK suite 20/20 (4 new real-server signal tests).
- Manual multiplayer run: pause on `review` → queued `steer` (202) → review delivery resumes, drains the steer at `pollSignal`, re-pauses → approve publishes with `approvedBy` attribution; `trace` shows attributed `signal`/`poll_signal` records; `resume` reproduces identical output.

Follow-ups noted, not included: `signalAny`/`timeoutMs` (Phase 2), live in-memory delivery to running tasks (Phase 3), and a latent gap where `check.rs` rejects the `run()` entrypoint form that the runtime itself supports.

https://claude.ai/code/session_014bzjqLbubdusCPZws2uqmB

---
_Generated by [Claude Code](https://claude.ai/code/session_014bzjqLbubdusCPZws2uqmB)_