### PR TITLE
Implement Phase 3: window compaction and local prompt cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,15 @@ at the provider's cached rates. Caching never changes results — replay returns
 recorded results and pays zero tokens either way. See
 [`docs/context-management.md`](./docs/context-management.md).
 
+When a conversation outgrows the window, `await ctx.compact({ budgetTokens })`
+is the explicit (never automatic) escape valve: it folds the older turns into
+one durable summary segment via a recorded prompt call — so it replays
+deterministically — and keeps the stable head and newest turns verbatim under
+a fresh cache breakpoint. And setting `CHIDORI_PROMPT_CACHE_DIR=<dir>` opts
+into a local content-addressed response cache: an exact repeat of a prompt,
+even across runs, is served locally without calling the provider and still
+recorded as a normal call-log entry.
+
 ## 🚦 Running Modes
 
 ### 1. One-shot CLI

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@ runtime, CLI, server, and tool work should target `.ts` agents and tools.
 | Call-log replay | Done |
 | Human input and policy approval pause/resume | Done through live VM resume with replay fallback |
 | Multiplayer signals (`chidori.signal` / `pollSignal` / `signalAny` + `timeoutMs`, `POST /sessions/{id}/signal`, live in-memory delivery to streaming runs) | Done — Phases 1–3 of `docs/signals.md` |
+| Context management (provider prompt caching, `chidori.context` builder, `Context.compact()`, opt-in local prompt cache via `CHIDORI_PROMPT_CACHE_DIR`) | Done — Phases 1–3 of `docs/context-management.md` |
 | TypeScript tool discovery | Done |
 | TypeScript and Python SDK parity | Done |
 | Snapshot manifests, policy/source validation, host promise records | Done |

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -1,15 +1,14 @@
 # Context Management — Cache-Aware, Composable Prompts
 
-> **Status:** Phases 1 and 2 are **implemented** (see the implementation-status
-> section below). Phase 3 (window compaction + the local content-addressed
-> cache) remains future work. The doc was drafted before the QuickJS removal
-> (#39); references to a "QuickJS path" / `rust-engine` feature describe the
-> pre-#39 tree — `chidori-js` is now the only engine and everything here ships
-> on it unconditionally.
+> **Status:** Phases 1, 2, and 3 are **implemented** (see the
+> implementation-status section below). The doc was drafted before the QuickJS
+> removal (#39); references to a "QuickJS path" / `rust-engine` feature
+> describe the pre-#39 tree — `chidori-js` is now the only engine and
+> everything here ships on it unconditionally.
 > **Related:** `docs/signals.md`, `docs/branching-execution.md`,
 > `docs/captured-effects-vfs-crypto-timers.md`, `docs/pure-rust-js-engine-plan.md`.
 
-## Implementation status (Phases 1–2 landed)
+## Implementation status (Phases 1–3 landed)
 
 **Phase 1 — cache-aware request layout + accounting** (no author API change):
 
@@ -65,8 +64,38 @@
   `LlmResponseJson`, `PromptOptions.cache`, `chidori.context()`. Example:
   `examples/agents/context_qa.ts`. API reference: `llm.txt`.
 
-**Not yet implemented (Phase 3):** `.compact(strategy)`, the local
-content-addressed prompt cache, and budget helpers beyond `estimateTokens()`.
+**Phase 3 — window compaction + local content-addressed prompt cache:**
+
+- `Context.compact(options?)` (`src/runtime/typescript/helpers.rs`): explicit,
+  opt-in window compaction. Splits the chain into the stable head
+  (system/tools/doc) and the conversation tail, summarizes everything older
+  than the newest `keepTurns` turns (default 2) through a **recorded `prompt`
+  host call** (so the summary is durable and replays deterministically), and
+  rebuilds the chain as head + one `summary` segment + a fresh
+  `cacheBreakpoint` + the kept turns verbatim. `budgetTokens` makes the call a
+  pure no-op (same context value, no host call) while `estimateTokens()` is
+  within budget, so loops can call it unconditionally; `model`,
+  `instructions`, `maxTokens`, and `ttl` tune the summarizer. The host maps
+  the `summary` segment to a `<conversation-summary>…</conversation-summary>`
+  user turn (`bindings.rs::context_request_parts`). Never automatic — silent
+  truncation would change results invisibly (§3 non-goal holds).
+- Local content-addressed prompt cache (`src/runtime/prompt_cache.rs`):
+  opt-in via `CHIDORI_PROMPT_CACHE_DIR=<dir>`; one JSON entry per
+  `request_digest` (the §8.3 digest over the fully assembled request,
+  recomputed after model overrides so it keys on the request actually sent).
+  Consulted in `execute_prompt_text` / `execute_prompt_response` on the live
+  path only — strictly **after** the replay short-circuit and
+  completed-host-operation replay decline (§10) — and a hit completes the
+  same begin/safepoint/resolve/record sequence as a provider success, with
+  the identical recorded result and `token_usage: None` (nothing was billed).
+  Successful live responses write through (atomic temp-file + rename).
+  Disabled (the default) the module is inert. Both the `chidori.prompt` /
+  context paths and the native tool loop get it for free since all route
+  through the two executors.
+- Budget helpers: `estimateTokens()` (Phase 2) + `compact({ budgetTokens })`
+  as the decide-when-to-compact primitive.
+- SDK: `CompactOptions` + `Context.compact()` in `sdk/typescript/src/agent.ts`;
+  API reference in `llm.txt`.
 
 ---
 

--- a/examples/agents/context_qa.ts
+++ b/examples/agents/context_qa.ts
@@ -31,6 +31,11 @@ export async function agent(
   const answers: { question: string; answer: string }[] = [];
   let ctx = base;
   for (const question of input.questions) {
+    // Explicit window management: while the running Q&A tail stays under
+    // ~8K estimated tokens this is a pure no-op; past it, the older turns
+    // are folded into one recorded summary segment (the corpus head and the
+    // newest two turns survive verbatim).
+    ctx = await ctx.compact({ budgetTokens: 8000 });
     ctx = ctx.user(question);
     const { text, context } = await ctx.prompt({ type: "final" });
     ctx = context; // assistant turn appended; the corpus prefix stays shared

--- a/llm.txt
+++ b/llm.txt
@@ -116,8 +116,26 @@ first reads the shared prefix at the discounted cached rate.
 - `digest()` → stable content hash of the assembled request, also recorded in
   each prompt's call-log args as `request_digest`.
 - `estimateTokens()` → rough local size estimate for window budgeting.
+- `compact(options?)` → `Promise<Context>`: explicit, opt-in window
+  compaction. Summarizes the older conversation turns into ONE durable
+  summary segment (a recorded `prompt` host call, so it replays
+  deterministically) and returns a new context: stable head + summary +
+  fresh cache breakpoint + the newest `keepTurns` turns (default 2) kept
+  verbatim. `budgetTokens` makes it a pure no-op (no host call) while
+  `estimateTokens()` is within budget, so loops can call it unconditionally;
+  `model` / `instructions` / `maxTokens` / `ttl` tune the summarizer.
+  Compaction is never automatic — it changes what the model sees, so it is
+  always an author decision.
 
 See `examples/agents/context_qa.ts` for a complete corpus-Q&A agent.
+
+Setting `CHIDORI_PROMPT_CACHE_DIR=<dir>` opts into a local content-addressed
+prompt cache keyed on the assembled `request_digest`: an exact repeat of a
+prompt (same model, system, tools, messages, cache layout) — even from a
+different run — is served locally without calling the provider, then recorded
+as a normal call-log entry with the identical result (and no token usage,
+since nothing was billed). The cache is live-path only: replay always
+short-circuits to the call log first and never consults it.
 
 ### input
 

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -72,6 +72,27 @@ export interface LlmResponseJson {
   cache_read_tokens: number;
 }
 
+/** Options for `Context.compact()` — explicit, opt-in window compaction. */
+export interface CompactOptions {
+  /** How many of the newest conversation turns to keep verbatim (default 2). */
+  keepTurns?: number;
+  /**
+   * Skip compaction (pure no-op, no host call) while `estimateTokens()` is at
+   * or under this budget — lets a loop call `compact()` unconditionally.
+   */
+  budgetTokens?: number;
+  /** Model for the summarization prompt (defaults like `prompt()`). */
+  model?: string;
+  /** System instructions for the summarizer (a faithful-brief default). */
+  instructions?: string;
+  /** `maxTokens` for the summarization prompt. */
+  maxTokens?: number;
+  /** Cache posture for the summarization prompt (see `PromptOptions.cache`). */
+  cache?: boolean | CacheTtl | { ttl?: CacheTtl };
+  /** TTL of the fresh cache breakpoint placed on the summary (default "5m"). */
+  ttl?: CacheTtl;
+}
+
 /**
  * An immutable, content-addressed, turn-structured prompt context.
  *
@@ -113,6 +134,16 @@ export interface Context {
   prompt(options?: PromptOptions): Promise<{ text: string; context: Context }>;
   /** Single structured turn for author-driven tool loops. */
   respond(options?: PromptOptions): Promise<{ response: LlmResponseJson; context: Context }>;
+  /**
+   * Summarize the older conversation turns into one durable summary segment
+   * (via a recorded `prompt` host call, so it replays deterministically) and
+   * return a new context: stable head + summary + fresh cache breakpoint +
+   * the kept newest turns. Never automatic — compaction changes what the
+   * model sees, so it is always an explicit author decision. Returns this
+   * context unchanged (without a host call) when there is nothing to compact
+   * or the context is within `budgetTokens`.
+   */
+  compact(options?: CompactOptions): Promise<Context>;
   /** Stable content hash of the request this context would assemble. */
   digest(options?: PromptOptions): string;
   /** Rough local token estimate for window budgeting. */

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -11,6 +11,7 @@ export type {
   AgentJson,
   CacheTtl,
   Chidori,
+  CompactOptions,
   Context,
   DatePolicy,
   HttpRequestOptions,

--- a/src/runtime/host_core.rs
+++ b/src/runtime/host_core.rs
@@ -632,6 +632,54 @@ fn apply_model_override(ctx: &RuntimeContext, request: &mut LlmRequest) {
     }
 }
 
+/// Look up a prompt in the opt-in local content-addressed cache
+/// (`prompt_cache`, Phase 3 of `docs/context-management.md`). Consulted on
+/// the live path only, after the replay short-circuit and completed-operation
+/// replay have both declined, so it can never shadow the call log. The digest
+/// is recomputed here because `apply_model_override` may have changed the
+/// model after the caller stamped `request_digest` into its args — the cache
+/// must key on the request actually sent.
+fn local_prompt_cache_lookup(request: &LlmRequest) -> Option<LlmResponse> {
+    if !crate::runtime::prompt_cache::enabled() {
+        return None;
+    }
+    crate::runtime::prompt_cache::lookup(&prompt_request_digest(request))
+        .and_then(|value| llm_response_from_json(&value))
+}
+
+/// Complete a prompt host operation with a locally cached response: identical
+/// begin/safepoint/resolve/record/completion sequence to a live provider
+/// success, with the same `result` the provider would have produced.
+/// `token_usage` stays `None` because this run paid no tokens for it.
+fn complete_prompt_from_local_cache(
+    ctx: &RuntimeContext,
+    seq: u64,
+    args: Value,
+    result: Value,
+) -> Result<()> {
+    let host_operation = ctx.begin_host_operation_with_function(
+        seq,
+        PendingHostOperationKind::Prompt,
+        Some("prompt".to_string()),
+        args.clone(),
+    );
+    ctx.run_host_operation_safepoint(host_operation)?;
+    ctx.resolve_host_operation(host_operation, result.clone())?;
+    ctx.record_call(CallRecord {
+        seq,
+        parent_seq: None,
+        function: "prompt".to_string(),
+        args,
+        result,
+        duration_ms: 0,
+        token_usage: None,
+        timestamp: Utc::now(),
+        error: None,
+    });
+    ctx.run_host_operation_completion_safepoint(host_operation)?;
+    Ok(())
+}
+
 pub fn execute_prompt_text(
     ctx: &RuntimeContext,
     providers: &ProviderRegistry,
@@ -659,6 +707,12 @@ pub fn execute_prompt_text(
         return Ok(result);
     }
 
+    if let Some(cached) = local_prompt_cache_lookup(&request) {
+        let result = Value::String(cached.content);
+        complete_prompt_from_local_cache(ctx, seq, args, result.clone())?;
+        return Ok(result);
+    }
+
     let host_operation = ctx.begin_host_operation_with_function(
         seq,
         PendingHostOperationKind::Prompt,
@@ -675,6 +729,12 @@ pub fn execute_prompt_text(
 
     match response {
         Ok(response) => {
+            if crate::runtime::prompt_cache::enabled() {
+                crate::runtime::prompt_cache::store(
+                    &prompt_request_digest(&request),
+                    &llm_response_to_json(&response),
+                );
+            }
             let result = Value::String(response.content.clone());
             ctx.resolve_host_operation(host_operation, result.clone())?;
             ctx.record_call(CallRecord {
@@ -742,6 +802,11 @@ pub fn execute_prompt_response(
         });
     }
 
+    if let Some(cached) = local_prompt_cache_lookup(&request) {
+        complete_prompt_from_local_cache(ctx, seq, args, llm_response_to_json(&cached))?;
+        return Ok(cached);
+    }
+
     let host_operation = ctx.begin_host_operation_with_function(
         seq,
         PendingHostOperationKind::Prompt,
@@ -759,6 +824,9 @@ pub fn execute_prompt_response(
     match response {
         Ok(response) => {
             let result = llm_response_to_json(&response);
+            if crate::runtime::prompt_cache::enabled() {
+                crate::runtime::prompt_cache::store(&prompt_request_digest(&request), &result);
+            }
             ctx.resolve_host_operation(host_operation, result.clone())?;
             ctx.record_call(CallRecord {
                 seq,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,6 +9,7 @@ pub mod host_core;
 pub mod memory;
 pub mod native;
 pub mod otel;
+pub mod prompt_cache;
 /// Pure-Rust JS engine integration — the only JavaScript engine.
 pub mod rust_engine;
 pub mod secret_env;

--- a/src/runtime/prompt_cache.rs
+++ b/src/runtime/prompt_cache.rs
@@ -1,0 +1,96 @@
+//! Opt-in local content-addressed prompt cache (Phase 3 of
+//! `docs/context-management.md`).
+//!
+//! Keyed on the versioned request digest (`host_core::prompt_request_digest`)
+//! over the fully assembled request, so an exact repeat of a prompt — same
+//! model, system, tools, messages, and cache layout — can be served locally
+//! without calling the provider at all. The cache lives entirely on the live
+//! path: replay short-circuits to the call log before the cache is ever
+//! consulted, and a cache hit is recorded as a normal `CallRecord`, so two
+//! runs issuing an identical prompt record identical results whether or not
+//! the second paid the provider.
+//!
+//! Enabled by setting `CHIDORI_PROMPT_CACHE_DIR` to a directory path; one
+//! JSON file per digest (the `llm_response_to_json` form, shared by the text
+//! and structured prompt paths). Disabled (the default) this module is inert.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+fn cache_dir() -> Option<PathBuf> {
+    let dir = std::env::var("CHIDORI_PROMPT_CACHE_DIR").ok()?;
+    let dir = dir.trim();
+    if dir.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(dir))
+}
+
+/// Whether the local prompt cache is enabled for this process.
+pub fn enabled() -> bool {
+    cache_dir().is_some()
+}
+
+/// Look up a previously stored response JSON by request digest. Any read or
+/// parse failure is a miss — the cache can only ever skip a provider call,
+/// never fail one.
+pub fn lookup(digest: &str) -> Option<Value> {
+    lookup_in(&cache_dir()?, digest)
+}
+
+/// Store a successful response JSON under its request digest.
+pub fn store(digest: &str, response: &Value) {
+    if let Some(dir) = cache_dir() {
+        store_in(&dir, digest, response);
+    }
+}
+
+fn lookup_in(dir: &Path, digest: &str) -> Option<Value> {
+    let raw = std::fs::read_to_string(dir.join(format!("{digest}.json"))).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Best-effort store: the write is atomic (temp file + rename) so concurrent
+/// runs never observe a torn entry, and any I/O failure is silently ignored.
+fn store_in(dir: &Path, digest: &str, response: &Value) {
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let tmp = dir.join(format!(".{digest}.{}.tmp", std::process::id()));
+    let path = dir.join(format!("{digest}.json"));
+    if std::fs::write(&tmp, response.to_string()).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn store_then_lookup_roundtrips_and_misses_are_none() {
+        let dir =
+            std::env::temp_dir().join(format!("chidori-prompt-cache-{}", uuid::Uuid::new_v4()));
+        let response = json!({ "content": "answer", "blocks": [], "tool_calls": [] });
+        assert_eq!(lookup_in(&dir, "deadbeef"), None);
+        store_in(&dir, "deadbeef", &response);
+        assert_eq!(lookup_in(&dir, "deadbeef"), Some(response));
+        assert_eq!(lookup_in(&dir, "0000beef"), None);
+        // A torn/corrupt entry is a miss, never an error.
+        std::fs::write(dir.join("0bad.json"), "{not json").unwrap();
+        assert_eq!(lookup_in(&dir, "0bad"), None);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn disabled_without_env_flag() {
+        // The suite never sets CHIDORI_PROMPT_CACHE_DIR globally, so the
+        // default posture is observable here: inert lookup and store.
+        if std::env::var("CHIDORI_PROMPT_CACHE_DIR").is_err() {
+            assert!(!enabled());
+            assert_eq!(lookup("deadbeef"), None);
+            store("deadbeef", &json!({}));
+        }
+    }
+}

--- a/src/runtime/rust_engine.rs
+++ b/src/runtime/rust_engine.rs
@@ -1000,6 +1000,13 @@ mod tests {
         }
     }
 
+    /// Serializes the prompt-issuing context tests against the local
+    /// prompt-cache test: `CHIDORI_PROMPT_CACHE_DIR` is process-global, and
+    /// the two CONTEXT_AGENT_SRC tests send byte-identical requests — run
+    /// concurrently with the cache enabled, one could be served from entries
+    /// the other stored and break its provider call-count assertions.
+    static PROMPT_ENV_LOCK: StdMutex<()> = StdMutex::new(());
+
     fn context_test_backend(
         ctx: RuntimeContext,
         providers: crate::providers::ProviderRegistry,
@@ -1046,6 +1053,7 @@ mod tests {
 
     #[test]
     fn context_builder_composes_multi_turn_prompts_with_cache_layout() {
+        let _env = PROMPT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let ctx = RuntimeContext::new();
         let dir =
             std::env::temp_dir().join(format!("chidori-rust-context-{}", uuid::Uuid::new_v4()));
@@ -1132,6 +1140,7 @@ mod tests {
 
     #[test]
     fn context_conversation_replays_without_provider_calls() {
+        let _env = PROMPT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = std::env::temp_dir().join(format!(
             "chidori-rust-context-replay-{}",
             uuid::Uuid::new_v4()
@@ -1160,6 +1169,211 @@ mod tests {
             context_test_backend(replay_ctx, crate::providers::ProviderRegistry::new());
         let replay_output = run_agent(&path, CONTEXT_AGENT_SRC, &input, &replay_backend).unwrap();
         assert_eq!(live_output, replay_output);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    const COMPACT_AGENT_SRC: &str = r#"
+        export async function agent(input: { questions: string[] }) {
+            let ctx = chidori.context()
+                .system("You are a terse assistant for the compaction test.");
+            for (const q of input.questions) {
+                ctx = ctx.user(q);
+                const r = await ctx.prompt({ model: "test-model" });
+                ctx = r.context;
+            }
+            const beforeTokens = ctx.estimateTokens();
+            const underBudget = await ctx.compact({ budgetTokens: 1000000 });
+            const compacted = await ctx.compact({ keepTurns: 2 });
+            const next = compacted.user("compact-final-question?");
+            const r = await next.prompt({ model: "test-model" });
+            return {
+                finalText: r.text,
+                noopUnderBudget: underBudget === ctx,
+                compactedIsNew: compacted !== ctx,
+                shrank: compacted.estimateTokens() < beforeTokens,
+            };
+        }
+    "#;
+
+    #[test]
+    fn context_compact_summarizes_old_turns_into_recorded_segment() {
+        let _env = PROMPT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let ctx = RuntimeContext::new();
+        let dir =
+            std::env::temp_dir().join(format!("chidori-rust-compact-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(&path, COMPACT_AGENT_SRC).unwrap();
+
+        let requests = Arc::new(StdMutex::new(Vec::new()));
+        let mut providers = crate::providers::ProviderRegistry::new();
+        providers.register(Box::new(SequenceProvider {
+            responses: vec![
+                "a long first answer about compaction alpha".to_string(),
+                "a long second answer about compaction beta".to_string(),
+                "a long third answer about compaction gamma".to_string(),
+                "brief summary".to_string(),
+                "final answer".to_string(),
+            ],
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            requests: Arc::clone(&requests),
+        }));
+        let backend = context_test_backend(ctx.clone(), providers);
+        let input = serde_json::json!({
+            "questions": ["compact-q-alpha?", "compact-q-beta?", "compact-q-gamma?"]
+        });
+        let output = run_agent(&path, COMPACT_AGENT_SRC, &input, &backend).unwrap();
+
+        assert_eq!(output["finalText"], serde_json::json!("final answer"));
+        // Under budget and "nothing old enough" paths are pure no-ops that
+        // return the SAME context value without a host call.
+        assert_eq!(output["noopUnderBudget"], serde_json::json!(true));
+        assert_eq!(output["compactedIsNew"], serde_json::json!(true));
+        assert_eq!(output["shrank"], serde_json::json!(true));
+
+        let requests = requests.lock().unwrap();
+        // 3 conversation turns + 1 summarization call + 1 post-compact turn;
+        // the under-budget compact made NO provider call.
+        assert_eq!(requests.len(), 5);
+
+        // The summarization request: transcript of the old turns as one user
+        // message under the summarizer system instructions.
+        let summarize = &requests[3];
+        assert!(summarize
+            .system
+            .as_deref()
+            .unwrap()
+            .contains("compact conversation history"));
+        assert_eq!(summarize.messages.len(), 1);
+        let transcript = match &summarize.messages[0].content[0] {
+            crate::providers::ContentBlock::Text { text } => text.clone(),
+            other => panic!("expected text transcript, got {other:?}"),
+        };
+        assert!(transcript.contains("User: compact-q-alpha?"));
+        assert!(transcript.contains("Assistant: a long first answer about compaction alpha"));
+        assert!(transcript.contains("User: compact-q-beta?"));
+        // The kept turns are NOT summarized.
+        assert!(!transcript.contains("compact-q-gamma?"));
+
+        // The post-compact request: summary segment + the two kept turns +
+        // the new question, with a fresh cache breakpoint on the summary.
+        let after = &requests[4];
+        assert_eq!(after.messages.len(), 4);
+        let summary_text = match &after.messages[0].content[0] {
+            crate::providers::ContentBlock::Text { text } => text.clone(),
+            other => panic!("expected summary text, got {other:?}"),
+        };
+        assert!(summary_text.contains("<conversation-summary>"));
+        assert!(summary_text.contains("brief summary"));
+        assert!(
+            after.messages[0].cache_control.is_some(),
+            "summary segment must carry a fresh cache breakpoint"
+        );
+        let kept_q = match &after.messages[1].content[0] {
+            crate::providers::ContentBlock::Text { text } => text.clone(),
+            other => panic!("expected kept user turn, got {other:?}"),
+        };
+        assert_eq!(kept_q, "compact-q-gamma?");
+
+        // The summarization is a normal recorded prompt: 5 prompt records.
+        let records = ctx.call_log().into_records();
+        let prompts: Vec<_> = records.iter().filter(|r| r.function == "prompt").collect();
+        assert_eq!(prompts.len(), 5);
+
+        // Replay against an empty provider registry reproduces the whole run,
+        // compaction included, from the call log alone.
+        let replay_ctx = RuntimeContext::with_replay(records);
+        let replay_backend =
+            context_test_backend(replay_ctx, crate::providers::ProviderRegistry::new());
+        let replay_output = run_agent(&path, COMPACT_AGENT_SRC, &input, &replay_backend).unwrap();
+        assert_eq!(output, replay_output);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Removes the prompt-cache env flag even if the test panics, so a failure
+    /// can't leave the process-global cache enabled for unrelated tests.
+    struct PromptCacheEnvGuard;
+    impl Drop for PromptCacheEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("CHIDORI_PROMPT_CACHE_DIR");
+        }
+    }
+
+    #[test]
+    fn local_prompt_cache_serves_identical_request_without_provider() {
+        let _env = PROMPT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-rust-prompt-cache-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        let src = r#"
+            export async function agent(input: {}) {
+                const text = await chidori.prompt(
+                    "local-prompt-cache-unique-question?",
+                    { model: "test-model" },
+                );
+                return { text };
+            }
+        "#;
+        std::fs::write(&path, src).unwrap();
+        std::env::set_var(
+            "CHIDORI_PROMPT_CACHE_DIR",
+            dir.join("prompt-cache").to_str().unwrap(),
+        );
+        let _cache_env = PromptCacheEnvGuard;
+
+        // First run pays the provider and populates the cache.
+        let first_ctx = RuntimeContext::new();
+        let first_calls = Arc::new(StdMutex::new(Vec::new()));
+        let mut providers = crate::providers::ProviderRegistry::new();
+        providers.register(Box::new(SequenceProvider {
+            responses: vec!["the locally cached answer".to_string()],
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            requests: Arc::clone(&first_calls),
+        }));
+        let first_backend = context_test_backend(first_ctx.clone(), providers);
+        let first_output = run_agent(&path, src, &serde_json::json!({}), &first_backend).unwrap();
+        assert_eq!(
+            first_output,
+            serde_json::json!({ "text": "the locally cached answer" })
+        );
+        assert_eq!(first_calls.lock().unwrap().len(), 1);
+
+        // A FRESH run (empty call log, so no replay) issuing the identical
+        // request is served from the local cache: zero provider calls, yet it
+        // records an identical result as a normal CallRecord.
+        let second_ctx = RuntimeContext::new();
+        let second_calls = Arc::new(StdMutex::new(Vec::new()));
+        let mut providers = crate::providers::ProviderRegistry::new();
+        providers.register(Box::new(SequenceProvider {
+            responses: vec!["WRONG: provider must not be consulted".to_string()],
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            requests: Arc::clone(&second_calls),
+        }));
+        let second_backend = context_test_backend(second_ctx.clone(), providers);
+        let second_output = run_agent(&path, src, &serde_json::json!({}), &second_backend).unwrap();
+        assert_eq!(second_output, first_output);
+        assert_eq!(second_calls.lock().unwrap().len(), 0);
+
+        let first_records = first_ctx.call_log().into_records();
+        let second_records = second_ctx.call_log().into_records();
+        let first_prompt = first_records
+            .iter()
+            .find(|r| r.function == "prompt")
+            .unwrap();
+        let second_prompt = second_records
+            .iter()
+            .find(|r| r.function == "prompt")
+            .unwrap();
+        assert_eq!(second_prompt.result, first_prompt.result);
+        assert_eq!(second_prompt.args, first_prompt.args);
+        // The first run paid tokens; the cache-served run paid none.
+        assert!(first_prompt.token_usage.is_some());
+        assert!(second_prompt.token_usage.is_none());
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -1169,6 +1169,13 @@ fn context_request_parts(
                     "<document label=\"{label}\">\n{text}\n</document>"
                 )));
             }
+            // The recorded product of `Context.compact()`: prior turns folded
+            // into one durable summary, framed so the model knows it reads
+            // condensed history rather than a live user turn.
+            "summary" => messages.push(LlmMessage::user_text(format!(
+                "<conversation-summary>\n{}\n</conversation-summary>",
+                str_field(seg, "text")
+            ))),
             "user" => messages.push(LlmMessage::user_text(str_field(seg, "text"))),
             "assistant" => messages.push(LlmMessage::assistant_blocks(vec![ContentBlock::Text {
                 text: str_field(seg, "text"),

--- a/src/runtime/typescript/helpers.rs
+++ b/src/runtime/typescript/helpers.rs
@@ -134,6 +134,50 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
             }
             return value;
         }
+        // A "turn" is a segment that lands in the conversation `messages`
+        // array (vs the stable system/tools head). `doc` is intentionally not
+        // a turn: docs anchor the cacheable head, but a doc appended after the
+        // conversation started is still summarizable content (see compact()).
+        function isTurn(segment) {
+            return segment.kind === "user" || segment.kind === "assistant" ||
+                segment.kind === "toolResult" || segment.kind === "message" ||
+                segment.kind === "summary";
+        }
+        function renderBlock(block) {
+            if (!block || typeof block !== "object") return String(block);
+            if (block.type === "text") return block.text;
+            if (block.type === "tool_use") {
+                return "[tool call " + block.name + ": " + JSON.stringify(block.input) + "]";
+            }
+            if (block.type === "tool_result") {
+                return "[tool result: " + block.content + "]";
+            }
+            return JSON.stringify(block);
+        }
+        function renderSegment(segment) {
+            if (segment.kind === "user") return "User: " + segment.text;
+            if (segment.kind === "assistant") return "Assistant: " + segment.text;
+            if (segment.kind === "summary") {
+                return "Summary of earlier conversation: " + segment.text;
+            }
+            if (segment.kind === "toolResult") {
+                return "Tool result (" + segment.id + "): " + segment.content;
+            }
+            if (segment.kind === "doc") {
+                return "Document \"" + segment.label + "\": " + segment.text;
+            }
+            if (segment.kind === "message") {
+                const role = segment.message.role === "assistant" ? "Assistant" : "User";
+                const content = segment.message.content || [];
+                return role + ": " + content.map(renderBlock).join("\n");
+            }
+            return "";
+        }
+        const DEFAULT_COMPACT_INSTRUCTIONS =
+            "You compact conversation history. Summarize the transcript into a " +
+            "concise brief that preserves every fact, decision, constraint, open " +
+            "question, and commitment needed to continue the conversation " +
+            "faithfully. Reply with only the summary.";
         async function send(ctx, options, mode) {
             const opts = Object.assign({}, options || {}, {
                 __context: flatten(ctx),
@@ -190,6 +234,71 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
             async respond(options) {
                 const { out, extended } = await send(this, options, "respond");
                 return { response: out.response, context: extended };
+            },
+            // Explicit, opt-in window compaction: summarize the old turns into
+            // ONE summary segment (via a recorded `prompt` host call, so the
+            // result is durable and replays deterministically) and rebuild the
+            // chain as head + summary + fresh cache breakpoint + the kept
+            // tail. Pure no-op (no host call) when there is nothing to
+            // compact or the context is still within `budgetTokens`.
+            async compact(options) {
+                const opts = options || {};
+                const keepTurns = Number.isFinite(Number(opts.keepTurns))
+                    ? Math.max(0, Math.floor(Number(opts.keepTurns)))
+                    : 2;
+                const budget = Number(opts.budgetTokens);
+                if (Number.isFinite(budget) && budget > 0 && this.estimateTokens() <= budget) {
+                    return this;
+                }
+                const flat = flatten(this);
+                let headEnd = 0;
+                while (headEnd < flat.length && !isTurn(flat[headEnd])) headEnd += 1;
+                const head = flat.slice(0, headEnd);
+                const tail = flat.slice(headEnd);
+                const turnCount = tail.filter(isTurn).length;
+                if (turnCount <= keepTurns) {
+                    return this;
+                }
+                // Cut so the last `keepTurns` turns (plus anything appended
+                // after them) survive verbatim; everything older is
+                // summarized. Breakpoint markers in the old region are
+                // placement metadata, not content — drop them.
+                let cut = tail.length;
+                let seen = 0;
+                for (let i = tail.length - 1; i >= 0; i -= 1) {
+                    if (isTurn(tail[i])) {
+                        seen += 1;
+                        if (seen === keepTurns) { cut = i; break; }
+                    }
+                }
+                const old = tail.slice(0, cut).filter((s) => s.kind !== "cacheBreakpoint");
+                const kept = tail.slice(cut);
+                if (old.length === 0) {
+                    return this;
+                }
+                const transcript = old.map(renderSegment).join("\n");
+                const promptOpts = {
+                    system: typeof opts.instructions === "string" && opts.instructions
+                        ? opts.instructions
+                        : DEFAULT_COMPACT_INSTRUCTIONS,
+                };
+                if (typeof opts.model === "string") promptOpts.model = opts.model;
+                if (opts.maxTokens !== undefined) promptOpts.maxTokens = opts.maxTokens;
+                if (opts.cache !== undefined) promptOpts.cache = opts.cache;
+                const summary = await nativePrompt.call(
+                    globalThis.chidori,
+                    transcript,
+                    promptOpts,
+                );
+                let ctx = append(null, null);
+                for (const segment of head) ctx = append(ctx, segment);
+                ctx = append(ctx, { kind: "summary", text: String(summary) });
+                ctx = append(ctx, {
+                    kind: "cacheBreakpoint",
+                    ttl: opts.ttl === "1h" ? "1h" : "5m",
+                });
+                for (const segment of kept) ctx = append(ctx, segment);
+                return ctx;
             },
             digest(options) {
                 return nativeDigest.call(globalThis.chidori, flatten(this), options || null);


### PR DESCRIPTION
Completes Phase 3 of context management by adding explicit window compaction and an opt-in local content-addressed prompt cache.

## Summary

This PR implements two complementary features for managing long-running conversations:

1. **Window Compaction** (`Context.compact()`): Explicit, opt-in summarization of older conversation turns into a single durable summary segment via a recorded prompt call. The summary is deterministically replayed and never applied automatically, preserving the principle that compaction is always an author decision.

2. **Local Prompt Cache**: An opt-in content-addressed cache (enabled via `CHIDORI_PROMPT_CACHE_DIR`) that serves identical prompts from disk without calling the provider, while still recording them as normal call-log entries with `token_usage: None`.

## Key Changes

- **`src/runtime/typescript/helpers.rs`**: Added `compact()` method to the Context API with support for `keepTurns`, `budgetTokens`, custom instructions, and cache control. Includes helper functions (`isTurn`, `renderSegment`, `renderBlock`) for transcript generation and default summarization instructions.

- **`src/runtime/prompt_cache.rs`** (new file): Implements the local cache with `lookup()` and `store()` functions keyed on request digest. Atomic writes via temp-file + rename prevent torn entries under concurrent access. Disabled by default; inert when `CHIDORI_PROMPT_CACHE_DIR` is unset.

- **`src/runtime/host_core.rs`**: Integrated cache lookup into both `execute_prompt_text()` and `execute_prompt_response()` on the live path only (after replay short-circuits). Cache hits complete the same begin/safepoint/resolve/record sequence as provider responses, with identical results and zero token usage.

- **`src/runtime/typescript/bindings.rs`**: Added mapping for the `summary` segment kind to a `<conversation-summary>` user turn in the request.

- **`src/runtime/rust_engine.rs`**: Added comprehensive tests:
  - `context_compact_summarizes_old_turns_into_recorded_segment()`: Validates compaction produces a recorded prompt call, respects `keepTurns`, and replays deterministically.
  - `local_prompt_cache_serves_identical_request_without_provider()`: Verifies cache hits skip provider calls while recording identical results.
  - Added `PROMPT_ENV_LOCK` mutex to serialize cache-related tests and prevent cross-test pollution from the process-global `CHIDORI_PROMPT_CACHE_DIR`.

- **SDK and Documentation**: Updated `sdk/typescript/src/agent.ts` with `CompactOptions` interface, `llm.txt` with API reference, `docs/context-management.md` marking Phase 3 complete, and `README.md` with user-facing examples.

## Implementation Details

- Compaction is **never automatic**: it requires explicit `await ctx.compact()` calls, preserving the principle that context changes are always author decisions.
- The summarization call is a **recorded `prompt` host operation**, making it durable and deterministically replayed.
- Cache lookup happens **strictly after** replay short-circuits, so the call log is always the source of truth.
- Cache entries are **atomic** (temp-file + rename) to prevent torn reads under concurrent access.
- Both `chidori.prompt()` and context-based prompts benefit from caching automatically since they route through the same executors.

https://claude.ai/code/session_01FomAHRE3BT8ZH3iSnfrXgh