### PR TITLE
Add chidori.branch: in-agent execution branching (Phase 1 MVP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ An agent is a `.ts` file that exports an async `agent(input, chidori)` function.
 | `chidori.tool(name, args)` | Invoke a registered tool |
 | `chidori.callAgent(path, input)` | Call a sub-agent |
 | `chidori.parallel(fns)` | Run functions concurrently |
+| `chidori.branch(variants)` | Fork the run into per-strategy sub-runs from the current state; returns every outcome for comparison ([design](./docs/branching-execution.md)) |
 | `chidori.input(msg, options)` | Human-in-the-loop — pauses execution |
 | `chidori.signal(name, options)` | Multiplayer — pause at a named listen point until an outside party (human or agent) delivers `{ name, payload, from }`; drains a durable mailbox if one is queued |
 | `chidori.pollSignal(name)` | Non-blocking signal check — consume a queued signal of this name or resolve to `null` |

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,10 @@ completion audit lives in
 - [x] `chidori.callAgent()`
 - [x] `chidori.tool()`
 - [x] `chidori.parallel()`
+- [x] `chidori.branch()` — in-agent execution branching (Phase 1 of
+      `docs/branching-execution.md`): fork into per-strategy sub-runs from the
+      anchored state, outcomes returned for comparison; pausable/persisted
+      branches and the whole-agent replay-prefix model are future work.
 - [x] `chidori.retry()`
 - [x] `chidori.tryCall()`
 - [x] `chidori.http()`

--- a/TODO.md
+++ b/TODO.md
@@ -55,10 +55,12 @@ completion audit lives in
 - [x] `chidori.callAgent()`
 - [x] `chidori.tool()`
 - [x] `chidori.parallel()`
-- [x] `chidori.branch()` — in-agent execution branching (Phase 1 of
+- [x] `chidori.branch()` — in-agent execution branching (Phases 1 + 2 of
       `docs/branching-execution.md`): fork into per-strategy sub-runs from the
-      anchored state, outcomes returned for comparison; pausable/persisted
-      branches and the whole-agent replay-prefix model are future work.
+      anchored state with outcomes returned for comparison; persisted branch
+      stores with out-of-band resume and edit-and-rerun (`chidori branches` /
+      `branch-resume` / `branch-rerun`) and concurrency-capped wave execution.
+      The whole-agent replay-prefix model (Phase 3) is future work.
 - [x] `chidori.retry()`
 - [x] `chidori.tryCall()`
 - [x] `chidori.http()`

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -261,6 +261,24 @@ impl Engine {
             });
         let d = dispatch.clone();
         self.vm
+            .define_method(&chidori, "branch", 2, move |vm, _t, args| {
+                let variants = args
+                    .first()
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                let options = args
+                    .get(1)
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                forward_effect(
+                    vm,
+                    &d,
+                    "branch",
+                    serde_json::json!({ "variants": variants, "options": options }),
+                )
+            });
+        let d = dispatch.clone();
+        self.vm
             .define_method(&chidori, "execJs", 2, move |vm, _t, args| {
                 let source = args
                     .first()

--- a/docs/branching-execution.md
+++ b/docs/branching-execution.md
@@ -1,8 +1,30 @@
 # In-Agent Execution Branching — Design Doc & Implementation Plan
 
-> **Status:** Draft for review.
-> **Target engine:** pure-Rust JS engine (`CHIDORI_JS_ENGINE=rust`, `rust-engine`
-> feature). The default QuickJS path is untouched.
+> **Status:** Phase 1 (MVP) **implemented** — `chidori.branch` ships as a host
+> effect (`src/runtime/host_branch.rs`, dispatched from `bindings.rs`), with
+> SDK types, tests, and `examples/branching/`. Phases 2 (pausable/persisted
+> branches) and 3 (whole-agent replay-prefix model) remain future work.
+> **Target engine:** the doc was drafted before the QuickJS removal (#39);
+> `chidori-js` is now the only engine, so the `CHIDORI_JS_ENGINE=rust` /
+> `rust-engine`-feature framing below is historical. Implementation notes where
+> the shipped MVP deviates from the draft:
+> - Branch `source` paths resolve like `callAgent` paths (relative to the
+>   working directory) — the host backend doesn't track the parent agent's
+>   path. `source` is **required** in Phase 1 ("omit to reuse parent" would
+>   re-reach `chidori.branch` and recurse, §8.2).
+> - Sequence ranges still come from `ParallelBranchManifest::with_sequence_width`,
+>   but the slot id is derived from the parent's `branch`-call seq
+>   (`slot = seq / (width × count) + 1`) instead of a host-promise op id, so
+>   successive branch ops' reserved blocks grow linearly and stay disjoint.
+>   After the fan-out the branch records are folded into the parent log and the
+>   parent's counter advances past them — exactly what
+>   `absorb_replayed_subtree` reproduces on replay, keeping live and replayed
+>   sequence numbering aligned.
+> - Nested `chidori.branch` inside a branch is rejected (`is_branch` on the
+>   branch `RuntimeContext`): a nested fork would allocate ranges outside the
+>   parent branch's reserved range.
+> - Phase 1 reports a suspended branch as `status: "paused"` (+`pendingPrompt`)
+>   without persisting it for out-of-band resume; that is the Phase 2 work.
 > **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md),
 > [`docs/captured-effects-vfs-crypto-timers.md`](./captured-effects-vfs-crypto-timers.md).
 
@@ -358,26 +380,30 @@ satisfies the stated goal.
 
 ## 12. Implementation plan (phased)
 
-**Phase 1 — MVP: synchronous branching, outcomes returned**
-- `crates/chidori-js/src/lib.rs`: add `branch` to `install_chidori_effects` (§7). Test
-  it marshals/returns.
-- `src/runtime/rust_engine.rs`: `dispatch_effect` `"branch"` arm; new module
-  `host_branch.rs` (or inline) with `run_branches(ctx, tools, args) -> Result<Value>`:
-  reserved ranges via `ParallelBranchManifest::with_sequence_width`; per-branch fresh
-  `RuntimeContext` seeded from parent VFS/memory; `run_module` per variant; collect
-  `BranchOutcome[]`; wrap in `execute_durable_json_call(ctx, "branch", …)`.
-- `src/runtime/context.rs`: a constructor to build a branch `RuntimeContext` seeded
-  with parent VFS + memory + a base seq (reuse `with_replay*`/`new` patterns + the VFS
-  setter that already exists for resume).
-- `sdk/typescript/src/agent.ts`: `BranchVariant`/`BranchOutcome` + `branch` on
-  `Chidori`.
-- Tests (`--features rust-engine`): agent does shared work, then
-  `chidori.branch([{source:A},{source:B}])`; assert (a) two outcomes with the right
-  outputs, (b) branch records carry `parent_seq` = the `branch` seq, (c) records land
-  in disjoint reserved ranges, (d) a counting native tool proves the parent prefix
-  fired once (handed over, not re-run).
-- Example: `examples/branching/` — an agent that branches into two strategy modules
-  from a shared state and prints both outcomes (runs on `CHIDORI_JS_ENGINE=rust`).
+**Phase 1 — MVP: synchronous branching, outcomes returned** ✅ **shipped**
+- [x] `crates/chidori-js/src/lib.rs`: `branch` added to `install_chidori_effects` (§7),
+  marshalling `(variants, options)`.
+- [x] `src/runtime/host_branch.rs`: `run_branches(backend, args)` — reserved ranges via
+  `ParallelBranchManifest::with_sequence_width` (slot derived from the branch call's
+  seq), per-branch fresh `RuntimeContext` seeded from parent VFS, native
+  `run_agent_file` per variant, `BranchOutcome[]` collected, all inside
+  `execute_durable_json_call_at_seq(ctx, seq, "branch", …)`. Dispatched from the
+  `"branch"` arm in `bindings.rs` (the engine's effect dispatcher).
+- [x] `src/runtime/context.rs`: `RuntimeContext::for_branch` (parent VFS + config +
+  input mode + shared OTEL run span/event sink, reserved base seq, call stack seeded
+  with the parent `branch` seq so records nest), `is_branch`, and
+  `merge_branch_records` (folds branch records into the parent log without
+  re-emitting, advancing the counter the way replay's `absorb_replayed_subtree` does).
+- [x] `sdk/typescript/src/agent.ts`: `BranchVariant`/`BranchOutcome`/`BranchOptions` +
+  `branch` on `Chidori`.
+- [x] Tests (`src/runtime/host_branch.rs`): (a) two outcomes with the right outputs,
+  (b) branch records carry `parent_seq` = the `branch` seq, (c) records land in
+  disjoint reserved ranges, (d) a counting native tool proves the parent prefix fired
+  once (handed over, not re-run) — plus parent replay returning cached outcomes
+  without re-running branches, a paused-branch outcome, nested-branch rejection, and
+  fail-fast variant validation.
+- [x] Example: `examples/branching/` — shared research, two strategy modules, compare
+  and pick; replays via `chidori resume`.
 
 **Phase 2 — pausable + editable + persisted branches**
 - Persist each branch under `branch_store` (`source.ts`, `checkpoint.json`, snapshot

--- a/docs/branching-execution.md
+++ b/docs/branching-execution.md
@@ -1,17 +1,22 @@
 # In-Agent Execution Branching — Design Doc & Implementation Plan
 
-> **Status:** Phase 1 (MVP) **implemented** — `chidori.branch` ships as a host
+> **Status:** Phases 1 and 2 **implemented** — `chidori.branch` ships as a host
 > effect (`src/runtime/host_branch.rs`, dispatched from `bindings.rs`), with
-> SDK types, tests, and `examples/branching/`. Phases 2 (pausable/persisted
-> branches) and 3 (whole-agent replay-prefix model) remain future work.
+> persisted branch stores, out-of-band resume and edit-and-rerun (CLI:
+> `chidori branches` / `branch-resume` / `branch-rerun`), concurrency-capped
+> wave execution, SDK types, tests, and `examples/branching/`. Phase 3 (the
+> whole-agent replay-prefix model) remains future work.
 > **Target engine:** the doc was drafted before the QuickJS removal (#39);
 > `chidori-js` is now the only engine, so the `CHIDORI_JS_ENGINE=rust` /
 > `rust-engine`-feature framing below is historical. Implementation notes where
-> the shipped MVP deviates from the draft:
+> the shipped version deviates from the draft:
 > - Branch `source` paths resolve like `callAgent` paths (relative to the
 >   working directory) — the host backend doesn't track the parent agent's
->   path. `source` is **required** in Phase 1 ("omit to reuse parent" would
->   re-reach `chidori.branch` and recurse, §8.2).
+>   path. `source` is **required** ("omit to reuse parent" would re-reach
+>   `chidori.branch` and recurse, §8.2).
+> - `branchId` is `<parent run id>-op<branch seq>-branch-<k>` (not
+>   `<parent run id>-branch-<k>`) so ids stay unique when one run forks more
+>   than once; it maps 1:1 to the branch-store path.
 > - Sequence ranges still come from `ParallelBranchManifest::with_sequence_width`,
 >   but the slot id is derived from the parent's `branch`-call seq
 >   (`slot = seq / (width × count) + 1`) instead of a host-promise op id, so
@@ -23,8 +28,24 @@
 > - Nested `chidori.branch` inside a branch is rejected (`is_branch` on the
 >   branch `RuntimeContext`): a nested fork would allocate ranges outside the
 >   parent branch's reserved range.
-> - Phase 1 reports a suspended branch as `status: "paused"` (+`pendingPrompt`)
->   without persisting it for out-of-band resume; that is the Phase 2 work.
+> - Phase 2 persistence is **replay-native**, not VM snapshots: the QuickJS-era
+>   `save_live_parallel_branch_runtime_snapshot` / `resume_live_parallel_branch_from_store`
+>   blob helpers were not used (resume is call-log replay everywhere post-#39).
+>   Each branch persists `source.ts` + `checkpoint.json` + `branch.json` under
+>   `.chidori/runs/<run>/branches/op-<seq>/branch-<k>/`, with the fork-time VFS
+>   in a per-op `anchor.json`. Resume = replay the branch checkpoint with a
+>   synthetic `input` record (the server's `/resume` mechanism); edit-and-rerun
+>   = fresh run from the anchor with the stored (editable) source. The "relaxed
+>   `ensure_sources_match` loader" is moot — branch runs never go through the
+>   manifest source gate. Resume answers `input()` pauses; approval/signal
+>   pauses are reported but not yet resumable out-of-band.
+> - Concurrency runs variants in waves of `options.concurrency` OS threads
+>   (default 1 — sequential), settling/merging in variant order after each wave
+>   joins, so the durable log and outcome order are deterministic regardless of
+>   completion order. (The server's `run_semaphore` is not involved — branches
+>   are in-process workers under the parent run's slot.)
+> - A resumed/re-run branch updates only its own store; the parent's recorded
+>   `branch` outcome is immutable history (compare, don't merge).
 > **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md),
 > [`docs/captured-effects-vfs-crypto-timers.md`](./captured-effects-vfs-crypto-timers.md).
 
@@ -405,14 +426,26 @@ satisfies the stated goal.
 - [x] Example: `examples/branching/` — shared research, two strategy modules, compare
   and pick; replays via `chidori resume`.
 
-**Phase 2 — pausable + editable + persisted branches**
-- Persist each branch under `branch_store` (`source.ts`, `checkpoint.json`, snapshot
-  blob). Pause → `save_live_parallel_branch_runtime_snapshot`; resume →
-  `resume_live_parallel_branch_from_store`. `status:"paused"`+`branchId` outcomes.
-- Relaxed branch loader: skip `ensure_sources_match` for branches.
-- Edit-and-rerun a single branch from the parent anchor with edited `source.ts`.
-- Tests: pause a branch on `chidori.input`, resume with a value, assert continuation;
-  edit a branch source, re-run, assert divergent output from the same anchor.
+**Phase 2 — pausable + editable + persisted branches** ✅ **shipped**
+(replay-native adaptation — see the status header for the deltas from this draft)
+- [x] Persist each branch under `.chidori/runs/<run>/branches/op-<seq>/branch-<k>/`
+  (`source.ts`, `checkpoint.json`, `branch.json`; fork-time VFS in the per-op
+  `anchor.json`). The anchor and source copies are written *before* the fan-out
+  runs, so a crash mid-fan-out still leaves re-runnable stores.
+  `status:"paused"`+`branchId` outcomes carry the resume handle.
+- [x] Resume: `resume_branch` (host_branch.rs; `Engine::resume_branch`;
+  `chidori branch-resume <run> <branch-id> --value …`) — synthetic `input`
+  record + checkpoint replay, continuing live to the next outcome.
+- [x] Edit-and-rerun: `rerun_branch` (`Engine::rerun_branch`;
+  `chidori branch-rerun <run> <branch-id>`) — fresh run from the anchor with
+  the edited `source.ts`; `ensure_sources_match` never applies to branch runs.
+- [x] `chidori branches <run>` lists a run's persisted branch stores.
+- [x] Concurrency (from §15): `options.concurrency` runs variants in waves of
+  worker threads; outcome order and the merged log stay variant-ordered.
+- [x] Tests: pause a branch on `chidori.input`, resume with a value out-of-band,
+  assert continuation + store update + range confinement; edit a branch source,
+  re-run, assert divergent output from the same anchor (fork-time VFS + input
+  preserved); a rendezvous tool proves real overlap under `concurrency: 2`.
 
 **Phase 3 — whole-agent replay-prefix model (optional, §8.9)**
 - `try_replay_checked` branch-mode soft divergence; `replay.rs` `Mode::Branch` +
@@ -444,7 +477,8 @@ satisfies the stated goal.
 
 ## 15. Future work
 - Merge/promote a chosen branch into the parent run.
-- Concurrent branch execution via `run_semaphore`.
+- ~~Concurrent branch execution via `run_semaphore`.~~ Done — in-process worker
+  threads capped by `options.concurrency` (see the status header).
 - A comparison view in tael keyed on the `branch` span (diff branch subtrees).
 - Server/SDK surface (`POST /sessions/{id}/fork`, `session.fork()`) if a programmatic
   (non-in-agent) driver is later wanted.

--- a/examples/branching/README.md
+++ b/examples/branching/README.md
@@ -1,0 +1,69 @@
+# Branching — fork an agent into strategies, compare, pick one
+
+A runnable example of **`chidori.branch`** (see
+[`docs/branching-execution.md`](../../docs/branching-execution.md)): an agent
+forks itself mid-run into N branches that each explore a strategy **from the
+same anchored state**, then compares the outcomes and picks one.
+
+The agent ([`agent.ts`](./agent.ts)) does shared "research" once, then forks:
+
+```ts
+const outcomes = await chidori.branch([
+  { label: "outline-first", source: "examples/branching/strategies/outline_first.ts", input: { topic, research } },
+  { label: "draft-direct",  source: "examples/branching/strategies/draft_direct.ts",  input: { topic, research } },
+]);
+const best = outcomes.filter((o) => o.status === "completed").reduce(pick);
+```
+
+Why this beats re-running the whole agent per idea:
+
+- **The prefix is paid once.** Branches act on the prefix's *result* (the
+  parent's VFS plus the explicit `input`); they don't re-derive it — so the
+  shared state is byte-identical across branches and the only variable is each
+  branch's code. A controlled experiment, not a stochastic re-roll.
+- **Each branch is its own editable source.** Edit
+  `strategies/outline_first.ts` and re-run: the branch re-anchors to the same
+  shared state, the other strategy is untouched.
+- **One durable record.** The fan-out is recorded as a single `branch` call
+  whose result is the outcomes array. `chidori replay <run-id>` returns it
+  from the call log without re-running either branch.
+- **Branches nest in the trace.** Each branch's host calls carry
+  `parent_seq = the branch call's seq`, so an OTLP viewer (tael) shows a
+  `branch` span with one subtree per strategy, side by side.
+
+## Run it
+
+```bash
+cargo run -- run examples/branching/agent.ts --input '{"topic": "incident postmortem"}'
+```
+
+Branch `source` paths resolve like `callAgent` paths (relative to the working
+directory), so run from the repository root.
+
+With an OTLP endpoint configured the fork is visible live:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 \
+  cargo run -- run examples/branching/agent.ts
+```
+
+The strategies are offline-friendly local transforms; swap their bodies for
+`chidori.prompt(...)` calls to compare real model strategies (each branch's
+LLM spend is live — cap the fan-out accordingly).
+
+## Outcome shape
+
+```ts
+type BranchOutcome = {
+  label: string;
+  branchId: string;              // <parent run id>-branch-<k>
+  status: "completed" | "paused" | "failed";
+  output?: Json;                 // when completed
+  pendingPrompt?: string;        // when paused (e.g. a chidori.input prompt)
+  error?: string;                // when failed
+};
+```
+
+A `paused` branch is reported (Phase 1) — resuming it out-of-band is the
+Phase 2 follow-up in the design doc. Nested `chidori.branch` inside a branch
+is rejected.

--- a/examples/branching/README.md
+++ b/examples/branching/README.md
@@ -56,7 +56,7 @@ LLM spend is live — cap the fan-out accordingly).
 ```ts
 type BranchOutcome = {
   label: string;
-  branchId: string;              // <parent run id>-branch-<k>
+  branchId: string;              // <parent run id>-op<branch seq>-branch-<k>
   status: "completed" | "paused" | "failed";
   output?: Json;                 // when completed
   pendingPrompt?: string;        // when paused (e.g. a chidori.input prompt)
@@ -64,6 +64,29 @@ type BranchOutcome = {
 };
 ```
 
-A `paused` branch is reported (Phase 1) — resuming it out-of-band is the
-Phase 2 follow-up in the design doc. Nested `chidori.branch` inside a branch
-is rejected.
+Nested `chidori.branch` inside a branch is rejected. Pass
+`{ concurrency: N }` as the second argument to run up to N branches at once
+(default 1 — sequential); outcome order always follows variant order.
+
+## The branch store: resume and edit-and-rerun
+
+Each branch persists under the parent run
+(`.chidori/runs/<run>/branches/op-<seq>/branch-<k>/`): its own editable
+`source.ts`, its call log, and the fork-time anchor. That makes a branch
+independently operable **after the parent has moved on**:
+
+```bash
+# List this run's branches and their states:
+chidori branches <run-id> --dir examples/branching
+
+# A branch paused on chidori.input()? Answer it — the branch replays its
+# checkpoint with the response and runs to its next outcome:
+chidori branch-resume <run-id> <branch-id> --value "blue" --dir examples/branching
+
+# Edit a strategy and re-run ONLY that branch from the same anchored state:
+$EDITOR examples/branching/.chidori/runs/<run-id>/branches/op-*/branch-001/source.ts
+chidori branch-rerun <run-id> <branch-id> --dir examples/branching
+```
+
+A resumed or re-run branch updates its own store; the parent's recorded
+outcome is immutable history (compare, don't merge).

--- a/examples/branching/agent.ts
+++ b/examples/branching/agent.ts
@@ -1,0 +1,67 @@
+import type { BranchOutcome, Chidori } from "chidori";
+
+/**
+ * Branching example (docs/branching-execution.md).
+ *
+ * The agent does shared "expensive" prefix work once, then calls
+ * `chidori.branch` to fork into two strategy modules from that anchored state.
+ * Each branch runs its OWN source file (editable independently under
+ * `strategies/`), receives the prefix's result as explicit `input`, and
+ * returns an outcome. The agent compares the outcomes and picks one — the fork
+ * is a controlled experiment: the shared prefix is identical, so the only
+ * variable is each branch's code.
+ *
+ * Durability: the whole fan-out is ONE recorded `branch` call. Replaying this
+ * run (`chidori replay <run-id>`) returns the outcomes from the call log
+ * without re-running either branch.
+ *
+ * `summarizeBrief` is a local helper so the example runs offline with no LLM
+ * provider; swap it (and the strategies) for `chidori.prompt(...)` calls to
+ * see real model spans nested under each branch subtree in the trace.
+ */
+
+type Brief = { topic?: string };
+
+export async function agent(input: Brief, chidori: Chidori) {
+  const topic = input.topic ?? "incident postmortem";
+
+  // Shared prefix: paid once, handed to every branch as state.
+  await chidori.log(`researching: ${topic}`);
+  const research = summarizeBrief(topic);
+
+  const outcomes = await chidori.branch([
+    {
+      label: "outline-first",
+      source: "examples/branching/strategies/outline_first.ts",
+      input: { topic, research },
+    },
+    {
+      label: "draft-direct",
+      source: "examples/branching/strategies/draft_direct.ts",
+      input: { topic, research },
+    },
+  ]);
+
+  for (const outcome of outcomes) {
+    await chidori.log(
+      `branch ${outcome.label}: ${outcome.status}` +
+        (outcome.status === "failed" ? ` (${outcome.error})` : ""),
+    );
+  }
+
+  // Compare and pick: here, the longest completed draft wins.
+  const completed = outcomes.filter((o) => o.status === "completed");
+  const best = completed.reduce((a, b) => (score(a) >= score(b) ? a : b));
+  await chidori.log(`picked: ${best.label}`);
+
+  return { picked: best.label, draft: best.output, outcomes };
+}
+
+function score(outcome: BranchOutcome): number {
+  const draft = (outcome.output as { draft?: string } | undefined)?.draft ?? "";
+  return draft.length;
+}
+
+function summarizeBrief(topic: string): string {
+  return `key facts about ${topic}: timeline reconstructed; root cause identified; two follow-ups proposed`;
+}

--- a/examples/branching/strategies/draft_direct.ts
+++ b/examples/branching/strategies/draft_direct.ts
@@ -1,0 +1,15 @@
+import type { Chidori } from "chidori";
+
+/**
+ * Strategy B: write a flowing draft straight from the research, no outline.
+ * The variant under test against `outline_first.ts` — same anchored input,
+ * different approach.
+ */
+
+type BranchInput = { topic: string; research: string };
+
+export async function agent(input: BranchInput, chidori: Chidori) {
+  await chidori.log("draft-direct: writing straight through");
+  const draft = `# ${input.topic}\n\nIn short: ${input.research}. Told as one continuous narrative.`;
+  return { strategy: "draft-direct", draft };
+}

--- a/examples/branching/strategies/outline_first.ts
+++ b/examples/branching/strategies/outline_first.ts
@@ -1,0 +1,17 @@
+import type { Chidori } from "chidori";
+
+/**
+ * Strategy A: build an outline from the handed-over research, then expand each
+ * point. Edit this file freely — re-running the parent re-anchors the branch
+ * to the same shared prefix, so only this strategy's behavior changes.
+ */
+
+type BranchInput = { topic: string; research: string };
+
+export async function agent(input: BranchInput, chidori: Chidori) {
+  await chidori.log("outline-first: structuring before writing");
+  const points = input.research.split(";").map((p) => p.trim());
+  const outline = points.map((p, i) => `${i + 1}. ${p}`).join("\n");
+  const draft = `# ${input.topic}\n\n${outline}\n\nEach point expanded in order, building on the last.`;
+  return { strategy: "outline-first", draft };
+}

--- a/llm.txt
+++ b/llm.txt
@@ -180,9 +180,24 @@ source module (resolved like `callAgent` paths) on a fresh context whose
 records occupy a reserved, disjoint sequence range nested under the `branch`
 call, and returns `{ label, branchId, status, output?, pendingPrompt?,
 error? }`. The whole fan-out is one recorded durable call: replay returns the
-outcomes from the call log without re-running the branches. Nested
-`chidori.branch` inside a branch is rejected. See
-`docs/branching-execution.md`.
+outcomes from the call log without re-running the branches. Variants run in
+waves of `options.concurrency` worker threads (default 1 — sequential);
+outcome order always follows variant order. Nested `chidori.branch` inside a
+branch is rejected.
+
+When the parent run persists, each branch is stored under
+`.chidori/runs/<run>/branches/op-<seq>/branch-<k>/` (`source.ts`,
+`checkpoint.json`, `branch.json`, plus the fork-time VFS anchor), making
+branches independently operable after the parent moves on:
+
+```bash
+chidori branches <run-id>                                   # list branch stores
+chidori branch-resume <run-id> <branch-id> --value "blue"   # answer a paused input()
+chidori branch-rerun <run-id> <branch-id>                   # re-run edited source.ts from the anchor
+```
+
+A resumed or re-run branch updates only its own store; the parent's recorded
+`branch` outcome is immutable history. See `docs/branching-execution.md`.
 
 ### http
 

--- a/llm.txt
+++ b/llm.txt
@@ -164,6 +164,26 @@ const [a, b] = await chidori.parallel([
 The current TypeScript helper uses `Promise.all` semantics. True durable
 parallel host execution is gated on host-backed promises and branch snapshots.
 
+### branch
+
+```ts
+const outcomes = await chidori.branch([
+  { label: "outline-first", source: "strategies/outline_first.ts", input: { research } },
+  { label: "draft-direct", source: "strategies/draft_direct.ts", input: { research } },
+]);
+const best = outcomes.filter((o) => o.status === "completed").reduce(pick);
+```
+
+Fork the run into one sub-run per variant from the current anchored state (the
+parent's VFS plus each variant's explicit `input`). Each branch runs its own
+source module (resolved like `callAgent` paths) on a fresh context whose
+records occupy a reserved, disjoint sequence range nested under the `branch`
+call, and returns `{ label, branchId, status, output?, pendingPrompt?,
+error? }`. The whole fan-out is one recorded durable call: replay returns the
+outcomes from the call log without re-running the branches. Nested
+`chidori.branch` inside a branch is rejected. See
+`docs/branching-execution.md`.
+
 ### http
 
 ```ts

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -157,6 +157,41 @@ export interface ParallelOptions {
   concurrency?: number;
 }
 
+/**
+ * One `chidori.branch` variant (`docs/branching-execution.md` §6.1). A branch
+ * runs its own continuation source module from the parent's anchored state —
+ * not a re-run of the parent agent — so `source` is required.
+ */
+export interface BranchVariant {
+  /** Branch label, shown in outcomes and the trace. Defaults to `branch-<k>`. */
+  label?: string;
+  /** Branch source module path, resolved like `callAgent` paths. */
+  source: string;
+  /** State handed to the branch as its run input. Defaults to `{}`. */
+  input?: AgentJson;
+}
+
+export type BranchStatus = "completed" | "paused" | "failed";
+
+/** The result of one branch sub-run, returned for comparison (not merged). */
+export interface BranchOutcome<T extends AgentJson = AgentJson> {
+  label: string;
+  /** `<parent run id>-branch-<k>` — identifies the branch sub-run. */
+  branchId: string;
+  status: BranchStatus;
+  /** The branch's output, when `status` is `"completed"`. */
+  output?: T;
+  /** What the branch is waiting on, when `status` is `"paused"`. */
+  pendingPrompt?: string;
+  /** The failure message, when `status` is `"failed"`. */
+  error?: string;
+}
+
+export interface BranchOptions {
+  /** Requested live-branch concurrency (cost cap). The MVP runs sequentially. */
+  concurrency?: number;
+}
+
 export interface RetryOptions {
   attempts?: number;
   delayMs?: number;
@@ -259,6 +294,17 @@ export interface Chidori {
     path: string,
     input?: TInput,
   ): Promise<TOutput>;
+  /**
+   * Fork the run into one sub-run per variant from the current anchored state
+   * (the VFS plus each variant's explicit `input`), run each variant's own
+   * source module, and return every outcome so the agent can compare and pick.
+   * The whole fan-out is one recorded durable call: a replay of this run
+   * returns the outcomes from cache without re-running the branches.
+   */
+  branch<T extends AgentJson = AgentJson>(
+    variants: BranchVariant[],
+    options?: BranchOptions,
+  ): Promise<BranchOutcome<T>[]>;
   tool<TArgs extends JsonObject = JsonObject, TResult extends AgentJson = AgentJson>(
     name: string,
     args?: TArgs,

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -176,7 +176,11 @@ export type BranchStatus = "completed" | "paused" | "failed";
 /** The result of one branch sub-run, returned for comparison (not merged). */
 export interface BranchOutcome<T extends AgentJson = AgentJson> {
   label: string;
-  /** `<parent run id>-branch-<k>` — identifies the branch sub-run. */
+  /**
+   * `<parent run id>-op<branch seq>-branch-<k>` — identifies the branch
+   * sub-run, including for out-of-band `chidori branch-resume` /
+   * `branch-rerun` against its persisted store.
+   */
   branchId: string;
   status: BranchStatus;
   /** The branch's output, when `status` is `"completed"`. */
@@ -188,7 +192,11 @@ export interface BranchOutcome<T extends AgentJson = AgentJson> {
 }
 
 export interface BranchOptions {
-  /** Requested live-branch concurrency (cost cap). The MVP runs sequentially. */
+  /**
+   * Maximum branches running live at once (cost cap). Defaults to 1 —
+   * sequential. Higher values run variants in concurrent waves; outcome
+   * order always follows variant order.
+   */
   concurrency?: number;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,51 @@ enum Commands {
         dir: Option<PathBuf>,
     },
 
+    /// List a run's persisted `chidori.branch` sub-runs and their states.
+    Branches {
+        /// Run id (subdirectory name under `.chidori/runs/`)
+        run_id: String,
+
+        /// Project dir containing `.chidori/runs/` (defaults to current dir)
+        #[arg(short, long)]
+        dir: Option<PathBuf>,
+    },
+
+    /// Resume a paused branch sub-run by answering its pending input prompt.
+    /// The branch replays its checkpoint with the response and continues to
+    /// its next outcome; the parent run's history is untouched.
+    BranchResume {
+        /// Run id (subdirectory name under `.chidori/runs/`)
+        run_id: String,
+
+        /// Branch id, as reported in the branch outcome / `chidori branches`
+        branch_id: String,
+
+        /// The response to the branch's pending input prompt
+        #[arg(short, long)]
+        value: String,
+
+        /// Project dir containing `.chidori/runs/` (defaults to current dir)
+        #[arg(short, long)]
+        dir: Option<PathBuf>,
+    },
+
+    /// Re-run a branch sub-run fresh from its parent anchor, using its stored
+    /// (editable) `source.ts`. Edit the file under
+    /// `.chidori/runs/<run>/branches/.../source.ts`, then re-run: only that
+    /// strategy changes while the anchored state stays identical.
+    BranchRerun {
+        /// Run id (subdirectory name under `.chidori/runs/`)
+        run_id: String,
+
+        /// Branch id, as reported in the branch outcome / `chidori branches`
+        branch_id: String,
+
+        /// Project dir containing `.chidori/runs/` (defaults to current dir)
+        #[arg(short, long)]
+        dir: Option<PathBuf>,
+    },
+
     /// Pretty-print a persisted run's call log.
     Trace {
         /// Run id (subdirectory name under `.chidori/runs/`)
@@ -193,6 +238,21 @@ fn main() {
         Commands::Resume { file, run_id, dir } => {
             (cmd_resume(&file, &run_id, dir.as_deref()), false)
         }
+        Commands::Branches { run_id, dir } => (cmd_branches(&run_id, dir.as_deref()), false),
+        Commands::BranchResume {
+            run_id,
+            branch_id,
+            value,
+            dir,
+        } => (
+            cmd_branch_resume(&run_id, &branch_id, &value, dir.as_deref()),
+            false,
+        ),
+        Commands::BranchRerun {
+            run_id,
+            branch_id,
+            dir,
+        } => (cmd_branch_rerun(&run_id, &branch_id, dir.as_deref()), false),
         Commands::Trace { run_id, dir } => (cmd_trace(&run_id, dir.as_deref()), false),
         Commands::Snapshot { run_id, dir } => (cmd_snapshot(&run_id, dir.as_deref()), false),
         Commands::Serve {
@@ -756,6 +816,67 @@ fn cmd_resume(file: &PathBuf, run_id: &str, dir: Option<&std::path::Path>) -> Re
         run_id,
         result.call_log.total_duration_ms()
     );
+    Ok(())
+}
+
+/// Resolve `<base>/.chidori/runs/<run_id>` for the branch commands.
+fn branch_run_dir(run_id: &str, dir: Option<&std::path::Path>) -> Result<PathBuf> {
+    let base_dir = dir
+        .map(|d| d.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let run_dir = base_dir.join(".chidori").join("runs").join(run_id);
+    if !run_dir.is_dir() {
+        anyhow::bail!("No persisted run at {}", run_dir.display());
+    }
+    Ok(run_dir)
+}
+
+/// The engine for out-of-band branch operations, wired like `cmd_resume`'s:
+/// providers/policy from env, tools from `<base>/tools`.
+fn branch_engine(dir: Option<&std::path::Path>) -> Result<Engine> {
+    let base_dir = dir
+        .map(|d| d.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let providers = Arc::new(ProviderRegistry::from_env());
+    let template_engine = Arc::new(TemplateEngine::new(&base_dir));
+    let tokio_rt =
+        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+    let tools_dir = base_dir.join("tools");
+    let tools = Arc::new(
+        ToolRegistry::load_from_dirs(&[tools_dir]).unwrap_or_else(|_| ToolRegistry::new()),
+    );
+    Ok(Engine::new(providers, template_engine, tokio_rt).with_tools(tools))
+}
+
+fn cmd_branches(run_id: &str, dir: Option<&std::path::Path>) -> Result<()> {
+    let run_dir = branch_run_dir(run_id, dir)?;
+    let branches = Engine::list_branches(&run_dir)?;
+    if branches.is_empty() {
+        eprintln!("No persisted branches under {}", run_dir.display());
+        return Ok(());
+    }
+    println!("{}", serde_json::to_string_pretty(&branches)?);
+    Ok(())
+}
+
+fn cmd_branch_resume(
+    run_id: &str,
+    branch_id: &str,
+    value: &str,
+    dir: Option<&std::path::Path>,
+) -> Result<()> {
+    let run_dir = branch_run_dir(run_id, dir)?;
+    let engine = branch_engine(dir)?;
+    let outcome = engine.resume_branch(&run_dir, branch_id, value)?;
+    println!("{}", serde_json::to_string_pretty(&outcome)?);
+    Ok(())
+}
+
+fn cmd_branch_rerun(run_id: &str, branch_id: &str, dir: Option<&std::path::Path>) -> Result<()> {
+    let run_dir = branch_run_dir(run_id, dir)?;
+    let engine = branch_engine(dir)?;
+    let outcome = engine.rerun_branch(&run_dir, branch_id)?;
+    println!("{}", serde_json::to_string_pretty(&outcome)?);
     Ok(())
 }
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -455,9 +455,62 @@ impl RuntimeContext {
         }
     }
 
+    /// Rebuild the context for one persisted `chidori.branch` sub-run resumed
+    /// or re-run **out-of-band** — after the parent run has moved on (or its
+    /// process exited), so there is no live parent context to inherit from.
+    /// The anchor state comes from the branch store instead: the fork-time VFS
+    /// snapshot, the branch's reserved base sequence, and the parent `branch`
+    /// call's seq for call-stack seeding (so re-recorded records keep the same
+    /// parentage the original run stamped). `replay_log` carries the branch's
+    /// recorded records (plus a synthetic `input` record when resuming a
+    /// pause); pass an empty log for a fresh edit-and-rerun from the anchor.
+    /// Input mode is `Pause` so an unanswered later `input()` pauses again
+    /// rather than reading stdin.
+    pub fn for_branch_resume(
+        replay_log: Vec<CallRecord>,
+        vfs: Vfs,
+        base_seq: u64,
+        parent_branch_seq: u64,
+        run_id: String,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RuntimeContextInner {
+                config: AgentConfig::default(),
+                call_log: CallLog::new(),
+                seq: base_seq,
+                replay_log: Some(replay_log),
+                run_id,
+                persist_dir: None,
+                input_mode: InputMode::Pause,
+                pending_input: None,
+                pending_approval: None,
+                pending_signal: None,
+                signal_inbox: Vec::new(),
+                host_promises: HostPromiseTable::new(),
+                event_sender: None,
+                emit_call_events: true,
+                otel_run: None,
+                host_operation_safepoint: None,
+                host_operation_completion_safepoint: None,
+                workspace_root: default_workspace_root(),
+                call_stack: vec![parent_branch_seq],
+                capabilities: CapabilityLedger::new(),
+                vfs,
+                is_branch: true,
+                model_override: None,
+            })),
+        }
+    }
+
     /// Whether this context belongs to a `chidori.branch` sub-run.
     pub fn is_branch(&self) -> bool {
         self.inner.lock().unwrap().is_branch
+    }
+
+    /// The run's persistence directory, when persistence is enabled. Branch
+    /// sub-runs persist their stores under `<persist_dir>/branches/`.
+    pub fn persist_dir(&self) -> Option<PathBuf> {
+        self.inner.lock().unwrap().persist_dir.clone()
     }
 
     /// Fold a completed branch sub-run's records into this (parent) log without

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -175,6 +175,11 @@ struct RuntimeContextInner {
     /// Reads/writes never touch the host disk; the tree rides the snapshot
     /// manifest so it survives suspend → restore identically.
     pub vfs: Vfs,
+    /// Whether this context belongs to a `chidori.branch` sub-run. Branch
+    /// contexts may not fork again: a nested branch would allocate sequence
+    /// ranges outside the parent branch's reserved range and break the
+    /// disjointness invariant, so `run_branches` rejects it up front.
+    pub is_branch: bool,
     /// Optional host-supplied model override (Pi-style save point). When set,
     /// every prompt host call (`execute_prompt_text` / `execute_prompt_response`)
     /// consults it just before sending and, if it yields `Some(model)`, swaps
@@ -296,6 +301,7 @@ impl RuntimeContext {
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
                 vfs: vfs_from_seed_env(),
+                is_branch: false,
                 model_override: None,
             })),
         }
@@ -361,6 +367,7 @@ impl RuntimeContext {
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
                 vfs,
+                is_branch: false,
                 model_override: None,
             })),
         }
@@ -396,8 +403,79 @@ impl RuntimeContext {
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
                 vfs: vfs_from_seed_env(),
+                is_branch: false,
                 model_override: None,
             })),
+        }
+    }
+
+    /// Build the context for one `chidori.branch` sub-run, anchored to the
+    /// parent's state (`docs/branching-execution.md` §8.3): the parent's config,
+    /// VFS snapshot, input mode, workspace root, model override, streaming event
+    /// sink, and OTEL run span are inherited; the call log is fresh and the
+    /// sequence counter starts at `base_seq` (the branch's reserved
+    /// `CallLogSequenceRange` start minus one, so its records stay disjoint from
+    /// the parent and sibling branches). The call stack is seeded with
+    /// `parent_branch_seq` — the parent's `branch` call — so every top-level
+    /// record the branch makes carries `parent_seq = branch seq` and the shared
+    /// OTEL span tree nests the branch's subtree under the `branch` span.
+    pub fn for_branch(
+        parent: &RuntimeContext,
+        run_id: String,
+        base_seq: u64,
+        parent_branch_seq: u64,
+    ) -> Self {
+        let parent_inner = parent.inner.lock().unwrap();
+        Self {
+            inner: Arc::new(Mutex::new(RuntimeContextInner {
+                config: parent_inner.config.clone(),
+                call_log: CallLog::new(),
+                seq: base_seq,
+                replay_log: None,
+                run_id,
+                persist_dir: None,
+                input_mode: parent_inner.input_mode,
+                pending_input: None,
+                pending_approval: None,
+                pending_signal: None,
+                signal_inbox: Vec::new(),
+                host_promises: HostPromiseTable::new(),
+                event_sender: parent_inner.event_sender.clone(),
+                emit_call_events: parent_inner.emit_call_events,
+                otel_run: parent_inner.otel_run.clone(),
+                host_operation_safepoint: None,
+                host_operation_completion_safepoint: None,
+                workspace_root: parent_inner.workspace_root.clone(),
+                call_stack: vec![parent_branch_seq],
+                capabilities: CapabilityLedger::new(),
+                vfs: parent_inner.vfs.clone(),
+                is_branch: true,
+                model_override: parent_inner.model_override.clone(),
+            })),
+        }
+    }
+
+    /// Whether this context belongs to a `chidori.branch` sub-run.
+    pub fn is_branch(&self) -> bool {
+        self.inner.lock().unwrap().is_branch
+    }
+
+    /// Fold a completed branch sub-run's records into this (parent) log without
+    /// re-emitting stream events or OTEL spans — the branch context already
+    /// emitted them live. Advances the sequence counter past every merged seq,
+    /// mirroring what `absorb_replayed_subtree` does for the same subtree on
+    /// replay, so live and replayed runs agree on the next sequence number after
+    /// a `branch` op. Persists the checkpoint once at the end.
+    pub fn merge_branch_records(&self, records: Vec<CallRecord>) {
+        let mut inner = self.inner.lock().unwrap();
+        for record in records {
+            inner.seq = inner.seq.max(record.seq);
+            inner.call_log.push(record);
+        }
+        if let Some(ref dir) = inner.persist_dir {
+            if let Ok(json) = inner.call_log.to_json() {
+                let _ = std::fs::write(dir.join("checkpoint.json"), json);
+            }
         }
     }
 

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -161,6 +161,59 @@ impl Engine {
         self
     }
 
+    /// Resume a persisted, paused `chidori.branch` sub-run of the run at
+    /// `run_dir` by answering its pending `input()` prompt. The branch replays
+    /// its checkpoint with a synthetic input record and continues live to its
+    /// next outcome (out-of-band — the parent run is untouched history).
+    /// Returns the updated `BranchOutcome` JSON.
+    pub fn resume_branch(&self, run_dir: &Path, branch_id: &str, response: &str) -> Result<Value> {
+        let backend = self.branch_backend(branch_id)?;
+        crate::runtime::host_branch::resume_branch(&backend, run_dir, branch_id, response)
+            .map_err(|err| anyhow::anyhow!(err))
+    }
+
+    /// Re-run a persisted `chidori.branch` sub-run fresh from its parent
+    /// anchor with whatever its stored `source.ts` now contains — the
+    /// edit-and-rerun flow. Returns the updated `BranchOutcome` JSON.
+    pub fn rerun_branch(&self, run_dir: &Path, branch_id: &str) -> Result<Value> {
+        let backend = self.branch_backend(branch_id)?;
+        crate::runtime::host_branch::rerun_branch(&backend, run_dir, branch_id)
+            .map_err(|err| anyhow::anyhow!(err))
+    }
+
+    /// List the persisted branch stores of the run at `run_dir`.
+    pub fn list_branches(run_dir: &Path) -> Result<Vec<Value>> {
+        crate::runtime::host_branch::list_branches(run_dir).map_err(|err| anyhow::anyhow!(err))
+    }
+
+    /// The host backend for out-of-band branch operations: same wiring as a
+    /// run's backend (providers, policy + seeded approvals, tools, MCP); the
+    /// placeholder context is swapped for the rebuilt branch context inside
+    /// `host_branch`.
+    fn branch_backend(
+        &self,
+        branch_id: &str,
+    ) -> Result<crate::runtime::typescript::bindings::HostBindingBackend> {
+        let policy = RuntimePolicy::from_env_for_durable_run(branch_id)?;
+        let mut seeded = PolicyCache::default();
+        for (target, args) in &self.approvals {
+            seeded.approve(target, args);
+        }
+        Ok(
+            crate::runtime::typescript::bindings::HostBindingBackend::for_runtime(
+                RuntimeContext::new(),
+                self.providers.clone(),
+                self.template_engine.clone(),
+                self.tokio_rt.clone(),
+                self.policy.clone(),
+                Arc::new(StdMutex::new(seeded)),
+                policy,
+                self.tools.clone(),
+                self.mcp.clone(),
+            ),
+        )
+    }
+
     /// Parse and validate an agent or tool file without executing it.
     pub fn check(&self, path: &Path) -> Result<()> {
         if path.extension().and_then(|e| e.to_str()) == Some("ts") {

--- a/src/runtime/host_branch.rs
+++ b/src/runtime/host_branch.rs
@@ -1,0 +1,588 @@
+//! `chidori.branch` — in-agent execution branching (Phase 1 MVP).
+//!
+//! An agent forks itself mid-run into N branches that each explore a strategy
+//! from the same anchored state and return an outcome for comparison
+//! (`docs/branching-execution.md`). A branch is a **separate continuation
+//! source run once** — not a re-run of the parent (which would re-reach
+//! `chidori.branch` and recurse, §8.2). The prefix is handed over as state:
+//! each branch inherits the parent's VFS snapshot and receives an explicit
+//! `input`, then runs live on its own [`RuntimeContext`] whose sequence
+//! numbers come from a reserved, disjoint [`CallLogSequenceRange`].
+//!
+//! The whole fan-out is one recorded durable call on the parent, so a parent
+//! replay returns the outcomes from cache and never re-runs the branches.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+use crate::runtime::context::{RuntimeContext, PAUSE_MARKER};
+use crate::runtime::host_core;
+use crate::runtime::snapshot::{
+    HostOperationId, ParallelBranchManifest, DEFAULT_BRANCH_SEQUENCE_RANGE_WIDTH,
+};
+use crate::runtime::typescript::bindings::HostBindingBackend;
+
+/// Hard cap on the branch fan-out: every branch makes live host calls past the
+/// fork (real LLM/tool spend), so an unbounded `variants` array is a cost
+/// hazard before it is a correctness one.
+const MAX_BRANCHES: usize = 16;
+
+/// One validated `chidori.branch` variant: a label for outcomes/trace, the
+/// branch's own source module, and the state handed over as its run input.
+struct BranchVariant {
+    label: String,
+    source: String,
+    input: Value,
+}
+
+/// Run `chidori.branch(variants, options)`: fork the agent into one sub-run per
+/// variant from the parent's current state, sequentially (the MVP ignores
+/// `options.concurrency` beyond validating it), and return the
+/// `BranchOutcome[]` JSON the agent awaits. The fan-out executes inside the
+/// durable boundary as a single recorded `branch` call.
+pub(crate) fn run_branches(
+    backend: &HostBindingBackend,
+    args: &Value,
+) -> std::result::Result<Value, String> {
+    let ctx = backend
+        .runtime_ctx()
+        .ok_or("chidori.branch requires the runtime host backend")?;
+    if ctx.is_branch() {
+        return Err(
+            "nested chidori.branch is not supported: a branch cannot fork again (its records \
+             must stay inside the reserved sequence range of the parent branch)"
+                .to_string(),
+        );
+    }
+
+    let variants = parse_variants(args)?;
+    let concurrency = args
+        .get("options")
+        .and_then(|options| options.get("concurrency"))
+        .and_then(Value::as_u64)
+        .unwrap_or(1)
+        .max(1) as u32;
+
+    // Validate every branch source up front: failing fast before any branch
+    // runs means a typo'd path can't burn LLM spend on the variants before it.
+    for variant in &variants {
+        let path = Path::new(&variant.source);
+        if !path.is_file() {
+            return Err(format!(
+                "chidori.branch variant `{}`: source not found: {}",
+                variant.label, variant.source
+            ));
+        }
+    }
+
+    // Normalized args make the durable record self-describing (defaults
+    // resolved), independent of the exact JS-side argument shape.
+    let call_args = json!({
+        "variants": variants
+            .iter()
+            .map(|v| json!({ "label": v.label, "source": v.source, "input": v.input }))
+            .collect::<Vec<_>>(),
+        "options": { "concurrency": concurrency },
+    });
+
+    // Allocate the seq explicitly so the fan-out below can seed each branch
+    // context's call stack with it (`execute_durable_json_call` doesn't expose
+    // the seq to its `live()` closure).
+    let seq = ctx.next_seq();
+    host_core::execute_durable_json_call_at_seq(ctx, seq, "branch", call_args, || {
+        run_branches_live(backend, ctx, seq, &variants, concurrency)
+            .map_err(|err| anyhow::anyhow!(err))
+    })
+    .map_err(|err| err.to_string())
+}
+
+/// The live fan-out: reserve disjoint sequence ranges, run each variant on a
+/// fresh branch context, validate range confinement, fold the branch records
+/// into the parent log, and return the outcomes array.
+fn run_branches_live(
+    backend: &HostBindingBackend,
+    ctx: &RuntimeContext,
+    branch_seq: u64,
+    variants: &[BranchVariant],
+    concurrency: u32,
+) -> std::result::Result<Value, String> {
+    let count = variants.len() as u32;
+    let width = DEFAULT_BRANCH_SEQUENCE_RANGE_WIDTH;
+    // Reserve the next disjoint block of `count` ranges above every sequence
+    // number used so far. The manifest derives `base = slot * width * count`,
+    // so picking the first slot whose base clears the branch call's own seq
+    // keeps successive branch ops' ranges monotonically increasing (linear,
+    // not geometric, growth) and disjoint from all earlier records. The base
+    // never needs to be re-derived on replay — the recorded branch records
+    // keep their seqs and `absorb_replayed_subtree` realigns the counter.
+    let block = width.saturating_mul(u64::from(count));
+    let slot = branch_seq / block + 1;
+    let parent_run_id = ctx.run_id();
+    let manifest = ParallelBranchManifest::with_sequence_width(
+        parent_run_id.clone(),
+        HostOperationId(slot),
+        count,
+        concurrency,
+        width,
+    );
+
+    let mut outcomes = Vec::with_capacity(variants.len());
+    for (index, variant) in variants.iter().enumerate() {
+        let branch = manifest
+            .branch(index as u32)
+            .ok_or_else(|| format!("missing branch metadata for index {index}"))?;
+        let range = branch.sequence_range.clone();
+        let branch_id = format!("{parent_run_id}-branch-{index}");
+        let branch_ctx =
+            RuntimeContext::for_branch(ctx, branch_id.clone(), range.start - 1, branch_seq);
+        let branch_backend = backend
+            .with_runtime_ctx(branch_ctx.clone())
+            .ok_or("chidori.branch requires the runtime host backend")?;
+
+        let result = crate::runtime::rust_engine::run_agent_file(
+            Path::new(&variant.source),
+            &variant.input,
+            &branch_backend,
+        );
+
+        let mut outcome = json!({
+            "label": variant.label,
+            "branchId": branch_id,
+        });
+        match result {
+            Ok(output) => {
+                outcome["status"] = json!("completed");
+                outcome["output"] = output;
+            }
+            Err(err) if err.to_string().contains(PAUSE_MARKER) => {
+                // Phase 1: a suspended branch is reported, not resumable — the
+                // persisted-branch resume flow is Phase 2. Surface what the
+                // branch is waiting on so the agent (or a human) can decide.
+                outcome["status"] = json!("paused");
+                if let Some(pending) = branch_ctx.take_pending_input() {
+                    outcome["pendingPrompt"] = json!(pending.prompt);
+                } else if let Some(pending) = branch_ctx.take_pending_approval() {
+                    outcome["pendingPrompt"] =
+                        json!(format!("approval required: {}", pending.target));
+                } else if let Some(pending) = branch_ctx.take_pending_signal() {
+                    outcome["pendingPrompt"] =
+                        json!(format!("waiting on signal: {}", pending.name));
+                }
+            }
+            Err(err) => {
+                outcome["status"] = json!("failed");
+                outcome["error"] = json!(err.to_string());
+            }
+        }
+
+        // Disjointness is the determinism guarantee: every record the branch
+        // produced must sit inside its reserved range before it may join the
+        // parent's durable log. A violation is an invariant break (e.g. a
+        // branch that outgrew its range width), not a comparable outcome.
+        let records = branch_ctx.call_log().into_records();
+        for record in &records {
+            if !range.contains(record.seq) {
+                return Err(format!(
+                    "branch `{}` emitted call seq {} outside its reserved range {}..{}",
+                    variant.label, record.seq, range.start, range.end_exclusive
+                ));
+            }
+        }
+        ctx.merge_branch_records(records);
+
+        outcomes.push(outcome);
+    }
+
+    Ok(Value::Array(outcomes))
+}
+
+/// Parse and validate the `variants` array: each needs a `source` (the branch's
+/// own continuation module — reusing the parent source would re-reach
+/// `chidori.branch` and recurse, §8.2); `label` defaults to `branch-<k>` and
+/// `input` to `{}`.
+fn parse_variants(args: &Value) -> std::result::Result<Vec<BranchVariant>, String> {
+    let variants = args
+        .get("variants")
+        .and_then(Value::as_array)
+        .ok_or("chidori.branch requires an array of variants")?;
+    if variants.is_empty() {
+        return Err("chidori.branch requires at least one variant".to_string());
+    }
+    if variants.len() > MAX_BRANCHES {
+        return Err(format!(
+            "chidori.branch supports at most {MAX_BRANCHES} variants, got {}",
+            variants.len()
+        ));
+    }
+    variants
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| {
+            let label = variant
+                .get("label")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| format!("branch-{index}"));
+            let source = variant
+                .get("source")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| {
+                    format!(
+                        "chidori.branch variant `{label}` requires a `source` module path (a \
+                         branch runs its own continuation source, not a copy of the parent)"
+                    )
+                })?;
+            let input = variant
+                .get("input")
+                .cloned()
+                .filter(|value| !value.is_null())
+                .unwrap_or_else(|| json!({}));
+            Ok(BranchVariant {
+                label,
+                source,
+                input,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+
+    use serde_json::json;
+
+    use crate::mcp::McpManager;
+    use crate::policy::{PolicyCache, PolicyConfig};
+    use crate::providers::ProviderRegistry;
+    use crate::runtime::context::{InputMode, RuntimeContext};
+    use crate::runtime::rust_engine::run_agent;
+    use crate::runtime::snapshot::RuntimePolicy;
+    use crate::runtime::template::TemplateEngine;
+    use crate::runtime::typescript::bindings::HostBindingBackend;
+    use crate::tools::ToolRegistry;
+
+    /// A fully-wired runtime backend over `ctx`/`tools`, mirroring the
+    /// rust_engine test harness.
+    fn test_backend(ctx: RuntimeContext, tools: Arc<ToolRegistry>) -> HostBindingBackend {
+        HostBindingBackend::for_runtime(
+            ctx,
+            Arc::new(ProviderRegistry::new()),
+            Arc::new(TemplateEngine::new(".")),
+            Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            PolicyConfig::from_env(),
+            Arc::new(StdMutex::new(PolicyCache::default())),
+            RuntimePolicy::durable_default("branch-test"),
+            tools,
+            Arc::new(McpManager::new()),
+        )
+    }
+
+    /// A registry with a native `count` tool that increments `counter` and
+    /// echoes its `value` argument — the live-execution probe: replayed or
+    /// handed-over prefixes must not bump it.
+    fn counting_registry(counter: Arc<AtomicUsize>) -> Arc<ToolRegistry> {
+        let mut registry = ToolRegistry::new();
+        registry.register_native(
+            "count",
+            "counts live invocations",
+            Vec::new(),
+            move |args| {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({ "value": args.get("value").cloned().unwrap_or(json!(0)) }))
+            },
+        );
+        Arc::new(registry)
+    }
+
+    fn write_branch_sources(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        std::fs::write(
+            dir.join("branches").join("double.ts"),
+            r#"
+            export async function agent(input: { base: number }) {
+                await chidori.log("strategy double");
+                return { strategy: "double", value: input.base * 2 };
+            }
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("branches").join("triple.ts"),
+            r#"
+            export async function agent(input: { base: number }) {
+                await chidori.log("strategy triple");
+                return { strategy: "triple", value: input.base * 3 };
+            }
+            "#,
+        )
+        .unwrap();
+    }
+
+    /// The shared parent agent: one live tool call (the prefix), a two-variant
+    /// branch, and a post-branch host call (which proves live/replay sequence
+    /// alignment after the fan-out).
+    fn parent_agent_source(dir: &std::path::Path) -> String {
+        r#"
+            export async function agent(input: { base: number }) {
+                const seed = await chidori.tool("count", { value: input.base });
+                const outcomes = await chidori.branch([
+                    { label: "double", source: "__DIR__/branches/double.ts", input: { base: seed.value } },
+                    { label: "triple", source: "__DIR__/branches/triple.ts", input: { base: seed.value } },
+                ]);
+                await chidori.log("after branch");
+                return { outcomes };
+            }
+        "#
+        .replace("__DIR__", &dir.to_string_lossy())
+    }
+
+    #[test]
+    fn branch_runs_variants_with_disjoint_ranges_and_nested_records() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let ctx = RuntimeContext::new();
+        let dir = std::env::temp_dir().join(format!("chidori-branch-{}", uuid::Uuid::new_v4()));
+        write_branch_sources(&dir);
+        let path = dir.join("agent.ts");
+        let src = parent_agent_source(&dir);
+        std::fs::write(&path, &src).unwrap();
+
+        let backend = test_backend(ctx.clone(), counting_registry(counter.clone()));
+        let output = run_agent(&path, &src, &json!({ "value": 0, "base": 21 }), &backend).unwrap();
+
+        // Two outcomes, completed, with each strategy's output.
+        let outcomes = output["outcomes"].as_array().unwrap();
+        assert_eq!(outcomes.len(), 2);
+        assert_eq!(outcomes[0]["label"], json!("double"));
+        assert_eq!(outcomes[0]["status"], json!("completed"));
+        assert_eq!(
+            outcomes[0]["output"],
+            json!({ "strategy": "double", "value": 42 })
+        );
+        assert_eq!(outcomes[1]["label"], json!("triple"));
+        assert_eq!(
+            outcomes[1]["output"],
+            json!({ "strategy": "triple", "value": 63 })
+        );
+        assert_eq!(
+            outcomes[1]["branchId"],
+            json!(format!("{}-branch-1", ctx.run_id()))
+        );
+
+        // The prefix (the parent's `count` tool) fired exactly once: it was
+        // handed over as state, not re-run per branch.
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        // Branch records nest under the `branch` call and live in disjoint
+        // reserved ranges. With the parent's `tool` at seq 1 and `branch` at
+        // seq 2 (block = 2 * 10_000), the slot-derived base is 20_000:
+        // branch 0 owns [20_001, 30_001), branch 1 owns [30_001, 40_001).
+        let records = ctx.call_log().into_records();
+        let branch = records.iter().find(|r| r.function == "branch").unwrap();
+        assert_eq!(branch.seq, 2);
+        let log_double = records
+            .iter()
+            .find(|r| r.function == "log" && r.args["message"] == "strategy double")
+            .unwrap();
+        let log_triple = records
+            .iter()
+            .find(|r| r.function == "log" && r.args["message"] == "strategy triple")
+            .unwrap();
+        assert_eq!(log_double.parent_seq, Some(branch.seq));
+        assert_eq!(log_triple.parent_seq, Some(branch.seq));
+        assert!(
+            (20_001..30_001).contains(&log_double.seq),
+            "{}",
+            log_double.seq
+        );
+        assert!(
+            (30_001..40_001).contains(&log_triple.seq),
+            "{}",
+            log_triple.seq
+        );
+
+        // The post-branch parent call continues above the merged branch seqs.
+        let log_after = records
+            .iter()
+            .find(|r| r.function == "log" && r.args["message"] == "after branch")
+            .unwrap();
+        assert!(log_after.seq > log_triple.seq);
+        assert_eq!(log_after.parent_seq, None);
+
+        // The branch record's durable result is the outcomes array itself.
+        assert_eq!(branch.result.as_array().unwrap().len(), 2);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn branch_outcomes_replay_from_cache_without_rerunning_branches() {
+        // Branches that each make their own live tool call. On replay of the
+        // parent, the recorded `branch` outcome must come from cache: the
+        // counter stays at its live value and the output is identical.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let dir =
+            std::env::temp_dir().join(format!("chidori-branch-replay-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        for (name, factor) in [("double", 2), ("triple", 3)] {
+            std::fs::write(
+                dir.join("branches").join(format!("{name}.ts")),
+                format!(
+                    r#"
+                    export async function agent(input: {{ base: number }}) {{
+                        const counted = await chidori.tool("count", {{ value: input.base }});
+                        return {{ strategy: "{name}", value: counted.value * {factor} }};
+                    }}
+                    "#
+                ),
+            )
+            .unwrap();
+        }
+        let path = dir.join("agent.ts");
+        let src = parent_agent_source(&dir);
+        std::fs::write(&path, &src).unwrap();
+        let input = json!({ "value": 0, "base": 10 });
+
+        let live_ctx = RuntimeContext::new();
+        let registry = counting_registry(counter.clone());
+        let live_backend = test_backend(live_ctx.clone(), registry.clone());
+        let live_output = run_agent(&path, &src, &input, &live_backend).unwrap();
+        // One parent prefix call + one call per branch.
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+
+        let records = live_ctx.call_log().into_records();
+        let replay_ctx = RuntimeContext::with_replay(records);
+        let replay_backend = test_backend(replay_ctx, registry);
+        let replay_output = run_agent(&path, &src, &input, &replay_backend).unwrap();
+
+        assert_eq!(live_output, replay_output);
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            3,
+            "replay must not re-run branches"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn paused_branch_surfaces_pending_prompt_outcome() {
+        // A branch that suspends on `chidori.input` in Pause mode is reported
+        // as a paused outcome (resume is Phase 2); the parent run completes.
+        let ctx = RuntimeContext::new();
+        ctx.set_input_mode(InputMode::Pause);
+        let dir =
+            std::env::temp_dir().join(format!("chidori-branch-pause-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        std::fs::write(
+            dir.join("branches").join("ask.ts"),
+            r#"
+            export async function agent() {
+                const answer = await chidori.input("Which option?");
+                return { answer };
+            }
+            "#,
+        )
+        .unwrap();
+        let path = dir.join("agent.ts");
+        let src = r#"
+            export async function agent() {
+                const outcomes = await chidori.branch([
+                    { label: "ask", source: "__DIR__/branches/ask.ts" },
+                ]);
+                return { outcomes };
+            }
+        "#
+        .replace("__DIR__", &dir.to_string_lossy());
+        std::fs::write(&path, &src).unwrap();
+
+        let backend = test_backend(ctx, Arc::new(ToolRegistry::new()));
+        let output = run_agent(&path, &src, &json!({}), &backend).unwrap();
+
+        let outcome = &output["outcomes"][0];
+        assert_eq!(outcome["status"], json!("paused"));
+        assert_eq!(outcome["pendingPrompt"], json!("Which option?"));
+        assert!(outcome.get("output").is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn nested_branch_is_rejected_inside_a_branch() {
+        let ctx = RuntimeContext::new();
+        let dir =
+            std::env::temp_dir().join(format!("chidori-branch-nested-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        std::fs::write(
+            dir.join("branches").join("forker.ts"),
+            r#"
+            export async function agent() {
+                return await chidori.branch([{ label: "inner", source: "anything.ts" }]);
+            }
+            "#,
+        )
+        .unwrap();
+        let path = dir.join("agent.ts");
+        let src = r#"
+            export async function agent() {
+                const outcomes = await chidori.branch([
+                    { label: "forker", source: "__DIR__/branches/forker.ts" },
+                ]);
+                return { outcomes };
+            }
+        "#
+        .replace("__DIR__", &dir.to_string_lossy());
+        std::fs::write(&path, &src).unwrap();
+
+        let backend = test_backend(ctx, Arc::new(ToolRegistry::new()));
+        let output = run_agent(&path, &src, &json!({}), &backend).unwrap();
+
+        let outcome = &output["outcomes"][0];
+        assert_eq!(outcome["status"], json!("failed"));
+        assert!(
+            outcome["error"]
+                .as_str()
+                .unwrap()
+                .contains("nested chidori.branch"),
+            "{}",
+            outcome["error"]
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn branch_validates_variants_before_running_any() {
+        let ctx = RuntimeContext::new();
+        let dir =
+            std::env::temp_dir().join(format!("chidori-branch-invalid-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        // Missing `source` on the second variant must fail the whole call —
+        // before the first (valid-looking) variant runs anything.
+        let src = r#"
+            export async function agent() {
+                return await chidori.branch([
+                    { label: "a", source: "missing-on-purpose.ts" },
+                    { label: "b" },
+                ]);
+            }
+        "#;
+        std::fs::write(&path, src).unwrap();
+
+        let backend = test_backend(ctx.clone(), Arc::new(ToolRegistry::new()));
+        let err = run_agent(&path, src, &json!({}), &backend).unwrap_err();
+        assert!(
+            err.to_string().contains("requires a `source` module path"),
+            "{err}"
+        );
+        // Nothing ran, nothing recorded: validation precedes the durable call.
+        assert!(ctx.call_log().into_records().is_empty());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src/runtime/host_branch.rs
+++ b/src/runtime/host_branch.rs
@@ -1,4 +1,4 @@
-//! `chidori.branch` — in-agent execution branching (Phase 1 MVP).
+//! `chidori.branch` — in-agent execution branching.
 //!
 //! An agent forks itself mid-run into N branches that each explore a strategy
 //! from the same anchored state and return an outcome for comparison
@@ -11,36 +11,192 @@
 //!
 //! The whole fan-out is one recorded durable call on the parent, so a parent
 //! replay returns the outcomes from cache and never re-runs the branches.
+//! Variants run in waves of `options.concurrency` threads (default 1 —
+//! sequential); outcome order always follows variant order.
+//!
+//! ## The branch store (Phase 2)
+//!
+//! When the parent run persists (`.chidori/runs/<run id>/`), every branch
+//! sub-run is persisted under it:
+//!
+//! ```text
+//! <run dir>/branches/op-<branch seq>/
+//!   anchor.json              fork-time anchor: the parent VFS snapshot
+//!   branch-<k>/
+//!     source.ts              the branch's own EDITABLE source copy
+//!     checkpoint.json        the branch's call log (same shape as a run's)
+//!     branch.json            metadata: label, id, status, pending input,
+//!                            reserved sequence range, input, output/error
+//! ```
+//!
+//! That store makes a branch independently operable out-of-band, after the
+//! parent has moved on:
+//! - [`resume_branch`] answers a paused branch's pending `input()` by
+//!   replaying its checkpoint with a synthetic `input` record (the same
+//!   mechanism the server's `/resume` uses) and running to the next outcome.
+//! - [`rerun_branch`] re-runs a branch **fresh from the parent anchor** with
+//!   whatever `source.ts` now contains — edit the file, re-run, and only that
+//!   strategy changes while the anchored state stays identical.
+//!
+//! A resumed or re-run branch updates its own store; the parent's recorded
+//! `branch` outcome is immutable history (branches are independent referenced
+//! sub-runs, compared — not merged — per the design's non-goals).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::runtime::context::{RuntimeContext, PAUSE_MARKER};
+use crate::runtime::call_log::CallRecord;
+use crate::runtime::context::{PendingInput, RuntimeContext, PAUSE_MARKER};
 use crate::runtime::host_core;
 use crate::runtime::snapshot::{
-    HostOperationId, ParallelBranchManifest, DEFAULT_BRANCH_SEQUENCE_RANGE_WIDTH,
+    CallLogSequenceRange, HostOperationId, ParallelBranchManifest, BRANCHES_DIR,
+    DEFAULT_BRANCH_SEQUENCE_RANGE_WIDTH,
 };
 use crate::runtime::typescript::bindings::HostBindingBackend;
+use crate::runtime::vfs::Vfs;
 
 /// Hard cap on the branch fan-out: every branch makes live host calls past the
 /// fork (real LLM/tool spend), so an unbounded `variants` array is a cost
 /// hazard before it is a correctness one.
 const MAX_BRANCHES: usize = 16;
 
+/// Stack size for branch worker threads. The JS interpreter recurses with the
+/// agent's call depth, so give branch threads the same headroom the main
+/// thread gets rather than the 2 MiB std default.
+const BRANCH_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+
+const BRANCH_META_FILE: &str = "branch.json";
+const BRANCH_SOURCE_FILE: &str = "source.ts";
+const BRANCH_CHECKPOINT_FILE: &str = "checkpoint.json";
+const BRANCH_ANCHOR_FILE: &str = "anchor.json";
+const BRANCH_STORE_VERSION: u32 = 1;
+
 /// One validated `chidori.branch` variant: a label for outcomes/trace, the
-/// branch's own source module, and the state handed over as its run input.
+/// branch's own source module (path + the text read at validation time, which
+/// seeds the branch store's editable copy), and the state handed over as its
+/// run input.
 struct BranchVariant {
     label: String,
     source: String,
+    source_text: String,
     input: Value,
 }
 
-/// Run `chidori.branch(variants, options)`: fork the agent into one sub-run per
-/// variant from the parent's current state, sequentially (the MVP ignores
-/// `options.concurrency` beyond validating it), and return the
+/// Fork-time anchor persisted once per branch op: everything a branch needs to
+/// re-run from the same shared state after the parent is gone.
+#[derive(Serialize, Deserialize)]
+struct BranchAnchor {
+    version: u32,
+    parent_run_id: String,
+    branch_seq: u64,
+    vfs: Vfs,
+    created_at: DateTime<Utc>,
+}
+
+/// Per-branch metadata (`branch.json`): identity, anchor coordinates, the
+/// reserved sequence range, and the latest outcome state.
+#[derive(Serialize, Deserialize)]
+struct BranchMeta {
+    version: u32,
+    branch_id: String,
+    label: String,
+    branch_index: u32,
+    branch_seq: u64,
+    parent_run_id: String,
+    original_source: String,
+    input: Value,
+    sequence_range: CallLogSequenceRange,
+    status: String,
+    pending_input: Option<PendingInput>,
+    pending_prompt: Option<String>,
+    output: Option<Value>,
+    error: Option<String>,
+    updated_at: DateTime<Utc>,
+}
+
+/// How one branch run ended, normalized from `run_agent_file`'s result plus
+/// the branch context's pending state. Shared by the in-agent fan-out and the
+/// out-of-band resume/rerun paths so all three report identical outcomes.
+struct SettledBranch {
+    status: &'static str,
+    output: Option<Value>,
+    error: Option<String>,
+    pending_input: Option<PendingInput>,
+    pending_prompt: Option<String>,
+}
+
+fn settle_branch(result: anyhow::Result<Value>, branch_ctx: &RuntimeContext) -> SettledBranch {
+    match result {
+        Ok(output) => SettledBranch {
+            status: "completed",
+            output: Some(output),
+            error: None,
+            pending_input: None,
+            pending_prompt: None,
+        },
+        Err(err) if err.to_string().contains(PAUSE_MARKER) => {
+            // A suspended branch is reported as paused; when it suspended on
+            // `input()` the persisted pending op makes it resumable via
+            // `resume_branch`. Approval/signal pauses are reported but not yet
+            // resumable out-of-band.
+            let pending_input = branch_ctx.take_pending_input();
+            let pending_prompt = pending_input
+                .as_ref()
+                .map(|pending| pending.prompt.clone())
+                .or_else(|| {
+                    branch_ctx
+                        .take_pending_approval()
+                        .map(|pending| format!("approval required: {}", pending.target))
+                })
+                .or_else(|| {
+                    branch_ctx
+                        .take_pending_signal()
+                        .map(|pending| format!("waiting on signal: {}", pending.name))
+                });
+            SettledBranch {
+                status: "paused",
+                output: None,
+                error: None,
+                pending_input,
+                pending_prompt,
+            }
+        }
+        Err(err) => SettledBranch {
+            status: "failed",
+            output: None,
+            error: Some(err.to_string()),
+            pending_input: None,
+            pending_prompt: None,
+        },
+    }
+}
+
+fn branch_outcome_json(branch_id: &str, label: &str, settled: &SettledBranch) -> Value {
+    let mut outcome = json!({
+        "label": label,
+        "branchId": branch_id,
+        "status": settled.status,
+    });
+    if let Some(ref output) = settled.output {
+        outcome["output"] = output.clone();
+    }
+    if let Some(ref prompt) = settled.pending_prompt {
+        outcome["pendingPrompt"] = json!(prompt);
+    }
+    if let Some(ref error) = settled.error {
+        outcome["error"] = json!(error);
+    }
+    outcome
+}
+
+/// Run `chidori.branch(variants, options)`: fork the agent into one sub-run
+/// per variant from the parent's current state and return the
 /// `BranchOutcome[]` JSON the agent awaits. The fan-out executes inside the
-/// durable boundary as a single recorded `branch` call.
+/// durable boundary as a single recorded `branch` call; variants run in waves
+/// of `options.concurrency` worker threads (default 1 — sequential).
 pub(crate) fn run_branches(
     backend: &HostBindingBackend,
     args: &Value,
@@ -62,19 +218,8 @@ pub(crate) fn run_branches(
         .and_then(|options| options.get("concurrency"))
         .and_then(Value::as_u64)
         .unwrap_or(1)
-        .max(1) as u32;
-
-    // Validate every branch source up front: failing fast before any branch
-    // runs means a typo'd path can't burn LLM spend on the variants before it.
-    for variant in &variants {
-        let path = Path::new(&variant.source);
-        if !path.is_file() {
-            return Err(format!(
-                "chidori.branch variant `{}`: source not found: {}",
-                variant.label, variant.source
-            ));
-        }
-    }
+        .max(1)
+        .min(variants.len() as u64) as usize;
 
     // Normalized args make the durable record self-describing (defaults
     // resolved), independent of the exact JS-side argument shape.
@@ -97,15 +242,16 @@ pub(crate) fn run_branches(
     .map_err(|err| err.to_string())
 }
 
-/// The live fan-out: reserve disjoint sequence ranges, run each variant on a
-/// fresh branch context, validate range confinement, fold the branch records
-/// into the parent log, and return the outcomes array.
+/// The live fan-out: reserve disjoint sequence ranges, persist the fork
+/// anchor, run the variants in concurrency-capped waves on worker threads,
+/// validate range confinement, fold each branch's records into the parent
+/// log, persist each branch store, and return the outcomes array.
 fn run_branches_live(
     backend: &HostBindingBackend,
     ctx: &RuntimeContext,
     branch_seq: u64,
     variants: &[BranchVariant],
-    concurrency: u32,
+    concurrency: usize,
 ) -> std::result::Result<Value, String> {
     let count = variants.len() as u32;
     let width = DEFAULT_BRANCH_SEQUENCE_RANGE_WIDTH;
@@ -123,84 +269,134 @@ fn run_branches_live(
         parent_run_id.clone(),
         HostOperationId(slot),
         count,
-        concurrency,
+        concurrency as u32,
         width,
     );
 
+    // Persist the fork anchor + each branch's editable source copy up front,
+    // before any branch spends anything — so even a crash mid-fan-out leaves
+    // re-runnable branch stores behind. Best-effort: the durable record of the
+    // fan-out is the parent call log; the store enables out-of-band ops.
+    let store_op_dir = ctx
+        .persist_dir()
+        .map(|run_dir| op_dir(&run_dir, branch_seq));
+    if let Some(ref op_dir) = store_op_dir {
+        let anchor = BranchAnchor {
+            version: BRANCH_STORE_VERSION,
+            parent_run_id: parent_run_id.clone(),
+            branch_seq,
+            vfs: ctx.vfs_snapshot(),
+            created_at: Utc::now(),
+        };
+        if let Err(err) = persist_anchor_and_sources(op_dir, &anchor, variants) {
+            tracing::warn!(error = %err, "failed to persist branch store anchor");
+        }
+    }
+
     let mut outcomes = Vec::with_capacity(variants.len());
-    for (index, variant) in variants.iter().enumerate() {
-        let branch = manifest
-            .branch(index as u32)
-            .ok_or_else(|| format!("missing branch metadata for index {index}"))?;
-        let range = branch.sequence_range.clone();
-        let branch_id = format!("{parent_run_id}-branch-{index}");
-        let branch_ctx =
-            RuntimeContext::for_branch(ctx, branch_id.clone(), range.start - 1, branch_seq);
-        let branch_backend = backend
-            .with_runtime_ctx(branch_ctx.clone())
-            .ok_or("chidori.branch requires the runtime host backend")?;
-
-        let result = crate::runtime::rust_engine::run_agent_file(
-            Path::new(&variant.source),
-            &variant.input,
-            &branch_backend,
-        );
-
-        let mut outcome = json!({
-            "label": variant.label,
-            "branchId": branch_id,
-        });
-        match result {
-            Ok(output) => {
-                outcome["status"] = json!("completed");
-                outcome["output"] = output;
+    let indexed: Vec<(usize, &BranchVariant)> = variants.iter().enumerate().collect();
+    for wave in indexed.chunks(concurrency.max(1)) {
+        // One thread per branch in the wave; the chidori-js VM is built inside
+        // the thread, host effects flow through the branch's own context, and
+        // the disjoint sequence ranges keep concurrent records collision-free.
+        // Settling, validation, merging, and persistence happen back on this
+        // thread, in variant order, after the wave joins — so the merged log
+        // and the outcomes array are deterministic regardless of completion
+        // order.
+        let mut wave_runs = Vec::with_capacity(wave.len());
+        std::thread::scope(|scope| -> std::result::Result<(), String> {
+            let mut handles = Vec::with_capacity(wave.len());
+            for (index, variant) in wave {
+                let branch = manifest
+                    .branch(*index as u32)
+                    .ok_or_else(|| format!("missing branch metadata for index {index}"))?;
+                let range = branch.sequence_range.clone();
+                let branch_id = format!("{parent_run_id}-op{branch_seq}-branch-{index}");
+                let branch_ctx =
+                    RuntimeContext::for_branch(ctx, branch_id.clone(), range.start - 1, branch_seq);
+                let branch_backend = backend
+                    .with_runtime_ctx(branch_ctx.clone())
+                    .ok_or("chidori.branch requires the runtime host backend")?;
+                let source = variant.source.clone();
+                let input = variant.input.clone();
+                let handle = std::thread::Builder::new()
+                    .name(format!("chidori-branch-{index}"))
+                    .stack_size(BRANCH_THREAD_STACK_BYTES)
+                    .spawn_scoped(scope, move || {
+                        crate::runtime::rust_engine::run_agent_file(
+                            Path::new(&source),
+                            &input,
+                            &branch_backend,
+                        )
+                    })
+                    .map_err(|err| format!("spawning branch thread: {err}"))?;
+                handles.push((*index, *variant, branch_ctx, range, branch_id, handle));
             }
-            Err(err) if err.to_string().contains(PAUSE_MARKER) => {
-                // Phase 1: a suspended branch is reported, not resumable — the
-                // persisted-branch resume flow is Phase 2. Surface what the
-                // branch is waiting on so the agent (or a human) can decide.
-                outcome["status"] = json!("paused");
-                if let Some(pending) = branch_ctx.take_pending_input() {
-                    outcome["pendingPrompt"] = json!(pending.prompt);
-                } else if let Some(pending) = branch_ctx.take_pending_approval() {
-                    outcome["pendingPrompt"] =
-                        json!(format!("approval required: {}", pending.target));
-                } else if let Some(pending) = branch_ctx.take_pending_signal() {
-                    outcome["pendingPrompt"] =
-                        json!(format!("waiting on signal: {}", pending.name));
+            for (index, variant, branch_ctx, range, branch_id, handle) in handles {
+                let result = handle
+                    .join()
+                    .map_err(|_| format!("branch `{}` thread panicked", variant.label))?;
+                wave_runs.push((index, variant, branch_ctx, range, branch_id, result));
+            }
+            Ok(())
+        })?;
+
+        for (index, variant, branch_ctx, range, branch_id, result) in wave_runs {
+            let settled = settle_branch(result, &branch_ctx);
+
+            // Disjointness is the determinism guarantee: every record the
+            // branch produced must sit inside its reserved range before it may
+            // join the parent's durable log. A violation is an invariant break
+            // (e.g. a branch that outgrew its range width), not a comparable
+            // outcome.
+            let records = branch_ctx.call_log().into_records();
+            for record in &records {
+                if !range.contains(record.seq) {
+                    return Err(format!(
+                        "branch `{}` emitted call seq {} outside its reserved range {}..{}",
+                        variant.label, record.seq, range.start, range.end_exclusive
+                    ));
                 }
             }
-            Err(err) => {
-                outcome["status"] = json!("failed");
-                outcome["error"] = json!(err.to_string());
-            }
-        }
 
-        // Disjointness is the determinism guarantee: every record the branch
-        // produced must sit inside its reserved range before it may join the
-        // parent's durable log. A violation is an invariant break (e.g. a
-        // branch that outgrew its range width), not a comparable outcome.
-        let records = branch_ctx.call_log().into_records();
-        for record in &records {
-            if !range.contains(record.seq) {
-                return Err(format!(
-                    "branch `{}` emitted call seq {} outside its reserved range {}..{}",
-                    variant.label, record.seq, range.start, range.end_exclusive
-                ));
+            if let Some(ref op_dir) = store_op_dir {
+                let meta = BranchMeta {
+                    version: BRANCH_STORE_VERSION,
+                    branch_id: branch_id.clone(),
+                    label: variant.label.clone(),
+                    branch_index: index as u32,
+                    branch_seq,
+                    parent_run_id: parent_run_id.clone(),
+                    original_source: variant.source.clone(),
+                    input: variant.input.clone(),
+                    sequence_range: range.clone(),
+                    status: settled.status.to_string(),
+                    pending_input: settled.pending_input.clone(),
+                    pending_prompt: settled.pending_prompt.clone(),
+                    output: settled.output.clone(),
+                    error: settled.error.clone(),
+                    updated_at: Utc::now(),
+                };
+                if let Err(err) =
+                    persist_branch_state(&branch_dir(op_dir, index as u32), &meta, &records)
+                {
+                    tracing::warn!(error = %err, branch = %branch_id, "failed to persist branch store");
+                }
             }
-        }
-        ctx.merge_branch_records(records);
 
-        outcomes.push(outcome);
+            ctx.merge_branch_records(records);
+            outcomes.push(branch_outcome_json(&branch_id, &variant.label, &settled));
+        }
     }
 
     Ok(Value::Array(outcomes))
 }
 
-/// Parse and validate the `variants` array: each needs a `source` (the branch's
-/// own continuation module — reusing the parent source would re-reach
+/// Parse and validate the `variants` array: each needs a `source` (the
+/// branch's own continuation module — reusing the parent source would re-reach
 /// `chidori.branch` and recurse, §8.2); `label` defaults to `branch-<k>` and
-/// `input` to `{}`.
+/// `input` to `{}`. Sources are read here so a typo'd path fails the whole
+/// call before any branch spends anything.
 fn parse_variants(args: &Value) -> std::result::Result<Vec<BranchVariant>, String> {
     let variants = args
         .get("variants")
@@ -215,37 +411,296 @@ fn parse_variants(args: &Value) -> std::result::Result<Vec<BranchVariant>, Strin
             variants.len()
         ));
     }
-    variants
-        .iter()
-        .enumerate()
-        .map(|(index, variant)| {
-            let label = variant
-                .get("label")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| format!("branch-{index}"));
-            let source = variant
-                .get("source")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-                .ok_or_else(|| {
-                    format!(
-                        "chidori.branch variant `{label}` requires a `source` module path (a \
-                         branch runs its own continuation source, not a copy of the parent)"
-                    )
-                })?;
-            let input = variant
-                .get("input")
-                .cloned()
-                .filter(|value| !value.is_null())
-                .unwrap_or_else(|| json!({}));
+    // Validate every variant's shape before touching any file, so a missing
+    // `source` on variant N surfaces even when variant 0's path is bad too.
+    let mut parsed = Vec::with_capacity(variants.len());
+    for (index, variant) in variants.iter().enumerate() {
+        let label = variant
+            .get("label")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("branch-{index}"));
+        let source = variant
+            .get("source")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| {
+                format!(
+                    "chidori.branch variant `{label}` requires a `source` module path (a \
+                     branch runs its own continuation source, not a copy of the parent)"
+                )
+            })?;
+        let input = variant
+            .get("input")
+            .cloned()
+            .filter(|value| !value.is_null())
+            .unwrap_or_else(|| json!({}));
+        parsed.push((label, source, input));
+    }
+    parsed
+        .into_iter()
+        .map(|(label, source, input)| {
+            let source_text = std::fs::read_to_string(&source).map_err(|err| {
+                format!("chidori.branch variant `{label}`: reading source {source}: {err}")
+            })?;
             Ok(BranchVariant {
                 label,
                 source,
+                source_text,
                 input,
             })
         })
         .collect()
+}
+
+// --- Branch store: out-of-band resume / edit-and-rerun ----------------------
+
+/// List a persisted run's branch stores: one summary JSON per branch, ordered
+/// by op seq then branch index.
+pub(crate) fn list_branches(run_dir: &Path) -> std::result::Result<Vec<Value>, String> {
+    let mut summaries = Vec::new();
+    for (_, _, meta) in scan_branches(run_dir)? {
+        summaries.push(json!({
+            "branchId": meta.branch_id,
+            "label": meta.label,
+            "status": meta.status,
+            "branchSeq": meta.branch_seq,
+            "branchIndex": meta.branch_index,
+            "pendingPrompt": meta.pending_prompt,
+            "source": meta.original_source,
+            "updatedAt": meta.updated_at.to_rfc3339(),
+        }));
+    }
+    Ok(summaries)
+}
+
+/// Resume a persisted branch that paused on `chidori.input` by answering its
+/// pending prompt: replay the branch's checkpoint with a synthetic `input`
+/// record at the pending seq (the same mechanism the server's `/resume` uses)
+/// and run the branch's `source.ts` to its next outcome. Updates the branch
+/// store and returns the new `BranchOutcome` JSON.
+pub(crate) fn resume_branch(
+    backend: &HostBindingBackend,
+    run_dir: &Path,
+    branch_id: &str,
+    response: &str,
+) -> std::result::Result<Value, String> {
+    let (op_dir, branch_dir, meta) = find_branch(run_dir, branch_id)?;
+    if meta.status != "paused" {
+        return Err(format!(
+            "branch `{branch_id}` is {}, not paused",
+            meta.status
+        ));
+    }
+    let pending = meta.pending_input.clone().ok_or_else(|| {
+        format!(
+            "branch `{branch_id}` is paused on an operation that cannot be resumed with an \
+             input response ({})",
+            meta.pending_prompt.as_deref().unwrap_or("unknown")
+        )
+    })?;
+
+    let mut replay_log = load_branch_checkpoint(&branch_dir)?;
+    // Inject a synthetic `input` record at the pending seq so the replaying
+    // branch returns the response to the agent's input() call and continues
+    // live from there.
+    replay_log.push(CallRecord {
+        seq: pending.seq,
+        parent_seq: None,
+        function: "input".to_string(),
+        args: json!({ "prompt": pending.prompt }),
+        result: Value::String(response.to_string()),
+        duration_ms: 0,
+        token_usage: None,
+        timestamp: Utc::now(),
+        error: None,
+    });
+
+    run_persisted_branch(backend, &op_dir, &branch_dir, meta, replay_log)
+}
+
+/// Re-run a persisted branch **fresh from its parent anchor** with whatever
+/// `source.ts` now contains — the edit-and-rerun flow. The previous checkpoint
+/// is discarded (an edited source may diverge from it); the anchored state
+/// (fork-time VFS + the variant's `input`) is identical to the original fork,
+/// so only the branch's code is the variable. Updates the branch store and
+/// returns the new `BranchOutcome` JSON.
+pub(crate) fn rerun_branch(
+    backend: &HostBindingBackend,
+    run_dir: &Path,
+    branch_id: &str,
+) -> std::result::Result<Value, String> {
+    let (op_dir, branch_dir, meta) = find_branch(run_dir, branch_id)?;
+    run_persisted_branch(backend, &op_dir, &branch_dir, meta, Vec::new())
+}
+
+/// Shared core of [`resume_branch`] / [`rerun_branch`]: rebuild the branch
+/// context from the persisted anchor, run the store's `source.ts`, validate
+/// range confinement, and update the store with the new state.
+fn run_persisted_branch(
+    backend: &HostBindingBackend,
+    op_dir: &Path,
+    branch_dir: &Path,
+    mut meta: BranchMeta,
+    replay_log: Vec<CallRecord>,
+) -> std::result::Result<Value, String> {
+    let anchor = load_anchor(op_dir)?;
+    let branch_ctx = RuntimeContext::for_branch_resume(
+        replay_log,
+        anchor.vfs,
+        meta.sequence_range.start - 1,
+        meta.branch_seq,
+        meta.branch_id.clone(),
+    );
+    let branch_backend = backend
+        .with_runtime_ctx(branch_ctx.clone())
+        .ok_or("branch resume requires the runtime host backend")?;
+
+    let source_path = branch_dir.join(BRANCH_SOURCE_FILE);
+    let result =
+        crate::runtime::rust_engine::run_agent_file(&source_path, &meta.input, &branch_backend);
+    let settled = settle_branch(result, &branch_ctx);
+
+    let records = branch_ctx.call_log().into_records();
+    for record in &records {
+        if !meta.sequence_range.contains(record.seq) {
+            return Err(format!(
+                "branch `{}` emitted call seq {} outside its reserved range {}..{}",
+                meta.label,
+                record.seq,
+                meta.sequence_range.start,
+                meta.sequence_range.end_exclusive
+            ));
+        }
+    }
+
+    meta.status = settled.status.to_string();
+    meta.pending_input = settled.pending_input.clone();
+    meta.pending_prompt = settled.pending_prompt.clone();
+    meta.output = settled.output.clone();
+    meta.error = settled.error.clone();
+    meta.updated_at = Utc::now();
+    persist_branch_state(branch_dir, &meta, &records)?;
+
+    Ok(branch_outcome_json(&meta.branch_id, &meta.label, &settled))
+}
+
+fn op_dir(run_dir: &Path, branch_seq: u64) -> PathBuf {
+    run_dir
+        .join(BRANCHES_DIR)
+        .join(format!("op-{branch_seq:020}"))
+}
+
+fn branch_dir(op_dir: &Path, branch_index: u32) -> PathBuf {
+    op_dir.join(format!("branch-{branch_index:03}"))
+}
+
+fn persist_anchor_and_sources(
+    op_dir: &Path,
+    anchor: &BranchAnchor,
+    variants: &[BranchVariant],
+) -> std::result::Result<(), String> {
+    std::fs::create_dir_all(op_dir)
+        .map_err(|err| format!("creating {}: {err}", op_dir.display()))?;
+    let anchor_path = op_dir.join(BRANCH_ANCHOR_FILE);
+    let bytes = serde_json::to_vec_pretty(anchor).map_err(|err| err.to_string())?;
+    std::fs::write(&anchor_path, bytes)
+        .map_err(|err| format!("writing {}: {err}", anchor_path.display()))?;
+    for (index, variant) in variants.iter().enumerate() {
+        let dir = branch_dir(op_dir, index as u32);
+        std::fs::create_dir_all(&dir)
+            .map_err(|err| format!("creating {}: {err}", dir.display()))?;
+        let source_path = dir.join(BRANCH_SOURCE_FILE);
+        std::fs::write(&source_path, &variant.source_text)
+            .map_err(|err| format!("writing {}: {err}", source_path.display()))?;
+    }
+    Ok(())
+}
+
+fn persist_branch_state(
+    branch_dir: &Path,
+    meta: &BranchMeta,
+    records: &[CallRecord],
+) -> std::result::Result<(), String> {
+    std::fs::create_dir_all(branch_dir)
+        .map_err(|err| format!("creating {}: {err}", branch_dir.display()))?;
+    let meta_path = branch_dir.join(BRANCH_META_FILE);
+    let bytes = serde_json::to_vec_pretty(meta).map_err(|err| err.to_string())?;
+    std::fs::write(&meta_path, bytes)
+        .map_err(|err| format!("writing {}: {err}", meta_path.display()))?;
+    let checkpoint_path = branch_dir.join(BRANCH_CHECKPOINT_FILE);
+    let bytes = serde_json::to_vec_pretty(records).map_err(|err| err.to_string())?;
+    std::fs::write(&checkpoint_path, bytes)
+        .map_err(|err| format!("writing {}: {err}", checkpoint_path.display()))?;
+    Ok(())
+}
+
+fn load_anchor(op_dir: &Path) -> std::result::Result<BranchAnchor, String> {
+    let path = op_dir.join(BRANCH_ANCHOR_FILE);
+    let bytes = std::fs::read(&path).map_err(|err| format!("reading {}: {err}", path.display()))?;
+    serde_json::from_slice(&bytes).map_err(|err| format!("parsing {}: {err}", path.display()))
+}
+
+fn load_branch_checkpoint(branch_dir: &Path) -> std::result::Result<Vec<CallRecord>, String> {
+    let path = branch_dir.join(BRANCH_CHECKPOINT_FILE);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let bytes = std::fs::read(&path).map_err(|err| format!("reading {}: {err}", path.display()))?;
+    serde_json::from_slice(&bytes).map_err(|err| format!("parsing {}: {err}", path.display()))
+}
+
+/// Walk `<run dir>/branches/op-*/branch-*/branch.json`, ordered by op then
+/// branch index.
+fn scan_branches(
+    run_dir: &Path,
+) -> std::result::Result<Vec<(PathBuf, PathBuf, BranchMeta)>, String> {
+    let branches_root = run_dir.join(BRANCHES_DIR);
+    let mut found = Vec::new();
+    if !branches_root.is_dir() {
+        return Ok(found);
+    }
+    let mut op_dirs: Vec<PathBuf> = std::fs::read_dir(&branches_root)
+        .map_err(|err| format!("reading {}: {err}", branches_root.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_dir())
+        .collect();
+    op_dirs.sort();
+    for op_dir in op_dirs {
+        let mut branch_dirs: Vec<PathBuf> = std::fs::read_dir(&op_dir)
+            .map_err(|err| format!("reading {}: {err}", op_dir.display()))?
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| path.is_dir())
+            .collect();
+        branch_dirs.sort();
+        for branch_dir in branch_dirs {
+            let meta_path = branch_dir.join(BRANCH_META_FILE);
+            if !meta_path.is_file() {
+                continue;
+            }
+            let bytes = std::fs::read(&meta_path)
+                .map_err(|err| format!("reading {}: {err}", meta_path.display()))?;
+            let meta: BranchMeta = serde_json::from_slice(&bytes)
+                .map_err(|err| format!("parsing {}: {err}", meta_path.display()))?;
+            found.push((op_dir.clone(), branch_dir, meta));
+        }
+    }
+    Ok(found)
+}
+
+fn find_branch(
+    run_dir: &Path,
+    branch_id: &str,
+) -> std::result::Result<(PathBuf, PathBuf, BranchMeta), String> {
+    for entry in scan_branches(run_dir)? {
+        if entry.2.branch_id == branch_id {
+            return Ok(entry);
+        }
+    }
+    Err(format!(
+        "no persisted branch `{branch_id}` under {} (use `chidori branches <run id>` to list)",
+        run_dir.display()
+    ))
 }
 
 #[cfg(test)]
@@ -370,7 +825,7 @@ mod tests {
         );
         assert_eq!(
             outcomes[1]["branchId"],
-            json!(format!("{}-branch-1", ctx.run_id()))
+            json!(format!("{}-op2-branch-1", ctx.run_id()))
         );
 
         // The prefix (the parent's `count` tool) fired exactly once: it was
@@ -472,7 +927,7 @@ mod tests {
     #[test]
     fn paused_branch_surfaces_pending_prompt_outcome() {
         // A branch that suspends on `chidori.input` in Pause mode is reported
-        // as a paused outcome (resume is Phase 2); the parent run completes.
+        // as a paused outcome; the parent run completes.
         let ctx = RuntimeContext::new();
         ctx.set_input_mode(InputMode::Pause);
         let dir =
@@ -582,6 +1037,263 @@ mod tests {
         );
         // Nothing ran, nothing recorded: validation precedes the durable call.
         assert!(ctx.call_log().into_records().is_empty());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn paused_branch_persists_and_resumes_with_value() {
+        // Phase 2: a branch that pauses on input is persisted under the parent
+        // run's branch store and can be resumed OUT-OF-BAND — after the parent
+        // completed — by answering the pending prompt. The resumed branch
+        // replays its checkpoint (with the synthetic input record) and runs to
+        // completion, updating its store.
+        let base = std::env::temp_dir().join(format!(
+            "chidori-branch-resume-base-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let dir =
+            std::env::temp_dir().join(format!("chidori-branch-resume-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        std::fs::write(
+            dir.join("branches").join("ask.ts"),
+            r#"
+            export async function agent(input: { question: string }) {
+                await chidori.log("before input");
+                const answer = await chidori.input(input.question);
+                await chidori.log("after input: " + answer);
+                return { answer };
+            }
+            "#,
+        )
+        .unwrap();
+        let path = dir.join("agent.ts");
+        let src = r#"
+            export async function agent() {
+                const outcomes = await chidori.branch([
+                    { label: "ask", source: "__DIR__/branches/ask.ts", input: { question: "Pick a color" } },
+                ]);
+                return { outcomes };
+            }
+        "#
+        .replace("__DIR__", &dir.to_string_lossy());
+        std::fs::write(&path, &src).unwrap();
+
+        let ctx = RuntimeContext::new();
+        ctx.set_input_mode(InputMode::Pause);
+        let run_dir = ctx.enable_persistence(base.clone());
+        let backend = test_backend(ctx.clone(), Arc::new(ToolRegistry::new()));
+        let output = run_agent(&path, &src, &json!({}), &backend).unwrap();
+
+        let outcome = &output["outcomes"][0];
+        assert_eq!(outcome["status"], json!("paused"));
+        let branch_id = outcome["branchId"].as_str().unwrap().to_string();
+
+        // The branch store exists: anchor + source copy + checkpoint + meta.
+        let listed = super::list_branches(&run_dir).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0]["branchId"], json!(branch_id));
+        assert_eq!(listed[0]["status"], json!("paused"));
+        assert_eq!(listed[0]["pendingPrompt"], json!("Pick a color"));
+        let (op_dir, branch_dir, meta) = super::find_branch(&run_dir, &branch_id).unwrap();
+        assert!(op_dir.join(super::BRANCH_ANCHOR_FILE).is_file());
+        assert!(branch_dir.join(super::BRANCH_SOURCE_FILE).is_file());
+        assert!(branch_dir.join(super::BRANCH_CHECKPOINT_FILE).is_file());
+        let pending = meta.pending_input.as_ref().unwrap();
+        assert_eq!(pending.prompt, "Pick a color");
+
+        // Resume with a fresh backend (the parent context is history).
+        let resume_backend = test_backend(RuntimeContext::new(), Arc::new(ToolRegistry::new()));
+        let resumed = super::resume_branch(&resume_backend, &run_dir, &branch_id, "blue").unwrap();
+        assert_eq!(resumed["status"], json!("completed"));
+        assert_eq!(resumed["output"], json!({ "answer": "blue" }));
+
+        // The store reflects the new state, and every record (replayed and
+        // newly live) stayed inside the reserved range.
+        let (_, _, meta) = super::find_branch(&run_dir, &branch_id).unwrap();
+        assert_eq!(meta.status, "completed");
+        assert!(meta.pending_input.is_none());
+        let records = super::load_branch_checkpoint(&branch_dir).unwrap();
+        let input = records.iter().find(|r| r.function == "input").unwrap();
+        assert_eq!(input.result, json!("blue"));
+        let after = records
+            .iter()
+            .find(|r| r.function == "log" && r.args["message"] == "after input: blue")
+            .unwrap();
+        assert!(meta.sequence_range.contains(after.seq));
+
+        // Resuming a branch that isn't paused is rejected.
+        let err = super::resume_branch(&resume_backend, &run_dir, &branch_id, "again").unwrap_err();
+        assert!(err.contains("not paused"), "{err}");
+
+        let _ = std::fs::remove_dir_all(dir);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn edited_branch_reruns_from_anchor() {
+        // Phase 2 edit-and-rerun: edit the branch store's source.ts and re-run
+        // it fresh from the parent anchor. The anchored state — the fork-time
+        // VFS (a file the parent wrote before forking) and the variant input —
+        // is identical; only the edited code diverges.
+        let base = std::env::temp_dir().join(format!(
+            "chidori-branch-rerun-base-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let dir =
+            std::env::temp_dir().join(format!("chidori-branch-rerun-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        std::fs::write(
+            dir.join("branches").join("read.ts"),
+            r#"
+            import { readFileSync } from "node:fs";
+            export async function agent(input: { suffix: string }) {
+                const note = readFileSync("/notes/anchor.txt", "utf8");
+                return { version: "v1", note, suffix: input.suffix };
+            }
+            "#,
+        )
+        .unwrap();
+        let path = dir.join("agent.ts");
+        let src = r#"
+            import { mkdirSync, writeFileSync } from "node:fs";
+            export async function agent() {
+                mkdirSync("/notes", { recursive: true });
+                writeFileSync("/notes/anchor.txt", "from-parent");
+                const outcomes = await chidori.branch([
+                    { label: "read", source: "__DIR__/branches/read.ts", input: { suffix: "s1" } },
+                ]);
+                return { outcomes };
+            }
+        "#
+        .replace("__DIR__", &dir.to_string_lossy());
+        std::fs::write(&path, &src).unwrap();
+
+        let ctx = RuntimeContext::new();
+        let run_dir = ctx.enable_persistence(base.clone());
+        let backend = test_backend(ctx.clone(), Arc::new(ToolRegistry::new()));
+        let output = run_agent(&path, &src, &json!({}), &backend).unwrap();
+        let outcome = &output["outcomes"][0];
+        assert_eq!(
+            outcome["output"],
+            json!({ "version": "v1", "note": "from-parent", "suffix": "s1" })
+        );
+        let branch_id = outcome["branchId"].as_str().unwrap().to_string();
+
+        // Edit the branch's persisted source: a new strategy version.
+        let (_, branch_dir, _) = super::find_branch(&run_dir, &branch_id).unwrap();
+        let source_path = branch_dir.join(super::BRANCH_SOURCE_FILE);
+        let edited = std::fs::read_to_string(&source_path)
+            .unwrap()
+            .replace("\"v1\"", "\"v2-edited\"");
+        std::fs::write(&source_path, edited).unwrap();
+
+        // Re-run from the anchor with a fresh backend: divergent output, same
+        // anchored state (the parent-written VFS file and the input).
+        let rerun_backend = test_backend(RuntimeContext::new(), Arc::new(ToolRegistry::new()));
+        let rerun = super::rerun_branch(&rerun_backend, &run_dir, &branch_id).unwrap();
+        assert_eq!(rerun["status"], json!("completed"));
+        assert_eq!(
+            rerun["output"],
+            json!({ "version": "v2-edited", "note": "from-parent", "suffix": "s1" })
+        );
+        let (_, _, meta) = super::find_branch(&run_dir, &branch_id).unwrap();
+        assert_eq!(meta.status, "completed");
+        assert_eq!(
+            meta.output,
+            Some(json!({ "version": "v2-edited", "note": "from-parent", "suffix": "s1" }))
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn branches_run_concurrently_when_requested() {
+        // With options.concurrency = 2, both branches run in the same wave on
+        // worker threads. Each calls a rendezvous tool that waits (bounded)
+        // until BOTH branches have arrived — which only ever happens when they
+        // overlap in time. Outcome order still follows variant order, and the
+        // merged records keep their disjoint reserved ranges.
+        let arrivals = Arc::new(AtomicUsize::new(0));
+        let mut registry = ToolRegistry::new();
+        let tool_arrivals = arrivals.clone();
+        registry.register_native(
+            "rendezvous",
+            "waits until both branches arrive",
+            Vec::new(),
+            move |_args| {
+                tool_arrivals.fetch_add(1, Ordering::SeqCst);
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+                while tool_arrivals.load(Ordering::SeqCst) < 2 {
+                    if std::time::Instant::now() > deadline {
+                        return Ok(json!({ "overlapped": false }));
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Ok(json!({ "overlapped": true }))
+            },
+        );
+
+        let ctx = RuntimeContext::new();
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-branch-concurrent-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(dir.join("branches")).unwrap();
+        for name in ["a", "b"] {
+            std::fs::write(
+                dir.join("branches").join(format!("{name}.ts")),
+                format!(
+                    r#"
+                    export async function agent() {{
+                        const meet = await chidori.tool("rendezvous", {{}});
+                        return {{ name: "{name}", overlapped: meet.overlapped }};
+                    }}
+                    "#
+                ),
+            )
+            .unwrap();
+        }
+        let path = dir.join("agent.ts");
+        let src = r#"
+            export async function agent() {
+                const outcomes = await chidori.branch([
+                    { label: "a", source: "__DIR__/branches/a.ts" },
+                    { label: "b", source: "__DIR__/branches/b.ts" },
+                ], { concurrency: 2 });
+                return { outcomes };
+            }
+        "#
+        .replace("__DIR__", &dir.to_string_lossy());
+        std::fs::write(&path, &src).unwrap();
+
+        let backend = test_backend(ctx.clone(), Arc::new(registry));
+        let output = run_agent(&path, &src, &json!({}), &backend).unwrap();
+
+        let outcomes = output["outcomes"].as_array().unwrap();
+        assert_eq!(outcomes[0]["label"], json!("a"));
+        assert_eq!(outcomes[1]["label"], json!("b"));
+        for outcome in outcomes {
+            assert_eq!(outcome["status"], json!("completed"));
+            assert_eq!(
+                outcome["output"]["overlapped"],
+                json!(true),
+                "branches must run concurrently under concurrency=2: {outcome}"
+            );
+        }
+
+        // Concurrent execution still confines each branch to its reserved
+        // range: branch 0 in [20_001, 30_001), branch 1 in [30_001, 40_001).
+        let records = ctx.call_log().into_records();
+        let tools: Vec<u64> = records
+            .iter()
+            .filter(|r| r.function == "tool")
+            .map(|r| r.seq)
+            .collect();
+        assert_eq!(tools.len(), 2);
+        assert!(tools.iter().any(|seq| (20_001..30_001).contains(seq)));
+        assert!(tools.iter().any(|seq| (30_001..40_001).contains(seq)));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@ pub mod context;
 pub mod cost;
 pub mod crypto;
 pub mod engine;
+pub mod host_branch;
 pub mod host_core;
 pub mod memory;
 pub mod native;

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -1,7 +1,5 @@
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
-use std::rc::Rc;
 use std::sync::{Arc, Mutex as StdMutex};
 
 use serde::{Deserialize, Serialize};
@@ -1216,17 +1214,20 @@ fn context_request_parts(
 
 #[derive(Debug, Clone, Default)]
 pub struct HostBindingRecorder {
-    calls: Rc<RefCell<Vec<HostBindingCall>>>,
+    // Arc<Mutex> (not Rc<RefCell>) so HostBindingBackend is Send — branch
+    // sub-runs execute on their own threads when `chidori.branch` runs with
+    // `concurrency > 1`.
+    calls: Arc<StdMutex<Vec<HostBindingCall>>>,
 }
 
 impl HostBindingRecorder {
     #[allow(dead_code)]
     pub fn calls(&self) -> Vec<HostBindingCall> {
-        self.calls.borrow().clone()
+        self.calls.lock().unwrap().clone()
     }
 
     fn push(&self, function: impl Into<String>, args: serde_json::Value) {
-        self.calls.borrow_mut().push(HostBindingCall {
+        self.calls.lock().unwrap().push(HostBindingCall {
             function: function.into(),
             args,
         });

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -766,6 +766,37 @@ impl HostBindingBackend {
         }
     }
 
+    /// Clone this runtime backend with a different [`RuntimeContext`] — same
+    /// providers, policy (and approval cache), tools, and MCP. Used by
+    /// `chidori.branch` to run each branch sub-run on its own context while
+    /// enforcing the parent's policy. `None` for the recorder backend.
+    pub(crate) fn with_runtime_ctx(&self, runtime_ctx: RuntimeContext) -> Option<Self> {
+        match self {
+            HostBindingBackend::Runtime {
+                providers,
+                template_engine,
+                tokio_rt,
+                policy,
+                policy_cache,
+                runtime_policy,
+                tools,
+                mcp,
+                ..
+            } => Some(HostBindingBackend::Runtime {
+                runtime_ctx,
+                providers: providers.clone(),
+                template_engine: template_engine.clone(),
+                tokio_rt: tokio_rt.clone(),
+                policy: policy.clone(),
+                policy_cache: policy_cache.clone(),
+                runtime_policy: runtime_policy.clone(),
+                tools: tools.clone(),
+                mcp: mcp.clone(),
+            }),
+            HostBindingBackend::Recorder(_) => None,
+        }
+    }
+
     /// The runtime context, when this is the runtime backend.
     pub(crate) fn runtime_ctx(&self) -> Option<&RuntimeContext> {
         match self {
@@ -967,6 +998,7 @@ impl HostBindingBackend {
                     .unwrap_or_else(|| serde_json::json!({}));
                 self.call_agent(path, input)
             }
+            "branch" => crate::runtime::host_branch::run_branches(self, a),
             "workspace" => self.dispatch_workspace(a),
             "contextDigest" => {
                 let segments = a


### PR DESCRIPTION
An agent can now fork itself mid-run into N branches that each explore a
strategy from the same anchored state and return an outcome for comparison
(docs/branching-execution.md). Each branch runs its own continuation source
module on a fresh RuntimeContext seeded with the parent's VFS, config, and
input mode; its records occupy a reserved, disjoint sequence range and nest
under the branch call (parent_seq), so the trace shows one subtree per
strategy. The whole fan-out is a single recorded durable call: a parent
replay returns the outcomes from cache without re-running the branches, and
merge-time counter advancement mirrors absorb_replayed_subtree so live and
replayed sequence numbering stay aligned.

- crates/chidori-js: `branch` host effect on install_chidori_effects
- runtime: new host_branch module (validation, slot-derived sequence-range
  allocation via ParallelBranchManifest, per-branch sub-run, range
  confinement check, record merge); RuntimeContext::for_branch /
  merge_branch_records / is_branch; "branch" dispatch arm +
  HostBindingBackend::with_runtime_ctx
- a suspended branch is reported as status "paused" with its pendingPrompt
  (resume is Phase 2); nested chidori.branch inside a branch is rejected;
  fan-out capped at 16 variants
- SDK: BranchVariant / BranchOutcome / BranchOptions + Chidori.branch
- examples/branching: shared prefix, two strategy modules, compare-and-pick;
  verified live and via `chidori resume` replay
- tests: outcomes, parent_seq nesting, disjoint reserved ranges,
  prefix-fired-once, replay-from-cache, paused outcome, nested rejection,
  fail-fast validation

https://claude.ai/code/session_013RFiQnt1Qx7Va212PWxseK