### PR TITLE
Implement chidori.step() — durable value checkpoints for memoized compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ An agent is a `.ts` file that exports an async `agent(input, chidori)` function.
 | `chidori.memory(action, ...)` | Persistent storage (key-value + vector) |
 | `chidori.log(msg, data)` | Structured logging |
 | `chidori.checkpoint(label, meta)` | Record an explicit call-log marker for trace/replay |
+| `chidori.step(name, fn)` | Durable value checkpoint — run pure compute once, journal the result, never re-pay it on replay/resume |
 | `chidori.retry(fn, options)` | Retry with backoff |
 | `chidori.tryCall(fn)` | Capture errors without raising |
 

--- a/TODO.md
+++ b/TODO.md
@@ -62,6 +62,9 @@ completion audit lives in
 - [x] `chidori.log()`
 - [x] `chidori.memory()`
 - [x] `chidori.checkpoint()`
+- [x] `chidori.step()` — durable value checkpoints (plan P6): memoize pure
+      compute into the call log so replay/resume never re-pays it
+      (`docs/value-checkpoints.md`).
 - [x] `chidori.execJs()`
 - [x] `chidori.execPython()`
 - [x] `chidori.execWasm()`

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -180,6 +180,88 @@ impl Engine {
                 forward_effect(vm, &d, "poll_signal", serde_json::json!({ "name": name }))
             });
         let d = dispatch.clone();
+        // chidori.step(name, fn) — durable value checkpoint. Unlike the other
+        // effects, the second argument is a JS callback, which cannot cross the
+        // JSON dispatch boundary; instead the binding drives a two-call
+        // protocol: probe the journal (`step_begin`), run the callback
+        // synchronously only on a miss, then record its outcome (`step_end`).
+        // On replay the probe returns the recorded value (or re-throws the
+        // recorded error) and the callback never runs — that is the point: it
+        // bounds resume cost for expensive deterministic compute. Results are
+        // JSON round-tripped on the live path too, so live and replayed runs
+        // observe byte-identical values.
+        self.vm
+            .define_method(&chidori, "step", 2, move |vm, _t, args| {
+                let name = match args.first() {
+                    Some(Value::String(s)) => s.as_str().to_string(),
+                    _ => {
+                        return Err(vm.make_error(
+                            crate::vm::ErrorKind::Type,
+                            "chidori.step requires a string name as its first argument",
+                        ))
+                    }
+                };
+                let f = args.get(1).cloned().unwrap_or(Value::Undefined);
+                if !vm.is_callable(&f) {
+                    return Err(vm.make_error(
+                        crate::vm::ErrorKind::Type,
+                        "chidori.step requires a callback as its second argument",
+                    ));
+                }
+                let begin = match d("step_begin", &serde_json::json!({ "name": name })) {
+                    Ok(j) => j,
+                    Err(e) => return Err(vm.make_error(crate::vm::ErrorKind::Error, &e)),
+                };
+                if begin
+                    .get("cached")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    if let Some(err) = begin.get("error").and_then(serde_json::Value::as_str) {
+                        return Err(vm.make_error(crate::vm::ErrorKind::Error, err));
+                    }
+                    let value = begin.get("value").unwrap_or(&serde_json::Value::Null);
+                    return Ok(vm.json_to_value(value));
+                }
+                match vm.call(f, Value::Undefined, &[]) {
+                    Ok(v) => {
+                        let is_promise = matches!(
+                            &v,
+                            Value::Object(o) if matches!(
+                                o.borrow().internal,
+                                crate::value::Internal::Promise(_)
+                            )
+                        );
+                        if is_promise {
+                            let msg = "chidori.step callback must return synchronously \
+                                       (got a Promise): step bodies are pure compute — run \
+                                       host effects outside the step and pass results in";
+                            let _ = d(
+                                "step_end",
+                                &serde_json::json!({ "name": name, "error": msg }),
+                            );
+                            return Err(vm.make_error(crate::vm::ErrorKind::Type, msg));
+                        }
+                        let j = vm.value_to_json(&v);
+                        match d("step_end", &serde_json::json!({ "name": name, "value": j })) {
+                            Ok(rj) => Ok(vm.json_to_value(&rj)),
+                            Err(e) => Err(vm.make_error(crate::vm::ErrorKind::Error, &e)),
+                        }
+                    }
+                    Err(e) => {
+                        let msg = vm.error_to_string(&e);
+                        let _ = d(
+                            "step_end",
+                            &serde_json::json!({ "name": name, "error": msg }),
+                        );
+                        // Rebuild from the recorded message (instead of
+                        // re-throwing `e`) so the live throw matches the
+                        // replayed one exactly.
+                        Err(vm.make_error(crate::vm::ErrorKind::Error, &msg))
+                    }
+                }
+            });
+        let d = dispatch.clone();
         self.vm
             .define_method(&chidori, "checkpoint", 2, move |vm, _t, args| {
                 let label = args

--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -262,10 +262,15 @@ The real gaps, restated post-#39:
   snapshot/resume machinery was deleted in #39, which *simplified* the
   architecture (the silent snapshot→replay fallback this review previously
   flagged is gone — replay is the only, explicit mechanism) at the cost of
-  the original performance idea. With **no value checkpointing** (the
+  the original performance idea. ~~With **no value checkpointing** (the
   deferred P6), resume cost equals re-execution of the journal from the
   top, so very long histories get slower to resume; `durableStep(fn)`
-  memoization is the partial mitigation.
+  memoization is the partial mitigation.~~ **Update (2026-06-12): P6 landed
+  as `chidori.step(name, fn)`** — pure deterministic compute is memoized
+  into the call log and skipped on replay/resume, with the pure-compute
+  contract enforced loudly (see `docs/value-checkpoints.md`). Host effects
+  were already journal-served; un-wrapped pure JS between effects remains
+  the only re-executed cost.
 - Concurrency is bounded by a per-run tokio semaphore in the server; no
   distributed scheduling.
 
@@ -391,12 +396,13 @@ The original items, for the record:
    migration docs carry a "historical — superseded" banner; both SDK READMEs no
    longer claim resume is "gated on the QuickJS serializer"; and the stale
    QuickJS-path comments in `src/runtime/engine.rs` are corrected.
-7. Longer-term, as adoption demands: per-VM memory accounting, value
-   checkpointing for long journals (P6), a broader `node:` allowlist
-   (~~`path`, `events`, `url` are cheap wins~~ — done 2026-06-12, along
-   with `assert` and a virtualized `os`; `stream`/`zlib` remain), more
-   native providers or first-class embeddings, and a queryable storage
-   schema.
+7. Longer-term, as adoption demands: per-VM memory accounting, ~~value
+   checkpointing for long journals (P6)~~ (done 2026-06-12:
+   `chidori.step(name, fn)`, `docs/value-checkpoints.md`), a broader
+   `node:` allowlist (~~`path`, `events`, `url` are cheap wins~~ — done
+   2026-06-12, along with `assert` and a virtualized `os`; `stream`/`zlib`
+   remain), more native providers or first-class embeddings, and a
+   queryable storage schema.
 
 ---
 

--- a/docs/value-checkpoints.md
+++ b/docs/value-checkpoints.md
@@ -1,0 +1,138 @@
+# Value Checkpoints — `chidori.step(name, fn)`
+
+> **Status:** Implemented. This is the production landing of the engine plan's
+> deferred **P6** ("value checkpoints"): bound resume cost on long histories by
+> memoizing expensive deterministic computation into the durable call log. The
+> engine-level prototype (`durableStep` on `chidori_js::ReplayRuntime`,
+> `crates/chidori-js/src/replay.rs`) shipped with the engine; this doc covers
+> the `chidori.*` host API every agent gets.
+> **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md)
+> (historical; P6 row), [`docs/fable_review.md`](./fable_review.md),
+> [`docs/signals.md`](./signals.md).
+
+---
+
+## 1. Summary (TL;DR)
+
+Chidori's durability model is **deterministic replay**: resume re-executes the
+agent's JavaScript from the top while every recorded host effect (`prompt`,
+`tool`, `http`, …) is served from the journal instead of re-performed. Host
+effects are therefore cheap on resume — but **pure JS compute between effects
+is re-executed every time**. For agents that do heavy deterministic work
+(parsing large documents, building plans, transforming corpora), a long-lived
+run gets progressively more expensive to resume.
+
+`chidori.step(name, fn)` fixes that:
+
+```ts
+const plan = await chidori.step("plan", () => buildPlan(input)); // expensive, pure
+```
+
+Live, `fn` runs once and its JSON-serializable result is recorded as a `step`
+call-log record. On **every** subsequent replay — crash recovery, `input()` /
+approval / signal resume, `chidori trace` re-derivation, `POST
+/sessions/{id}/replay` — the recorded value is returned (or the recorded error
+re-thrown) **without re-running `fn`**. Resume cost becomes proportional to the
+un-wrapped code, not the total compute the run has ever done.
+
+## 2. The contract: pure, synchronous compute
+
+A skipped callback must be skippable: if `fn` had observable effects, replay
+(which never runs it) would lose them — state would silently diverge, or the
+journal's sequence numbers would desynchronize. So step callbacks must be
+**pure, synchronous computation**, and the runtime enforces the classes of
+violation it can see, loudly:
+
+| inside a step callback | behavior |
+|---|---|
+| any `chidori.*` effect (`log`, `prompt`, `tool`, nested `step`, …) | throws `chidori.<effect> is not allowed inside chidori.step(...)` |
+| captured randomness (`node:crypto` `randomBytes`, `crypto.getRandomValues`) | throws (it would write a `crypto.random` record) |
+| VFS writes (`node:fs` write/append/mkdir/rm/rename) | throws (the mutation would be lost on replay) |
+| timer / microtask scheduling (`setTimeout`, `setInterval`, `queueMicrotask`) | throws (the scheduled callback would never exist on replay) |
+| an `async` callback / returned `Promise` | throws `chidori.step callback must return synchronously` |
+
+Allowed: everything deterministic and recordless — plain compute, `JSON`,
+`Math.random`/`Date` (deterministic by engine policy), crypto **hashing**, and
+VFS **reads** (read-only, and the memoized result keeps replay exact
+regardless). The result must be JSON-serializable; it is JSON round-tripped on
+the live path too, so live and replayed runs observe byte-identical values.
+
+What cannot be policed at reasonable cost: leaking work out of the callback by
+closure mutation plus deferred promise reactions. Don't do that — the contract
+is "compute a value from your inputs and return it".
+
+## 3. Semantics and mechanics
+
+A step is **one** `CallRecord` — `function: "step"`, `args: {name}`, the
+result (or `error`) holding the outcome — at one sequence number. The
+implementation is a two-phase protocol because the callback is a JS value that
+cannot cross the JSON host boundary:
+
+1. **`step_begin {name}`** (`host_core::execute_step_begin`): allocates the
+   seq and checks the replay log.
+   - *Replay hit* (`try_replay_checked(seq, "step")`): returns the recorded
+     value or error. The recorded `name` must match the call's name, else the
+     code was edited before the resume frontier — fail-loud divergence, same
+     contract as every other host effect.
+   - *Miss*: marks the step live on the `RuntimeContext`
+     (`begin_step(seq, name)`) and the engine binding runs the callback. While
+     the step is live, the effect dispatchers (`HostBindingBackend::dispatch`,
+     the `__chidori_*` sync natives) refuse the calls in the table above.
+2. **`step_end {name, value | error}`** (`host_core::execute_step_end`): takes
+   the live-step marker back and writes the `step` record at the reserved seq.
+
+The engine binding lives in `chidori-js`'s `install_chidori_effects`
+(`crates/chidori-js/src/lib.rs`): probe, `vm.call(fn)` only on a miss, report.
+A thrown callback records the error message and replays as the same throw.
+
+**No pending host operation, no pause.** A step cannot suspend (everything
+suspendable is refused inside it), so it needs no `PendingHostOperation` /
+host-promise entry. A crash between begin and end simply re-runs the
+(deterministic) callback on resume — memoization is an optimization, never a
+correctness dependency.
+
+## 4. Determinism analysis
+
+- **Match key** is `(seq, "step")` plus the `name` carried in args. `seq` comes
+  from the deterministic `next_seq()` walk, so a replayed run reaches the same
+  step at the same seq (inductively: the prefix is deterministic). A renamed
+  or moved step fails loudly instead of silently mis-replaying.
+- **The journal cannot gap.** Because every record-producing or
+  state-mutating operation is refused while a step is live, the step's record
+  at seq `N` is always immediately followed by the next effect at `N+1` — in
+  the live log and in every replayed log. Skipping the callback can therefore
+  never desynchronize sequence numbers (the failure mode that would otherwise
+  make memoize-and-skip unsound).
+- **Errors replay as errors.** A failed step records `error` and re-throws on
+  replay, so a `try/catch` around a step takes the same branch every run.
+- **Edit-and-resume composes.** Editing a step's body *after* the resume
+  frontier takes effect on the next fresh run; editing it *before* the
+  frontier is invisible (the recorded value wins) — which is exactly the
+  modify-and-resume contract everywhere else in the journal. Renaming a
+  pre-frontier step is detected as divergence.
+
+## 5. Relation to neighbors
+
+- **`chidori.checkpoint(label, data)`** records an explicit *marker* you
+  compute yourself; it doesn't skip anything. `step` is the memoizing version:
+  the runtime decides record-vs-replay and the callback body is the thing
+  being saved.
+- **`durableStep(fn)`** (`ReplayRuntime::install_memo`) is the engine-crate
+  prototype with the same record/replay semantics, keyed by invocation index
+  only. `chidori.step` is the production surface: named, divergence-checked,
+  recorded in the real call log, enforced pure, visible in traces and
+  `chidori trace` output as a `step` record.
+- **Provider prompt caching** (`docs/context-management.md`) bounds *token*
+  re-billing; `step` bounds *CPU* re-execution. Both are live-only
+  optimizations layered under the same source of truth, the call log.
+
+## 6. Future work
+
+- **Periodic value snapshots of agent-declared state** ("restore from the last
+  checkpoint, skip the prefix entirely") would bound even the un-wrapped
+  replay cost, at the price of a checkpoint-aware programming model for loops.
+  `step` is the composable primitive that doesn't change the model; revisit
+  the bigger version if journals grow past what stepped replay handles.
+- **Async step bodies** (awaiting only pure promises) could be supported by
+  draining jobs inside the binding; deferred until a real agent needs it.
+- A `chidori stats` / trace view that reports replay time saved per step.

--- a/examples/agents/value_checkpoint.ts
+++ b/examples/agents/value_checkpoint.ts
@@ -1,0 +1,36 @@
+// Value checkpoints (`chidori.step`) — bound resume cost on long runs.
+//
+// Resume re-executes the agent from the top, serving recorded host effects
+// from the journal. Pure JS compute is normally re-executed on every replay;
+// wrapping it in `chidori.step(name, fn)` journals the result once, so a
+// resumed or replayed run returns the recorded value without re-running fn.
+//
+//   chidori run examples/agents/value_checkpoint.ts --input '{"docs": 2000}'
+//
+// The run pauses on `input()`; resume it and the "index" step is served from
+// the journal instead of being recomputed. See docs/value-checkpoints.md.
+import type { Chidori } from "chidori";
+
+export async function agent(input: { docs?: number }, chidori: Chidori) {
+  const docs = input.docs ?? 1000;
+
+  // Expensive, deterministic, effect-free — exactly what a step is for.
+  // Host effects, randomness, fs writes, and timers throw inside the
+  // callback: a skipped body must have nothing to skip but compute.
+  const index = await chidori.step("index", () => {
+    const buckets: Record<string, number> = {};
+    for (let i = 0; i < docs; i++) {
+      const shard = `shard-${i % 16}`;
+      buckets[shard] = (buckets[shard] ?? 0) + 1;
+    }
+    return { docs, shards: Object.keys(buckets).length, buckets };
+  });
+
+  await chidori.log("index built", { docs: index.docs, shards: index.shards });
+
+  // The pause that makes the checkpoint pay off: resuming this run replays
+  // the journal — the step record answers instantly, the loop never re-runs.
+  const answer = await chidori.input("Publish the index?");
+
+  return { published: answer === "yes", docs: index.docs, shards: index.shards };
+}

--- a/llm.txt
+++ b/llm.txt
@@ -210,6 +210,20 @@ await chidori.checkpoint("after-draft", { tokens: 120 });
 `checkpoint()` records an explicit call-log marker. Persisted runs also refresh
 snapshot manifest metadata at durable host safepoints.
 
+### step
+
+```ts
+const plan = await chidori.step("plan", () => buildPlanDeterministically(input));
+```
+
+`step(name, fn)` is a durable value checkpoint: `fn` runs once and its
+JSON-serializable result is journaled; replay and resume return the recorded
+value (or re-throw the recorded error) without re-running `fn`. Wrap expensive
+deterministic computation in a step so resuming a long run does not re-pay it.
+The callback must be pure, synchronous compute: host effects, captured
+randomness, filesystem writes, timers, and async callbacks throw inside a step.
+See `docs/value-checkpoints.md`.
+
 ### log
 
 ```ts

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -255,6 +255,15 @@ export interface Chidori {
    * deterministic.
    */
   pollSignal<T = AgentJson>(name: string): Promise<Signal<T> | null>;
+  /**
+   * Durable value checkpoint: run `fn` once and journal its JSON-serializable
+   * result; on replay/resume the recorded value (or error) is returned without
+   * re-running `fn`. Wrap expensive deterministic computation in a step so a
+   * resumed run does not re-pay it. The callback must be pure, synchronous
+   * compute — host effects (`chidori.*`), captured randomness, filesystem
+   * writes, timers, and async callbacks are refused inside a step.
+   */
+  step<T extends AgentJson = AgentJson>(name: string, fn: () => T): Promise<T>;
   callAgent<TInput extends AgentJson = JsonObject, TOutput extends AgentJson = AgentJson>(
     path: string,
     input?: TInput,

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -130,6 +130,10 @@ struct RuntimeContextInner {
     /// Set by `signal()` when pausing at a listen point with an empty mailbox.
     /// The engine reads this after eval unwinds to surface a signal pause.
     pub pending_signal: Option<PendingSignal>,
+    /// The `chidori.step(name, fn)` callback currently live-executing, if any.
+    /// While set, all other host effects are refused (step callbacks must be
+    /// pure compute — `docs/value-checkpoints.md`).
+    pub active_step: Option<ActiveStep>,
     /// Durable per-run signal mailbox, loaded at run/resume start (threaded the
     /// same way `vfs` is). `take_queued_signal(name)` drains the lowest-
     /// `delivery_seq` matching entry and immediately re-persists the shrunken
@@ -234,6 +238,19 @@ pub struct PendingSignal {
     pub id: HostOperationId,
 }
 
+/// Set by `execute_step_begin` while a `chidori.step(name, fn)` callback is
+/// live-executing in the VM. The step's call-log record is written at `seq`
+/// when `execute_step_end` takes this back; while it is set, every other host
+/// effect refuses to run — a step callback must be pure, synchronous
+/// computation, or skipping it on replay would desynchronize the journal
+/// (see `docs/value-checkpoints.md`).
+#[derive(Debug, Clone)]
+pub struct ActiveStep {
+    pub seq: u64,
+    pub name: String,
+    pub started: chrono::DateTime<chrono::Utc>,
+}
+
 /// Set by the policy enforcer when a call needs user approval but the
 /// engine is running in Pause mode (server context). The engine catches the
 /// pause sentinel, takes this value, and returns it in `RunResult` so the
@@ -285,6 +302,7 @@ impl RuntimeContext {
                 pending_input: None,
                 pending_approval: None,
                 pending_signal: None,
+                active_step: None,
                 signal_inbox: Vec::new(),
                 host_promises: HostPromiseTable::new(),
                 event_sender: None,
@@ -350,6 +368,7 @@ impl RuntimeContext {
                 pending_input: None,
                 pending_approval: None,
                 pending_signal: None,
+                active_step: None,
                 signal_inbox,
                 host_promises: HostPromiseTable::from_records(host_promises),
                 event_sender: None,
@@ -385,6 +404,7 @@ impl RuntimeContext {
                 pending_input: None,
                 pending_approval: None,
                 pending_signal: None,
+                active_step: None,
                 signal_inbox: Vec::new(),
                 host_promises: HostPromiseTable::new(),
                 event_sender: None,
@@ -854,6 +874,34 @@ impl RuntimeContext {
 
     pub fn take_pending_signal(&self) -> Option<PendingSignal> {
         self.inner.lock().unwrap().pending_signal.take()
+    }
+
+    /// Mark a `chidori.step(name, fn)` callback as live-executing at `seq`.
+    /// While set, every other host effect refuses to run (the callback must be
+    /// pure compute), so the step's record at `seq` is always the next record —
+    /// skipping the callback on replay can never desynchronize the journal.
+    pub fn begin_step(&self, seq: u64, name: &str) {
+        self.inner.lock().unwrap().active_step = Some(ActiveStep {
+            seq,
+            name: name.to_string(),
+            started: chrono::Utc::now(),
+        });
+    }
+
+    /// Take back the live-executing step marker (set by [`begin_step`](Self::begin_step)).
+    pub fn take_active_step(&self) -> Option<ActiveStep> {
+        self.inner.lock().unwrap().active_step.take()
+    }
+
+    /// The name of the step callback currently live-executing, if any. Host
+    /// effect dispatchers consult this to refuse effects inside step bodies.
+    pub fn active_step_name(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .active_step
+            .as_ref()
+            .map(|s| s.name.clone())
     }
 
     /// Replace the in-memory signal mailbox. Used by the

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -2036,4 +2036,291 @@ def agent(value):
 
         let _ = std::fs::remove_dir_all(dir);
     }
+
+    /// `chidori.step(name, fn)` — the durable value checkpoint
+    /// (`docs/value-checkpoints.md`): the callback runs once and its result is
+    /// journaled as a `step` CallRecord; replay returns the recorded value
+    /// WITHOUT re-running the callback. Proven by replaying against an edited
+    /// agent whose step body now throws — the recorded value wins.
+    #[test]
+    fn engine_step_memoizes_value_checkpoint_on_replay() {
+        let dir =
+            std::env::temp_dir().join(format!("chidori-engine-ts-step-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    const plan = await chidori.step("plan", () => {
+                        let total = 0;
+                        for (let i = 0; i <= 1000; i++) total += i;
+                        return { total, source: "computed" };
+                    });
+                    return { total: plan.total, source: plan.source };
+                }
+            "#,
+        )
+        .unwrap();
+
+        let engine = || {
+            Engine::new(
+                Arc::new(ProviderRegistry::new()),
+                Arc::new(TemplateEngine::new(&dir)),
+                Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            )
+        };
+
+        let recorded = engine().run(&path, &serde_json::json!({})).unwrap();
+        assert_eq!(
+            recorded.output,
+            serde_json::json!({ "total": 500500, "source": "computed" })
+        );
+        let records = recorded.call_log.into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "step");
+        assert_eq!(records[0].args, serde_json::json!({ "name": "plan" }));
+        assert_eq!(
+            records[0].result,
+            serde_json::json!({ "total": 500500, "source": "computed" })
+        );
+
+        // Replay against an edited body that would throw if re-executed: the
+        // journaled value must win (the whole point of the value checkpoint).
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    const plan = await chidori.step("plan", () => {
+                        throw new Error("step callback must not re-run on replay");
+                    });
+                    return { total: plan.total, source: plan.source };
+                }
+            "#,
+        )
+        .unwrap();
+        let replayed = engine()
+            .run_with_replay(&path, &serde_json::json!({}), records)
+            .unwrap();
+        assert_eq!(replayed.output, recorded.output);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// A step callback that throws journals the error, and replay re-throws the
+    /// recorded error without re-running the callback — even when the edited
+    /// callback would now succeed.
+    #[test]
+    fn engine_step_replays_recorded_error() {
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-engine-ts-step-err-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    try {
+                        await chidori.step("parse", () => { throw new Error("bad parse"); });
+                        return { ok: true };
+                    } catch (e) {
+                        return { caught: String(e) };
+                    }
+                }
+            "#,
+        )
+        .unwrap();
+
+        let engine = || {
+            Engine::new(
+                Arc::new(ProviderRegistry::new()),
+                Arc::new(TemplateEngine::new(&dir)),
+                Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            )
+        };
+
+        let recorded = engine().run(&path, &serde_json::json!({})).unwrap();
+        let caught = recorded
+            .output
+            .get("caught")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        assert!(caught.contains("bad parse"), "got: {caught}");
+        let records = recorded.call_log.into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "step");
+        assert!(records[0].error.as_deref().unwrap().contains("bad parse"));
+
+        // Edited callback now succeeds — but the journaled error replays.
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    try {
+                        await chidori.step("parse", () => ({ fine: true }));
+                        return { ok: true };
+                    } catch (e) {
+                        return { caught: String(e) };
+                    }
+                }
+            "#,
+        )
+        .unwrap();
+        let replayed = engine()
+            .run_with_replay(&path, &serde_json::json!({}), records)
+            .unwrap();
+        assert_eq!(replayed.output, recorded.output);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The pure-compute contract is enforced loudly: host effects, captured
+    /// randomness, and async callbacks are all refused inside a step body.
+    #[test]
+    fn engine_step_enforces_pure_compute_contract() {
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-engine-ts-step-pure-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            &path,
+            r#"
+                import { randomBytes } from "node:crypto";
+                export async function agent(input, chidori) {
+                    const tryStep = async (name, fn) => {
+                        try { await chidori.step(name, fn); return "ok"; }
+                        catch (e) { return String(e); }
+                    };
+                    return {
+                        effect: await tryStep("effect", () => { chidori.log("nope"); return 1; }),
+                        random: await tryStep("random", () => randomBytes(4).toString("hex")),
+                        timer: await tryStep("timer", () => { setTimeout(() => {}, 1); return 1; }),
+                        asyncFn: await tryStep("asyncFn", async () => 1),
+                    };
+                }
+            "#,
+        )
+        .unwrap();
+
+        let engine = Engine::new(
+            Arc::new(ProviderRegistry::new()),
+            Arc::new(TemplateEngine::new(&dir)),
+            Arc::new(tokio::runtime::Runtime::new().unwrap()),
+        );
+        let result = engine.run(&path, &serde_json::json!({})).unwrap();
+        let field = |k: &str| {
+            result
+                .output
+                .get(k)
+                .and_then(|v| v.as_str())
+                .unwrap()
+                .to_string()
+        };
+        assert!(
+            field("effect").contains("not allowed inside chidori.step(\"effect\")"),
+            "got: {}",
+            field("effect")
+        );
+        assert!(
+            field("random").contains("not allowed inside chidori.step(\"random\")"),
+            "got: {}",
+            field("random")
+        );
+        assert!(
+            field("timer").contains("not allowed inside chidori.step(\"timer\")"),
+            "got: {}",
+            field("timer")
+        );
+        assert!(
+            field("asyncFn").contains("must return synchronously"),
+            "got: {}",
+            field("asyncFn")
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The P6 acceptance: a resume after a pause does not re-pay the step. The
+    /// agent computes a step, then pauses on `input()`; the resume replays from
+    /// the journal against an edited step body that would throw — and completes
+    /// with the recorded step value.
+    #[test]
+    fn engine_step_skips_recompute_on_input_resume() {
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-engine-ts-step-resume-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    const plan = await chidori.step("plan", () => ({ total: 42 }));
+                    const answer = await chidori.input("Approve the plan?");
+                    return { total: plan.total, approved: answer === "yes" };
+                }
+            "#,
+        )
+        .unwrap();
+
+        let engine = || {
+            Engine::new(
+                Arc::new(ProviderRegistry::new()),
+                Arc::new(TemplateEngine::new(&dir)),
+                Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            )
+        };
+
+        let paused = engine()
+            .run_pausable(&path, &serde_json::json!({}))
+            .unwrap();
+        let pending = paused.paused.expect("expected an input pause");
+        assert_eq!(pending.seq, 2, "step takes seq 1, input pauses at seq 2");
+        let mut replay = paused.call_log.into_records();
+        assert_eq!(replay.len(), 1);
+        assert_eq!(replay[0].function, "step");
+
+        // Resume = journal replay + the synthetic input record, against an
+        // edited step body that must not run.
+        replay.push(CallRecord {
+            seq: pending.seq,
+            parent_seq: None,
+            function: "input".to_string(),
+            args: serde_json::json!({ "prompt": pending.prompt }),
+            result: serde_json::json!("yes"),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: chrono::Utc::now(),
+            error: None,
+        });
+        std::fs::write(
+            &path,
+            r#"
+                export async function agent(input, chidori) {
+                    const plan = await chidori.step("plan", () => {
+                        throw new Error("resume must not re-pay the step");
+                    });
+                    const answer = await chidori.input("Approve the plan?");
+                    return { total: plan.total, approved: answer === "yes" };
+                }
+            "#,
+        )
+        .unwrap();
+        let resumed = engine()
+            .run_replay_pausable(&path, &serde_json::json!({}), replay)
+            .unwrap();
+        assert!(resumed.paused.is_none());
+        assert_eq!(
+            resumed.output,
+            serde_json::json!({ "total": 42, "approved": true })
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/src/runtime/host_core.rs
+++ b/src/runtime/host_core.rs
@@ -404,6 +404,105 @@ pub fn execute_poll_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> 
     Ok(result)
 }
 
+/// First half of `chidori.step(name, fn)` — the durable value checkpoint
+/// (`docs/value-checkpoints.md`). The VM-side binding calls this *before*
+/// running the callback:
+///   1. replay short-circuit (`try_replay_checked(seq, "step")`) — a recorded
+///      result (or recorded error) is returned as `{cached: true, ...}` and the
+///      callback is never run. The recorded `name` must match, else the agent
+///      code moved/renamed steps before the resume point (fail-loud divergence,
+///      same contract as `try_replay_checked`'s function-name check).
+///   2. otherwise mark the step live (`begin_step`) and return
+///      `{cached: false}` — the binding runs the callback and reports its
+///      result through [`execute_step_end`], which writes the record at this
+///      same `seq`.
+/// While the step is live, every other host effect is refused (the dispatchers
+/// check `active_step_name`), so the callback is guaranteed pure compute and
+/// skipping it on replay cannot desynchronize the journal. Steps never pause
+/// and need no pending host operation: a crash between begin and end simply
+/// re-runs the (deterministic) callback on resume.
+pub fn execute_step_begin(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
+    let name = args
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("chidori.step requires a string name"))?
+        .to_string();
+    if let Some(active) = ctx.active_step_name() {
+        anyhow::bail!(
+            "chidori.step(\"{name}\") cannot start inside chidori.step(\"{active}\"): \
+             step callbacks must be pure, synchronous computation"
+        );
+    }
+    let seq = ctx.next_seq();
+
+    if let Some(record) = ctx
+        .try_replay_checked(seq, "step")
+        .map_err(|err| anyhow::anyhow!(err))?
+    {
+        let recorded_name = record
+            .args
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if recorded_name != name {
+            anyhow::bail!(
+                "Replay divergence at seq {seq}: checkpoint has step \"{recorded_name}\" \
+                 but agent called step \"{name}\". The agent code changed since the \
+                 checkpoint was saved — re-run without replay to regenerate."
+            );
+        }
+        return Ok(match record.error {
+            Some(error) => json!({ "cached": true, "error": error }),
+            None => json!({ "cached": true, "value": record.result }),
+        });
+    }
+
+    ctx.begin_step(seq, &name);
+    Ok(json!({ "cached": false }))
+}
+
+/// Second half of `chidori.step(name, fn)` — record the callback's outcome at
+/// the seq [`execute_step_begin`] reserved. `args` carries either `value` (the
+/// callback's JSON-serialized return value) or `error` (its thrown message).
+/// Returns the canonical (JSON round-tripped) value so live and replayed runs
+/// observe byte-identical results.
+pub fn execute_step_end(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
+    let name = args
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("chidori.step requires a string name"))?;
+    let Some(step) = ctx.take_active_step() else {
+        anyhow::bail!("chidori.step internal error: step_end(\"{name}\") without an active step");
+    };
+    if step.name != name {
+        anyhow::bail!(
+            "chidori.step internal error: step_end(\"{name}\") while step \"{}\" is active",
+            step.name
+        );
+    }
+    let duration_ms = Utc::now()
+        .signed_duration_since(step.started)
+        .num_milliseconds()
+        .max(0) as u64;
+    let error = args.get("error").and_then(Value::as_str);
+    let result = match error {
+        Some(_) => Value::Null,
+        None => args.get("value").cloned().unwrap_or(Value::Null),
+    };
+    ctx.record_call(CallRecord {
+        seq: step.seq,
+        parent_seq: None,
+        function: "step".to_string(),
+        args: json!({ "name": name }),
+        result: result.clone(),
+        duration_ms,
+        token_usage: None,
+        timestamp: step.started,
+        error: error.map(str::to_string),
+    });
+    Ok(result)
+}
+
 /// Whether (and how long) a prompt request should mark cacheable prefix
 /// boundaries. The default is on with the 5-minute TTL — caching is a billing
 /// optimization that never changes a response, so it is safe by default; a
@@ -2177,5 +2276,120 @@ mod tests {
         let ctx = RuntimeContext::new();
         let err = execute_signal(&ctx, &json!({ "name": 42, "opts": null })).unwrap_err();
         assert!(err.to_string().contains("requires a string name"));
+    }
+
+    #[test]
+    fn step_begin_and_end_record_one_step_call() {
+        let ctx = RuntimeContext::new();
+        let begin = execute_step_begin(&ctx, &json!({ "name": "plan" })).unwrap();
+        assert_eq!(begin, json!({ "cached": false }));
+        assert_eq!(ctx.active_step_name().as_deref(), Some("plan"));
+
+        let result =
+            execute_step_end(&ctx, &json!({ "name": "plan", "value": { "total": 42 } })).unwrap();
+        assert_eq!(result, json!({ "total": 42 }));
+        assert!(ctx.active_step_name().is_none());
+
+        let records = ctx.call_log().into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "step");
+        assert_eq!(records[0].seq, 1);
+        assert_eq!(records[0].args, json!({ "name": "plan" }));
+        assert_eq!(records[0].result, json!({ "total": 42 }));
+        assert!(records[0].error.is_none());
+    }
+
+    #[test]
+    fn step_begin_replays_recorded_value_and_error_without_running() {
+        let records = vec![
+            CallRecord {
+                seq: 1,
+                parent_seq: None,
+                function: "step".to_string(),
+                args: json!({ "name": "plan" }),
+                result: json!({ "total": 42 }),
+                duration_ms: 0,
+                token_usage: None,
+                timestamp: Utc::now(),
+                error: None,
+            },
+            CallRecord {
+                seq: 2,
+                parent_seq: None,
+                function: "step".to_string(),
+                args: json!({ "name": "boom" }),
+                result: Value::Null,
+                duration_ms: 0,
+                token_usage: None,
+                timestamp: Utc::now(),
+                error: Some("Error: bad parse".to_string()),
+            },
+        ];
+        let ctx = RuntimeContext::with_replay(records);
+
+        let hit = execute_step_begin(&ctx, &json!({ "name": "plan" })).unwrap();
+        assert_eq!(hit, json!({ "cached": true, "value": { "total": 42 } }));
+        // A cache hit leaves no active step — the callback never runs, so no
+        // step_end follows.
+        assert!(ctx.active_step_name().is_none());
+
+        let err_hit = execute_step_begin(&ctx, &json!({ "name": "boom" })).unwrap();
+        assert_eq!(
+            err_hit,
+            json!({ "cached": true, "error": "Error: bad parse" })
+        );
+    }
+
+    #[test]
+    fn step_begin_diverges_on_renamed_step() {
+        let records = vec![CallRecord {
+            seq: 1,
+            parent_seq: None,
+            function: "step".to_string(),
+            args: json!({ "name": "plan" }),
+            result: json!(1),
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        }];
+        let ctx = RuntimeContext::with_replay(records);
+        let err = execute_step_begin(&ctx, &json!({ "name": "renamed" })).unwrap_err();
+        assert!(err.to_string().contains("Replay divergence"));
+        assert!(err.to_string().contains("\"plan\""));
+        assert!(err.to_string().contains("\"renamed\""));
+    }
+
+    #[test]
+    fn step_rejects_nesting_and_unmatched_end() {
+        let ctx = RuntimeContext::new();
+        execute_step_begin(&ctx, &json!({ "name": "outer" })).unwrap();
+        let nested = execute_step_begin(&ctx, &json!({ "name": "inner" })).unwrap_err();
+        assert!(nested
+            .to_string()
+            .contains("cannot start inside chidori.step(\"outer\")"));
+
+        // Close the outer step, then a stray step_end has nothing to match.
+        execute_step_end(&ctx, &json!({ "name": "outer", "value": 1 })).unwrap();
+        let stray = execute_step_end(&ctx, &json!({ "name": "outer", "value": 1 })).unwrap_err();
+        assert!(stray.to_string().contains("without an active step"));
+    }
+
+    #[test]
+    fn step_end_records_error_outcome() {
+        let ctx = RuntimeContext::new();
+        execute_step_begin(&ctx, &json!({ "name": "boom" })).unwrap();
+        let result = execute_step_end(
+            &ctx,
+            &json!({ "name": "boom", "error": "Error: bad parse" }),
+        )
+        .unwrap();
+        assert_eq!(result, Value::Null);
+
+        let records = ctx.call_log().into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "step");
+        assert_eq!(records[0].error.as_deref(), Some("Error: bad parse"));
+        assert_eq!(records[0].result, Value::Null);
     }
 }

--- a/src/runtime/rust_engine.rs
+++ b/src/runtime/rust_engine.rs
@@ -518,6 +518,32 @@ fn build_sync_native_dispatch(
     use crate::runtime::capability::Capability;
     Rc::new(
         move |name: &str, args: &Value| -> std::result::Result<Value, String> {
+            // Inside a live `chidori.step` callback (pure-compute contract,
+            // docs/value-checkpoints.md), refuse the captured-effect natives
+            // whose work would be skipped on replay: recorded randomness, VFS
+            // mutation, and timer/microtask scheduling (the polyfills note a
+            // capability at schedule time, so blocking that blocks them).
+            // Hashing and VFS reads stay allowed — they record nothing and
+            // mutate nothing, and the step's memoized result keeps replay
+            // deterministic regardless.
+            if matches!(
+                name,
+                "__chidori_crypto_random"
+                    | "__chidori_fs_write"
+                    | "__chidori_fs_append"
+                    | "__chidori_fs_mkdir"
+                    | "__chidori_fs_rm"
+                    | "__chidori_fs_rename"
+                    | "__chidori_note_capability"
+            ) {
+                if let Some(step) = ctx.active_step_name() {
+                    return Err(format!(
+                        "captured effects (randomness, fs writes, timers) are not allowed \
+                         inside chidori.step(\"{step}\"): step callbacks must be pure, \
+                         synchronous computation"
+                    ));
+                }
+            }
             let str_arg = |i: usize| -> std::result::Result<String, String> {
                 args.get(i)
                     .and_then(|v| v.as_str())

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -793,6 +793,20 @@ impl HostBindingBackend {
         effect: &str,
         a: &serde_json::Value,
     ) -> std::result::Result<serde_json::Value, String> {
+        // A live `chidori.step` callback must be pure compute: skipping it on
+        // replay skips everything it did, so any effect it performed would be
+        // lost (state) or desynchronize the journal (records). Refuse loudly.
+        // `step_begin`/`step_end` are the step protocol itself and
+        // `contextDigest` is a pure inline hash that records nothing.
+        if !matches!(effect, "step_begin" | "step_end" | "contextDigest") {
+            if let Some(step) = self.runtime_ctx().and_then(|ctx| ctx.active_step_name()) {
+                return Err(format!(
+                    "chidori.{effect} is not allowed inside chidori.step(\"{step}\"): \
+                     step callbacks must be pure, synchronous computation \
+                     (run host effects outside the step and pass their results in)"
+                ));
+            }
+        }
         let opt_null = |v: Option<serde_json::Value>| v.unwrap_or(serde_json::Value::Null);
         match effect {
             "log" => {
@@ -813,6 +827,27 @@ impl HostBindingBackend {
             }
             "signal" => self.signal(a),
             "poll_signal" => self.poll_signal(a),
+            // The two halves of `chidori.step(name, fn)` — the durable value
+            // checkpoint (docs/value-checkpoints.md). The engine binding probes
+            // for a recorded result, runs the callback only on a miss, then
+            // reports the outcome; one `step` CallRecord results either way.
+            "step_begin" => match self {
+                HostBindingBackend::Runtime { runtime_ctx, .. } => {
+                    host_core::execute_step_begin(runtime_ctx, a).map_err(|err| err.to_string())
+                }
+                // The recorder has no replay log, so the callback always runs.
+                HostBindingBackend::Recorder(_) => Ok(serde_json::json!({ "cached": false })),
+            },
+            "step_end" => match self {
+                HostBindingBackend::Runtime { runtime_ctx, .. } => {
+                    host_core::execute_step_end(runtime_ctx, a).map_err(|err| err.to_string())
+                }
+                HostBindingBackend::Recorder(recorder) => {
+                    let name = a.get("name").cloned().unwrap_or(serde_json::Value::Null);
+                    recorder.push("step", serde_json::json!({ "name": name }));
+                    Ok(a.get("value").cloned().unwrap_or(serde_json::Value::Null))
+                }
+            },
             "checkpoint" => {
                 let args = serde_json::json!({
                     "label": a.get("label").cloned().unwrap_or(serde_json::Value::Null),


### PR DESCRIPTION
## Summary

Implements `chidori.step(name, fn)` — a durable value checkpoint feature that memoizes expensive deterministic computation into the call log. On replay and resume, the recorded value (or error) is returned without re-running the callback, bounding resume cost for long-lived runs.

## Key Changes

**Runtime Core (`src/runtime/host_core.rs`)**
- Added `execute_step_begin()`: allocates sequence number, checks replay log for cached result, marks step live if miss
- Added `execute_step_end()`: records the callback outcome (value or error) at the reserved sequence number
- Enforces step name matching on replay to detect divergence (code edits before resume frontier)

**Engine Binding (`crates/chidori-js/src/lib.rs`)**
- Implemented `chidori.step(name, fn)` method: two-phase protocol driving the host calls
- Probes journal on `step_begin`, runs callback synchronously only on miss, reports outcome via `step_end`
- Detects and rejects async callbacks (Promises) with clear error message
- JSON round-trips results on live path so live and replayed runs observe identical values

**Runtime Context (`src/runtime/context.rs`)**
- Added `ActiveStep` struct to track live step execution (seq, name, start time)
- Added `active_step` field to `RuntimeContextInner`
- Added helper methods: `begin_step()`, `take_active_step()`, `active_step_name()`

**Effect Dispatch Guards (`src/runtime/typescript/bindings.rs` and `src/runtime/rust_engine.rs`)**
- Refuse all host effects while a step is live (pure-compute contract enforcement)
- Exceptions: `step_begin`/`step_end` (the protocol itself) and `contextDigest` (pure inline hash)
- Refuse captured-effect natives: randomness, VFS writes, timer/microtask scheduling
- Allow VFS reads and crypto hashing (recordless, deterministic)

**Tests (`src/runtime/engine.rs`)**
- `engine_step_memoizes_value_checkpoint_on_replay`: verifies recorded value wins on replay even when callback would throw
- `engine_step_replays_recorded_error`: confirms recorded errors re-throw without re-running callback
- `engine_step_enforces_pure_compute_contract`: validates rejection of effects, randomness, timers, async callbacks
- `engine_step_skips_recompute_on_input_resume`: P6 acceptance test — resume after pause doesn't re-pay the step

**Unit Tests (`src/runtime/host_core.rs`)**
- `step_begin_and_end_record_one_step_call`: basic record flow
- `step_begin_replays_recorded_value_and_error_without_running`: cache hit behavior
- `step_begin_diverges_on_renamed_step`: divergence detection
- `step_rejects_nesting_and_unmatched_end`: contract enforcement
- `step_end_records_error_outcome`: error recording

**Documentation**
- Added `docs/value-checkpoints.md`: comprehensive guide covering contract, semantics, determinism analysis, and relation to neighbors
- Added `examples/agents/value_checkpoint.ts`: practical example with pause/resume scenario
- Updated `docs/fable_review.md`: marked P6 as landed
- Updated `llm.txt`, `sdk/typescript/src/agent.ts`, `TODO.md`, `README.md`: API documentation

## Implementation Details

- **No pending host operation**: steps cannot suspend (everything suspendable is refused), so no `PendingHostOperation` needed
- **Determinism by design**: sequence numbers remain synchronized because no record-producing operations occur while a step is live
- **Edit-and-resume safety**: renaming a pre-frontier step is detected as divergence; editing post-frontier takes effect on next fresh run
- **Error handling**: thrown callbacks record the error message and replay as the same throw, preserving `try/catch` semantics
- **JSON round-tripping**: results are JSON serialized on live path too, ensuring byte

https://claude.ai/code/session_01KaZx5XNSdt9zwo4DMNJV92