### PR TITLE
Per-run memory metering and deny-by-default server policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ cargo build
 ./target/debug/chidori run examples/agents/parallel.ts \
   --input '{"topic": "runtime snapshots"}'
 
-# Event-driven webhook handler
-./target/debug/chidori serve examples/agents/webhook.ts --port 8080
+# Event-driven webhook handler (--trusted: the example makes outbound
+# http calls, which the server's deny-by-default policy would refuse)
+./target/debug/chidori serve examples/agents/webhook.ts --port 8080 --trusted
 ```
 
 ## ▶️ Try The Demo
@@ -296,6 +297,12 @@ chidori tools --dir tools/                   # list available tools
 chidori serve agents/my_agent.ts --port 8080
 ```
 
+The server is **deny-by-default**: unless you configure a policy
+(`CHIDORI_POLICY*` env vars) or pass `--trusted`, gated effects (`chidori.http`,
+workspace mutations) are refused — sessions arrive from callers you may not
+control. Local `chidori run` keeps the permissive default. See
+[docs/sandbox-model.md](./docs/sandbox-model.md).
+
 Exposes:
 - `GET  /health` — health check
 - `ANY  /*` — any request is passed to `agent(event)` as an event dict
@@ -331,7 +338,7 @@ export async function agent(
 ```
 
 ```bash
-chidori serve agents/webhook.ts --port 8080
+chidori serve agents/webhook.ts --port 8080 --trusted   # the agent calls chidori.http
 
 curl -X POST http://localhost:8080/github \
   -H "Content-Type: application/json" \

--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -240,10 +240,18 @@ The real gaps, restated post-#39:
    env vars) — but it is still opt-in, not automatic. A `supervised`
    sibling (ask-by-default, settled through the server's `/approve` flow)
    and per-session profile selection over the HTTP API (stricter-wins
-   layering on the server policy) landed on this branch.
+   layering on the server policy) landed on this branch. *(Update
+   2026-06-12: resolved for the network surface — `chidori serve` is now
+   deny-by-default when no `CHIDORI_POLICY*` configuration is present, with
+   a `--trusted` opt-out; `chidori run` deliberately keeps the permissive
+   default.)*
 2. **Memory accounting is process-wide, not per-VM** (`src/mem_guard.rs`):
    under concurrent agents one run's allocations can be attributed to
    another; enforcement is polled, so brief overshoot is possible.
+   *(Update 2026-06-12: each run now registers a per-run meter on its
+   execution thread, so concurrent runs no longer trip each other's caps;
+   the watchdog polls every 10 ms, tunable via `CHIDORI_JS_MEM_POLL_MS`.
+   Residual drift: attribution is by thread, not ownership.)*
 3. **No per-agent CPU quota** — the opcode budget bounds a run, not a
    tenant.
 4. **No seccomp/namespace/process isolation** — though "zero `unsafe`, no C"
@@ -377,9 +385,13 @@ The original items, for the record:
    on `POST /sessions` / `/sessions/stream`, persisted on the session and
    re-applied across resume/approve/replay, exposed in both SDKs). Session
    profiles layer on the server policy with stricter-wins semantics, so a
-   caller can tighten but never relax the operator's policy. The default
+   caller can tighten but never relax the operator's policy. ~~The default
    profile remains `AlwaysAllow` — making `untrusted` automatic for
-   untrusted callers is the remaining (design-level) follow-up.
+   untrusted callers is the remaining (design-level) follow-up.~~ — **done**
+   (2026-06-12): `chidori serve` is deny-by-default when the operator has
+   configured no `CHIDORI_POLICY*` source (malformed configuration fails
+   closed), with `--trusted` as the explicit opt-out; `chidori run` keeps
+   the permissive default for local developer-authored code.
 4. ~~Run Test262 in CI~~ — **done** (#41). Add TypeScript SDK tests next.
 5. **Automate SDK publishing** to npm/PyPI, or remove the registry badges.
 6. ~~**Pay down the doc drift** (the list above): README engine section, SDK

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -54,8 +54,8 @@ remaining distance.
 | Hang the host with an infinite loop | ✅ Yes — opcode budget |
 | OOM the host (string / heap growth) | ✅ Yes — string cap + memory ceiling |
 | Crash the host with a panic | ✅ Yes — `catch_unwind` boundary |
-| Abuse an injected powerful effect (`http`, `workspace`) | ⚠️ Only if the host gates it — see [gaps](#current-gaps) |
-| Starve co-tenant agents / exceed a precise per-agent memory quota | ⚠️ Coarse only — see [gaps](#current-gaps) |
+| Abuse an injected powerful effect (`http`, `workspace`) | ✅ On the server (deny-by-default unless the operator opts out); ⚠️ on the bare CLI only if the operator gates it — see [gaps](#current-gaps) |
+| Starve co-tenant agents / exceed a per-agent memory quota | ✅ Per-run meter (thread-attributed; small cross-thread drift) — see [gaps](#current-gaps) |
 | Break out of the process / OS | ❌ No process or OS isolation |
 
 ## Architecture: capability injection, not ambient authority
@@ -141,15 +141,20 @@ Two complementary layers:
    opcode can allocate without bound.
 
 2. **Per-run live-heap ceiling (watchdog).** A `CountingAllocator`
-   (`src/mem_guard.rs`) is installed as the binary's `#[global_allocator]` and
-   tracks live (allocated-minus-freed) bytes with one relaxed atomic per
-   alloc/free. A background watchdog samples baseline-relative growth and trips the
-   VM's cooperative-cancellation flag (`vm.interrupt`, polled every 256 ops) when a
+   (`src/mem_guard.rs`) is installed as the binary's `#[global_allocator]`. Each
+   run registers a **per-run meter** on its execution thread (`RunMeterGuard`);
+   every alloc/free performed on that thread is charged to that run, so under
+   concurrent multi-agent execution one run's allocations are attributed to that
+   run rather than to whichever co-tenant happens to be sampled (nested
+   `callAgent` children meter themselves and hand accounting back to the
+   parent). A background watchdog samples the meter and trips the VM's
+   cooperative-cancellation flag (`vm.interrupt`, polled every 256 ops) when a
    run exceeds its cap — catching the vector a per-op cap cannot: accumulating many
    capped objects in a long-lived container (`Map`/`Set`/array). The VM unwinds with
    `RangeError: execution interrupted`.
 
-   - Env: `CHIDORI_JS_MEM_CAP_MB` (default `4096`; `0` disables).
+   - Env: `CHIDORI_JS_MEM_CAP_MB` (default `4096`; `0` disables) and
+     `CHIDORI_JS_MEM_POLL_MS` (watchdog sampling interval, default `10`).
 
 ### Wall-clock deadline — optional, off by default
 
@@ -180,7 +185,8 @@ The same watchdog can enforce a wall-clock deadline, also via `vm.interrupt`.
 | Control | Env var | Default | Disable |
 |---|---|---|---|
 | Opcode budget | `CHIDORI_JS_OP_BUDGET` | `5_000_000_000` | `0` |
-| Memory ceiling (MB, baseline-relative) | `CHIDORI_JS_MEM_CAP_MB` | `4096` | `0` |
+| Memory ceiling (MB, per-run meter) | `CHIDORI_JS_MEM_CAP_MB` | `4096` | `0` |
+| Memory watchdog poll interval (ms) | `CHIDORI_JS_MEM_POLL_MS` | `10` | — |
 | Wall-clock deadline (ms) | `CHIDORI_JS_DEADLINE_MS` | off | — |
 | String length | (compile constant) | 16 MB | — |
 | Dense array length | (compile constant) | 1,000,000 | — |
@@ -193,35 +199,37 @@ These are the known limitations as of this writing. None of them are
 memory-safety holes (the engine is safe Rust); they are confinement and
 resource-precision gaps.
 
-1. **Not every powerful effect is gated yet.** The remaining powerful effects are
-   `http` (real outbound network requests) and `workspace.*` (real disk I/O within
-   a sanitized root); the `exec*` snippet sandboxes were removed in #39. Both `http`
-   and every `workspace.*` action now pass through the policy enforcement gate
-   (`enforce_policy`): `http` against the `http` target, and workspace actions
-   against `workspace:list` / `workspace:read` / `workspace:write` /
-   `workspace:delete` / `workspace:manifest`. A restrictive profile can therefore
-   deny or require approval for disk writes while still allowing reads. The
-   remaining gap is the *default*: the fallback decision is still `AlwaysAllow`, so
-   out of the box nothing is denied. Deny-by-default is now one switch away — the
-   built-in [`untrusted` profile](#the-untrusted-policy-profile-deny-by-default),
-   selectable as `chidori run --untrusted` / `chidori serve --untrusted` or via
-   `CHIDORI_POLICY_PROFILE=untrusted` — but it is opt-in, not automatic.
-   *Remaining fix:* make it the default for untrusted runs.
+1. **The bare-CLI default is still allow.** The powerful effects — `http` (real
+   outbound network requests) and `workspace.*` (real disk I/O within a sanitized
+   root) — all pass through the policy enforcement gate (`enforce_policy`), and the
+   surface where untrusted callers actually arrive is now deny-by-default:
+   **`chidori serve` runs under the [`untrusted` profile](#the-untrusted-policy-profile-deny-by-default)
+   unless the operator explicitly configures policy** (any valid `CHIDORI_POLICY*`
+   source, or the `--trusted` flag to opt back into the permissive default;
+   malformed policy configuration fails closed to deny rather than falling back to
+   allow-all). What deliberately remains permissive is `chidori run` without
+   flags: local CLI runs of developer-authored code keep the historical
+   `AlwaysAllow` fallback, with `--untrusted` /
+   `CHIDORI_POLICY_PROFILE=untrusted` available when the code being run is not
+   trusted.
 
-2. **The memory ceiling is process-wide, not per-VM.** The `CountingAllocator`
-   counter is global; the watchdog caps *baseline-relative* growth
-   (`current - baseline_at_run_start`). Under concurrent multi-agent execution, one
-   run's allocations can be attributed to another, so the cap is a coarse safety
-   backstop tuned generously — **not** a precise per-agent quota, and it can in
-   principle trip an innocent co-tenant under heavy load. *Fix:* precise per-VM
-   byte accounting (e.g. a thread-local meter charged at string/object allocation
-   and credited on `Drop`).
+2. **Per-run memory accounting is thread-attributed, not ownership-attributed.**
+   Each run registers a per-run meter on its execution thread
+   (`src/mem_guard.rs::RunMeterGuard`), so the cap measures that run's own
+   allocations and concurrent runs no longer trip each other's caps. The residual
+   imprecision: bytes a host effect allocates on *other* threads (e.g. tokio
+   workers buffering an HTTP response) are not charged until they reach the run
+   thread, and a value allocated on the run thread but freed elsewhere stays
+   charged (the meter clamps at zero in the other direction). For a
+   single-threaded VM run this drift is small; true ownership accounting (charge
+   at string/object allocation, credit on `Drop` inside the engine) remains the
+   eventual fix.
 
 3. **Memory enforcement granularity.** The live-heap check is polled (watchdog
-   every ~20 ms; the VM observes the trip every 256 ops). A run can therefore
-   overshoot the cap briefly before unwinding. Bounded in practice because the
-   per-op size caps mean no single opcode allocates more than ~16 MB, but it is not
-   a hard instantaneous ceiling.
+   every ~10 ms by default, tunable via `CHIDORI_JS_MEM_POLL_MS`; the VM observes
+   the trip every 256 ops). A run can therefore overshoot the cap briefly before
+   unwinding. Bounded in practice because the per-op size caps mean no single
+   opcode allocates more than ~16 MB, but it is not a hard instantaneous ceiling.
 
 4. **No process / OS-level isolation.** The engine runs in-process with the host;
    there is no seccomp, namespace, or separate-process boundary. Isolation is
@@ -251,17 +259,20 @@ resource-precision gaps.
 
 The permission policy (`src/policy.rs`) gates the powerful host effects — `http`
 and every `workspace:*` action (`workspace:list` / `read` / `write` / `delete` /
-`manifest`) — through `enforce_policy`. By default the fallback for an unmatched
-effect is `AlwaysAllow`, so out of the box nothing is denied; deny-by-default is
-something you turn on.
+`manifest`) — through `enforce_policy`. The fallback for an unmatched effect
+depends on the surface: on `chidori run` (trusted, developer-authored code on the
+developer's own machine) it is `AlwaysAllow`; on **`chidori serve`** — the surface
+untrusted callers reach — it is **deny-by-default** unless the operator
+explicitly configures policy.
 
 The **`untrusted`** profile is a ready-made, deny-by-default policy you can select
-by name — no hand-written JSON. Enable it with a CLI flag (on `run` and `serve`)
-or an environment variable:
+by name — no hand-written JSON. It is what `chidori serve` runs under out of the
+box; select it explicitly with a CLI flag (on `run` and `serve`) or an
+environment variable:
 
 ```sh
 chidori run --untrusted agent.ts                       # CLI flag
-chidori serve --untrusted agent.ts                     # also on serve
+chidori serve --untrusted agent.ts                     # also on serve (already the default there)
 CHIDORI_POLICY_PROFILE=untrusted chidori run agent.ts  # env-var equivalent
 ```
 
@@ -284,11 +295,20 @@ The fallback governs exactly the powerful surface, because the *pure* effects
 (`log`, `template`, `memory`, `prompt`, …) never call `enforce_policy` and so run
 regardless of the profile — they have no ambient authority to abuse.
 
-Selection order is the `--untrusted` flag first, then `PolicyConfig::from_env`:
+Selection order is the `--untrusted` flag first, then env-driven resolution:
 `CHIDORI_POLICY_FILE` → `CHIDORI_POLICY` (inline JSON) → `CHIDORI_POLICY_PROFILE`
-(a built-in name) → default. The **default profile is unchanged** (`AlwaysAllow` fallback, no rules):
-the `untrusted` profile is purely opt-in. To customize further, copy the profile's
-shape into your own `CHIDORI_POLICY` JSON (rules + `"default": "never_allow"`).
+(a built-in name) → the surface default. The surface default differs:
+
+- **`chidori run`** falls back to the permissive profile (`AlwaysAllow`, no
+  rules) — the historical default for trusted local development.
+- **`chidori serve`** falls back to the `untrusted` profile, with a denial
+  reason that names the opt-outs. A malformed `CHIDORI_POLICY*` source fails
+  closed to this default rather than silently serving allow-all. Pass
+  `--trusted` to restore the permissive `chidori run` resolution (the startup
+  banner's `Policy:` line reports the active posture either way).
+
+To customize further, copy the profile's shape into your own `CHIDORI_POLICY`
+JSON (rules + `"default": "never_allow"`).
 
 ### The `supervised` profile (ask-by-default)
 
@@ -338,14 +358,16 @@ TypeScript, `client.run(input, policy_profile="untrusted")` in Python.
 If you intend to run code you do not trust on this engine today:
 
 1. Select the deny-by-default policy: `chidori run --untrusted` (or
-   `CHIDORI_POLICY_PROFILE=untrusted`, above). This denies `http` and `workspace`
-   mutations while leaving read-only workspace introspection available.
-2. Lower `CHIDORI_JS_OP_BUDGET` and `CHIDORI_JS_MEM_CAP_MB` to fit the workload, and
-   enable `CHIDORI_JS_DEADLINE_MS` (acceptable because untrusted code should not be
+   `CHIDORI_POLICY_PROFILE=untrusted`, above); `chidori serve` is already there
+   by default. This denies `http` and `workspace` mutations while leaving
+   read-only workspace introspection available.
+2. Lower `CHIDORI_JS_OP_BUDGET` and `CHIDORI_JS_MEM_CAP_MB` to fit the workload
+   (and tighten `CHIDORI_JS_MEM_POLL_MS` alongside a small cap), and enable
+   `CHIDORI_JS_DEADLINE_MS` (acceptable because untrusted code should not be
    making slow trusted host calls).
-3. Run each agent in its own process (or container) so the process-wide memory
-   counter and the lack of OS isolation (gaps 2, 4) do not allow cross-tenant
-   interference or a true breakout.
+3. Run each agent in its own process (or container) so the lack of OS isolation
+   (gap 4) does not allow a true breakout; per-run memory accounting (gap 2)
+   already keeps co-tenant caps separate within one process.
 4. Keep `node:fs` on `FsPolicy::Captured` (the VFS) and avoid `workspace.*`.
 
 ## Verification

--- a/llm.txt
+++ b/llm.txt
@@ -43,7 +43,7 @@ chidori run agents/my_agent.ts --input key=value
 chidori run agents/my_agent.ts --input '{"document": "text"}'
 chidori run agents/my_agent.ts --stream
 chidori run agents/my_agent.ts --trace
-chidori serve agents/webhook.ts --port 8080
+chidori serve agents/webhook.ts --port 8080 --trusted
 chidori trace <run_id>
 chidori snapshot <run_id>
 ```
@@ -355,8 +355,14 @@ events are emitted through the shared runtime context.
 Start a server:
 
 ```bash
-chidori serve examples/agents/webhook.ts --port 8080
+chidori serve examples/agents/webhook.ts --port 8080 --trusted
 ```
+
+`chidori serve` is deny-by-default: without `--trusted` or explicit
+`CHIDORI_POLICY*` configuration, gated effects (`chidori.http`, workspace
+mutations) are refused under the built-in `untrusted` profile (read-only
+workspace introspection stays allowed). `--untrusted` forces that profile over
+any env configuration; `chidori run` keeps the permissive default.
 
 Session endpoints:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,8 +204,19 @@ enum Commands {
         /// gated effects (http, workspace mutations) are refused unless
         /// allowlisted. Equivalent to CHIDORI_POLICY_PROFILE=untrusted, but
         /// takes precedence over all CHIDORI_POLICY* env vars.
-        #[arg(long)]
+        ///
+        /// This is also the server's default posture when no CHIDORI_POLICY*
+        /// configuration is present; pass --trusted to opt back into the
+        /// permissive allow-all default.
+        #[arg(long, conflicts_with = "trusted")]
         untrusted: bool,
+
+        /// Opt out of the server's deny-by-default posture: with no
+        /// CHIDORI_POLICY* configuration, gated effects (http, workspace
+        /// mutations) run without restriction, as `chidori run` does.
+        /// Explicit CHIDORI_POLICY* configuration still applies.
+        #[arg(long)]
+        trusted: bool,
     },
 }
 
@@ -260,7 +271,8 @@ fn main() {
             port,
             verbose,
             untrusted,
-        } => (cmd_serve(&file, port, verbose, untrusted), false),
+            trusted,
+        } => (cmd_serve(&file, port, verbose, untrusted, trusted), false),
     };
 
     // Flush any buffered OTLP spans before the process exits. No-op when
@@ -436,7 +448,9 @@ fn cmd_demo() -> Result<()> {
             if !confirm_start_server(*port)? {
                 return Ok(());
             }
-            cmd_serve(&PathBuf::from(file), *port, false, false)
+            // The demo serves the developer's own example agent on their own
+            // machine — the trusted posture, like `chidori run`.
+            cmd_serve(&PathBuf::from(file), *port, false, false, true)
         }
     }
 }
@@ -502,6 +516,42 @@ fn cli_policy(untrusted: bool) -> Arc<policy::PolicyConfig> {
         Arc::new(policy::builtin_profile("untrusted").expect("built-in untrusted profile exists"))
     } else {
         policy::PolicyConfig::from_env()
+    }
+}
+
+/// Resolve the permission policy for `chidori serve`. Unlike `chidori run`
+/// (trusted, developer-authored code on the developer's own machine), the
+/// server is the surface untrusted callers reach, so when the operator has
+/// said nothing it is deny-by-default. Precedence:
+///   1. `--untrusted` — deny-by-default, wins over all CHIDORI_POLICY* env.
+///   2. `--trusted` — the permissive `chidori run` resolution (env-driven,
+///      allow-all when nothing is configured).
+///   3. Explicit, valid CHIDORI_POLICY* configuration — as configured.
+///   4. Nothing configured (or only malformed configuration, which fails
+///      closed) — the deny-by-default serve profile.
+/// Returns the policy plus a posture label for the startup banner.
+fn serve_policy(untrusted: bool, trusted: bool) -> (Arc<policy::PolicyConfig>, String) {
+    if untrusted {
+        return (
+            Arc::new(
+                policy::builtin_profile("untrusted").expect("built-in untrusted profile exists"),
+            ),
+            "deny-by-default (--untrusted)".to_string(),
+        );
+    }
+    if trusted {
+        return (
+            policy::PolicyConfig::from_env(),
+            "trusted (--trusted; CHIDORI_POLICY* env still applies)".to_string(),
+        );
+    }
+    match policy::PolicyConfig::from_env_configured() {
+        Some(cfg) => (cfg, "from CHIDORI_POLICY* configuration".to_string()),
+        None => (
+            Arc::new(policy::serve_default_profile()),
+            "deny-by-default (no policy configured; pass --trusted or set CHIDORI_POLICY* to relax)"
+                .to_string(),
+        ),
     }
 }
 
@@ -1065,7 +1115,13 @@ fn cmd_stats(dir: Option<&std::path::Path>) -> Result<()> {
     Ok(())
 }
 
-fn cmd_serve(file: &PathBuf, port: u16, verbose: bool, untrusted: bool) -> Result<()> {
+fn cmd_serve(
+    file: &PathBuf,
+    port: u16,
+    verbose: bool,
+    untrusted: bool,
+    trusted: bool,
+) -> Result<()> {
     if verbose {
         tracing_subscriber::fmt()
             .with_env_filter("info")
@@ -1093,13 +1149,15 @@ fn cmd_serve(file: &PathBuf, port: u16, verbose: bool, untrusted: bool) -> Resul
 
     eprintln!("Agent: {}", file.display());
 
+    let (policy, policy_posture) = serve_policy(untrusted, trusted);
     let tokio_rt = tokio::runtime::Runtime::new().context("Failed to create server runtime")?;
     tokio_rt.block_on(server::serve(
         providers,
         template_engine,
         file.clone(),
         port,
-        cli_policy(untrusted),
+        policy,
+        policy_posture,
     ))?;
 
     Ok(())
@@ -1155,4 +1213,58 @@ fn parse_inputs(inputs: &[String]) -> Result<Value> {
     }
 
     Ok(Value::Object(map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::Decision;
+    use serde_json::json;
+
+    // serve_policy reads CHIDORI_POLICY* env vars only on its non-flag paths;
+    // the flag-driven branches below are deterministic regardless of ambient
+    // configuration. Nothing in this test binary sets those vars in-process.
+
+    #[test]
+    fn serve_policy_untrusted_flag_is_deny_by_default() {
+        let (cfg, posture) = serve_policy(true, false);
+        let (decision, _) = cfg.decide("http", &json!({}));
+        assert_eq!(decision, Decision::NeverAllow);
+        assert!(posture.contains("--untrusted"));
+    }
+
+    #[test]
+    fn serve_policy_default_denies_and_names_the_opt_out() {
+        // No flags and (in the test environment) no CHIDORI_POLICY* vars:
+        // the server posture is deny-by-default with an actionable reason.
+        if std::env::var_os("CHIDORI_POLICY_FILE").is_some()
+            || std::env::var_os("CHIDORI_POLICY").is_some()
+            || std::env::var_os("CHIDORI_POLICY_PROFILE").is_some()
+        {
+            return; // ambient configuration would legitimately change the result
+        }
+        let (cfg, posture) = serve_policy(false, false);
+        let (decision, reason) = cfg.decide("http", &json!({}));
+        assert_eq!(decision, Decision::NeverAllow);
+        assert!(reason.unwrap_or_default().contains("--trusted"));
+        assert!(posture.contains("deny-by-default"));
+
+        // The read-only workspace allowlist still applies.
+        let (decision, _) = cfg.decide("workspace:read", &json!({}));
+        assert_eq!(decision, Decision::AlwaysAllow);
+    }
+
+    #[test]
+    fn serve_policy_trusted_flag_restores_the_permissive_default() {
+        if std::env::var_os("CHIDORI_POLICY_FILE").is_some()
+            || std::env::var_os("CHIDORI_POLICY").is_some()
+            || std::env::var_os("CHIDORI_POLICY_PROFILE").is_some()
+        {
+            return;
+        }
+        let (cfg, posture) = serve_policy(false, true);
+        let (decision, _) = cfg.decide("http", &json!({}));
+        assert_eq!(decision, Decision::AlwaysAllow);
+        assert!(posture.contains("--trusted"));
+    }
 }

--- a/src/mem_guard.rs
+++ b/src/mem_guard.rs
@@ -3,52 +3,132 @@
 //! [`CountingAllocator`] wraps the system allocator and maintains a running
 //! count of live (allocated-minus-freed) bytes. The binary installs it as the
 //! `#[global_allocator]` (see `main.rs`); the rust-engine watchdog
-//! (`runtime::rust_engine`) samples [`current_allocated_bytes`] on a background
-//! thread and trips the VM's cooperative-cancellation flag when a run's heap
-//! growth exceeds its configured cap, so a runaway agent is stopped before it
-//! can OOM the host.
+//! (`runtime::rust_engine`) samples a per-run meter on a background thread and
+//! trips the VM's cooperative-cancellation flag when a run's heap growth
+//! exceeds its configured cap, so a runaway agent is stopped before it can
+//! OOM the host.
+//!
+//! Accounting has two levels:
+//!   * A **process-wide** counter ([`current_allocated_bytes`]) — a cheap
+//!     diagnostic statistic.
+//!   * A **per-run meter** ([`RunMeterGuard`]): a run registers a meter on its
+//!     execution thread and every alloc/free performed *on that thread* is
+//!     charged to it. Because a VM run is single-threaded, this attributes a
+//!     run's allocations to that run even under concurrent multi-agent
+//!     execution — concurrent runs no longer trip each other's caps.
 //!
 //! Notes / limitations:
-//!   * The counter is **process-wide**, not per-VM. The watchdog therefore caps
-//!     *baseline-relative* growth (`current - baseline_at_run_start`); under
-//!     heavy concurrency one run's allocations can be attributed to another, so
-//!     the cap is a coarse safety backstop tuned generously, not a precise
-//!     per-agent quota. Precise per-VM accounting is a documented follow-up.
+//!   * The per-run meter charges by *thread*, not by ownership: bytes a host
+//!     effect allocates on other threads (e.g. tokio workers buffering an
+//!     HTTP response) are not charged until they reach the run thread, and a
+//!     value allocated on the run thread but freed elsewhere stays charged.
+//!     For a single-threaded VM run this drift is small; the meter is clamped
+//!     at zero in the negative direction.
 //!   * When the allocator is not installed (e.g. `cargo test` against the lib,
-//!     which has no `#[global_allocator]`), the counter stays at 0 and the
+//!     which has no `#[global_allocator]`), both counters stay at 0 and the
 //!     watchdog's memory check is simply inert.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// Live bytes currently allocated through [`CountingAllocator`]. Relaxed
 /// ordering is sufficient: this is a monotonically-maintained statistic, not a
 /// synchronization primitive, and the watchdog only needs an approximate sample.
 static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
 
+thread_local! {
+    /// The meter of the run currently executing on this thread, if any.
+    /// `const`-initialized so the allocator's fast path never allocates.
+    static RUN_METER: RefCell<Option<Arc<AtomicIsize>>> = const { RefCell::new(None) };
+}
+
+/// Adjust both the process-wide counter and (when registered) the current
+/// thread's run meter by `delta` bytes.
+fn charge(delta: isize) {
+    if delta >= 0 {
+        ALLOCATED.fetch_add(delta as usize, Ordering::Relaxed);
+    } else {
+        ALLOCATED.fetch_sub(delta.unsigned_abs(), Ordering::Relaxed);
+    }
+    // `try_with` so an allocation during TLS teardown is counted process-wide
+    // but never panics. `fetch_add` cannot allocate, so the borrow can never
+    // be re-entered.
+    let _ = RUN_METER.try_with(|slot| {
+        if let Some(meter) = slot.borrow().as_ref() {
+            meter.fetch_add(delta, Ordering::Relaxed);
+        }
+    });
+}
+
+/// RAII registration of a per-run allocation meter on the current thread.
+///
+/// Install it on the thread that will execute the run *before* agent code
+/// runs; every alloc/free on this thread is then charged to [`handle`]
+/// (`RunMeterGuard::handle`), which a watchdog on another thread can sample.
+/// Dropping the guard (on the same thread) restores the previously registered
+/// meter, so nested runs on one thread — a `callAgent` child executing inline
+/// — meter themselves while registered and hand accounting back to the parent
+/// afterwards.
+pub struct RunMeterGuard {
+    meter: Arc<AtomicIsize>,
+    previous: Option<Arc<AtomicIsize>>,
+}
+
+impl RunMeterGuard {
+    pub fn install() -> Self {
+        let meter = Arc::new(AtomicIsize::new(0));
+        let previous = RUN_METER.with(|slot| slot.borrow_mut().replace(meter.clone()));
+        RunMeterGuard { meter, previous }
+    }
+
+    /// A sampling handle for the watchdog thread.
+    pub fn handle(&self) -> Arc<AtomicIsize> {
+        self.meter.clone()
+    }
+}
+
+impl Drop for RunMeterGuard {
+    fn drop(&mut self) {
+        // Move the replaced Arc out of the borrow before it is released; the
+        // guard and watchdog still hold references, so nothing deallocates
+        // (and thus re-enters the allocator) while the slot is borrowed.
+        let _replaced = RUN_METER
+            .try_with(|slot| std::mem::replace(&mut *slot.borrow_mut(), self.previous.take()));
+    }
+}
+
+/// Net live bytes charged to a run meter, clamped at zero (cross-thread frees
+/// can push the raw counter negative).
+pub fn run_meter_bytes(meter: &AtomicIsize) -> usize {
+    meter.load(Ordering::Relaxed).max(0) as usize
+}
+
 /// A `#[global_allocator]`-compatible wrapper over [`System`] that tracks live
-/// byte usage. Per-call overhead is a single relaxed atomic add/sub — the same
-/// pattern used by crates like `cap`/`stats_alloc`.
+/// byte usage. Per-call overhead is a relaxed atomic add/sub plus a
+/// thread-local check for the per-run meter — the same pattern used by crates
+/// like `cap`/`stats_alloc`.
 pub struct CountingAllocator;
 
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ptr = System.alloc(layout);
         if !ptr.is_null() {
-            ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+            charge(layout.size() as isize);
         }
         ptr
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         System.dealloc(ptr, layout);
-        ALLOCATED.fetch_sub(layout.size(), Ordering::Relaxed);
+        charge(-(layout.size() as isize));
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let ptr = System.alloc_zeroed(layout);
         if !ptr.is_null() {
-            ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+            charge(layout.size() as isize);
         }
         ptr
     }
@@ -57,12 +137,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
         let new_ptr = System.realloc(ptr, layout, new_size);
         if !new_ptr.is_null() {
             // Adjust by the net delta of the resize.
-            let old = layout.size();
-            if new_size >= old {
-                ALLOCATED.fetch_add(new_size - old, Ordering::Relaxed);
-            } else {
-                ALLOCATED.fetch_sub(old - new_size, Ordering::Relaxed);
-            }
+            charge(new_size as isize - layout.size() as isize);
         }
         new_ptr
     }
@@ -72,4 +147,76 @@ unsafe impl GlobalAlloc for CountingAllocator {
 /// allocator is not installed.
 pub fn current_allocated_bytes() -> usize {
     ALLOCATED.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests drive `charge` directly and compare meter *deltas* rather
+    // than absolute values: in the binary's test build the counting allocator
+    // is live, so incidental allocations (Arc::new, thread bookkeeping) are
+    // also charged to a registered meter.
+
+    #[test]
+    fn meter_charges_only_while_registered_on_this_thread() {
+        charge(64); // no meter registered — process counter only
+        let guard = RunMeterGuard::install();
+        let meter = guard.handle();
+        let base = run_meter_bytes(&meter);
+        charge(128);
+        charge(-28);
+        assert_eq!(run_meter_bytes(&meter), base + 100);
+        let at_drop = run_meter_bytes(&meter);
+        drop(guard);
+        charge(512); // after unregistration nothing is charged to the meter
+        assert_eq!(run_meter_bytes(&meter), at_drop);
+    }
+
+    #[test]
+    fn meter_is_clamped_at_zero_for_cross_thread_frees() {
+        let guard = RunMeterGuard::install();
+        let meter = guard.handle();
+        // A buffer allocated elsewhere but freed on the run thread drives the
+        // raw counter negative; the sampled value clamps at zero.
+        charge(-(1 << 30));
+        assert_eq!(run_meter_bytes(&meter), 0);
+    }
+
+    #[test]
+    fn nested_guards_restore_the_parent_meter() {
+        let parent = RunMeterGuard::install();
+        let parent_meter = parent.handle();
+        charge(10);
+
+        let child = RunMeterGuard::install();
+        let child_meter = child.handle();
+        let parent_paused_at = run_meter_bytes(&parent_meter);
+        let child_base = run_meter_bytes(&child_meter);
+        charge(7);
+        // The child meters itself; the parent is paused.
+        assert_eq!(run_meter_bytes(&child_meter), child_base + 7);
+        assert_eq!(run_meter_bytes(&parent_meter), parent_paused_at);
+        drop(child);
+
+        // Accounting hands back to the parent after the child completes.
+        charge(5);
+        assert_eq!(run_meter_bytes(&parent_meter), parent_paused_at + 5);
+        assert_eq!(run_meter_bytes(&child_meter), child_base + 7);
+    }
+
+    #[test]
+    fn other_threads_do_not_charge_this_runs_meter() {
+        let guard = RunMeterGuard::install();
+        let meter = guard.handle();
+        let base = run_meter_bytes(&meter) as isize;
+        std::thread::spawn(|| charge(1 << 20)).join().unwrap();
+        // Thread spawn/join bookkeeping allocates a little on this thread;
+        // the megabyte charged on the other thread must not land here.
+        let after = run_meter_bytes(&meter) as isize;
+        assert!(
+            (after - base).abs() < (1 << 19),
+            "cross-thread charge leaked into the run meter: {base} -> {after}"
+        );
+    }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -66,6 +66,11 @@ pub struct PolicyConfig {
     /// Fallback when no rule matches.
     #[serde(default)]
     pub default: Decision,
+    /// Optional reason attached to the fallback decision, surfaced in the
+    /// denial/approval message so an operator hitting a deny-by-default
+    /// posture is told how to relax it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_reason: Option<String>,
     /// An additional policy layered on top of this one: the effective decision
     /// for a call is the *stricter* of the two. Set via [`restricted_by`]
     /// (e.g. a per-session profile on the server) so a caller-selected policy
@@ -77,17 +82,29 @@ pub struct PolicyConfig {
 
 impl PolicyConfig {
     pub fn from_env() -> Arc<Self> {
+        Self::from_env_configured().unwrap_or_else(|| Arc::new(PolicyConfig::default()))
+    }
+
+    /// Env-driven policy resolution that distinguishes "the operator
+    /// configured a policy" from "nothing was configured". Returns `Some`
+    /// only when a `CHIDORI_POLICY*` source resolved successfully; a
+    /// malformed source warns and falls through to the next, exactly as
+    /// [`from_env`] always has. Callers that want a deny-by-default posture
+    /// when nothing (valid) is configured — `chidori serve` — map `None` to
+    /// [`serve_default_profile`] so misconfiguration fails closed instead of
+    /// silently running allow-all.
+    pub fn from_env_configured() -> Option<Arc<Self>> {
         if let Ok(path) = std::env::var("CHIDORI_POLICY_FILE") {
             if let Ok(text) = std::fs::read_to_string(&path) {
                 match serde_json::from_str::<PolicyConfig>(&text) {
-                    Ok(cfg) => return Arc::new(cfg),
+                    Ok(cfg) => return Some(Arc::new(cfg)),
                     Err(e) => tracing::warn!("CHIDORI_POLICY_FILE parse error: {}", e),
                 }
             }
         }
         if let Ok(inline) = std::env::var("CHIDORI_POLICY") {
             match serde_json::from_str::<PolicyConfig>(&inline) {
-                Ok(cfg) => return Arc::new(cfg),
+                Ok(cfg) => return Some(Arc::new(cfg)),
                 Err(e) => tracing::warn!("CHIDORI_POLICY parse error: {}", e),
             }
         }
@@ -95,7 +112,7 @@ impl PolicyConfig {
             let profile = profile.trim();
             if !profile.is_empty() {
                 match builtin_profile(profile) {
-                    Some(cfg) => return Arc::new(cfg),
+                    Some(cfg) => return Some(Arc::new(cfg)),
                     None => tracing::warn!(
                         "CHIDORI_POLICY_PROFILE: unknown profile `{}` (known: {})",
                         profile,
@@ -104,7 +121,7 @@ impl PolicyConfig {
                 }
             }
         }
-        Arc::new(PolicyConfig::default())
+        None
     }
 
     /// Resolve a call against the policy. `target` is the normalized target
@@ -138,7 +155,7 @@ impl PolicyConfig {
             }
             return (rule.decision, rule.reason.clone());
         }
-        (self.default, None)
+        (self.default, self.default_reason.clone())
     }
 
     /// Layer `profile` on top of this policy: every decision becomes the
@@ -196,8 +213,25 @@ fn untrusted_profile() -> PolicyConfig {
     PolicyConfig {
         rules: read_only_workspace_allowlist(),
         default: Decision::NeverAllow,
+        default_reason: None,
         overlay: None,
     }
+}
+
+/// The policy `chidori serve` runs under when the operator has not configured
+/// one. The server is the surface untrusted callers reach, so sessions there
+/// are deny-by-default out of the box: the `untrusted` profile, with a
+/// fallback reason telling the operator how to relax it. `chidori run` keeps
+/// the permissive default — the primary model for local CLI runs is trusted,
+/// developer-authored agent code.
+pub fn serve_default_profile() -> PolicyConfig {
+    let mut cfg = untrusted_profile();
+    cfg.default_reason = Some(
+        "chidori serve is deny-by-default: configure CHIDORI_POLICY / CHIDORI_POLICY_FILE / \
+         CHIDORI_POLICY_PROFILE, or start the server with --trusted, to allow this effect"
+            .to_string(),
+    );
+    cfg
 }
 
 /// Ask-by-default profile: identical allowlist to `untrusted`, but unmatched
@@ -209,6 +243,7 @@ fn supervised_profile() -> PolicyConfig {
     PolicyConfig {
         rules: read_only_workspace_allowlist(),
         default: Decision::AskBefore,
+        default_reason: None,
         overlay: None,
     }
 }
@@ -356,6 +391,7 @@ mod tests {
                 reason: Some("operator denies egress".to_string()),
             }],
             default: Decision::AlwaysAllow,
+            default_reason: None,
             overlay: None,
         };
         let layered = base.restricted_by(Arc::new(builtin_profile("supervised").unwrap()));
@@ -379,6 +415,41 @@ mod tests {
         assert_eq!(decision, Decision::NeverAllow);
         let (decision, _) = layered.decide("workspace:read", &json!({}));
         assert_eq!(decision, Decision::AlwaysAllow);
+    }
+
+    #[test]
+    fn serve_default_profile_denies_with_actionable_reason() {
+        let cfg = serve_default_profile();
+        assert_eq!(cfg.default, Decision::NeverAllow);
+
+        let (decision, reason) = cfg.decide("http", &json!({ "url": "https://example.com" }));
+        assert_eq!(decision, Decision::NeverAllow);
+        let reason = reason.expect("serve default denial carries a how-to-relax reason");
+        assert!(
+            reason.contains("--trusted"),
+            "reason should name the opt-out: {reason}"
+        );
+        assert!(
+            reason.contains("CHIDORI_POLICY"),
+            "reason should name the env config: {reason}"
+        );
+
+        let (decision, reason) = cfg.decide("workspace:write", &json!({ "path": "a.txt" }));
+        assert_eq!(decision, Decision::NeverAllow);
+        assert!(reason.is_some());
+    }
+
+    #[test]
+    fn serve_default_profile_keeps_read_only_workspace_allowlist() {
+        let cfg = serve_default_profile();
+        for target in ["workspace:list", "workspace:read", "workspace:manifest"] {
+            let (decision, _) = cfg.decide(target, &json!({}));
+            assert_eq!(
+                decision,
+                Decision::AlwaysAllow,
+                "{target} should be allowed"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1156,6 +1156,7 @@ mod tests {
                 reason: Some("test approval".to_string()),
             }],
             default: crate::policy::Decision::AlwaysAllow,
+            default_reason: None,
             overlay: None,
         });
 

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -1002,6 +1002,7 @@ mod tests {
                 reason: Some("test approval".to_string()),
             }],
             default: Decision::AlwaysAllow,
+            default_reason: None,
             overlay: None,
         }));
 
@@ -1224,6 +1225,7 @@ mod tests {
                 reason: Some("write tool requires approval".to_string()),
             }],
             default: Decision::AlwaysAllow,
+            default_reason: None,
             overlay: None,
         }));
 

--- a/src/runtime/rust_engine.rs
+++ b/src/runtime/rust_engine.rs
@@ -170,11 +170,16 @@ struct ExecutionLimits {
     /// `while (true) {}` terminates with a `RangeError`. `None` disables.
     /// Env `CHIDORI_JS_OP_BUDGET` (default 5e9; `0` disables).
     op_budget: Option<u64>,
-    /// Live process-heap growth ceiling in bytes, enforced by the watchdog via the
-    /// counting allocator. `None` disables. Env `CHIDORI_JS_MEM_CAP_MB` (default
-    /// 4096; `0` disables). A coarse process-wide backstop, not a precise per-agent
-    /// quota — see [`crate::mem_guard`].
+    /// Live heap growth ceiling in bytes for this run, enforced by the watchdog
+    /// via the counting allocator's per-run meter (allocations made on the run's
+    /// own thread — see [`crate::mem_guard`]). `None` disables. Env
+    /// `CHIDORI_JS_MEM_CAP_MB` (default 4096; `0` disables).
     mem_cap: Option<usize>,
+    /// Watchdog sampling interval for the memory cap and deadline checks.
+    /// Env `CHIDORI_JS_MEM_POLL_MS` (default 10; clamped to at least 1).
+    /// A run can overshoot the cap by what it allocates within one interval,
+    /// so tighten this together with the cap when confining untrusted code.
+    poll_interval: Duration,
     /// Optional wall-clock deadline. `None` disables (the default).
     /// Env `CHIDORI_JS_DEADLINE_MS`.
     ///
@@ -206,9 +211,12 @@ impl ExecutionLimits {
             0 => None,
             ms => Some(Duration::from_millis(ms)),
         };
+        let poll_interval =
+            Duration::from_millis(env_u64("CHIDORI_JS_MEM_POLL_MS").unwrap_or(10).max(1));
         ExecutionLimits {
             op_budget,
             mem_cap,
+            poll_interval,
             deadline,
         }
     }
@@ -222,6 +230,10 @@ impl ExecutionLimits {
 struct ExecutionGuard {
     done: Arc<AtomicBool>,
     watchdog: Option<JoinHandle<()>>,
+    /// Keeps the per-run allocation meter registered on the run thread for the
+    /// lifetime of the run. Declared after `watchdog` is irrelevant — `Drop`
+    /// joins the watchdog explicitly before this guard unregisters.
+    _meter: Option<crate::mem_guard::RunMeterGuard>,
 }
 
 impl ExecutionGuard {
@@ -233,14 +245,23 @@ impl ExecutionGuard {
         let interrupt = Arc::new(AtomicBool::new(false));
         vm.interrupt = Some(interrupt.clone());
 
+        // Per-run accounting: register a meter on this thread (the thread the
+        // VM runs on) so the cap measures this run's own allocations rather
+        // than process-wide growth — concurrent runs no longer trip each
+        // other's caps.
+        let meter_guard = limits
+            .mem_cap
+            .map(|_| crate::mem_guard::RunMeterGuard::install());
+
         let done = Arc::new(AtomicBool::new(false));
         // Only spend a thread when there is something time- or memory-based to
         // watch; the opcode budget is enforced inline by the VM and needs none.
         let watchdog = if limits.mem_cap.is_some() || limits.deadline.is_some() {
             let done_w = done.clone();
-            let baseline = crate::mem_guard::current_allocated_bytes();
             let deadline_at = limits.deadline.map(|d| Instant::now() + d);
             let mem_cap = limits.mem_cap;
+            let meter = meter_guard.as_ref().map(|g| g.handle());
+            let poll_interval = limits.poll_interval;
             Some(std::thread::spawn(move || loop {
                 if done_w.load(Ordering::Relaxed) {
                     return;
@@ -251,19 +272,22 @@ impl ExecutionGuard {
                         return;
                     }
                 }
-                if let Some(cap) = mem_cap {
-                    let used = crate::mem_guard::current_allocated_bytes().saturating_sub(baseline);
-                    if used > cap {
+                if let (Some(cap), Some(meter)) = (mem_cap, meter.as_ref()) {
+                    if crate::mem_guard::run_meter_bytes(meter) > cap {
                         interrupt.store(true, Ordering::Relaxed);
                         return;
                     }
                 }
-                std::thread::sleep(Duration::from_millis(20));
+                std::thread::sleep(poll_interval);
             }))
         } else {
             None
         };
-        ExecutionGuard { done, watchdog }
+        ExecutionGuard {
+            done,
+            watchdog,
+            _meter: meter_guard,
+        }
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -434,6 +434,7 @@ pub async fn serve(
     agent_path: PathBuf,
     port: u16,
     policy: Arc<PolicyConfig>,
+    policy_posture: String,
 ) -> anyhow::Result<()> {
     // Configurable concurrency cap. Default 8 is low enough to keep one
     // LLM provider from being flooded and high enough that a small agent
@@ -569,6 +570,7 @@ pub async fn serve(
             "disabled (set CHIDORI_API_KEY to enable)"
         }
     );
+    eprintln!("  Policy:      {}", policy_posture);
     eprintln!(
         "  CORS:        {}",
         match std::env::var("CHIDORI_CORS_ORIGINS").ok() {
@@ -3912,6 +3914,29 @@ mod tests {
         assert!(
             error.contains("unknown policy profile 'nonsense'") && error.contains("untrusted"),
             "expected an unknown-profile error listing the builtins, got: {error}"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn serve_default_profile_denies_sessions_and_explains_the_opt_out() {
+        // The policy `chidori serve` resolves when the operator configured
+        // nothing: sessions are deny-by-default and the denial tells the
+        // operator how to relax the posture.
+        let (temp_dir, mut state) =
+            policy_test_project("chidori-server-policy-serve-default", HTTP_AGENT);
+        state.policy = Arc::new(crate::policy::serve_default_profile());
+
+        let (status, body) =
+            response_json(create_session(State(state), Json(create_request(None))).await).await;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["status"], json!("failed"));
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("policy: `http` denied") && error.contains("--trusted"),
+            "expected an actionable deny-by-default error, got: {error}"
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/tests/cli_typescript.rs
+++ b/tests/cli_typescript.rs
@@ -536,6 +536,39 @@ fn cli_untrusted_flag_overrides_permissive_policy_env() {
 }
 
 #[test]
+fn cli_serve_rejects_conflicting_trust_flags() {
+    let dir = temp_project("serve-trust-flag-conflict");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                return { ok: true };
+            }
+        "#,
+    )
+    .unwrap();
+
+    // --trusted and --untrusted contradict each other; clap must refuse the
+    // combination before any server starts.
+    let output = run_chidori(
+        &["serve", agent.to_str().unwrap(), "--untrusted", "--trusted"],
+        &dir,
+    );
+    assert!(
+        !output.status.success(),
+        "conflicting trust flags must not start a server"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--untrusted") && stderr.contains("--trusted"),
+        "expected a flag-conflict error, got stderr:\n{stderr}"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
+#[test]
 fn cli_stream_accepts_multiline_typed_agent_signature() {
     let dir = temp_project("stream-multiline-types");
     let agent = dir.join("agent.ts");


### PR DESCRIPTION
## Summary

This PR implements two major security and resource-isolation improvements:

1. **Per-run memory metering**: Replaces process-wide memory accounting with thread-attributed per-run meters, so concurrent agents no longer trip each other's memory caps.
2. **Deny-by-default server policy**: `chidori serve` now denies gated effects (http, workspace mutations) by default when no policy is configured, with `--trusted` and `--untrusted` flags to control the posture.

## Key Changes

### Memory Metering (`src/mem_guard.rs`)
- Introduced `RunMeterGuard`: an RAII guard that registers a per-run allocation meter on the execution thread
- Added thread-local `RUN_METER` to track the active meter for the current thread
- Refactored `CountingAllocator` to charge allocations to both the process-wide counter and the active per-run meter via a new `charge()` function
- Added `run_meter_bytes()` to sample a meter (clamped at zero to handle cross-thread frees)
- Supports nested runs (e.g., `callAgent` children) that meter themselves and restore parent accounting on drop
- Comprehensive test coverage for meter registration, nesting, and cross-thread behavior

### Watchdog Integration (`src/runtime/rust_engine.rs`)
- Updated `ExecutionLimits` to include `poll_interval` (configurable via `CHIDORI_JS_MEM_POLL_MS`, default 10ms)
- Modified `ExecutionGuard` to install a `RunMeterGuard` when a memory cap is set
- Changed watchdog to sample the per-run meter instead of baseline-relative process-wide growth
- Watchdog now measures a run's own allocations, eliminating cross-tenant interference

### Server Policy (`src/policy.rs`, `src/main.rs`)
- Added `default_reason` field to `PolicyConfig` to surface actionable denial messages
- Split `PolicyConfig::from_env()` into two methods:
  - `from_env()`: returns a policy (allow-all default if nothing configured)
  - `from_env_configured()`: returns `Option`, distinguishing "configured" from "not configured"
- Introduced `serve_default_profile()`: deny-by-default policy with a reason explaining how to relax it
- Added `serve_policy()` function with precedence: `--untrusted` > `--trusted` > explicit `CHIDORI_POLICY*` > deny-by-default
- Added `--trusted` flag to `chidori serve` (conflicts with `--untrusted`)
- `chidori run` retains the permissive default (trusted, developer-authored code)
- `chidori serve` defaults to deny-by-default unless operator configures policy or passes `--trusted`

### Documentation & Examples
- Updated `docs/sandbox-model.md` to reflect per-run metering and server deny-by-default posture
- Updated `docs/fable_review.md` with resolution notes
- Updated README and llm.txt to show `--trusted` flag in serve examples
- Clarified limitations: per-run metering is thread-attributed (not ownership-attributed), with small cross-thread drift for single-threaded runs

### Testing
- Added comprehensive tests in `src/mem_guard.rs` for meter registration, nesting, and cross-thread isolation
- Added tests in `src/main.rs` for `serve_policy()` flag precedence and default behavior
- Added server integration test for deny-by-default denial with actionable reason
- Added CLI test for conflicting `--trusted` / `--untrusted` flags

## Implementation Details

- **Thread-local meter registration**: Uses `RefCell<Option<Arc<AtomicIsize>>>` so the allocator's fast path never allocates
- **Clamping at zero**: Handles cross-thread frees (e.g., tokio workers) that would otherwise push the meter negative
- **Nested run support**: Previous meter is saved and restored on drop, enabling `callAgent` children to meter themselves
- **Watchdog sampling interval**: Tunable via `CHIDORI_JS_MEM_

https://claude.ai/code/session_01TWvEWG96xFhJjYmftAoBa1