### PR TITLE
Add npm/PyPI release automation for the SDKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release SDKs
+
+# Publishes the TypeScript SDK to npm (@1kbirds/chidori) and the Python SDK
+# to PyPI (chidori) when a vX.Y.Z tag is pushed. Both publish jobs use OIDC
+# trusted publishing — no long-lived registry tokens — and skip versions that
+# are already on the registry, so re-running a tag's workflow is safe.
+#
+# A manual workflow_dispatch run is a dry run: it builds and validates both
+# packages but publishes nothing.
+#
+# One-time registry setup is documented in docs/releasing.md. Rust crates are
+# published separately via ./publish.sh.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify release versions
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check the version train
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            ./scripts/check-sdk-versions.sh "${GITHUB_REF_NAME#v}"
+          else
+            ./scripts/check-sdk-versions.sh
+          fi
+
+  npm:
+    name: Publish TypeScript SDK to npm
+    needs: verify
+    runs-on: ubuntu-24.04
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write # npm trusted publishing (OIDC) + provenance
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      # Trusted publishing requires npm >= 11.5.1; the runner image ships older.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Check whether this version is already on npm
+        id: check
+        run: |
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if [[ -n "$(npm view "${name}@${version}" version 2>/dev/null || true)" ]]; then
+            echo "${name}@${version} is already published; skipping"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish (dry run)
+        if: github.event_name == 'workflow_dispatch'
+        run: npm publish --dry-run
+
+      - name: Publish
+        if: github.ref_type == 'tag' && steps.check.outputs.published == 'false'
+        run: npm publish
+
+  pypi:
+    name: Publish Python SDK to PyPI
+    needs: verify
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write # PyPI trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build sdk/python --outdir dist
+
+      - name: Check package metadata
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      - name: Publish
+        if: github.ref_type == 'tag'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <a href="https://github.com/ThousandBirdsInc/chidori/commits"><img alt="GitHub Last Commit" src="https://img.shields.io/github/last-commit/ThousandBirdsInc/chidori" /></a>
 <a href="https://crates.io/crates/chidori"><img alt="crates.io version" src="https://img.shields.io/crates/v/chidori" /></a>
 <a href="https://pypi.org/project/chidori/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/chidori" /></a>
-<a href="https://www.npmjs.com/package/chidori"><img alt="npm version" src="https://img.shields.io/npm/v/chidori" /></a>
+<a href="https://www.npmjs.com/package/@1kbirds/chidori"><img alt="npm version" src="https://img.shields.io/npm/v/%401kbirds%2Fchidori" /></a>
 <a href="https://github.com/ThousandBirdsInc/chidori/blob/main/LICENSE"><img alt="License Apache-2.0" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" /></a>
 </p>
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,82 @@
+# Releasing
+
+Chidori ships from a single version train: the root `chidori` crate, the
+TypeScript SDK, and the Python SDK all carry the same `X.Y.Z` version, and a
+release is cut by pushing a `vX.Y.Z` tag.
+
+| Artifact | Registry | Name | How it publishes |
+| --- | --- | --- | --- |
+| Rust crates | crates.io | `chidori`, `chidori-js` | Manually, via `./publish.sh` (see that script's header) |
+| TypeScript SDK | npm | [`@1kbirds/chidori`](https://www.npmjs.com/package/@1kbirds/chidori) | `.github/workflows/release.yml` on tag push |
+| Python SDK | PyPI | [`chidori`](https://pypi.org/project/chidori/) | `.github/workflows/release.yml` on tag push |
+
+The unscoped npm name `chidori` belongs to an unrelated project, so the
+TypeScript SDK publishes under the `@1kbirds` scope (which also carries the
+legacy 0.1.x SDK releases). Agent authors who want the historical
+`import ... from "chidori"` spelling can install via an npm alias:
+
+```bash
+npm install chidori@npm:@1kbirds/chidori
+```
+
+The runtime accepts both `"chidori"` and `"@1kbirds/chidori"` as the virtual
+SDK module specifier in agent files.
+
+## Cutting a release
+
+1. Bump the version in all three places:
+   - `Cargo.toml` (`[package] version`)
+   - `sdk/typescript/package.json` (then `npm install --package-lock-only`
+     in `sdk/typescript` to refresh the lock file)
+   - `sdk/python/pyproject.toml` (`[project] version`)
+2. Sanity-check the train locally:
+
+   ```bash
+   ./scripts/check-sdk-versions.sh X.Y.Z
+   ```
+
+3. Commit, merge to `main`, then tag and push:
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+4. The `Release SDKs` workflow verifies the tag matches the version train,
+   builds both SDKs, and publishes each one — skipping any version that is
+   already on its registry, so re-running the workflow is safe.
+5. Publish the crates separately: `CARGO_REGISTRY_TOKEN=... ./publish.sh`
+   from the tagged commit.
+
+To rehearse without publishing, run the workflow manually from the Actions
+tab (`workflow_dispatch`): it builds both packages, runs `npm publish
+--dry-run` and `twine check`, and uploads nothing.
+
+## One-time registry setup
+
+Both publish jobs authenticate with OIDC trusted publishing — no long-lived
+tokens stored in repository secrets. Each registry needs a one-time trusted
+publisher configuration by an owner of the package:
+
+**npm (`@1kbirds/chidori`)** — on npmjs.com, package → Settings → Trusted
+publisher → GitHub Actions, with:
+
+- Organization or user: `ThousandBirdsInc`
+- Repository: `chidori`
+- Workflow filename: `release.yml`
+- Environment: `npm`
+
+**PyPI (`chidori`)** — on pypi.org, project → Manage → Publishing → Add a new
+publisher → GitHub, with:
+
+- Owner: `ThousandBirdsInc`
+- Repository name: `chidori`
+- Workflow name: `release.yml`
+- Environment name: `pypi`
+
+**GitHub** — create the `npm` and `pypi` environments under repository
+Settings → Environments (they can be empty; add required reviewers if
+publishes should need manual approval).
+
+Until the trusted publishers are configured, tag pushes will fail in the
+publish steps with an authentication error; the build/verify steps still run.

--- a/scripts/check-sdk-versions.sh
+++ b/scripts/check-sdk-versions.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Verify the release version train: the root crate, the TypeScript SDK, and
+# the Python SDK must all carry the same version. Releases are cut from a
+# single vX.Y.Z tag, so the workflow also passes the tag version as an
+# expected value.
+#
+# Usage:
+#   ./scripts/check-sdk-versions.sh          # packages must agree with each other
+#   ./scripts/check-sdk-versions.sh 3.0.0    # ...and with the expected version
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECTED="${1:-}"
+
+crate_version() {
+  python3 -c 'import tomllib
+with open("Cargo.toml", "rb") as f:
+    print(tomllib.load(f)["package"]["version"])'
+}
+
+ts_version() {
+  python3 -c 'import json
+with open("sdk/typescript/package.json") as f:
+    print(json.load(f)["version"])'
+}
+
+py_version() {
+  python3 -c 'import tomllib
+with open("sdk/python/pyproject.toml", "rb") as f:
+    print(tomllib.load(f)["project"]["version"])'
+}
+
+cd "$REPO_ROOT"
+
+CRATE="$(crate_version)"
+TS="$(ts_version)"
+PY="$(py_version)"
+
+echo "chidori crate:           ${CRATE}"
+echo "TypeScript SDK:          ${TS}"
+echo "Python SDK:               ${PY}"
+[[ -n "$EXPECTED" ]] && echo "expected (release tag):   ${EXPECTED}"
+
+status=0
+if [[ "$TS" != "$CRATE" || "$PY" != "$CRATE" ]]; then
+  echo "error: crate and SDK versions disagree; bump them together" >&2
+  status=1
+fi
+if [[ -n "$EXPECTED" && "$CRATE" != "$EXPECTED" ]]; then
+  echo "error: versions do not match the release tag ${EXPECTED}" >&2
+  status=1
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  echo "ok: all release versions agree"
+fi
+exit "$status"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,6 +5,14 @@ bindings, no third-party dependencies.
 
 ## Install
 
+From [PyPI](https://pypi.org/project/chidori/):
+
+```bash
+pip install chidori
+```
+
+Or from a checkout of this repository:
+
 ```bash
 pip install -e ./sdk/python
 ```

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -5,16 +5,33 @@ Uses the global `fetch` (Node 18+, browsers). Mirrors the Python SDK.
 
 ## Install
 
+The package is published to npm as
+[`@1kbirds/chidori`](https://www.npmjs.com/package/@1kbirds/chidori) (the
+unscoped `chidori` npm name belongs to an unrelated project). Installing it
+under the `chidori` alias keeps the historical import spelling working:
+
+```bash
+npm install chidori@npm:@1kbirds/chidori
+```
+
+```ts
+import { AgentClient, Checkpoint } from "chidori";
+```
+
+Or install under the scoped name directly — the Chidori runtime accepts both
+`"chidori"` and `"@1kbirds/chidori"` as the SDK module specifier in agent
+files:
+
+```bash
+npm install @1kbirds/chidori
+```
+
+To build from source instead:
+
 ```bash
 cd sdk/typescript
 npm install
 npm run build
-```
-
-Then import from the package or link it locally:
-
-```ts
-import { AgentClient, Checkpoint } from "chidori";
 ```
 
 Agent and tool authoring types are also exported:

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "chidori",
+  "name": "@1kbirds/chidori",
   "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "chidori",
+      "name": "@1kbirds/chidori",
       "version": "3.0.0",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "chidori",
+  "name": "@1kbirds/chidori",
   "version": "3.0.0",
   "description": "TypeScript SDK for the Chidori agent framework — HTTP client plus agent authoring types.",
+  "publishConfig": { "access": "public" },
   "homepage": "https://github.com/ThousandBirdsInc/chidori",
   "repository": { "type": "git", "url": "https://github.com/ThousandBirdsInc/chidori.git" },
   "license": "Apache-2.0",

--- a/src/runtime/typescript/transpile.rs
+++ b/src/runtime/typescript/transpile.rs
@@ -314,7 +314,7 @@ pub fn validate_imports(
     let mut node_resolver: Option<Resolver> = None;
 
     for (line_no, specifier) in import_specifiers(source) {
-        if specifier == "chidori" {
+        if is_chidori_sdk_specifier(&specifier) {
             imports.push(ModuleImport {
                 specifier,
                 resolved_path: None,
@@ -414,8 +414,18 @@ fn import_specifiers(source: &str) -> Vec<(usize, String)> {
     out
 }
 
+/// The virtual SDK module has no on-disk form at runtime; the host injects its
+/// exports. Agents may import it by the bare historical name or by the
+/// published npm package name.
+fn is_chidori_sdk_specifier(specifier: &str) -> bool {
+    specifier == "chidori" || specifier == "@1kbirds/chidori"
+}
+
 fn is_chidori_sdk_import(line: &str) -> bool {
-    line.starts_with("import ") && specifier_after_from(line).as_deref() == Some("chidori")
+    line.starts_with("import ")
+        && specifier_after_from(line)
+            .as_deref()
+            .is_some_and(is_chidori_sdk_specifier)
 }
 
 fn specifier_after_from(line: &str) -> Option<String> {
@@ -747,6 +757,33 @@ mod tests {
         assert!(js.contains(r#"type: "object""#));
         assert!(js.contains("now: Date.now()"));
         assert!(js.contains("iso: new Date().toISOString()"));
+    }
+
+    #[test]
+    fn transpile_strips_scoped_chidori_sdk_imports() {
+        let source = r#"
+            import { chidori } from "@1kbirds/chidori";
+            import type { Chidori, ToolDefinition } from "@1kbirds/chidori";
+
+            export async function agent(input, chidori: Chidori) {
+                return { ok: true };
+            }
+        "#;
+
+        let js = transpile_module(
+            Path::new("/tmp/project/agents/scoped.ts"),
+            source,
+            &TranspileOptions {
+                import_policy: TypeScriptImportPolicy::Relative,
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !js.contains("@1kbirds/chidori"),
+            "scoped import survived:\n{js}"
+        );
+        assert!(js.contains("return { ok: true }"));
     }
 
     #[test]


### PR DESCRIPTION
Closes the top follow-through item from docs/fable_review.md: both SDKs sat
at 3.0.0 with registry badges but no publish automation.

- Add .github/workflows/release.yml: on vX.Y.Z tag push, verifies the
  crate/TS/Python version train matches the tag, builds both SDKs, and
  publishes to npm and PyPI via OIDC trusted publishing (no stored tokens).
  Already-published versions are skipped, so re-running a tag is safe.
  workflow_dispatch runs the same pipeline as a dry run.
- Add scripts/check-sdk-versions.sh to enforce the single version train
  locally and in CI.
- Rename the TypeScript SDK package to @1kbirds/chidori: the unscoped
  npm name belongs to an unrelated project, and the 1kbirds scope already
  carries the legacy 0.1.x SDK releases. Recommend the
  `npm install chidori@npm:@1kbirds/chidori` alias so existing
  `from "chidori"` imports keep working.
- Teach the runtime to accept "@1kbirds/chidori" alongside "chidori" as
  the virtual SDK module specifier in agent files.
- Document the release flow and one-time registry setup in
  docs/releasing.md; fix the README npm badge to point at the real
  package and update both SDK install sections.

https://claude.ai/code/session_01JHJRzCSibhtTS1pYiBYz5W