### PR TITLE
Implement Phase 3: Live in-memory signal delivery to streaming runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,9 @@ An agent is a `.ts` file that exports an async `agent(input, chidori)` function.
 | `chidori.callAgent(path, input)` | Call a sub-agent |
 | `chidori.parallel(fns)` | Run functions concurrently |
 | `chidori.input(msg, options)` | Human-in-the-loop — pauses execution |
-| `chidori.signal(name, options)` | Multiplayer — pause at a named listen point until an outside party (human or agent) delivers `{ name, payload, from }`; drains a durable mailbox if one is queued |
+| `chidori.signal(name, options)` | Multiplayer — pause at a named listen point until an outside party (human or agent) delivers `{ name, payload, from }`; drains a durable mailbox if one is queued; `timeoutMs` resolves to a `{ timedOut: true }` sentinel after the deadline |
 | `chidori.pollSignal(name)` | Non-blocking signal check — consume a queued signal of this name or resolve to `null` |
+| `chidori.signalAny(names, options)` | Fan-in — pause until ANY of the named signals is delivered; the result's `name` says which fired |
 | `chidori.http(url, options)` | Make an HTTP request |
 | `chidori.memory(action, ...)` | Persistent storage (key-value + vector) |
 | `chidori.log(msg, data)` | Structured logging |
@@ -303,7 +304,7 @@ Exposes:
 - `GET  /sessions/{id}/checkpoint` — get the call log and snapshot manifest metadata
 - `GET  /sessions/{id}/snapshot` — inspect the durable journal-scaffold manifest metadata (no VM image — resume is call-log replay)
 - `POST /sessions/{id}/resume` — resume a paused `input()` or approval session
-- `POST /sessions/{id}/signal` — deliver a signal `{ name, payload?, from? }`: resolves+resumes a run paused-waiting on that name (200), else enqueues into the durable mailbox (202), or 409 for a terminal run
+- `POST /sessions/{id}/signal` — deliver a signal `{ name, payload?, from? }`: resolves+resumes a run paused-waiting on that name (200); delivers in-memory to a live streaming run, resuming a matching pause in-process (202 `delivered_live`); else enqueues into the durable mailbox (202 `queued`); 409 for a terminal run
 - `POST /sessions/{id}/replay` — replay from a session's checkpoint
 - `POST /sessions/{id}/cancel` — cancel a running or stored session
 - `POST /sessions/stream` — run a session with SSE call and prompt progress events

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ runtime, CLI, server, and tool work should target `.ts` agents and tools.
 | Language-neutral host core | Done |
 | Call-log replay | Done |
 | Human input and policy approval pause/resume | Done through live VM resume with replay fallback |
-| Multiplayer signals (`chidori.signal` / `pollSignal`, `POST /sessions/{id}/signal`) | Done — Phase 1 + `pollSignal` (`docs/signals.md`); `signalAny` / `timeoutMs` / live in-memory delivery are future work |
+| Multiplayer signals (`chidori.signal` / `pollSignal` / `signalAny` + `timeoutMs`, `POST /sessions/{id}/signal`, live in-memory delivery to streaming runs) | Done — Phases 1–3 of `docs/signals.md` |
 | TypeScript tool discovery | Done |
 | TypeScript and Python SDK parity | Done |
 | Snapshot manifests, policy/source validation, host promise records | Done |
@@ -47,11 +47,13 @@ completion audit lives in
 
 - [x] `chidori.prompt()`
 - [x] `chidori.input()`
-- [x] `chidori.signal()` / `chidori.pollSignal()` — multiplayer named signals:
-      blocking listen point, durable per-run mailbox, `POST /sessions/{id}/signal`
-      delivery (resolve+resume / enqueue / 409), deterministic replay (Phase 1 +
-      `pollSignal` of `docs/signals.md`; `signalAny` / `timeoutMs` / live in-memory
-      delivery are future work).
+- [x] `chidori.signal()` / `chidori.pollSignal()` / `chidori.signalAny()` —
+      multiplayer named signals: blocking listen point, fan-in listen sets,
+      durable per-run mailbox, `timeoutMs` with a deterministic
+      `{timedOut: true}` sentinel (server-armed deadline timers, re-armed on
+      restart), `POST /sessions/{id}/signal` delivery (resolve+resume / enqueue /
+      live in-memory to streaming runs / 409), sender provenance as OTEL span
+      attributes, deterministic replay (Phases 1–3 of `docs/signals.md`).
 - [x] `chidori.callAgent()`
 - [x] `chidori.tool()`
 - [x] `chidori.parallel()`

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -181,6 +181,24 @@ impl Engine {
             });
         let d = dispatch.clone();
         self.vm
+            .define_method(&chidori, "signalAny", 2, move |vm, _t, args| {
+                let names = args
+                    .first()
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                let opts = args
+                    .get(1)
+                    .map(|v| vm.value_to_json(v))
+                    .unwrap_or(serde_json::Value::Null);
+                forward_effect(
+                    vm,
+                    &d,
+                    "signal_any",
+                    serde_json::json!({ "names": names, "opts": opts }),
+                )
+            });
+        let d = dispatch.clone();
+        self.vm
             .define_method(&chidori, "checkpoint", 2, move |vm, _t, args| {
                 let label = args
                     .first()

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,12 +1,21 @@
 # Runtime Signals — Multiplayer Agents — Design Doc & Implementation Plan
 
-> **Status:** Implemented. Phase 1 plus `pollSignal` have shipped: the named
+> **Status:** Implemented — Phases 1–3 have all shipped. Phase 1: the named
 > **blocking** `chidori.signal(name)`, the durable **per-run mailbox**, the
 > `POST /sessions/{id}/signal` **delivery endpoint** (resolve+resume, enqueue, or
 > 409), and **deterministic replay** of the whole multiplayer session.
-> `signalAny`, `timeoutMs`, and live zero-latency in-memory delivery to a running
-> task (the Phase 2/3 remainder) are **future work**. The same-name tie-break is
-> pinned to **pending-pause-wins-with-newest**.
+> Phase 2: **`pollSignal`**, the fan-in **`chidori.signalAny([names])`**,
+> **`timeoutMs`** (pinned: resolve to a `{timedOut: true}` **sentinel**, enforced
+> by a server timer against a persisted deadline, re-armed on restart), and
+> signal `name`/`from` stamped as **OTEL span attributes**. Phase 3: **live
+> in-memory delivery** — the delivery endpoint enqueues straight into a
+> streaming run's in-memory mailbox (write-through to `signals/inbox.json`) and
+> wakes the supervising worker, which resolves a matching pause **in-process**
+> (no HTTP `/resume` round-trip) and keeps the SSE stream open across the
+> resume. Pinned decisions: the same-name tie-break is
+> **pending-pause-wins-with-newest** (also applied by the live worker, which
+> takes the just-delivered entry back out of the mailbox); the `signalAny`
+> result shape is the **bare `Signal`** whose `name` says which fired.
 > **Engine:** chidori-js (the pure-Rust JS engine) is now the only runtime — there
 > is no `CHIDORI_JS_ENGINE=rust` selector, no `rust-engine` cargo feature gate to
 > opt in, and no separate QuickJS path to keep untouched.
@@ -211,19 +220,25 @@ import { chidori } from "chidori";
 type Signal<T = Json> = { name: string; payload: T; from: SignalSender };
 type SignalSender = { kind: "human" | "agent"; id: string; runId?: string };
 
-// Blocking: pause at a named listen point until a matching signal is delivered
-// (or already queued in the mailbox).
-chidori.signal<T = Json>(name: string, opts?: {
-  timeoutMs?: number;          // Phase 2: resolve to a Timeout sentinel instead of waiting forever
-}): Promise<Signal<T>>;
+type SignalTimeout = { name: string | null; payload: null; from: null; timedOut: true };
 
-// Non-blocking (Phase 2): consume a queued signal if present, else null. Records
+// Blocking: pause at a named listen point until a matching signal is delivered
+// (or already queued in the mailbox). With timeoutMs, resolves to the
+// SignalTimeout sentinel after the deadline (discriminate with "timedOut" in r).
+chidori.signal<T = Json>(name: string, opts?: {
+  timeoutMs?: number;
+}): Promise<Signal<T> | SignalTimeout>;
+
+// Non-blocking: consume a queued signal if present, else null. Records
 // the result (value OR null) so replay is deterministic at this seq.
 chidori.pollSignal<T = Json>(name: string): Promise<Signal<T> | null>;
 
-// Fan-in (Phase 2): pause until ANY of the named signals is delivered; the result
-// says which fired.
-chidori.signalAny<T = Json>(names: string[]): Promise<Signal<T>>;
+// Fan-in: pause until ANY of the named signals is delivered; the result is the
+// bare consumed signal — its `name` says which fired. Pre-arrived candidates
+// are consumed in arrival order (lowest delivery_seq across the name set).
+chidori.signalAny<T = Json>(names: string[], opts?: {
+  timeoutMs?: number;          // sentinel `name` is null (no name fired)
+}): Promise<Signal<T> | SignalTimeout>;
 ```
 
 ### 6.2 SDK types
@@ -567,21 +582,45 @@ Tests (`--features rust-engine`):
   chidori.signal("review")`, a second terminal (or peer agent) POSTs the review; streams
   to tael (`CHIDORI_JS_ENGINE=rust`).
 
-**Phase 2 — Non-blocking poll + fan-in/select + sender identity in trace** *(partially shipped: `pollSignal` done; `signalAny` / `timeoutMs` / `from`-as-span-attribute are future)*
-- `chidori.pollSignal` (records value *or* null at the seq → deterministic),
-  `chidori.signalAny([names])` (pauses on a name *set*; result says which fired; match key
-  `{names:[...]}`). `from` stamped as an OTEL span attribute in `RunSpan::stream_record`.
-  Optional `timeoutMs` → a `Timer`-backed Timeout sentinel.
-- Tests: poll returns null then a value deterministically; select fires on first matching
-  name; `from` appears in the streamed span.
+**Phase 2 — Non-blocking poll + fan-in/select + timeout + sender identity in trace** *(shipped)*
+- `chidori.pollSignal` (records value *or* null at the seq → deterministic).
+- `chidori.signalAny([names])`: pauses on a name *set* (match key `{names:[...]}`,
+  function `signal_any`); the result is the bare consumed signal whose `name` says which
+  fired; the mailbox drain takes the lowest-`delivery_seq` entry across the whole set.
+  A delivery matching ANY name in `pending_signal_names` resolves the pause.
+- `timeoutMs` (on both `signal` and `signalAny`): the pause records the timeout, the
+  server persists an absolute `pending_signal_deadline` on the session and arms an
+  in-process timer (re-armed for every paused session at server startup). On expiry the
+  pause resolves to the `{name, payload: null, from: null, timedOut: true}` sentinel
+  (`name` is null for a multi-name `signalAny`) — recorded like any signal result, so
+  the timed-out run replays deterministically. A delivery that lands first wins; the
+  late timer validates against the stored session and no-ops.
+- `name`/`from` stamped as OTEL span attributes (`signal.name`, `signal.listen_names`,
+  `signal.from.kind/id/run_id`, `signal.timed_out`) on `signal`/`poll_signal`/
+  `signal_any` spans.
+- Tests: poll returns null then a value deterministically; select fires on the earliest
+  matching delivery; timeout resolves the sentinel and replays; delivery-before-timeout
+  wins.
 
-**Phase 3 — Live in-memory delivery to running tasks** *(future)*
-- `ActiveSession.signal_tx` (analogous to `cancel_tx`); streaming worker `select!`s on
-  `signal_rx`, write-through to `inbox.json`, in-process fast resume trigger (skip the
-  HTTP `/resume` round-trip). Determinism unchanged (it is still a deterministic resume
-  re-run; the channel only removes the disk/HTTP latency).
-- Tests: a streaming run receives a mid-stream signal with low latency and produces a
-  call_log identical to the persist-resume path.
+**Phase 3 — Live in-memory delivery to running tasks** *(shipped)*
+- `ActiveSession.signals` carries the live run's context slot plus a `signal_tx` wake
+  channel (analogous to `cancel_tx`). The delivery endpoint enqueues straight into the
+  live run's in-memory mailbox — write-through persisted to `inbox.json` in the same
+  critical section — and wakes the streaming worker (`202 {"status":"delivered_live"}`).
+- The streaming worker (`stream_session`) is a supervision loop: a `signal()` pause
+  persists durably, emits a `paused` SSE event, and keeps the stream open; the worker
+  `select!`s on `signal_rx` / cancel / the `timeoutMs` deadline and resolves a matching
+  pause **in-process** (resolve persisted op + synthetic record + replay re-run, the
+  same shape as `/resume`) — skipping the HTTP round-trip. The pinned
+  pending-pause-wins-with-newest tie-break is preserved: the worker takes the
+  just-delivered entry back out of the mailbox by its `delivery_seq`, leaving older
+  queued entries for later listen points. Determinism unchanged (it is still a
+  deterministic resume re-run; the live path only removes the disk/HTTP latency).
+- Input/approval pauses end live supervision and hand off to the durable HTTP
+  endpoints; terminal states close the stream with the usual `done` event.
+- Tests: a streaming run's delivered signal records a call identical to the
+  persist-resume path; a non-matching live delivery survives the in-process resume and
+  is drained by a later `pollSignal`; a streaming `timeoutMs` pause resolves in-process.
 
 ---
 
@@ -598,11 +637,21 @@ Tests (`--features rust-engine`):
   unless the agent calls them).
 
 ## 16. Open questions
-- **Same-name tie-break** when a pause and a queued entry both match (§11) — confirm
-  "pending-pause-wins-with-newest" vs "drain-oldest-queued".
-- **`timeoutMs` semantics** — resolve to a `Timeout` sentinel vs reject the promise.
-- **`signalAny` result shape** — `{firedName, signal}` vs the bare `Signal` with its
-  `name`.
+
+**Pinned (decided with Phase 2/3):**
+- **Same-name tie-break**: **pending-pause-wins-with-newest** — the pending pause
+  resolves with the just-delivered signal; older queued same-name entries stay for later
+  listen points. The live worker preserves this by taking the delivered entry back out
+  of the mailbox by `delivery_seq`.
+- **`timeoutMs` semantics**: **resolve to a sentinel** (`{name, payload: null,
+  from: null, timedOut: true}`), never reject — a timeout is an expected outcome the
+  agent discriminates on, not an error. Enforcement is server-side (in-process timer
+  against a persisted `pending_signal_deadline`, re-armed on restart); a CLI run that
+  pauses on a timed listen point just reports the pause.
+- **`signalAny` result shape**: the **bare `Signal`** — its `name` already says which
+  fired; no wrapper object.
+
+**Still open:**
 - **Per-branch addressing** — is a single per-run mailbox enough for the branching
   composition, or is `branch_index`-addressed delivery wanted sooner?
 - **Auth/identity for `from`** — is sender identity asserted by the caller (trusted) or

--- a/examples/multiplayer-review/README.md
+++ b/examples/multiplayer-review/README.md
@@ -171,7 +171,12 @@ replay with an empty mailbox still reproduces every consumed signal.
 
 - chidori-js (the pure-Rust JS engine) is the only runtime; no engine env var or
   cargo feature is needed.
-- Phase 1 + `pollSignal` are shipped: a blocking named signal, a durable per-run
-  mailbox, the `/signal` delivery endpoint, and deterministic replay. `signalAny`,
-  `timeoutMs`, and zero-latency in-memory delivery to a running task are future
-  work (see [`docs/signals.md`](../../docs/signals.md) §14).
+- All three phases of [`docs/signals.md`](../../docs/signals.md) §14 are
+  shipped: the blocking named signal, durable per-run mailbox, `/signal`
+  delivery endpoint, and deterministic replay (Phase 1); `pollSignal`, the
+  fan-in `chidori.signalAny(["review", "steer"])`, `timeoutMs` (resolves to a
+  `{timedOut: true}` sentinel after the deadline), and sender provenance as
+  OTEL span attributes (Phase 2); and live in-memory delivery — a signal sent
+  to a run streaming over `/sessions/stream` lands in the running agent's
+  mailbox in-memory and resumes a matching pause in-process, the response
+  reporting `"delivered_live"` (Phase 3).

--- a/llm.txt
+++ b/llm.txt
@@ -132,6 +132,30 @@ const answer = await chidori.input("Approve this request?", {
 In server mode, `input()` pauses the session. Resume it with
 `POST /sessions/{id}/resume` or `AgentClient.resume(id, response)`.
 
+### signal / pollSignal / signalAny
+
+```ts
+// Pause at a named listen point until an outside party (human or agent)
+// delivers { name, payload, from } via POST /sessions/{id}/signal. A durable
+// per-run mailbox absorbs signals that arrive before the agent listens.
+const review = await chidori.signal("review");
+
+// With timeoutMs, resolves to { timedOut: true } after the deadline.
+const r = await chidori.signal("review", { timeoutMs: 60000 });
+if ("timedOut" in r && r.timedOut) { /* nobody answered */ }
+
+// Non-blocking: consume a queued signal or get null (recorded, replayable).
+const steer = await chidori.pollSignal("steer");
+
+// Fan-in: pause until ANY listed name fires; result.name says which.
+const fired = await chidori.signalAny(["review", "steer"]);
+```
+
+Every consumed signal is recorded in the call log, so multiplayer sessions
+replay deterministically. Signals delivered to a run streaming over
+`POST /sessions/stream` are pushed into the live agent's mailbox in-memory and
+resume a matching pause in-process. See `docs/signals.md`.
+
 ### tool
 
 ```ts
@@ -308,6 +332,9 @@ Session endpoints:
   `snapshot_manifest`.
 - `GET /sessions/{id}/snapshot`: get only snapshot manifest metadata.
 - `POST /sessions/{id}/resume`: resume a paused `input()` session.
+- `POST /sessions/{id}/signal`: deliver `{ name, payload?, from? }` — resolves
+  a matching signal pause (200), delivers live to a streaming run
+  (202 `delivered_live`), or enqueues into the durable mailbox (202 `queued`).
 - `POST /sessions/{id}/replay`: replay from a call-log checkpoint.
 - `POST /sessions/stream`: run with SSE events.
 

--- a/sdk/python/chidori/client.py
+++ b/sdk/python/chidori/client.py
@@ -50,10 +50,15 @@ class Checkpoint:
 
 @dataclass
 class SignalQueued:
-    """Returned by `AgentClient.signal` when the run was not paused-waiting on
-    this name (it was running, or paused on something else), so the signal was
-    enqueued into the durable mailbox to be drained at the next matching listen
-    point. Mirrors the server's 202 Accepted body.
+    """Returned by `AgentClient.signal` when the signal was accepted but did
+    not resolve a pause synchronously. Mirrors the server's 202 Accepted body:
+
+      * status == "queued" — the run was not waiting on this name; the signal
+        sits in the durable mailbox until a matching listen point drains it.
+      * status == "delivered_live" — a live streaming worker supervises the
+        run; the signal was enqueued into the running agent's in-memory
+        mailbox and the worker was woken to resume a matching pause
+        in-process.
     """
 
     id: str
@@ -81,6 +86,13 @@ class Session:
     # name it is waiting on (so the caller can deliver via `client.signal`).
     # None for plain `input()` pauses and non-signal states.
     pending_signal_name: str | None = None
+    # The full awaited name set: `[name]` for `chidori.signal(name)`, the
+    # listen set for `chidori.signalAny(names)`. Empty for non-signal states.
+    pending_signal_names: list[str] = field(default_factory=list)
+    # Absolute deadline (ISO timestamp) for a signal pause created with
+    # `timeoutMs`; the server resolves the pause with the `{timedOut: true}`
+    # sentinel when it passes. None when the pause has no timeout.
+    pending_signal_deadline: str | None = None
     snapshot_manifest: dict | None = None
     _client: AgentClient | None = field(default=None, repr=False)
 
@@ -173,6 +185,8 @@ class AgentClient:
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
             pending_signal_name=data.get("pending_signal_name"),
+            pending_signal_names=data.get("pending_signal_names") or [],
+            pending_signal_deadline=data.get("pending_signal_deadline"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -200,6 +214,8 @@ class AgentClient:
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
             pending_signal_name=data.get("pending_signal_name"),
+            pending_signal_names=data.get("pending_signal_names") or [],
+            pending_signal_deadline=data.get("pending_signal_deadline"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -220,6 +236,8 @@ class AgentClient:
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
             pending_signal_name=data.get("pending_signal_name"),
+            pending_signal_names=data.get("pending_signal_names") or [],
+            pending_signal_deadline=data.get("pending_signal_deadline"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -238,9 +256,12 @@ class AgentClient:
           * the run was paused-waiting on this exact name → the pause resolves
             and the run resumes; returns the advanced `Session` (200), now
             `completed` or re-`paused`.
-          * the run was running or paused on something else → the signal is
-            enqueued into the durable mailbox; returns a `SignalQueued`
-            descriptor (202) carrying the assigned `delivery_seq`.
+          * otherwise → the signal is accepted asynchronously; returns a
+            `SignalQueued` descriptor (202) carrying the assigned
+            `delivery_seq`. Its `status` is "queued" (durable mailbox, drained
+            at the next matching listen point) or "delivered_live" (a live
+            streaming worker received it in-memory and resumes a matching
+            pause in-process).
 
         Raises on 400 (empty name), 404 (unknown session), or 409 (terminal run).
         """
@@ -248,11 +269,12 @@ class AgentClient:
             f"/sessions/{session_id}/signal",
             {"name": name, "payload": payload, "from": from_},
         )
-        if status == 202 or data.get("status") == "queued":
+        if status == 202 or data.get("status") in ("queued", "delivered_live"):
             return SignalQueued(
                 id=data["id"],
                 name=data.get("name", name),
                 delivery_seq=data["delivery_seq"],
+                status=data.get("status", "queued"),
             )
         return Session(
             id=data["id"],
@@ -263,6 +285,8 @@ class AgentClient:
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
             pending_signal_name=data.get("pending_signal_name"),
+            pending_signal_names=data.get("pending_signal_names") or [],
+            pending_signal_deadline=data.get("pending_signal_deadline"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )
@@ -279,6 +303,8 @@ class AgentClient:
             pending_seq=data.get("pending_seq"),
             pending_prompt=data.get("pending_prompt"),
             pending_signal_name=data.get("pending_signal_name"),
+            pending_signal_names=data.get("pending_signal_names") or [],
+            pending_signal_deadline=data.get("pending_signal_deadline"),
             snapshot_manifest=data.get("snapshot_manifest"),
             _client=self,
         )

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -149,8 +149,26 @@ export interface Signal<T = AgentJson> {
 }
 
 export interface SignalOptions {
-  /** Phase 2 (future): resolve to a timeout sentinel instead of waiting forever. */
+  /**
+   * Resolve to a {@link SignalTimeout} sentinel after this many milliseconds
+   * instead of waiting forever. The deadline is enforced by the supervising
+   * server while the run idles; the recorded result (signal or sentinel)
+   * replays deterministically. Discriminate with `"timedOut" in result`.
+   */
   timeoutMs?: number;
+}
+
+/**
+ * The sentinel a `timeoutMs` listen point resolves to when the deadline passes
+ * with no matching delivery (`docs/signals.md` §16, pinned:
+ * resolve-to-sentinel rather than reject). `name` is the single awaited name,
+ * or `null` for a multi-name `signalAny`.
+ */
+export interface SignalTimeout {
+  name: string | null;
+  payload: null;
+  from: null;
+  timedOut: true;
 }
 
 export interface ParallelOptions {
@@ -248,13 +266,28 @@ export interface Chidori {
    * `{ name, payload, from }`. The inverse of `input()`: the run idles cheaply
    * on disk and an outside party delivers via `POST /sessions/{id}/signal`.
    */
-  signal<T = AgentJson>(name: string, options?: SignalOptions): Promise<Signal<T>>;
+  signal<T = AgentJson>(name: string): Promise<Signal<T>>;
+  signal<T = AgentJson>(
+    name: string,
+    options: SignalOptions,
+  ): Promise<Signal<T> | SignalTimeout>;
   /**
    * Non-blocking: consume a queued signal of this name if present, else resolve
    * to `null`. Records the result (value or null) at this seq so replay is
    * deterministic.
    */
   pollSignal<T = AgentJson>(name: string): Promise<Signal<T> | null>;
+  /**
+   * Fan-in: pause until ANY of the named signals is delivered (or one is
+   * already queued in the durable mailbox). Resolves to the bare consumed
+   * signal — its `name` says which fired. Pre-arrived candidates are consumed
+   * in delivery order (lowest `delivery_seq` across the whole name set).
+   */
+  signalAny<T = AgentJson>(names: string[]): Promise<Signal<T>>;
+  signalAny<T = AgentJson>(
+    names: string[],
+    options: SignalOptions,
+  ): Promise<Signal<T> | SignalTimeout>;
   callAgent<TInput extends AgentJson = JsonObject, TOutput extends AgentJson = AgentJson>(
     path: string,
     input?: TInput,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -30,6 +30,7 @@ export type {
   Signal,
   SignalOptions,
   SignalSender,
+  SignalTimeout,
   ToolDefinition,
   ToolFunction,
   TryCallResult,
@@ -194,15 +195,18 @@ export class Checkpoint {
 }
 
 /**
- * Returned by `client.signal` when the run was not paused-waiting on this name
- * (it was running, or paused on something else), so the signal was enqueued
- * into the durable mailbox to be drained at the next matching listen point.
- * Mirrors the server's 202 Accepted body.
+ * Returned by `client.signal` when the signal was accepted but did not resolve
+ * a pause synchronously. Mirrors the server's 202 Accepted body:
+ *   * `"queued"` — the run was not waiting on this name; the signal sits in
+ *     the durable mailbox until a matching listen point drains it.
+ *   * `"delivered_live"` — a live streaming worker supervises the run; the
+ *     signal was enqueued into the running agent's in-memory mailbox and the
+ *     worker was woken to resume a matching pause in-process.
  */
 export interface SignalQueued {
   /** Session id the signal was delivered to. */
   id: string;
-  status: "queued";
+  status: "queued" | "delivered_live";
   /** The signal name, echoed back. */
   name: string;
   /** Monotonic per-run sequence freezing global arrival order across senders. */
@@ -225,7 +229,8 @@ export interface SignalDelivery {
  * descriptor (the signal was enqueued for a later listen point).
  */
 export function isSignalQueued(result: Session | SignalQueued): result is SignalQueued {
-  return (result as SignalQueued).status === "queued";
+  const status = (result as SignalQueued).status;
+  return status === "queued" || status === "delivered_live";
 }
 
 /** One execution of an agent — result + call log + status. */
@@ -246,6 +251,18 @@ export class Session {
      * `null` for plain `input()` pauses and non-signal states.
      */
     public pendingSignalName: string | null = null,
+    /**
+     * The full awaited name set when paused on a signal listen point: `[name]`
+     * for `chidori.signal(name)`, the listen set for `chidori.signalAny(names)`.
+     * Empty for non-signal states.
+     */
+    public pendingSignalNames: string[] = [],
+    /**
+     * Absolute deadline (ISO timestamp) for a signal pause created with
+     * `timeoutMs`; the server resolves the pause with the timeout sentinel
+     * when it passes. `null` when the pause has no timeout.
+     */
+    public pendingSignalDeadline: string | null = null,
   ) {}
 
   get ok(): boolean {
@@ -298,6 +315,21 @@ export type StreamEvent =
       seq: number;
       prompt_type?: string | null;
       error?: string | null;
+    }
+  | {
+      /**
+       * The streamed run paused at a `signal()` / `signalAny()` listen point
+       * and stays live: the worker keeps supervising, and a delivered signal
+       * (or the `timeoutMs` deadline) resumes it in-process — further events
+       * follow on the same stream. Deliver with `client.signal`.
+       */
+      type: "paused";
+      id: string;
+      status: "paused";
+      pending_seq: number;
+      pending_signal_name?: string | null;
+      pending_signal_names?: string[];
+      pending_signal_deadline?: string | null;
     }
   | { type: "done"; id: string; status: SessionStatus; output?: Json; error?: string };
 
@@ -372,9 +404,11 @@ export class AgentClient {
    *   * the run was paused-waiting on this exact name → it resolves the pause
    *     and resumes; this returns the advanced `Session` (200), now `completed`
    *     or re-`paused`.
-   *   * the run was running or paused on something else → the signal is enqueued
-   *     into the durable mailbox; this returns a `SignalQueued` descriptor (202)
-   *     carrying the assigned `delivery_seq`.
+   *   * otherwise → the signal is accepted asynchronously; this returns a
+   *     `SignalQueued` descriptor (202) carrying the assigned `delivery_seq`,
+   *     with `status` `"queued"` (durable mailbox) or `"delivered_live"` (a
+   *     live streaming worker received it in-memory and resumes a matching
+   *     pause in-process).
    *
    * Throws on 400 (empty name), 404 (unknown session), or 409 (terminal run).
    */
@@ -390,7 +424,8 @@ export class AgentClient {
         from: delivery.from ?? null,
       },
     );
-    if (status === 202 || (data as { status?: string }).status === "queued") {
+    const accepted = (data as { status?: string }).status;
+    if (status === 202 || accepted === "queued" || accepted === "delivered_live") {
       return data as unknown as SignalQueued;
     }
     return this.sessionFrom(data, (data.input as Json | undefined) ?? null);
@@ -477,6 +512,8 @@ export class AgentClient {
       this,
       (data.snapshot_manifest as SnapshotManifest | undefined) ?? null,
       (data.pending_signal_name as string | undefined) ?? null,
+      (data.pending_signal_names as string[] | undefined) ?? [],
+      (data.pending_signal_deadline as string | undefined) ?? null,
     );
   }
 
@@ -528,6 +565,9 @@ function parseSseFrame(frame: string): StreamEvent | null {
     }
     if (event === "prompt_end") {
       return { type: "prompt_end", ...(data as object) } as StreamEvent;
+    }
+    if (event === "paused") {
+      return { type: "paused", ...(data as object) } as StreamEvent;
     }
     if (event === "done") return { type: "done", ...(data as object) } as StreamEvent;
   } catch {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -72,6 +72,8 @@ async fn create_thread(
         pending_seq: None,
         pending_prompt: None,
         pending_signal_name: None,
+        pending_signal_names: Vec::new(),
+        pending_signal_deadline: None,
         pending_approval: None,
         approvals: Vec::new(),
         policy_profile: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,9 +497,12 @@ fn cmd_run(
     // tell the user the run is awaiting a signal and how to deliver one rather
     // than printing a bare `null` output. See `docs/signals.md`.
     if let Some(signal) = &result.paused_signal {
+        let names = signal.listen_names();
         eprintln!(
-            "Run {} paused, awaiting signal '{}'.",
-            result.run_id, signal.name
+            "Run {} paused, awaiting signal{} '{}'.",
+            result.run_id,
+            if names.len() > 1 { " (any of)" } else { "" },
+            names.join("', '")
         );
         eprintln!(
             "Deliver it with: POST /sessions/{{id}}/signal \

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -222,16 +222,41 @@ pub struct PendingInput {
     pub prompt: String,
 }
 
-/// Set by `execute_signal` when a `chidori.signal(name)` listen point has no
+/// Set by `execute_signal` / `execute_signal_any` when a listen point has no
 /// matching mailbox entry and must pause. The engine reads this after eval
 /// unwinds to distinguish a signal pause (surfaced as `RunResult.paused_signal`)
 /// from a real error, mirroring [`PendingInput`]. The pending host operation's
-/// match key is `{ "name": name }`; `id` is its host-promise id.
+/// match key is `{ "name": name }` (or `{ "names": [...] }` for `signalAny`);
+/// `id` is its host-promise id.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PendingSignal {
     pub seq: u64,
+    /// The awaited name (`signal`) or the first of the awaited names
+    /// (`signalAny`). Kept as the primary name for views and messages.
     pub name: String,
+    /// The full awaited name set. `[name]` for `chidori.signal(name)`; the
+    /// listen set for `chidori.signalAny(names)`. A delivery matching ANY of
+    /// these resolves the pause.
+    #[serde(default)]
+    pub names: Vec<String>,
+    /// `timeoutMs` from the listen call's options, when given. The supervising
+    /// server arms a timer and, on expiry, resolves the pause with the
+    /// `{ timedOut: true }` sentinel instead of a delivered signal.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
     pub id: HostOperationId,
+}
+
+impl PendingSignal {
+    /// The awaited name set, falling back to `[name]` for values deserialized
+    /// from before `names` existed.
+    pub fn listen_names(&self) -> Vec<String> {
+        if self.names.is_empty() {
+            vec![self.name.clone()]
+        } else {
+            self.names.clone()
+        }
+    }
 }
 
 /// Set by the policy enforcer when a call needs user approval but the
@@ -877,17 +902,77 @@ impl RuntimeContext {
     /// delivery — on restart the recorded result wins and the inbox is never
     /// re-drained for that seq. Returns `None` when no matching entry exists.
     pub fn take_queued_signal(&self, name: &str) -> Option<QueuedSignal> {
+        self.take_queued_signal_any(std::slice::from_ref(&name.to_string()))
+    }
+
+    /// As [`take_queued_signal`](Self::take_queued_signal), but matching ANY of
+    /// `names` (the `chidori.signalAny` fan-in drain). The lowest-`delivery_seq`
+    /// entry across the whole set wins, so two queued candidates with different
+    /// names are consumed in arrival order — and that choice is frozen into the
+    /// recorded result.
+    pub fn take_queued_signal_any(&self, names: &[String]) -> Option<QueuedSignal> {
         let mut inner = self.inner.lock().unwrap();
         let idx = inner
             .signal_inbox
             .iter()
             .enumerate()
-            .filter(|(_, s)| s.name == name)
+            .filter(|(_, s)| names.iter().any(|n| n == &s.name))
             .min_by_key(|(_, s)| s.delivery_seq)
             .map(|(i, _)| i)?;
         let signal = inner.signal_inbox.remove(idx);
         persist_signal_inbox(&inner);
         Some(signal)
+    }
+
+    /// Remove a specific queued signal by its `delivery_seq`, re-persisting the
+    /// shrunken inbox in the same critical section. Used by the live streaming
+    /// supervisor (Phase 3, `docs/signals.md`) to apply the pinned
+    /// "pending-pause-wins-with-newest" tie-break: a just-delivered signal is
+    /// write-through enqueued for durability, then *that exact entry* is taken
+    /// back out to resolve the pending pause, leaving older queued same-name
+    /// entries for later listen points.
+    pub fn take_queued_signal_by_delivery_seq(&self, delivery_seq: u64) -> Option<QueuedSignal> {
+        let mut inner = self.inner.lock().unwrap();
+        let idx = inner
+            .signal_inbox
+            .iter()
+            .position(|s| s.delivery_seq == delivery_seq)?;
+        let signal = inner.signal_inbox.remove(idx);
+        persist_signal_inbox(&inner);
+        Some(signal)
+    }
+
+    /// Append a signal delivered to a LIVE run into its in-memory mailbox,
+    /// write-through persisting the grown inbox (`docs/signals.md` Phase 3).
+    /// The in-memory and on-disk inboxes mutate in one critical section, so the
+    /// running agent sees the entry at its next listen point and a crash after
+    /// the enqueue cannot lose an acknowledged delivery. Returns the stored
+    /// entry with its assigned `delivery_seq` (monotonic above every entry
+    /// currently queued).
+    pub fn enqueue_live_signal(
+        &self,
+        name: &str,
+        payload: serde_json::Value,
+        from: serde_json::Value,
+    ) -> QueuedSignal {
+        let mut inner = self.inner.lock().unwrap();
+        let delivery_seq = inner
+            .signal_inbox
+            .iter()
+            .map(|s| s.delivery_seq)
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let queued = QueuedSignal {
+            name: name.to_string(),
+            payload,
+            from,
+            delivery_seq,
+            enqueued_at: chrono::Utc::now(),
+        };
+        inner.signal_inbox.push(queued.clone());
+        persist_signal_inbox(&inner);
+        queued
     }
 
     #[allow(dead_code)]

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -397,6 +397,21 @@ impl Engine {
         self.run_with_context(path, inputs, ctx)
     }
 
+    /// Run an agent on a context the caller prepared (event sender, input
+    /// mode, replay state, run id). Used by the server's streaming supervisor,
+    /// which keeps a handle on the live context so externally delivered
+    /// signals can be enqueued into the running agent's mailbox in-memory
+    /// (`docs/signals.md` Phase 3) and swaps in a fresh replay context for
+    /// each in-process resume.
+    pub fn run_with_prepared_context(
+        &self,
+        path: &Path,
+        inputs: &Value,
+        ctx: RuntimeContext,
+    ) -> Result<RunResult> {
+        self.run_with_context(path, inputs, ctx)
+    }
+
     /// Resume/replay an interactive streaming run with persisted host-promise
     /// state. Used by embedders that mirror the server session interaction
     /// without routing through HTTP.

--- a/src/runtime/host_core.rs
+++ b/src/runtime/host_core.rs
@@ -196,7 +196,7 @@ fn host_operation_kind(function: &str) -> Option<PendingHostOperationKind> {
         "memory" => Some(PendingHostOperationKind::Memory),
         "checkpoint" => Some(PendingHostOperationKind::Checkpoint),
         "log" => Some(PendingHostOperationKind::Log),
-        "signal" | "poll_signal" => Some(PendingHostOperationKind::Signal),
+        "signal" | "poll_signal" | "signal_any" => Some(PendingHostOperationKind::Signal),
         _ => None,
     }
 }
@@ -270,6 +270,55 @@ fn signal_name(function: &str, args: &Value) -> Result<String> {
         .ok_or_else(|| anyhow::anyhow!("chidori.{function} requires a string name"))
 }
 
+/// Pull the required non-empty `names` string array from a `signalAny`
+/// binding's args (`{ "names": [<string>...], "opts": <json|null> }`).
+fn signal_names(args: &Value) -> Result<Vec<String>> {
+    let names: Vec<String> = args
+        .get("names")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(|v| v.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()
+        })
+        .ok_or_else(|| anyhow::anyhow!("chidori.signalAny requires an array of names"))?
+        .ok_or_else(|| anyhow::anyhow!("chidori.signalAny names must all be strings"))?;
+    if names.is_empty() {
+        anyhow::bail!("chidori.signalAny requires at least one name");
+    }
+    Ok(names)
+}
+
+/// Optional positive `timeoutMs` from a signal binding's opts
+/// (`{ ..., "opts": { "timeoutMs": <number> } }`). The runtime only records it
+/// on the pause; enforcement (resolving the pause with the
+/// [`signal_timeout_sentinel`] after the deadline) is the supervising server's
+/// job, since a paused run is not a live task.
+fn signal_timeout_ms(args: &Value) -> Option<u64> {
+    args.get("opts")
+        .and_then(|opts| opts.get("timeoutMs"))
+        .and_then(Value::as_u64)
+        .filter(|ms| *ms > 0)
+}
+
+/// The result a timed-out signal listen point resolves to (`docs/signals.md`
+/// §16, pinned: resolve-to-sentinel rather than reject). Shaped like a signal
+/// with `payload`/`from` nulled and `timedOut: true`, so agent code
+/// discriminates with `"timedOut" in result`. `name` is the single awaited
+/// name, or `null` for a multi-name `signalAny` (no name fired).
+pub fn signal_timeout_sentinel(names: &[String]) -> Value {
+    let name = match names {
+        [single] => Value::String(single.clone()),
+        _ => Value::Null,
+    };
+    json!({
+        "name": name,
+        "payload": Value::Null,
+        "from": Value::Null,
+        "timedOut": true,
+    })
+}
+
 /// `chidori.signal(name, opts)` — the blocking, named, externally-deliverable
 /// flavor of `input`, fronted by a durable per-run mailbox. See
 /// `docs/signals.md` §5/§8.3. Order:
@@ -338,9 +387,81 @@ pub fn execute_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
     ctx.set_pending_signal(PendingSignal {
         seq,
         name: name.clone(),
+        names: vec![name.clone()],
+        timeout_ms: signal_timeout_ms(args),
         id: host_operation,
     });
     Err(anyhow::anyhow!("{PAUSE_MARKER}: signal {name}"))
+}
+
+/// `chidori.signalAny(names, opts)` — the fan-in listen point (`docs/signals.md`
+/// §6.1): pause until ANY of the named signals is delivered (or one is already
+/// queued). Same shape as `execute_signal` with the match key `{ "names":
+/// [...] }` and function name `"signal_any"`. The result is the bare consumed
+/// signal `{name, payload, from}` — its `name` says which fired (§16, pinned).
+/// The mailbox drain takes the lowest-`delivery_seq` entry across the whole
+/// name set, freezing arrival order into the recorded result.
+pub fn execute_signal_any(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
+    let names = signal_names(args)?;
+    let match_args = json!({ "names": names });
+    let seq = ctx.next_seq();
+
+    if let Some(record) = ctx
+        .try_replay_checked(seq, "signal_any")
+        .map_err(|err| anyhow::anyhow!(err))?
+    {
+        return Ok(record.result);
+    }
+
+    if let Some(result) = replay_completed_host_operation(
+        ctx,
+        seq,
+        "signal_any",
+        PendingHostOperationKind::Signal,
+        &match_args,
+    )? {
+        return Ok(result);
+    }
+
+    let host_operation = ctx.begin_host_operation_with_function(
+        seq,
+        PendingHostOperationKind::Signal,
+        Some("signal_any".to_string()),
+        match_args.clone(),
+    );
+    ctx.run_host_operation_safepoint(host_operation)?;
+
+    if let Some(queued) = ctx.take_queued_signal_any(&names) {
+        let result = json!({
+            "name": queued.name,
+            "payload": queued.payload,
+            "from": queued.from,
+        });
+        ctx.resolve_host_operation(host_operation, result.clone())?;
+        ctx.record_call(CallRecord {
+            seq,
+            parent_seq: None,
+            function: "signal_any".to_string(),
+            args: match_args,
+            result: result.clone(),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        });
+        ctx.run_host_operation_completion_safepoint(host_operation)?;
+        return Ok(result);
+    }
+
+    let joined = names.join(", ");
+    ctx.set_pending_signal(PendingSignal {
+        seq,
+        name: names[0].clone(),
+        names,
+        timeout_ms: signal_timeout_ms(args),
+        id: host_operation,
+    });
+    Err(anyhow::anyhow!("{PAUSE_MARKER}: signalAny [{joined}]"))
 }
 
 /// `chidori.pollSignal(name)` — non-blocking signal consumption (`docs/signals.md`
@@ -2177,5 +2298,131 @@ mod tests {
         let ctx = RuntimeContext::new();
         let err = execute_signal(&ctx, &json!({ "name": 42, "opts": null })).unwrap_err();
         assert!(err.to_string().contains("requires a string name"));
+    }
+
+    #[test]
+    fn signal_pause_records_timeout_ms_from_opts() {
+        let ctx = RuntimeContext::new();
+
+        let err = execute_signal(
+            &ctx,
+            &json!({ "name": "review", "opts": { "timeoutMs": 1500 } }),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains(PAUSE_MARKER));
+        let pending = ctx.take_pending_signal().expect("pending signal set");
+        assert_eq!(pending.timeout_ms, Some(1500));
+        assert_eq!(pending.listen_names(), vec!["review".to_string()]);
+        // The durable match key stays name-only — timeoutMs must not leak into
+        // the args the resume matcher compares.
+        let ops = ctx.pending_host_operations();
+        assert_eq!(ops[0].args, json!({ "name": "review" }));
+    }
+
+    #[test]
+    fn signal_any_pauses_with_listen_set_when_inbox_empty() {
+        let ctx = RuntimeContext::new();
+
+        let err = execute_signal_any(&ctx, &json!({ "names": ["review", "steer"], "opts": null }))
+            .unwrap_err();
+
+        assert!(err.to_string().contains(PAUSE_MARKER));
+        let pending = ctx.pending_host_operations();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].kind, PendingHostOperationKind::Signal);
+        assert_eq!(pending[0].function.as_deref(), Some("signal_any"));
+        assert_eq!(pending[0].args, json!({ "names": ["review", "steer"] }));
+        let pending_signal = ctx.take_pending_signal().expect("pending signal set");
+        assert_eq!(
+            pending_signal.listen_names(),
+            vec!["review".to_string(), "steer".to_string()]
+        );
+        assert_eq!(pending_signal.name, "review");
+        assert!(ctx.call_log().into_records().is_empty());
+    }
+
+    #[test]
+    fn signal_any_consumes_lowest_delivery_seq_across_name_set() {
+        let ctx = RuntimeContext::new();
+        // Two candidates with DIFFERENT names; the earlier-arriving one (lower
+        // delivery_seq) must win regardless of name order in the listen set.
+        ctx.set_signal_inbox(vec![
+            queued_signal("review", json!("later"), json!({ "id": "r" }), 12),
+            queued_signal("steer", json!("earlier"), json!({ "id": "s" }), 4),
+        ]);
+
+        let result =
+            execute_signal_any(&ctx, &json!({ "names": ["review", "steer"], "opts": null }))
+                .unwrap();
+
+        assert_eq!(result["name"], json!("steer"));
+        assert_eq!(result["payload"], json!("earlier"));
+        // The non-consumed candidate stays queued for a later listen point.
+        assert_eq!(ctx.signal_inbox().len(), 1);
+        assert_eq!(ctx.signal_inbox()[0].name, "review");
+        let records = ctx.call_log().into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "signal_any");
+        assert_eq!(records[0].args, json!({ "names": ["review", "steer"] }));
+    }
+
+    #[test]
+    fn signal_any_replays_recorded_value_without_touching_inbox() {
+        let recorded = vec![CallRecord {
+            seq: 1,
+            parent_seq: None,
+            function: "signal_any".to_string(),
+            args: json!({ "names": ["review", "steer"] }),
+            result: json!({
+                "name": "steer",
+                "payload": { "priority": "high" },
+                "from": { "kind": "human", "id": "sam" },
+            }),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        }];
+        let ctx = RuntimeContext::with_replay(recorded);
+        ctx.set_signal_inbox(vec![queued_signal(
+            "review",
+            json!("other"),
+            json!({ "id": "x" }),
+            1,
+        )]);
+
+        let result =
+            execute_signal_any(&ctx, &json!({ "names": ["review", "steer"], "opts": null }))
+                .unwrap();
+
+        assert_eq!(result["name"], json!("steer"));
+        assert_eq!(ctx.signal_inbox().len(), 1);
+    }
+
+    #[test]
+    fn signal_any_rejects_empty_or_non_string_names() {
+        let ctx = RuntimeContext::new();
+        let err = execute_signal_any(&ctx, &json!({ "names": [], "opts": null })).unwrap_err();
+        assert!(err.to_string().contains("at least one name"));
+
+        let err =
+            execute_signal_any(&ctx, &json!({ "names": ["ok", 42], "opts": null })).unwrap_err();
+        assert!(err.to_string().contains("must all be strings"));
+
+        let err = execute_signal_any(&ctx, &json!({ "names": null, "opts": null })).unwrap_err();
+        assert!(err.to_string().contains("requires an array of names"));
+    }
+
+    #[test]
+    fn signal_timeout_sentinel_shapes() {
+        let single = signal_timeout_sentinel(&["review".to_string()]);
+        assert_eq!(
+            single,
+            json!({ "name": "review", "payload": null, "from": null, "timedOut": true })
+        );
+        let multi = signal_timeout_sentinel(&["a".to_string(), "b".to_string()]);
+        assert_eq!(multi["name"], Value::Null);
+        assert_eq!(multi["timedOut"], json!(true));
     }
 }

--- a/src/runtime/otel.rs
+++ b/src/runtime/otel.rs
@@ -326,6 +326,13 @@ impl RunSpan {
             append_tool_attributes(&mut attrs, record);
         }
 
+        if matches!(
+            record.function.as_str(),
+            "signal" | "poll_signal" | "signal_any"
+        ) {
+            append_signal_attributes(&mut attrs, record);
+        }
+
         let builder = SpanBuilder::from_name(span_name_for(record))
             .with_kind(span_kind_for(&record.function))
             .with_start_time(start_time)
@@ -538,6 +545,52 @@ fn span_name_for(record: &CallRecord) -> String {
     }
 }
 
+/// Stamp signal provenance on a `signal` / `poll_signal` / `signal_any` span
+/// (`docs/signals.md` Phase 2): the consumed signal's name and the sender
+/// (`from = {kind, id, runId?}`), so a multiplayer trace is filterable by
+/// participant. A `poll_signal` that found nothing stamps only the polled name;
+/// a timed-out listen point stamps `signal.timed_out`.
+fn append_signal_attributes(attrs: &mut Vec<KeyValue>, record: &CallRecord) {
+    // The fired name lives in the result; fall back to the listen-point args
+    // (`{name}` / `{names}`) when the result has none (poll miss, timeout).
+    let name = record
+        .result
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| record.args.get("name").and_then(Value::as_str));
+    if let Some(name) = name {
+        attrs.push(KeyValue::new("signal.name", name.to_string()));
+    }
+    if let Some(names) = record.args.get("names").and_then(Value::as_array) {
+        let listen_set = names
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join(",");
+        attrs.push(KeyValue::new("signal.listen_names", listen_set));
+    }
+    if record
+        .result
+        .get("timedOut")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        attrs.push(KeyValue::new("signal.timed_out", true));
+    }
+    let Some(from) = record.result.get("from").filter(|v| !v.is_null()) else {
+        return;
+    };
+    if let Some(kind) = from.get("kind").and_then(Value::as_str) {
+        attrs.push(KeyValue::new("signal.from.kind", kind.to_string()));
+    }
+    if let Some(id) = from.get("id").and_then(Value::as_str) {
+        attrs.push(KeyValue::new("signal.from.id", id.to_string()));
+    }
+    if let Some(run_id) = from.get("runId").and_then(Value::as_str) {
+        attrs.push(KeyValue::new("signal.from.run_id", run_id.to_string()));
+    }
+}
+
 fn append_tool_attributes(attrs: &mut Vec<KeyValue>, record: &CallRecord) {
     let tool_name = record
         .args
@@ -675,6 +728,60 @@ mod tests {
         assert!(rendered.contains("tool.source=MedlinePlus"));
         assert!(rendered.contains("tool.result_count=1"));
         assert!(rendered.contains("tool.status=ok"));
+    }
+
+    #[test]
+    fn signal_attributes_stamp_name_and_sender_provenance() {
+        // A consumed signal: name + from ride in the result.
+        let record = CallRecord {
+            seq: 3,
+            parent_seq: None,
+            function: "signal".to_string(),
+            args: json!({"name": "review"}),
+            result: json!({
+                "name": "review",
+                "payload": {"decision": "approve"},
+                "from": {"kind": "agent", "id": "compliance-bot", "runId": "run-9"},
+            }),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        };
+        let mut attrs = Vec::new();
+        append_signal_attributes(&mut attrs, &record);
+        let rendered = attrs
+            .iter()
+            .map(|attr| format!("{}={}", attr.key, attr.value))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("signal.name=review"));
+        assert!(rendered.contains("signal.from.kind=agent"));
+        assert!(rendered.contains("signal.from.id=compliance-bot"));
+        assert!(rendered.contains("signal.from.run_id=run-9"));
+
+        // A timed-out signalAny: listen set from args, timed_out flag, no from.
+        let timeout = CallRecord {
+            seq: 4,
+            parent_seq: None,
+            function: "signal_any".to_string(),
+            args: json!({"names": ["review", "steer"]}),
+            result: json!({"name": null, "payload": null, "from": null, "timedOut": true}),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        };
+        let mut attrs = Vec::new();
+        append_signal_attributes(&mut attrs, &timeout);
+        let rendered = attrs
+            .iter()
+            .map(|attr| format!("{}={}", attr.key, attr.value))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("signal.listen_names=review,steer"));
+        assert!(rendered.contains("signal.timed_out=true"));
+        assert!(!rendered.contains("signal.from"));
     }
 
     #[test]

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -559,6 +559,13 @@ impl HostBindingBackend {
         host_core::execute_poll_signal(runtime_ctx, a).map_err(|err| err.to_string())
     }
 
+    fn signal_any(&self, a: &serde_json::Value) -> std::result::Result<serde_json::Value, String> {
+        let HostBindingBackend::Runtime { runtime_ctx, .. } = self else {
+            return Err("chidori.signalAny requires the runtime host backend".to_string());
+        };
+        host_core::execute_signal_any(runtime_ctx, a).map_err(|err| err.to_string())
+    }
+
     fn enforce_policy(
         &self,
         target: &str,
@@ -813,6 +820,7 @@ impl HostBindingBackend {
             }
             "signal" => self.signal(a),
             "poll_signal" => self.poll_signal(a),
+            "signal_any" => self.signal_any(a),
             "checkpoint" => {
                 let args = serde_json::json!({
                     "label": a.get("label").cloned().unwrap_or(serde_json::Value::Null),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -127,6 +127,8 @@ pub async fn run_once(recipe: &Recipe, deps: &SchedulerDeps) -> Result<String> {
             pending_seq: None,
             pending_prompt: None,
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,8 +22,9 @@ use crate::policy::PolicyConfig;
 use crate::providers::ProviderRegistry;
 use crate::recipes::Recipe;
 use crate::runtime::call_log::CallRecord;
-use crate::runtime::context::RuntimeEvent;
-use crate::runtime::engine::Engine;
+use crate::runtime::context::{InputMode, RuntimeContext, RuntimeEvent};
+use crate::runtime::engine::{Engine, RunResult};
+use crate::runtime::host_core::signal_timeout_sentinel;
 use crate::runtime::snapshot::{
     HostOperationId, HostPromiseRecord, HostPromiseState, PendingHostOperation,
     PendingHostOperationKind, RuntimePolicy, SnapshotAbi, SnapshotStore, SourceFingerprint,
@@ -83,6 +84,30 @@ struct ActiveSession {
     cancelled: Arc<AtomicBool>,
     cancel_tx: tokio::sync::mpsc::UnboundedSender<String>,
     attempt_number: Option<u64>,
+    /// Live in-memory signal delivery (`docs/signals.md` Phase 3). Present
+    /// while a streaming worker supervises this session; the delivery endpoint
+    /// enqueues straight into the live run's mailbox and wakes the worker,
+    /// skipping the HTTP pause→deliver→resume round-trip.
+    signals: Option<LiveSignalSession>,
+}
+
+/// The live-delivery handle a streaming worker registers in `active_sessions`.
+#[derive(Clone)]
+struct LiveSignalSession {
+    /// The CURRENT run context of the supervised session. The endpoint
+    /// enqueues into this context's in-memory mailbox (which write-through
+    /// persists to `signals/inbox.json`), so a running agent sees the signal
+    /// at its next listen point with no disk re-read. The worker swaps in the
+    /// fresh context before each in-process resume while holding this lock,
+    /// so a concurrent delivery always lands in the context that will run.
+    ctx_slot: Arc<StdMutex<RuntimeContext>>,
+    /// Wake channel into the worker's `select!` loop. Carries the
+    /// `delivery_seq` and name of a just-enqueued signal so a worker idling on
+    /// a signal pause can resolve it immediately (pending-pause-wins-with-
+    /// newest: the woken worker takes *this exact entry* back out of the
+    /// mailbox, leaving older queued same-name entries for later listen
+    /// points).
+    signal_tx: tokio::sync::mpsc::UnboundedSender<(u64, String)>,
 }
 
 /// Render a StoredSession into the JSON shape historical clients expect.
@@ -98,6 +123,8 @@ fn session_view(s: &StoredSession) -> Value {
         "pending_seq": s.pending_seq,
         "pending_prompt": s.pending_prompt,
         "pending_signal_name": s.pending_signal_name,
+        "pending_signal_names": s.pending_signal_names,
+        "pending_signal_deadline": s.pending_signal_deadline,
         "pending_approval": s.pending_approval,
         "policy_profile": s.policy_profile,
     })
@@ -474,6 +501,16 @@ pub async fn serve(
         active_sessions: Arc::new(StdMutex::new(HashMap::new())),
         signal_inbox_locks: Arc::new(StdMutex::new(HashMap::new())),
     };
+
+    // Re-arm signal-pause timeout timers (`timeoutMs`, `docs/signals.md`
+    // Phase 2) for sessions persisted with a deadline by a previous server
+    // process. Deadlines already in the past fire (resolve to the timeout
+    // sentinel) immediately.
+    if let Ok(sessions) = state.session_store.list() {
+        for session in &sessions {
+            arm_signal_timeout(&state, session);
+        }
+    }
 
     let auth_required = std::env::var("CHIDORI_API_KEY").is_ok();
     let cors_layer = build_cors_layer();
@@ -945,93 +982,33 @@ async fn create_session(
     .await
     .unwrap();
 
-    let session = match result {
-        Ok(run_result) => {
-            let (
-                status,
-                pending_seq,
-                pending_prompt,
-                pending_signal_name,
-                pending_approval,
-                output,
-            ) = if let Some(pending) = run_result.paused {
-                (
-                    SessionStatus::Paused,
-                    Some(pending.seq),
-                    Some(pending.prompt),
-                    None,
-                    None,
-                    None,
-                )
-            } else if let Some(signal) = run_result.paused_signal {
-                // A `chidori.signal(name)` listen point with an empty mailbox.
-                // Reuse `Paused`; `pending_signal_name` (not the status) marks it
-                // as a signal pause so the delivery endpoint can match the name.
-                (
-                    SessionStatus::Paused,
-                    Some(signal.seq),
-                    None,
-                    Some(signal.name),
-                    None,
-                    None,
-                )
-            } else if let Some(appr) = run_result.paused_approval {
-                (
-                    SessionStatus::AwaitingApproval,
-                    None,
-                    None,
-                    None,
-                    Some(appr),
-                    None,
-                )
-            } else {
-                (
-                    SessionStatus::Completed,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(run_result.output),
-                )
-            };
-            StoredSession {
-                id: id.clone(),
-                run_id: Some(run_result.run_id),
-                status,
-                input,
-                output,
-                call_log: run_result.call_log.into_records(),
-                error: None,
-                pending_seq,
-                pending_prompt,
-                pending_signal_name,
-                pending_approval,
-                approvals: Vec::new(),
-                policy_profile: policy_profile.clone(),
-                created_at: chrono::Utc::now(),
-            }
-        }
-        Err(e) => StoredSession {
-            id: id.clone(),
-            run_id: None,
-            status: SessionStatus::Failed,
-            input,
-            output: None,
-            call_log: Vec::new(),
-            error: Some(e.to_string()),
-            pending_seq: None,
-            pending_prompt: None,
-            pending_signal_name: None,
-            pending_approval: None,
-            approvals: Vec::new(),
-            policy_profile,
-            created_at: chrono::Utc::now(),
-        },
+    let mut session = StoredSession {
+        id: id.clone(),
+        run_id: None,
+        status: SessionStatus::Failed,
+        input,
+        output: None,
+        call_log: Vec::new(),
+        error: None,
+        pending_seq: None,
+        pending_prompt: None,
+        pending_signal_name: None,
+        pending_signal_names: Vec::new(),
+        pending_signal_deadline: None,
+        pending_approval: None,
+        approvals: Vec::new(),
+        policy_profile,
+        created_at: chrono::Utc::now(),
     };
+    match result {
+        Ok(run_result) => apply_run_outcome(&mut session, run_result),
+        Err(e) => session.error = Some(e.to_string()),
+    }
 
     if let Some(err) = store_or_500(&state, &session) {
         return err;
     }
+    arm_signal_timeout(&state, &session);
     drop(permit);
     (StatusCode::CREATED, Json(session_view(&session))).into_response()
 }
@@ -1197,6 +1174,8 @@ async fn replay_session(State(state): State<AppState>, Path(id): Path<String>) -
                 pending_seq: None,
                 pending_prompt: None,
                 pending_signal_name: None,
+                pending_signal_names: Vec::new(),
+                pending_signal_deadline: None,
                 pending_approval: None,
                 approvals: original.approvals.clone(),
                 policy_profile: original.policy_profile.clone(),
@@ -1301,6 +1280,108 @@ fn runtime_event_to_sse_event(evt: RuntimeEvent, attempt_number: Option<u64>) ->
     Event::default().event(name).data(data)
 }
 
+/// Spawn one blocking agent run for the streaming supervisor, reporting the
+/// engine result back on `result_tx`. Holds a clone of the shared run permit
+/// for the duration of the run.
+fn spawn_streaming_run(
+    state: &AppState,
+    policy_profile: Option<String>,
+    ctx: RuntimeContext,
+    input: Value,
+    result_tx: tokio::sync::mpsc::UnboundedSender<anyhow::Result<RunResult>>,
+    permit: Arc<tokio::sync::OwnedSemaphorePermit>,
+) {
+    let app_state = state.clone();
+    let agent_path = state.agent_path.clone();
+    tokio::task::spawn_blocking(move || {
+        let _run_permit = permit;
+        let engine = build_engine(&app_state, policy_profile.as_deref());
+        let result = engine.run_with_prepared_context(&agent_path, &input, ctx);
+        let _ = result_tx.send(result);
+    });
+}
+
+/// Resolve a supervised signal pause in-process and kick off the resumed run
+/// (`docs/signals.md` Phase 3 — the fast resume trigger that skips the HTTP
+/// `/resume` round-trip). Completes the persisted pending `Signal` op with
+/// `value` (a delivered `{name,payload,from}` or the timeout sentinel),
+/// appends the synthetic resolution record, swaps a fresh replay context into
+/// the live slot — carrying over the in-memory mailbox so a delivery racing
+/// this resume is not lost — persists the session as Running, and spawns the
+/// blocking re-run, which reports back on `result_tx`. Returns false (leaving
+/// the pause supervised) when no matching pending op exists on disk.
+#[allow(clippy::too_many_arguments)]
+fn resume_signal_pause_in_process(
+    state: &AppState,
+    session: &mut StoredSession,
+    ctx_slot: &Arc<StdMutex<RuntimeContext>>,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<RuntimeEvent>,
+    result_tx: &tokio::sync::mpsc::UnboundedSender<anyhow::Result<RunResult>>,
+    permit: &Arc<tokio::sync::OwnedSemaphorePermit>,
+    policy_profile: Option<String>,
+    seq: u64,
+    value: Value,
+) -> bool {
+    let run_id = session.run_id.clone().unwrap_or_else(|| session.id.clone());
+    let completed = {
+        let lock = state.signal_inbox_lock(&run_id);
+        let _guard = lock.lock().unwrap();
+        complete_persisted_pending_host_operation(
+            &state.run_base,
+            session.run_id.as_deref(),
+            Some((seq, PendingHostOperationKind::Signal)),
+            HostPromiseCompletion::Resolved(value.clone()),
+        )
+    };
+    let Ok(Some(pending)) = completed else {
+        return false;
+    };
+    session
+        .call_log
+        .push(signal_resolution_record(&pending, seq, value));
+
+    let host_promises = load_persisted_host_promises(&state.run_base, session.run_id.as_deref())
+        .unwrap_or_default();
+    let vfs = load_persisted_vfs(&state.run_base, session.run_id.as_deref());
+
+    // Swap the resumed run's context into the live slot while holding it: the
+    // delivery endpoint enqueues into whatever context the slot currently
+    // names, so carrying the old context's in-memory mailbox into the new one
+    // under the lock means no delivery can fall between the two.
+    let ctx = {
+        let mut slot = ctx_slot.lock().unwrap();
+        let inbox = slot.signal_inbox();
+        let ctx = RuntimeContext::with_replay_host_promises_vfs_and_signals(
+            session.call_log.clone(),
+            host_promises,
+            vfs,
+            inbox,
+        );
+        ctx.set_run_id(run_id);
+        ctx.set_input_mode(InputMode::Pause);
+        ctx.set_event_sender(event_tx.clone());
+        *slot = ctx.clone();
+        ctx
+    };
+
+    session.status = SessionStatus::Running;
+    session.pending_seq = None;
+    session.pending_signal_name = None;
+    session.pending_signal_names = Vec::new();
+    session.pending_signal_deadline = None;
+    let _ = state.session_store.put(session);
+
+    spawn_streaming_run(
+        state,
+        policy_profile,
+        ctx,
+        session.input.clone(),
+        result_tx.clone(),
+        permit.clone(),
+    );
+    true
+}
+
 async fn stream_session(
     State(state): State<AppState>,
     Json(body): Json<CreateSessionRequest>,
@@ -1309,9 +1390,12 @@ async fn stream_session(
 
     // Gate on the concurrency semaphore. If we can't get a permit within
     // the acquire deadline, 503 before any streaming response headers are
-    // committed so clients see the overflow cleanly.
+    // committed so clients see the overflow cleanly. The permit is shared
+    // (Arc) between the supervisor stream and each blocking run, so the slot
+    // stays held across in-process signal resumes and is released when the
+    // last holder drops.
     let permit = match acquire_run_slot(&state).await {
-        Ok(p) => p,
+        Ok(p) => Arc::new(p),
         Err(resp) => return resp,
     };
 
@@ -1333,24 +1417,40 @@ async fn stream_session(
             .and_then(Value::as_u64)
     });
     let input = body.input.clone();
-    let app_state = state.clone();
 
     let (event_tx, mut event_rx) =
         mpsc::unbounded_channel::<crate::runtime::context::RuntimeEvent>();
-    let (result_tx, mut result_rx) = mpsc::unbounded_channel::<serde_json::Value>();
+    let (result_tx, mut result_rx) = mpsc::unbounded_channel::<anyhow::Result<RunResult>>();
     let (cancel_tx, mut cancel_rx) = mpsc::unbounded_channel::<String>();
+    let (signal_tx, mut signal_rx) = mpsc::unbounded_channel::<(u64, String)>();
     let cancelled = Arc::new(AtomicBool::new(false));
+
+    // Build the first run's context up front so the run id is known before the
+    // agent starts and the delivery endpoint can enqueue into the live
+    // in-memory mailbox from the first instant (`docs/signals.md` Phase 3).
+    // Pause mode: an `input()` or approval gate surfaces as a paused session
+    // (handed to the durable HTTP endpoints) instead of blocking on stdin.
+    let ctx = RuntimeContext::new();
+    ctx.set_event_sender(event_tx.clone());
+    ctx.set_input_mode(InputMode::Pause);
+    let run_id = ctx.run_id();
+    let ctx_slot = Arc::new(StdMutex::new(ctx.clone()));
+
     state.active_sessions.lock().unwrap().insert(
         session_id.clone(),
         ActiveSession {
             cancelled: cancelled.clone(),
             cancel_tx,
             attempt_number,
+            signals: Some(LiveSignalSession {
+                ctx_slot: ctx_slot.clone(),
+                signal_tx,
+            }),
         },
     );
-    let running_session = StoredSession {
+    let mut session = StoredSession {
         id: session_id.clone(),
-        run_id: None,
+        run_id: Some(run_id),
         status: SessionStatus::Running,
         input: input.clone(),
         output: None,
@@ -1359,113 +1459,33 @@ async fn stream_session(
         pending_seq: None,
         pending_prompt: None,
         pending_signal_name: None,
+        pending_signal_names: Vec::new(),
+        pending_signal_deadline: None,
         pending_approval: None,
         approvals: Vec::new(),
         policy_profile: policy_profile.clone(),
         created_at: chrono::Utc::now(),
     };
-    let _ = state.session_store.put(&running_session);
+    let _ = state.session_store.put(&session);
 
-    let agent_path = app_state.agent_path.clone();
-    let session_id_for_task = session_id.clone();
-    let cancelled_for_task = cancelled.clone();
-
-    // Move the permit into the blocking task so it's held for the entire
-    // agent run. Dropping it at the end of the closure releases the slot.
-    tokio::task::spawn_blocking(move || {
-        let _run_permit = permit;
-        let engine = build_engine(&app_state, policy_profile.as_deref());
-
-        let result = engine.run_streaming(&agent_path, &input, event_tx);
-        let final_event = match result {
-            Ok(run_result) => {
-                let cancelled = cancelled_for_task.load(Ordering::SeqCst);
-                let status = if cancelled {
-                    SessionStatus::Cancelled
-                } else {
-                    SessionStatus::Completed
-                };
-                let output = if cancelled {
-                    None
-                } else {
-                    Some(run_result.output.clone())
-                };
-                let error = if cancelled {
-                    Some("session cancelled".to_string())
-                } else {
-                    None
-                };
-                let completed_session = StoredSession {
-                    id: session_id_for_task.clone(),
-                    run_id: Some(run_result.run_id),
-                    status,
-                    input: input.clone(),
-                    output,
-                    call_log: run_result.call_log.into_records(),
-                    error: error.clone(),
-                    pending_seq: None,
-                    pending_prompt: None,
-                    pending_signal_name: None,
-                    pending_approval: None,
-                    approvals: Vec::new(),
-                    policy_profile: policy_profile.clone(),
-                    created_at: chrono::Utc::now(),
-                };
-                let _ = app_state.session_store.put(&completed_session);
-                if cancelled {
-                    json!({
-                        "id": session_id_for_task,
-                        "status": "cancelled",
-                        "error": error,
-                    })
-                } else {
-                    json!({
-                        "id": session_id_for_task,
-                        "status": "completed",
-                        "output": run_result.output,
-                    })
-                }
-            }
-            Err(e) => {
-                let status = if cancelled_for_task.load(Ordering::SeqCst) {
-                    SessionStatus::Cancelled
-                } else {
-                    SessionStatus::Failed
-                };
-                let error = if status == SessionStatus::Cancelled {
-                    "session cancelled".to_string()
-                } else {
-                    e.to_string()
-                };
-                let _ = app_state.session_store.put(&StoredSession {
-                    id: session_id_for_task.clone(),
-                    run_id: None,
-                    status,
-                    input: input.clone(),
-                    output: None,
-                    call_log: Vec::new(),
-                    error: Some(error.clone()),
-                    pending_seq: None,
-                    pending_prompt: None,
-                    pending_signal_name: None,
-                    pending_approval: None,
-                    approvals: Vec::new(),
-                    policy_profile: policy_profile.clone(),
-                    created_at: chrono::Utc::now(),
-                });
-                json!({
-                    "id": session_id_for_task,
-                    "status": if cancelled_for_task.load(Ordering::SeqCst) { "cancelled" } else { "failed" },
-                    "error": error,
-                })
-            }
-        };
-        let _ = result_tx.send(final_event);
-    });
+    spawn_streaming_run(
+        &state,
+        policy_profile.clone(),
+        ctx,
+        input.clone(),
+        result_tx.clone(),
+        permit.clone(),
+    );
 
     let state_for_stream = state.clone();
-    let session_id_for_stream = session_id.clone();
     let stream = async_stream::stream! {
+        // The supervisor's share of the run slot (see acquire above).
+        let permit = permit;
+        // The signal pause currently supervised: (pending seq, listen set).
+        // While set, the run idles and a matching delivery (or the timeout
+        // deadline) resumes it in-process without an HTTP round-trip.
+        let mut supervising: Option<(u64, Vec<String>)> = None;
+        let mut deadline: Option<tokio::time::Instant> = None;
         loop {
             tokio::select! {
                 Some(evt) = event_rx.recv() => {
@@ -1473,9 +1493,17 @@ async fn stream_session(
                 }
                 Some(reason) = cancel_rx.recv() => {
                     cancelled.store(true, Ordering::SeqCst);
-                    state_for_stream.active_sessions.lock().unwrap().remove(&session_id_for_stream);
+                    state_for_stream.active_sessions.lock().unwrap().remove(&session.id);
+                    // A run idling on a supervised signal pause has no blocking
+                    // task left to notice the flag — persist the cancellation
+                    // here. A still-executing run persists it when it returns.
+                    if supervising.is_some() {
+                        session.status = SessionStatus::Cancelled;
+                        session.error = Some(reason.clone());
+                        let _ = state_for_stream.session_store.put(&session);
+                    }
                     let final_event = stamp_attempt(json!({
-                        "id": session_id_for_stream,
+                        "id": session.id,
                         "status": "cancelled",
                         "error": reason,
                     }), attempt_number);
@@ -1483,14 +1511,152 @@ async fn stream_session(
                     yield Ok::<_, std::convert::Infallible>(Event::default().event("done").data(data));
                     break;
                 }
-                Some(final_event) = result_rx.recv() => {
-                    state_for_stream.active_sessions.lock().unwrap().remove(&session_id_for_stream);
+                Some((delivery_seq, name)) = signal_rx.recv() => {
+                    // A delivery landed while we supervise. If it matches the
+                    // pause we're idling on, apply the pinned tie-break
+                    // (pending-pause-wins-with-newest): take THIS exact entry
+                    // back out of the mailbox and resolve the pause with it,
+                    // leaving older queued entries for later listen points.
+                    // Otherwise it stays durably queued for a future drain.
+                    if let Some((seq, names)) = supervising.clone() {
+                        if names.iter().any(|n| n == &name) {
+                            let entry = ctx_slot.lock().unwrap()
+                                .take_queued_signal_by_delivery_seq(delivery_seq);
+                            if let Some(entry) = entry {
+                                let value = json!({
+                                    "name": entry.name,
+                                    "payload": entry.payload,
+                                    "from": entry.from,
+                                });
+                                if resume_signal_pause_in_process(
+                                    &state_for_stream, &mut session, &ctx_slot,
+                                    &event_tx, &result_tx, &permit,
+                                    policy_profile.clone(), seq, value,
+                                ) {
+                                    supervising = None;
+                                    deadline = None;
+                                }
+                            }
+                        }
+                    }
+                }
+                _ = async { tokio::time::sleep_until(deadline.unwrap()).await }, if deadline.is_some() => {
+                    // `timeoutMs` deadline passed with no matching delivery:
+                    // resolve the supervised pause with the timeout sentinel.
+                    if let Some((seq, names)) = supervising.clone() {
+                        let sentinel = signal_timeout_sentinel(&names);
+                        if resume_signal_pause_in_process(
+                            &state_for_stream, &mut session, &ctx_slot,
+                            &event_tx, &result_tx, &permit,
+                            policy_profile.clone(), seq, sentinel,
+                        ) {
+                            supervising = None;
+                        }
+                    }
+                    deadline = None;
+                }
+                Some(result) = result_rx.recv() => {
+                    let was_cancelled = cancelled.load(Ordering::SeqCst);
+                    match result {
+                        Ok(run_result) => apply_run_outcome(&mut session, run_result),
+                        Err(e) => {
+                            session.status = SessionStatus::Failed;
+                            session.output = None;
+                            session.error = Some(e.to_string());
+                        }
+                    }
+                    if was_cancelled {
+                        session.status = SessionStatus::Cancelled;
+                        session.output = None;
+                        session.error = Some("session cancelled".to_string());
+                    }
+                    let _ = state_for_stream.session_store.put(&session);
+
+                    if session.status == SessionStatus::Paused
+                        && !session.pending_signal_names.is_empty()
+                    {
+                        // A signal listen point: stay live. Announce the pause,
+                        // then either drain a signal that arrived while the run
+                        // was unwinding (mailbox order: lowest delivery_seq
+                        // first) or idle until a delivery/timeout resumes us.
+                        let names = session.pending_signal_names.clone();
+                        let seq = session.pending_seq.unwrap_or_default();
+                        let paused_event = stamp_attempt(json!({
+                            "id": session.id,
+                            "status": "paused",
+                            "pending_seq": seq,
+                            "pending_signal_name": session.pending_signal_name,
+                            "pending_signal_names": names,
+                            "pending_signal_deadline": session.pending_signal_deadline,
+                        }), attempt_number);
+                        let data = serde_json::to_string(&paused_event).unwrap_or_else(|_| "{}".into());
+                        yield Ok::<_, std::convert::Infallible>(Event::default().event("paused").data(data));
+
+                        let queued = ctx_slot.lock().unwrap().take_queued_signal_any(&names);
+                        let mut resumed = false;
+                        if let Some(entry) = queued {
+                            let value = json!({
+                                "name": entry.name,
+                                "payload": entry.payload,
+                                "from": entry.from,
+                            });
+                            resumed = resume_signal_pause_in_process(
+                                &state_for_stream, &mut session, &ctx_slot,
+                                &event_tx, &result_tx, &permit,
+                                policy_profile.clone(), seq, value,
+                            );
+                        }
+                        if resumed {
+                            supervising = None;
+                            deadline = None;
+                        } else {
+                            supervising = Some((seq, names));
+                            deadline = session.pending_signal_deadline.map(|d| {
+                                let wait = (d - chrono::Utc::now()).to_std().unwrap_or_default();
+                                tokio::time::Instant::now() + wait
+                            });
+                        }
+                        continue;
+                    }
+
+                    // Anything else ends live supervision: terminal states
+                    // close the stream, and input/approval pauses hand off to
+                    // the durable HTTP resume/approve endpoints.
+                    state_for_stream.active_sessions.lock().unwrap().remove(&session.id);
+                    let final_event = match session.status {
+                        SessionStatus::Completed => json!({
+                            "id": session.id,
+                            "status": "completed",
+                            "output": session.output,
+                        }),
+                        SessionStatus::Paused => json!({
+                            "id": session.id,
+                            "status": "paused",
+                            "pending_seq": session.pending_seq,
+                            "pending_prompt": session.pending_prompt,
+                        }),
+                        SessionStatus::AwaitingApproval => json!({
+                            "id": session.id,
+                            "status": "awaiting_approval",
+                            "pending_approval": session.pending_approval,
+                        }),
+                        SessionStatus::Cancelled => json!({
+                            "id": session.id,
+                            "status": "cancelled",
+                            "error": session.error,
+                        }),
+                        _ => json!({
+                            "id": session.id,
+                            "status": "failed",
+                            "error": session.error,
+                        }),
+                    };
                     let data = serde_json::to_string(&stamp_attempt(final_event, attempt_number)).unwrap_or_else(|_| "{}".into());
                     yield Ok::<_, std::convert::Infallible>(Event::default().event("done").data(data));
                     break;
                 }
                 else => {
-                    state_for_stream.active_sessions.lock().unwrap().remove(&session_id_for_stream);
+                    state_for_stream.active_sessions.lock().unwrap().remove(&session.id);
                     break;
                 },
             }
@@ -1541,6 +1707,8 @@ async fn cancel_session(
             pending_seq: None,
             pending_prompt: None,
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -1585,6 +1753,145 @@ async fn cancel_session(
         "reason": reason,
     }))
     .into_response()
+}
+
+/// Map a finished engine run onto a stored session: status, output, call log,
+/// and the pending-pause fields (input prompt / signal listen set + timeout
+/// deadline / approval). Shared by session creation, the durable resume tail,
+/// and the streaming supervisor so every path surfaces pauses identically.
+fn apply_run_outcome(session: &mut StoredSession, run_result: RunResult) {
+    session.run_id = Some(run_result.run_id);
+    session.call_log = run_result.call_log.into_records();
+    session.output = None;
+    session.pending_seq = None;
+    session.pending_prompt = None;
+    session.pending_signal_name = None;
+    session.pending_signal_names = Vec::new();
+    session.pending_signal_deadline = None;
+    session.pending_approval = None;
+    if let Some(pending) = run_result.paused {
+        session.status = SessionStatus::Paused;
+        session.pending_seq = Some(pending.seq);
+        session.pending_prompt = Some(pending.prompt);
+    } else if let Some(signal) = run_result.paused_signal {
+        // A signal listen point with an empty mailbox. Reuse `Paused`;
+        // `pending_signal_name(s)` (not the status) marks it as a signal pause
+        // so the delivery endpoint can match the name. A `timeoutMs` pause
+        // persists its absolute deadline so a timer (or restarted server) can
+        // resolve it with the timeout sentinel.
+        session.status = SessionStatus::Paused;
+        session.pending_seq = Some(signal.seq);
+        session.pending_signal_name = Some(signal.name.clone());
+        session.pending_signal_names = signal.listen_names();
+        session.pending_signal_deadline = signal
+            .timeout_ms
+            .map(|ms| chrono::Utc::now() + chrono::Duration::milliseconds(ms as i64));
+    } else if let Some(appr) = run_result.paused_approval {
+        session.status = SessionStatus::AwaitingApproval;
+        session.pending_approval = Some(appr);
+    } else {
+        session.status = SessionStatus::Completed;
+        session.output = Some(run_result.output);
+    }
+}
+
+/// The awaited listen set of a signal-paused session, tolerating sessions
+/// persisted before `pending_signal_names` existed (fall back to the single
+/// `pending_signal_name`). Empty when the session is not paused on a signal.
+fn pending_listen_names(session: &StoredSession) -> Vec<String> {
+    if !session.pending_signal_names.is_empty() {
+        session.pending_signal_names.clone()
+    } else {
+        session.pending_signal_name.clone().into_iter().collect()
+    }
+}
+
+/// Arm the in-process timer for a session just persisted with a signal-pause
+/// deadline (`timeoutMs`, `docs/signals.md` Phase 2). No-op when the session
+/// has no deadline. The timer re-validates against the stored session before
+/// firing, so a delivery that resolves the pause first wins and the timer
+/// becomes a no-op.
+fn arm_signal_timeout(state: &AppState, session: &StoredSession) {
+    let Some(deadline) = session.pending_signal_deadline else {
+        return;
+    };
+    if session.status != SessionStatus::Paused {
+        return;
+    }
+    let Some(seq) = session.pending_seq else {
+        return;
+    };
+    let state = state.clone();
+    let id = session.id.clone();
+    tokio::spawn(async move {
+        let wait = (deadline - chrono::Utc::now()).to_std().unwrap_or_default();
+        tokio::time::sleep(wait).await;
+        fire_signal_timeout(&state, &id, seq).await;
+    });
+}
+
+/// Resolve an expired signal pause with the `{ timedOut: true }` sentinel and
+/// resume the run — the timer-side twin of `signal_session`'s resolve+resume
+/// branch. Validates that the session is still paused on the SAME listen point
+/// (a delivery may have already resolved it) and that no live streaming worker
+/// owns the session (the Phase 3 supervisor runs its own deadline).
+async fn fire_signal_timeout(state: &AppState, id: &str, seq: u64) {
+    let Ok(Some(session)) = state.session_store.get(id) else {
+        return;
+    };
+    let names = pending_listen_names(&session);
+    if session.status != SessionStatus::Paused
+        || session.pending_seq != Some(seq)
+        || names.is_empty()
+    {
+        return;
+    }
+    if state.active_sessions.lock().unwrap().contains_key(id) {
+        return;
+    }
+
+    let sentinel = signal_timeout_sentinel(&names);
+    let lock = state.signal_inbox_lock(session.run_id.as_deref().unwrap_or(id));
+    let completed = {
+        let _guard = lock.lock().unwrap();
+        complete_persisted_pending_host_operation(
+            &state.run_base,
+            session.run_id.as_deref(),
+            Some((seq, PendingHostOperationKind::Signal)),
+            HostPromiseCompletion::Resolved(sentinel.clone()),
+        )
+    };
+    // No matching pending op on disk means the pause was already resolved (or
+    // never persisted); either way there is nothing to time out.
+    let Ok(Some(pending)) = completed else {
+        return;
+    };
+    let mut call_log = session.call_log.clone();
+    call_log.push(signal_resolution_record(&pending, seq, sentinel));
+    let _ = complete_pending_and_resume(state, session, call_log).await;
+}
+
+/// The synthetic CallRecord a server-side signal resolution injects at the
+/// pending seq, so the replaying engine returns the delivered value (or the
+/// timeout sentinel) to the agent's listen call. Uses the persisted pending
+/// op's function name and match-key args, so a `signal_any` pause replays as
+/// `signal_any` with its `{names}` key and a `signal` pause as `signal` with
+/// `{name}`.
+fn signal_resolution_record(pending: &PendingHostOperation, seq: u64, value: Value) -> CallRecord {
+    CallRecord {
+        seq,
+        parent_seq: None,
+        function: pending
+            .function
+            .clone()
+            .unwrap_or_else(|| "signal".to_string()),
+        args: pending.args.clone(),
+        result: value,
+        duration_ms: 0,
+        token_usage: None,
+        timestamp: chrono::Utc::now(),
+        error: None,
+    }
 }
 
 /// Shared tail of `resume_session` and `signal_session` (doc §9: "factor its
@@ -1657,41 +1964,14 @@ async fn complete_pending_and_resume(
     let mut session = original;
     match result {
         Ok(run_result) => {
-            session.run_id = Some(run_result.run_id);
-            session.call_log = run_result.call_log.into_records();
-            if let Some(pending) = run_result.paused {
-                session.status = SessionStatus::Paused;
-                session.pending_seq = Some(pending.seq);
-                session.pending_prompt = Some(pending.prompt.clone());
-                session.pending_signal_name = None;
-                session.pending_approval = None;
-            } else if let Some(signal) = run_result.paused_signal {
-                // Re-run reached a NEW signal listen point with an empty mailbox.
-                // Persist it exactly like an input pause (the pending op + host
-                // promise table + shrunken inbox were already written to disk by
-                // the runtime safepoints); surface the awaited name in the view.
-                session.status = SessionStatus::Paused;
-                session.pending_seq = Some(signal.seq);
-                session.pending_prompt = None;
-                session.pending_signal_name = Some(signal.name);
-                session.pending_approval = None;
-            } else if let Some(appr) = run_result.paused_approval {
-                session.status = SessionStatus::AwaitingApproval;
-                session.pending_seq = None;
-                session.pending_prompt = None;
-                session.pending_signal_name = None;
-                session.pending_approval = Some(appr);
-            } else {
-                session.status = SessionStatus::Completed;
-                session.output = Some(run_result.output.clone());
-                session.pending_seq = None;
-                session.pending_prompt = None;
-                session.pending_signal_name = None;
-                session.pending_approval = None;
-            }
+            // A re-run that reached a NEW pause persists it exactly like the
+            // initial run does (the pending op + host promise table + shrunken
+            // inbox were already written to disk by the runtime safepoints).
+            apply_run_outcome(&mut session, run_result);
             if let Some(err) = store_or_500(state, &session) {
                 return err;
             }
+            arm_signal_timeout(state, &session);
             (StatusCode::OK, Json(session_view(&session))).into_response()
         }
         Err(e) => {
@@ -1865,15 +2145,50 @@ async fn signal_session(
             .into_response();
     }
 
-    // Paused waiting on THIS exact name: resolve the pending pause with the
-    // newly arrived signal and resume. Tie-break (doc §11, pinned decision):
-    // "pending-pause-wins-with-newest" — when the run is paused on name X and a
-    // same-name entry is ALSO already queued in the inbox, the pending pause
-    // resolves with THIS just-delivered signal; the older queued entry stays in
-    // the inbox (threaded into the resumed run by `complete_pending_and_resume`)
-    // for the next `signal(name)` listen point.
+    // Phase 3 (`docs/signals.md`): a live streaming worker supervises this
+    // session — deliver in-memory. The signal is write-through enqueued into
+    // the live run's mailbox (durably mirrored to `signals/inbox.json` in the
+    // same critical section) and the worker is woken; a run mid-execution
+    // drains it at its next listen point, and a run idling on a matching
+    // listen point is resolved+resumed in-process by the worker, skipping the
+    // HTTP pause→resume round-trip.
+    let live = state
+        .active_sessions
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|active| active.signals.clone());
+    if let Some(live) = live {
+        let queued = {
+            let ctx = live.ctx_slot.lock().unwrap();
+            ctx.enqueue_live_signal(&body.name, body.payload.clone(), body.from.clone())
+        };
+        let _ = live
+            .signal_tx
+            .send((queued.delivery_seq, queued.name.clone()));
+        return (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "id": id,
+                "status": "delivered_live",
+                "name": queued.name,
+                "delivery_seq": queued.delivery_seq,
+            })),
+        )
+            .into_response();
+    }
+
+    // Paused waiting on THIS name (or a `signalAny` listen set containing it):
+    // resolve the pending pause with the newly arrived signal and resume.
+    // Tie-break (doc §11, pinned decision): "pending-pause-wins-with-newest" —
+    // when the run is paused on name X and a same-name entry is ALSO already
+    // queued in the inbox, the pending pause resolves with THIS just-delivered
+    // signal; the older queued entry stays in the inbox (threaded into the
+    // resumed run by `complete_pending_and_resume`) for the next listen point.
     let waiting_on_this_name = original.status == SessionStatus::Paused
-        && original.pending_signal_name.as_deref() == Some(body.name.as_str());
+        && pending_listen_names(&original)
+            .iter()
+            .any(|n| n == &body.name);
 
     if waiting_on_this_name {
         let Some(seq) = original.pending_seq else {
@@ -1916,22 +2231,13 @@ async fn signal_session(
             HostPromiseCompletion::Resolved(value.clone()),
         );
         match completed {
-            // The pending op matched a `Signal` at this seq: inject the synthetic
-            // `signal` record and resume (reusing the resume tail).
-            Ok(Some(_)) => {
+            // The pending op matched a `Signal` at this seq: inject the
+            // synthetic resolution record (a `signal` or `signal_any` record,
+            // taken from the persisted op) and resume (reusing the resume tail).
+            Ok(Some(pending)) => {
                 drop(_guard);
                 let mut call_log = original.call_log.clone();
-                call_log.push(CallRecord {
-                    seq,
-                    parent_seq: None,
-                    function: "signal".to_string(),
-                    args: json!({ "name": body.name }),
-                    result: value,
-                    duration_ms: 0,
-                    token_usage: None,
-                    timestamp: chrono::Utc::now(),
-                    error: None,
-                });
+                call_log.push(signal_resolution_record(&pending, seq, value));
                 complete_pending_and_resume(&state, original, call_log).await
             }
             // No matching pending op on disk (e.g. nothing persisted). Fall back
@@ -2328,6 +2634,7 @@ mod tests {
                 cancelled: cancelled.clone(),
                 cancel_tx,
                 attempt_number: Some(7),
+                signals: None,
             },
         );
         state
@@ -2343,6 +2650,8 @@ mod tests {
                 pending_seq: None,
                 pending_prompt: None,
                 pending_signal_name: None,
+                pending_signal_names: Vec::new(),
+                pending_signal_deadline: None,
                 pending_approval: None,
                 approvals: Vec::new(),
                 policy_profile: None,
@@ -2623,6 +2932,8 @@ mod tests {
             pending_seq: None,
             pending_prompt: None,
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2688,6 +2999,8 @@ mod tests {
             pending_seq: None,
             pending_prompt: None,
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2755,6 +3068,8 @@ mod tests {
             pending_seq: None,
             pending_prompt: None,
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2826,6 +3141,8 @@ mod tests {
             pending_seq: None,
             pending_prompt: None,
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -2913,6 +3230,8 @@ mod tests {
             pending_seq: Some(2),
             pending_prompt: Some("continue?".to_string()),
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -3012,6 +3331,8 @@ mod tests {
             pending_seq: Some(2),
             pending_prompt: Some("continue?".to_string()),
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -3116,6 +3437,8 @@ mod tests {
             pending_seq: Some(2),
             pending_prompt: Some("continue?".to_string()),
             pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
             pending_approval: None,
             approvals: Vec::new(),
             policy_profile: None,
@@ -4173,6 +4496,438 @@ mod tests {
         // Inbox file is untouched by replay.
         let inbox_after = load_persisted_signal_inbox(&state.run_base, Some(&run_id));
         assert_eq!(inbox_after, inbox_before);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2: signalAny + timeoutMs (`docs/signals.md` §14 Phase 2).
+    // -----------------------------------------------------------------------
+
+    /// Poll the session store until `id` reaches `status` (the timeout timers
+    /// and streaming supervisor advance sessions asynchronously).
+    async fn wait_for_status(state: &AppState, id: &str, status: SessionStatus) -> StoredSession {
+        for _ in 0..400 {
+            if let Ok(Some(s)) = state.session_store.get(id) {
+                if s.status == status {
+                    return s;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!("session {id} never reached {status:?}");
+    }
+
+    /// `chidori.signalAny([..])` pauses on the whole listen set, advertises it
+    /// in the session view, and a delivery matching ANY listed name resolves
+    /// the pause; the recorded call replays as `signal_any` with its `{names}`
+    /// match key and the bare fired signal as result.
+    #[tokio::test]
+    async fn signal_any_pauses_on_set_and_resolves_on_any_listed_name() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-any-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const fired = await chidori.signalAny(["review", "steer"]);
+                    return { fired: fired.name, payload: fired.payload, by: fired.from.id };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "any-1", json!({})).await;
+        assert_eq!(created["status"], json!("paused"));
+        assert_eq!(created["pending_signal_name"], json!("review"));
+        assert_eq!(created["pending_signal_names"], json!(["review", "steer"]));
+
+        // Deliver the SECOND listed name — it must resolve the pause.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("any-1".to_string()),
+                Json(SignalRequest {
+                    name: "steer".to_string(),
+                    payload: json!({ "dir": "left" }),
+                    from: json!({ "kind": "human", "id": "sam" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(
+            body["output"],
+            json!({ "fired": "steer", "payload": { "dir": "left" }, "by": "sam" })
+        );
+
+        // The synthetic record uses the persisted op's function + match key.
+        let stored = state.session_store.get("any-1").unwrap().unwrap();
+        let record = stored
+            .call_log
+            .iter()
+            .find(|r| r.function == "signal_any")
+            .expect("signal_any record");
+        assert_eq!(record.args, json!({ "names": ["review", "steer"] }));
+        assert_eq!(record.result["name"], json!("steer"));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// A `timeoutMs` signal pause persists its deadline, and the armed server
+    /// timer resolves it with the `{timedOut: true}` sentinel; a replay of the
+    /// timed-out session reproduces the sentinel from the recorded call.
+    #[tokio::test]
+    async fn signal_timeout_resolves_with_sentinel_and_replays() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-timeout-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const result = await chidori.signal("review", { timeoutMs: 150 });
+                    if (result.timedOut) {
+                        return { timedOut: true, name: result.name };
+                    }
+                    return { timedOut: false, decision: result.payload.decision };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "to-1", json!({})).await;
+        assert_eq!(created["status"], json!("paused"));
+        assert!(
+            !created["pending_signal_deadline"].is_null(),
+            "timeoutMs pause must persist its deadline: {created}"
+        );
+
+        // No delivery: the armed timer fires and resolves the sentinel.
+        let stored = wait_for_status(&state, "to-1", SessionStatus::Completed).await;
+        assert_eq!(
+            stored.output,
+            Some(json!({ "timedOut": true, "name": "review" }))
+        );
+        let record = stored
+            .call_log
+            .iter()
+            .find(|r| r.function == "signal")
+            .expect("signal record");
+        assert_eq!(record.result["timedOut"], json!(true));
+
+        // Replay reproduces the sentinel deterministically.
+        let (status, body) =
+            response_json(replay_session(State(state.clone()), Path("to-1".to_string())).await)
+                .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            body["output"],
+            json!({ "timedOut": true, "name": "review" })
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// A delivery that lands before the `timeoutMs` deadline wins; the timer
+    /// later fires as a no-op (the pause is already resolved).
+    #[tokio::test]
+    async fn signal_delivery_before_timeout_wins() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-race-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const result = await chidori.signal("review", { timeoutMs: 60000 });
+                    if (result.timedOut) {
+                        return { timedOut: true };
+                    }
+                    return { timedOut: false, decision: result.payload.decision };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        create_paused_session(&state, "race-1", json!({})).await;
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("race-1".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "approve" }),
+                    from: json!({ "id": "mara" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["output"],
+            json!({ "timedOut": false, "decision": "approve" })
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// A timed-out multi-name `signalAny` resolves to the sentinel with a null
+    /// `name` (no name fired).
+    #[tokio::test]
+    async fn signal_any_timeout_sentinel_has_null_name() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-signal-any-to-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const result = await chidori.signalAny(["a", "b"], { timeoutMs: 150 });
+                    return { timedOut: result.timedOut === true, name: result.name };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let created = create_paused_session(&state, "any-to", json!({})).await;
+        assert_eq!(created["pending_signal_names"], json!(["a", "b"]));
+
+        let stored = wait_for_status(&state, "any-to", SessionStatus::Completed).await;
+        assert_eq!(
+            stored.output,
+            Some(json!({ "timedOut": true, "name": null }))
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3: live in-memory delivery to streaming runs (`docs/signals.md`).
+    // -----------------------------------------------------------------------
+
+    /// Drive a streaming session through `stream_session` and collect its full
+    /// SSE body in a background task (the body future drives the supervisor).
+    async fn start_stream(
+        state: &AppState,
+        session_id: &str,
+        input: Value,
+    ) -> tokio::task::JoinHandle<String> {
+        let response = stream_session(
+            State(state.clone()),
+            Json(
+                serde_json::from_value(json!({
+                    "input": input,
+                    "session_id": session_id,
+                }))
+                .unwrap(),
+            ),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        tokio::spawn(async move {
+            let bytes = body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            String::from_utf8_lossy(&bytes).to_string()
+        })
+    }
+
+    /// A streaming run that pauses on `signal()` stays live: the delivery
+    /// endpoint reports `delivered_live` and the supervisor resolves the pause
+    /// in-process (no `/resume` round-trip), the stream carrying a `paused`
+    /// event and then `done`. The recorded signal call matches the durable
+    /// persist-resume path byte-for-byte on its match key and result.
+    #[tokio::test]
+    async fn stream_session_resolves_signal_pause_in_process() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-stream-signal-{}", uuid::Uuid::new_v4()));
+        let source = r#"
+            export async function agent(input, chidori) {
+                const review = await chidori.signal("review");
+                return { decision: review.payload.decision, by: review.from.id };
+            }
+        "#;
+        let agent_path = write_agent(&temp_dir, source);
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let sse = start_stream(&state, "live-1", json!({})).await;
+
+        // Wait for the worker to persist the supervised signal pause; the
+        // session must STAY in active_sessions (live supervision continues).
+        let paused = wait_for_status(&state, "live-1", SessionStatus::Paused).await;
+        assert_eq!(paused.pending_signal_name.as_deref(), Some("review"));
+        assert!(state.active_sessions.lock().unwrap().contains_key("live-1"));
+
+        // Deliver: routed to the live worker, not the durable resume path.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("live-1".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "approve" }),
+                    from: json!({ "kind": "human", "id": "mara" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["status"], json!("delivered_live"));
+
+        // The supervisor resumes in-process and completes the session.
+        let stored = wait_for_status(&state, "live-1", SessionStatus::Completed).await;
+        assert_eq!(
+            stored.output,
+            Some(json!({ "decision": "approve", "by": "mara" }))
+        );
+        assert!(!state.active_sessions.lock().unwrap().contains_key("live-1"));
+
+        // The stream announced the pause and finished with done/completed.
+        let sse_text = sse.await.unwrap();
+        assert!(sse_text.contains("event: paused"), "sse: {sse_text}");
+        assert!(sse_text.contains("event: done"), "sse: {sse_text}");
+        assert!(
+            sse_text.contains("\"status\":\"completed\""),
+            "sse: {sse_text}"
+        );
+
+        // Determinism: the same agent driven through the durable
+        // create→deliver path records the identical signal call.
+        let dir_b =
+            std::env::temp_dir().join(format!("chidori-stream-signal-b-{}", uuid::Uuid::new_v4()));
+        let agent_b = write_agent(&dir_b, source);
+        let state_b = signal_test_state(&dir_b, agent_b);
+        create_paused_session(&state_b, "durable-1", json!({})).await;
+        response_json(
+            signal_session(
+                State(state_b.clone()),
+                Path("durable-1".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "approve" }),
+                    from: json!({ "kind": "human", "id": "mara" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        let durable = state_b.session_store.get("durable-1").unwrap().unwrap();
+        let sig_live = stored
+            .call_log
+            .iter()
+            .find(|r| r.function == "signal")
+            .unwrap();
+        let sig_durable = durable
+            .call_log
+            .iter()
+            .find(|r| r.function == "signal")
+            .unwrap();
+        assert_eq!(sig_live.args, sig_durable.args);
+        assert_eq!(sig_live.result, sig_durable.result);
+        assert_eq!(sig_live.seq, sig_durable.seq);
+        assert_eq!(stored.output, durable.output);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+        let _ = std::fs::remove_dir_all(dir_b);
+    }
+
+    /// A signal delivered live for a name the run is NOT waiting on lands in
+    /// the live in-memory mailbox (write-through persisted) and survives the
+    /// in-process resume: the resumed run drains it at a later `pollSignal`.
+    #[tokio::test]
+    async fn stream_session_live_mailbox_carries_over_in_process_resume() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-stream-mailbox-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const review = await chidori.signal("review");
+                    const steer = await chidori.pollSignal("steer");
+                    return {
+                        decision: review.payload.decision,
+                        steer: steer ? steer.payload.dir : null,
+                    };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let sse = start_stream(&state, "live-2", json!({})).await;
+        wait_for_status(&state, "live-2", SessionStatus::Paused).await;
+
+        // Deliver a NON-matching name first: enqueued live, no resume.
+        let (status, body) = response_json(
+            signal_session(
+                State(state.clone()),
+                Path("live-2".to_string()),
+                Json(SignalRequest {
+                    name: "steer".to_string(),
+                    payload: json!({ "dir": "left" }),
+                    from: json!({ "id": "sam" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["status"], json!("delivered_live"));
+
+        // Now resolve the supervised pause; the resumed run must still see the
+        // queued "steer" at its pollSignal.
+        response_json(
+            signal_session(
+                State(state.clone()),
+                Path("live-2".to_string()),
+                Json(SignalRequest {
+                    name: "review".to_string(),
+                    payload: json!({ "decision": "approve" }),
+                    from: json!({ "id": "mara" }),
+                }),
+            )
+            .await,
+        )
+        .await;
+
+        let stored = wait_for_status(&state, "live-2", SessionStatus::Completed).await;
+        assert_eq!(
+            stored.output,
+            Some(json!({ "decision": "approve", "steer": "left" }))
+        );
+        let _ = sse.await.unwrap();
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// A streaming run paused with `timeoutMs` resolves to the sentinel from
+    /// the supervisor's own deadline (no external delivery, stream stays one
+    /// continuous session through to done).
+    #[tokio::test]
+    async fn stream_session_signal_timeout_resolves_in_process() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("chidori-stream-timeout-{}", uuid::Uuid::new_v4()));
+        let agent_path = write_agent(
+            &temp_dir,
+            r#"
+                export async function agent(input, chidori) {
+                    const result = await chidori.signal("review", { timeoutMs: 150 });
+                    return { timedOut: result.timedOut === true };
+                }
+            "#,
+        );
+        let state = signal_test_state(&temp_dir, agent_path);
+
+        let sse = start_stream(&state, "live-3", json!({})).await;
+        let stored = wait_for_status(&state, "live-3", SessionStatus::Completed).await;
+        assert_eq!(stored.output, Some(json!({ "timedOut": true })));
+        let sse_text = sse.await.unwrap();
+        assert!(sse_text.contains("event: paused"), "sse: {sse_text}");
+        assert!(
+            sse_text.contains("\"status\":\"completed\""),
+            "sse: {sse_text}"
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -50,6 +50,19 @@ pub struct StoredSession {
     /// status) distinguishes it from an `input()` pause. See `docs/signals.md`.
     #[serde(default)]
     pub pending_signal_name: Option<String>,
+    /// The full awaited name set for a signal pause: `[name]` for
+    /// `chidori.signal(name)`, the listen set for `chidori.signalAny(names)`.
+    /// The delivery endpoint matches `body.name` against ANY of these. Empty
+    /// when the session is not paused on a signal (sessions persisted before
+    /// `signalAny` deserialize as empty; fall back to `pending_signal_name`).
+    #[serde(default)]
+    pub pending_signal_names: Vec<String>,
+    /// Absolute deadline for a signal pause created with `timeoutMs`
+    /// (`docs/signals.md` Phase 2). When it passes, the supervising server
+    /// resolves the pause with the `{ timedOut: true }` sentinel. Persisted so
+    /// a restarted server can re-arm the timer.
+    #[serde(default)]
+    pub pending_signal_deadline: Option<chrono::DateTime<chrono::Utc>>,
     /// Set when status == AwaitingApproval. Carries the (target, args)
     /// the policy is asking about so the UI can render a prompt.
     #[serde(default)]


### PR DESCRIPTION
## Summary

This PR completes the multiplayer signals feature by implementing Phase 3: live in-memory signal delivery to streaming agent runs. When a signal is delivered to a session supervised by a streaming worker, it now enqueues directly into the running agent's in-memory mailbox and wakes the worker to resume a matching pause in-process, eliminating the HTTP `/resume` round-trip and keeping the SSE stream open across the resume.

## Key Changes

### Server Streaming Supervision (`src/server.rs`)
- **Live signal session tracking**: Added `LiveSignalSession` struct to hold a shared `RuntimeContext` slot and wake channel for streaming workers
- **In-process signal pause resolution**: Implemented `resume_signal_pause_in_process()` to complete persisted pending operations, swap fresh replay contexts into the live slot (preserving in-memory mailbox), and spawn resumed runs
- **Streaming supervisor loop**: Refactored `stream_session()` to:
  - Build the first run's context up front so the run ID is known before the agent starts
  - Supervise signal pauses with a `select!` loop that handles:
    - Signal deliveries via `signal_rx` (enqueued by the delivery endpoint)
    - Timeout deadlines from `pending_signal_deadline`
    - Run results that may pause on signals (stay live) or reach terminal states (close stream)
  - Drain queued signals that arrived while the run was unwinding
  - Apply the pinned tie-break: pending-pause-wins-with-newest (take the just-delivered entry back out of the mailbox)
- **Timeout re-arming**: Added `arm_signal_timeout()` call on server startup to re-arm timers for sessions persisted with deadlines by a previous process
- **Refactored run outcome handling**: Extracted `apply_run_outcome()` to unify session state updates across streaming and non-streaming paths

### Signal Delivery Endpoint (`src/server.rs`)
- Modified to enqueue into the live in-memory mailbox when a streaming worker supervises the session
- Returns `"delivered_live"` status in the 202 Accepted response to indicate in-process delivery

### Runtime Context (`src/runtime/context.rs`)
- **Extended `PendingSignal`**: Added `names` (full awaited set), `timeout_ms` (deadline), and `listen_names()` helper
- **In-memory mailbox methods**: 
  - `take_queued_signal_by_delivery_seq()` — extract a specific delivery by sequence
  - `take_queued_signal_any()` — drain the lowest-sequence entry matching any name in a set
- **Signal inbox access**: `signal_inbox()` returns the in-memory mailbox for context swaps

### Signal Execution (`src/runtime/host_core.rs`)
- **`execute_signal_any()`**: New function implementing fan-in listen points (`chidori.signalAny([names])`)
  - Pauses with match key `{ "names": [...] }` and function name `"signal_any"`
  - Result is the bare consumed signal `{name, payload, from}` (name says which fired)
  - Supports `timeoutMs` option
- **`signal_timeout_sentinel()`**: Public function returning the timeout resolution value (`{timedOut: true}`)
- **Helper functions**: `signal_names()`, `signal_timeout_ms()` for parsing options

### Observability (`src/runtime/otel.rs`)
- **Signal span attributes** (Phase 2): Added `append_signal_attributes()` to stamp signal provenance on traces:
  - `signal.name` — the fired name (or polled name for misses)
  - `signal.listen_names` — comma-separated awaited names for `signalAny`
  - `signal.timed_out` — true when the pause resolved to the timeout sentinel
  - `signal.from.{kind,id,run_id}` — sender provenance for multiplayer filtering

### Storage (`src/storage.rs`)
- **Extended `StoredSession`**: Added `pending_signal_names` (full awaited set) and `pending_signal_deadline` (

https://claude.ai/code/session_01TPBKjrKQzUrjpGHfC2gZgS