### PR TITLE
Update roadmap and design docs for pure-Rust engine consolidation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,23 +4,37 @@
 
 Chidori is a Rust agent runtime where first-party agents and tools are written
 in TypeScript. Agent code uses normal `async` / `await` control flow, while all
-side effects go through an injected `chidori` host object. The host boundary is
-where Chidori records call logs, streams prompt progress, enforces policy,
-persists checkpoints, pauses for human input, and replays completed work.
+side effects go through an injected `chidori` host object (plus captured base
+APIs such as `fetch`). The host boundary is where Chidori records call logs,
+streams prompt progress, enforces policy, persists checkpoints, pauses for human
+input, and replays completed work.
 
-The current migration target is TypeScript-only authoring. Legacy Starlark
-examples are archived under `examples/legacy-starlark/` for reference, but the
-runtime, CLI, server, and tool discovery paths now require `.ts` files.
+TypeScript is the only supported authoring format. Legacy Starlark examples are
+archived under `examples/legacy-starlark/` for reference, but the runtime, CLI,
+server, and tool discovery paths require `.ts` files.
 
-For the detailed durable VM snapshot architecture, see
-[`docs/typescript-vm-snapshot-runtime.md`](./docs/typescript-vm-snapshot-runtime.md).
-For the prompt-to-artifact migration checklist, see
-[`docs/typescript-migration-audit.md`](./docs/typescript-migration-audit.md).
-For running the runtime against the official ECMAScript conformance suite
-(the same Test262 corpus Bun and Node measure language parity with), see
-[`docs/conformance.md`](./docs/conformance.md).
-For what the pure-Rust engine confines (capability injection, resource limits)
-and the gaps that remain, see [`docs/sandbox-model.md`](./docs/sandbox-model.md).
+Agents run on **`crates/chidori-js`**, an in-tree, pure-Rust JavaScript engine
+(zero `unsafe`, oxc parser). It is the *only* JavaScript engine in the tree —
+for agents, tools, sub-agents, and the Test262 conformance harness alike. The
+earlier vendored QuickJS fork, the `rquickjs` parity path, and the WASM/Python
+exec sandboxes were removed; there is no fallback engine, so JavaScript-language
+correctness is measured continuously against Test262 (see below).
+
+Related design docs:
+
+- [`docs/pure-rust-js-engine-plan.md`](./docs/pure-rust-js-engine-plan.md) —
+  the engine's design (historical migration plan; the engine it describes is
+  now the shipping runtime).
+- [`docs/conformance.md`](./docs/conformance.md) — how the runtime is measured
+  against the official ECMAScript Test262 corpus and the CI baseline gate.
+- [`docs/sandbox-model.md`](./docs/sandbox-model.md) — what the engine confines
+  (capability injection, resource limits) and the gaps that remain.
+- [`docs/value-checkpoints.md`](./docs/value-checkpoints.md),
+  [`docs/context-management.md`](./docs/context-management.md),
+  [`docs/signals.md`](./docs/signals.md),
+  [`docs/branching-execution.md`](./docs/branching-execution.md), and
+  [`docs/captured-effects-vfs-crypto-timers.md`](./docs/captured-effects-vfs-crypto-timers.md)
+  — the host-API features layered on the runtime.
 
 ## Design Goals
 
@@ -37,53 +51,62 @@ and the gaps that remain, see [`docs/sandbox-model.md`](./docs/sandbox-model.md)
 
 ## Non-Goals
 
-- No automatic `.star` to `.ts` converter in the first migration.
+- No automatic `.star` to `.ts` converter.
 - No Node package ecosystem execution inside agents for v1.
-- No arbitrary mid-instruction VM snapshots for CPU-bound loops.
-- No serialization of active OS handles, sockets, provider streams, or native
-  Rust closures.
-- No support for `SharedArrayBuffer`, `Atomics`, WeakRef, finalizers, or worker
-  threads in durable v1 runs.
-- No visual editor work in the current roadmap.
+- No polyglot snippet execution: the `execJs` / `execPython` / `execWasm`
+  sandboxes were removed (the JS stubs remain but the host backend rejects the
+  effect).
+- No `Intl`, `Temporal`, `SharedArrayBuffer`, `Atomics`, `WeakRef`,
+  finalizers, decorators, or worker threads in durable v1 runs (skipped
+  honestly by the conformance runner).
+- No VM-image snapshots of suspended continuations: durability is the
+  deterministic-replay journal, not a frozen heap. Resume re-runs the agent and
+  serves recorded host results from the journal.
+- No OS-level isolation: the sandbox is capability confinement plus resource
+  limits, not seccomp/namespaces.
+- No visual editor work.
 
 ## Current State
 
-The migration has these production pieces in place:
+The runtime has these production pieces in place:
 
+- `crates/chidori-js` is the pure-Rust JavaScript engine: oxc-based parser,
+  bytecode compiler and interpreter, reference-counting GC with a cycle
+  collector (`gc.rs`), a custom ReDoS-bounded regex backtracker (`regexp.rs`),
+  a deterministic-replay journal (`journal.rs` / `replay.rs`), and the host
+  function seam (`host.rs`).
+- `crates/test262-runner` runs the pinned Test262 corpus against the engine and
+  gates CI on a committed per-test baseline.
 - `src/runtime/engine.rs` dispatches TypeScript agents, validates `.ts` files,
-  sets durable runtime policy, wires replay and pause modes, and persists run
-  checkpoints.
+  resolves durable runtime policy, wires replay and pause modes, and persists
+  run checkpoints.
+- `src/runtime/rust_engine.rs` adapts `chidori-js` to the runtime via the
+  `SnapshotCapableJsEngine` trait, exposing host effects as global async
+  functions and round-tripping a `{bundle, effects, journal}` blob for
+  snapshot/restore.
 - `src/runtime/host_core.rs` owns the language-neutral host-call behavior:
-  sequence allocation, replay lookup, policy enforcement, provider/tool/http
-  execution, memory, templates, sandbox helpers, call-log recording, events,
-  and safepoints.
-- `src/runtime/typescript/` owns TypeScript transpilation, active
-  `crates/chidori-quickjs` execution, native host bindings, value conversion,
-  tool metadata parsing, checking, and snapshot scaffolding. The legacy
-  `rquickjs` binding module is retained only for parity tests.
-- `src/runtime/snapshot.rs` defines snapshot manifests, ABI/source/policy
-  validation, host promise records, pending operation metadata, branch snapshot
-  helpers, and store/load behavior.
-- `crates/chidori-quickjs-sys` vendors the in-repo QuickJS fork and exposes the
-  raw FFI surface required by Chidori.
-- `crates/chidori-quickjs` wraps the fork with safe Rust helpers for runtime
-  limits, JSON value conversion, bytecode/value snapshot coverage, host promise
-  ids, and snapshot envelope validation.
-- `src/tools/mod.rs` discovers TypeScript `.ts` tools and ignores `.star` tool
-  files.
+  sequence allocation, replay lookup, policy enforcement, provider/tool/network
+  execution, memory, templates, call-log recording, events, and safepoints.
+- `src/runtime/context.rs`, `call_log.rs`, `capability.rs`, `cost.rs`,
+  `crypto.rs`, `vfs.rs`, `memory.rs`, `template.rs`, `prompt_cache.rs`,
+  `secret_env.rs`, `workspace.rs`, `host_branch.rs`, and `otel.rs` provide the
+  surrounding host machinery (runtime context, captured effects, capability
+  ledger, cost accounting, virtual filesystem, prompt caching, secrets,
+  workspace, branching, OTEL).
+- `src/runtime/typescript/` owns TypeScript transpilation (`transpile.rs`, oxc),
+  native host bindings (`bindings.rs`), the module graph and resolver
+  (`module_graph.rs`, `resolver.rs`), tool metadata evaluation (`tools.rs`),
+  `check.rs`, and runtime prelude/builtins (`builtins.rs`, `helpers.rs`).
+- `src/runtime/snapshot.rs` defines snapshot/journal manifests, runtime policy,
+  ABI/source/policy validation, capability ledgers, and store/load behavior.
+- `src/tools/mod.rs` discovers TypeScript `.ts` tools and ignores `.star` files.
 - `src/server.rs` and `src/main.rs` expose run, check, serve, sessions, replay,
-  resume, streaming events, trace, stats, and snapshot metadata commands.
-- `sdk/typescript/` and `sdk/python/` expose HTTP clients for run, replay,
-  resume, checkpoints, streaming, and snapshot manifest inspection.
-
-Direct live VM continuation is implemented for the current TypeScript runtime
-surface. The repository has manifests, runtime policy gates, source
-validation, live snapshot blob kind gating, host promise records, safepoint
-hooks, branch resume helpers, imported-module restore coverage through the
-bundled selected-root scaffold, and direct live resume coverage for nested
-suspending TypeScript `callAgent()` paths including grandchild rejection
-through parent `try/catch` handlers. Full QuickJS module/runtime-root
-serialization beyond that scaffold is future runtime generalization work.
+  resume, streaming events, trace, stats, branches, and snapshot metadata
+  commands. `src/providers/`, `src/mcp/`, `src/acp.rs`, `src/policy.rs`,
+  `src/scheduler.rs`, and `src/storage.rs` provide providers, MCP/ACP surfaces,
+  policy, scheduling, and persistence.
+- `sdk/typescript/` and `sdk/python/` expose zero-dependency HTTP clients for
+  run, replay, resume, checkpoints, streaming, and snapshot manifest inspection.
 
 ## Authoring Model
 
@@ -147,15 +170,24 @@ The injected `chidori` object provides:
 
 - `prompt(text, options?)`
 - `input(message, options?)`
+- `signal(name, options?)` / `pollSignal(name)` / `signalAny(names, options?)`
+  — multiplayer named signals (see `docs/signals.md`).
 - `callAgent(path, input?)`
 - `tool(name, args?)`
 - `parallel(tasks, options?)`
+- `branch(strategies, options?)` — in-agent execution branching
+  (`docs/branching-execution.md`).
 - `retry(fn, options?)`
 - `tryCall(fn)`
+- `step(name, fn)` — durable value checkpoints; memoize pure compute into the
+  call log so replay/resume never re-pays it (`docs/value-checkpoints.md`).
+- `context(...)` / `Context.compact(...)` — prompt context builder and window
+  compaction (`docs/context-management.md`).
 - `template(pathOrText, vars?, options?)`
 - `log(message, fields?)`
 - `memory(action, key?, value?, options?)`
 - `checkpoint(label?, data?)`
+- `workspace(action, ...)` — policy-gated workspace access.
 
 All side-effecting APIs are promise-returning durable host operations. Pure
 helpers may return synchronously only when they cannot suspend and do not need a
@@ -166,50 +198,57 @@ Networking is **not** on the `chidori` object: agents use the standard `fetch`
 The runtime replaces those base networking APIs with captured implementations
 that route through one policy-gated, replayable host op, so every request — even
 one issued inside a dependency — is gated and recorded automatically.
+Filesystem (`node:fs`), crypto (`node:crypto`, Web Crypto), and timers are
+similarly captured against a snapshot-resident virtual filesystem and a virtual
+clock (`docs/captured-effects-vfs-crypto-timers.md`).
 
 ## Execution Flow
 
 1. The CLI or server reads a `.ts` agent file and input JSON.
 2. Runtime policy is resolved from environment/config defaults.
-3. TypeScript is transpiled to JavaScript without full runtime typechecking.
-4. A bounded QuickJS runtime/context is created.
-5. Deterministic globals are installed according to policy.
+3. TypeScript is transpiled to JavaScript (oxc, type-stripping only — no
+   downleveling and no full typecheck).
+4. A bounded `chidori-js` VM is created (memory cap, opcode budget, deadline).
+5. Deterministic globals and captured base APIs are installed per policy.
 6. The `chidori` host object is installed.
-7. The agent module and allowed relative imports are evaluated.
+7. The agent module and allowed imports are evaluated through the module graph.
 8. The exported `agent(input, chidori)` function is called.
-9. Host calls allocate sequence numbers, consult replay data, persist
+9. Host calls allocate sequence numbers, consult journal/replay data, persist
    safepoints, execute side effects, record results, and resolve promises.
 10. The run finishes with JSON output, a pause state, or a structured error.
 
 ## Replay And Resume
 
-Replay uses the persisted call log. Given the same source, input, runtime
-policy, and recorded host-call results, Chidori can re-run the TypeScript agent
-and return cached results instead of repeating external side effects.
+Durability is the deterministic-replay journal. Each host effect is recorded in
+order against a code bundle referenced by content hash. Given the same source,
+input, runtime policy, and recorded host-call results, Chidori re-runs the
+TypeScript agent and serves cached results from the journal instead of repeating
+external side effects.
 
-Pause/resume currently supports `input()` and policy approval by recording the
-pending host operation, appending the human response or policy decision, and
-replaying to continue. Snapshot manifests are persisted alongside the call log
-and validated for ABI, source hashes, module graph, and policy.
-
-Live VM snapshot resume is intentionally gated until the QuickJS fork can
-serialize and restore suspended continuations, pending promise reactions, the
-job queue, evaluated module records, and host promise ids.
+Pause/resume (`input()`, policy approval, and other suspending host calls) is
+implemented by recording the pending host operation, appending the human
+response or policy decision, and replaying to continue. There is no VM-image
+snapshot of a suspended continuation; resume re-executes deterministically and
+the journal supplies every prior effect result. `chidori.step(name, fn)`
+(value checkpoints) memoizes pure compute into the journal so long histories do
+not re-pay that compute on resume; host effects are already journal-served, so
+only un-wrapped pure JS between effects is re-executed.
 
 ## Snapshot Files
 
 Persisted runs live under `.chidori/runs/<run_id>/` and may contain:
 
 - `input.json`: original run input.
-- `checkpoint.json`: call log.
-- `runtime.snapshot`: binary VM or scaffold snapshot blob.
+- `checkpoint.json`: call log / journal.
+- `runtime.snapshot`: a self-describing `{bundle, effects, journal}` blob (the
+  code bundle, exposed host effect names, and the replay journal) — not a VM
+  heap image.
 - `runtime.snapshot.json`: manifest with ABI, policy, source hashes, pending
-  operation, host promises, and snapshot kind.
+  operation, capability ledger, and snapshot kind.
 - `pending.json`: pending durable host operation, when paused.
 - `output.json`: final output, once complete.
 
-The snapshot manifest is safe to expose through SDKs and HTTP responses. Raw VM
-snapshot bytes stay server-side.
+The snapshot manifest is safe to expose through SDKs and HTTP responses.
 
 ## Determinism Policy
 
@@ -218,13 +257,17 @@ resume attempts.
 
 | Policy | Env var | Values | Default |
 | --- | --- | --- | --- |
-| Local TS imports | `CHIDORI_TS_IMPORTS` | `none`, `relative`, `project` | `relative` |
+| Local TS imports | `CHIDORI_TS_IMPORTS` | `none`, `relative`, `project`, `node` | `node` |
 | `Date` behavior | `CHIDORI_TS_DATE` | `disabled`, `fixed`, `host` | `fixed` |
 | Randomness behavior | `CHIDORI_TS_RANDOM` | `disabled`, `seeded`, `host` | `seeded` |
+| Filesystem | `CHIDORI_TS_FS` | `disabled`, `captured`, `host` | `captured` |
+| Crypto | `CHIDORI_TS_CRYPTO` | `disabled`, `seeded`, `captured`, `host` | `captured` |
+| Timers | `CHIDORI_TS_TIMERS` | `disabled`, `virtual`, `host` | `virtual` |
 | Map/Set snapshot support | `CHIDORI_SNAPSHOT_MAPS_SETS` | `reject`, `serialize` | `reject` |
 
-`host` date/random policies are rejected for durable runs because they can break
-replay and snapshot compatibility.
+`host` variants are rejected for durable runs because they can break replay and
+snapshot compatibility. The `node` import policy is the durable default so the
+snapshot-resident virtual filesystem (`node:fs`) is reachable.
 
 ## Project Layout
 
@@ -232,16 +275,27 @@ replay and snapshot compatibility.
 src/
   runtime/
     engine.rs              # agent dispatch, replay, pause, persistence
+    rust_engine.rs         # chidori-js adapter (SnapshotCapableJsEngine)
     host_core.rs           # language-neutral host operation behavior
-    snapshot.rs            # manifests, stores, validation, host promises
-    typescript/            # TS transpile, VM, bindings, tools, snapshots
-    sandbox.rs             # WASM / Python / JS sandbox helpers
+    context.rs             # runtime context shared across host calls
+    snapshot.rs            # manifests, policy, journal validation, stores
+    call_log.rs            # call-log / journal records
+    capability.rs          # capability ledger
+    vfs.rs crypto.rs       # captured filesystem and crypto effects
+    memory.rs template.rs  # memory store and templates
+    prompt_cache.rs        # opt-in local prompt cache
+    workspace.rs           # policy-gated workspace access
+    host_branch.rs         # in-agent branching
+    cost.rs otel.rs        # cost accounting and OTEL spans
+    typescript/            # TS transpile, bindings, module graph, tools, check
   server.rs                # HTTP/session/streaming APIs
+  providers/               # Anthropic, OpenAI, LiteLLM-compatible, static
   tools/mod.rs             # TypeScript tool discovery
+  mcp/ acp.rs              # MCP and ACP protocol surfaces
+  policy.rs scheduler.rs storage.rs   # policy, scheduling, persistence
 crates/
-  chidori-quickjs-sys/     # vendored QuickJS fork and raw FFI
-  chidori-quickjs/         # safe Rust wrapper
-  test262-runner/          # Test262 conformance runner (bun/node JS parity)
+  chidori-js/              # the pure-Rust JavaScript engine (the only engine)
+  test262-runner/          # Test262 conformance runner + baseline gate
 examples/
   agents/                  # TypeScript examples
   tools/                   # TypeScript tool examples
@@ -255,8 +309,10 @@ sdk/
 
 - TypeScript is the authoring format; JSON is the host boundary format.
 - Side effects are explicit and interceptable.
-- Replay remains useful even after live VM snapshots land.
-- Runtime policy is part of durable state, not ambient configuration.
-- Snapshot bytes are versioned and validated before restore.
-- Unsupported snapshot values fail loudly with actionable diagnostics.
+- One JavaScript engine, no fallback — so language correctness is a continuous,
+  CI-gated conformance bar, not a migration milestone.
+- Durability is the deterministic-replay journal; runtime policy is part of
+  durable state, not ambient configuration.
+- Journal blobs and manifests are versioned and validated before restore.
+- Unsupported values fail loudly with actionable diagnostics.
 - The embedded runtime remains small and owned by the Rust binary.

--- a/TODO.md
+++ b/TODO.md
@@ -1,317 +1,129 @@
 # TODO - Chidori TypeScript Runtime
 
-This roadmap tracks the TypeScript-runtime migration. Historical Starlark work
-is preserved in git history and under `examples/legacy-starlark/`, but new
-runtime, CLI, server, and tool work should target `.ts` agents and tools.
+This roadmap tracks the TypeScript runtime. Historical Starlark work is
+preserved in git history and under `examples/legacy-starlark/`; new runtime,
+CLI, server, and tool work targets `.ts` agents and tools.
+
+The TypeScript-runtime migration and the JavaScript-engine consolidation are
+**complete**. Agents, tools, sub-agents, and the conformance harness all run on
+the single in-tree pure-Rust engine `crates/chidori-js`; the vendored QuickJS
+fork, the `rquickjs` parity path, and the WASM/Python exec sandboxes were
+removed (#39). Durability is the deterministic-replay journal, not VM-image
+snapshots — so the bulk of the remaining work is now the standing conformance
+bar plus product follow-through, not migration.
 
 ## Status At A Glance
 
 | Area | Status |
 | --- | --- |
-| TypeScript agent dispatch | Done |
-| TypeScript host API bindings | Done |
+| TypeScript agent/tool/sub-agent dispatch | Done |
+| Single pure-Rust JS engine (`chidori-js`), QuickJS removed | Done (#39) |
 | Language-neutral host core | Done |
-| Call-log replay | Done |
-| Human input and policy approval pause/resume | Done through live VM resume with replay fallback |
-| Multiplayer signals (`chidori.signal` / `pollSignal` / `signalAny` + `timeoutMs`, `POST /sessions/{id}/signal`, live in-memory delivery to streaming runs) | Done — Phases 1–3 of `docs/signals.md` |
-| Context management (provider prompt caching, `chidori.context` builder, `Context.compact()`, opt-in local prompt cache via `CHIDORI_PROMPT_CACHE_DIR`) | Done — Phases 1–3 of `docs/context-management.md` |
-| TypeScript tool discovery | Done |
-| TypeScript and Python SDK parity | Done |
-| Snapshot manifests, policy/source validation, host promise records | Done |
-| In-repo QuickJS fork and Rust wrapper | Done for current runtime surface |
-| Full live VM continuation snapshot/restore | Done for current TypeScript runtime surface |
-| Server resume from `LiveQuickJsVm` blobs | Done for current production TypeScript host paths |
+| Captured base effects: networking (`fetch`/`node:http`), `node:fs` VFS, crypto, timers | Done |
+| Call-log replay + durable pause/resume (`input()`, policy approval, suspending host calls) | Done |
+| Value checkpoints (`chidori.step`) | Done — `docs/value-checkpoints.md` |
+| Multiplayer signals (`signal`/`pollSignal`/`signalAny`, `POST /sessions/{id}/signal`, live delivery) | Done — `docs/signals.md` |
+| Context management (prompt caching, `chidori.context`, `Context.compact()`, local prompt cache) | Done — `docs/context-management.md` |
+| In-agent branching (`chidori.branch`, branch stores, resume/rerun, capped waves) | Done (Phases 1–2) — `docs/branching-execution.md` |
+| Policy profiles (`untrusted`/`supervised`, `--untrusted`/`--trusted`, per-session) + deny-by-default `serve` | Done |
+| Test262 conformance with committed-baseline CI gate | Done; bar is now load-bearing (no fallback engine) |
+| TypeScript and Python SDK parity (run/replay/resume/checkpoint/stream) | Done |
 
-See [DESIGN.md](./DESIGN.md) for the top-level design and
-[docs/typescript-vm-snapshot-runtime.md](./docs/typescript-vm-snapshot-runtime.md)
-for the durable VM snapshot design. The concrete migration evidence and
-completion audit lives in
-[docs/typescript-migration-audit.md](./docs/typescript-migration-audit.md).
+See [DESIGN.md](./DESIGN.md) for the top-level design,
+[docs/conformance.md](./docs/conformance.md) for the conformance methodology and
+gate, [docs/sandbox-model.md](./docs/sandbox-model.md) for the confinement model
+and its gaps, and [docs/fable_review.md](./docs/fable_review.md) for the most
+recent full-repository review and prioritized recommendations.
 
-## Completed Migration Work
+## Completed Work (summary)
 
-### TypeScript Runtime
+Detailed, dated history lives in git and in the per-feature docs. At a high
+level:
 
-- [x] Require `.ts` agent files in runtime dispatch.
-- [x] Reject unsupported non-TypeScript agent files with clear errors.
-- [x] Transpile TypeScript at runtime without requiring `tsc`.
-- [x] Install deterministic `Date` and `Math.random` behavior.
-- [x] Enforce durable-run policy for host date/random settings.
-- [x] Reject dynamic imports and unsupported local import policies.
-- [x] Support relative TypeScript imports under runtime policy.
-- [x] Convert JS values to JSON-compatible host values.
-- [x] Fail clearly for functions, unsupported native values, class instances,
-  shared memory, WeakRef, and finalizers at the host boundary.
-- [x] Run TypeScript agents from CLI and server paths.
-
-### Host API
-
-- [x] `chidori.prompt()`
-- [x] `chidori.input()`
-- [x] `chidori.signal()` / `chidori.pollSignal()` / `chidori.signalAny()` —
-      multiplayer named signals: blocking listen point, fan-in listen sets,
-      durable per-run mailbox, `timeoutMs` with a deterministic
-      `{timedOut: true}` sentinel (server-armed deadline timers, re-armed on
-      restart), `POST /sessions/{id}/signal` delivery (resolve+resume / enqueue /
-      live in-memory to streaming runs / 409), sender provenance as OTEL span
-      attributes, deterministic replay (Phases 1–3 of `docs/signals.md`).
-- [x] `chidori.callAgent()`
-- [x] `chidori.tool()`
-- [x] `chidori.parallel()`
-- [x] `chidori.branch()` — in-agent execution branching (Phases 1 + 2 of
-      `docs/branching-execution.md`): fork into per-strategy sub-runs from the
-      anchored state with outcomes returned for comparison; persisted branch
-      stores with out-of-band resume and edit-and-rerun (`chidori branches` /
-      `branch-resume` / `branch-rerun`) and concurrency-capped wave execution.
-      The whole-agent replay-prefix model (Phase 3) is future work.
-- [x] `chidori.retry()`
-- [x] `chidori.tryCall()`
-- [x] Captured networking via `fetch`/`node:http` (replaces `chidori.http`)
-- [x] `chidori.template()`
-- [x] `chidori.log()`
-- [x] `chidori.memory()`
-- [x] `chidori.checkpoint()`
-- [x] `chidori.step()` — durable value checkpoints (plan P6): memoize pure
-      compute into the call log so replay/resume never re-pays it
-      (`docs/value-checkpoints.md`).
-- [x] `chidori.execJs()`
-- [x] `chidori.execPython()`
-- [x] `chidori.execWasm()`
-- [x] Replay cached host-call results without repeating side effects.
-- [x] Record host promise lifecycle metadata for durable host operations.
-- [x] Persist safepoints before live side effects and after results.
-
-### Tools And Examples
-
-- [x] Discover `.ts` tools and evaluate exported `tool` metadata.
-- [x] Validate TypeScript tool JSON schema metadata.
-- [x] Invoke TypeScript tool `run(args, chidori)` exports.
-- [x] Ignore `.star` files during tool discovery.
-- [x] Convert first-party examples to TypeScript.
-- [x] Move legacy Starlark examples to `examples/legacy-starlark/`.
-- [x] Reject Starlark sub-agents from TypeScript agents.
-
-### CLI, Server, And SDKs
-
-- [x] `chidori check <file.ts>`
-- [x] `chidori run <file.ts>`
-- [x] `chidori serve <file.ts>`
-- [x] `chidori trace <run_id>`
-- [x] `chidori stats`
-- [x] Snapshot metadata command/endpoint without exposing raw VM bytes.
-- [x] Session create/list/get/checkpoint/replay/resume APIs.
-- [x] Server-sent streaming for host calls and labelled prompt progress.
-- [x] Python SDK run/replay/resume/checkpoint/stream support.
-- [x] TypeScript SDK run/replay/resume/checkpoint/stream support.
-- [x] SDK snapshot manifest metadata types.
-
-### Snapshot Data Model
-
-- [x] Snapshot manifest types.
-- [x] Snapshot store read/write helpers.
-- [x] ABI, source, module graph, and policy validation.
-- [x] Snapshot blob kind gating.
-- [x] Pending host operation persistence.
-- [x] Host promise records for pending/resolved/rejected operations.
-- [x] Branch snapshot metadata and merge helpers.
-- [x] Live VM store helpers that reject invalid snapshot envelopes.
-
-### QuickJS Fork Bootstrap
-
-- [x] Add `crates/chidori-quickjs-sys`.
-- [x] Add `crates/chidori-quickjs`.
-- [x] Vendor QuickJS source under `crates/chidori-quickjs-sys/quickjs`.
-- [x] Use local path dependency from the main runtime.
-- [x] Add runtime memory limits and interrupt budget.
-- [x] Expose raw snapshot/restore FFI symbols.
-- [x] Expose host promise FFI symbols.
-- [x] Expose run-jobs-until-blocked FFI symbol.
-- [x] Add Rust snapshot reader/writer callback ABI.
-- [x] Add unsupported-value callback ABI.
-- [x] Validate runtime snapshot byte envelopes before persisting or loading.
-- [x] Exercise value/bytecode snapshot coverage in wrapper tests.
-- [x] Exercise snapshot-side generic `chidori.<method>()` host-promise
-  pause/restore coverage in wrapper-backed TypeScript tests, including
-  `input()` and `prompt()`.
-- [x] Include active host operation id and host-call records in default
-  TypeScript snapshot roots.
-- [x] Clear the snapshot-side active host operation id after restored host
-  promise resolution or rejection.
-- [x] Preserve queued snapshot-side host method promises so a restored agent can
-  pause again on a later host call with a distinct operation id.
-- [x] Return `BlockedOnHostOperation` from snapshot wrapper job draining when
-  resumed execution reaches another host pause.
-- [x] Add snapshot wrapper resolve/reject-and-run helpers that return the next
-  run state for future server restore wiring.
-- [x] Add TypeScript snapshot restore-from-snapshot plus resolve/reject helpers
-  that return the restored context plus next run state.
-- [x] Add a snapshot-side adapter from persisted pending host operations to
-  `chidori` host-promise method queues for unambiguous host APIs.
-- [x] Add a snapshot-side adapter from persisted host-promise records that
-  installs only pending operations for restore.
+- **TypeScript runtime** — `.ts`-only agent/tool dispatch, runtime oxc
+  transpilation (type-stripping), deterministic `Date`/`Math.random`, durable
+  import/date/random/fs/crypto/timer policy, JSON host-boundary validation.
+- **Host API** — `prompt`, `input`, `signal`/`pollSignal`/`signalAny`,
+  `callAgent`, `tool`, `parallel`, `branch`, `retry`, `tryCall`, `step`,
+  `context`/`Context.compact`, `template`, `log`, `memory`, `checkpoint`,
+  `workspace`; captured `fetch`/`node:http` networking replacing `chidori.http`.
+- **Engine consolidation (#39)** — moved all execution off the QuickJS fork /
+  `rquickjs` onto `crates/chidori-js`, deleted the vendored C, the WASM/Python
+  exec sandboxes, and the `chidori-quickjs{,-sys}` crates; replaced VM-image
+  snapshot/resume with the deterministic-replay journal.
+- **Conformance** — `crates/test262-runner` against the pinned Test262 corpus,
+  a committed per-test baseline, and a CI gate that fails on regressions and
+  hints on new passes (PRs touching the engine, pushes to `main`, nightly).
+- **CLI / server / SDKs** — `check`, `run`, `serve`, `trace`, `stats`, `demo`,
+  `branches`/`branch-resume`/`branch-rerun`; session create/list/get/checkpoint/
+  replay/resume APIs with SSE streaming; OTEL trace emission; zero-dependency
+  TypeScript and Python HTTP clients with snapshot-manifest types.
 
 ## Remaining Work
 
-### Runtime Backend Convergence
+### Conformance (standing bar)
 
-- [x] Move the active TypeScript host-binding execution path off `rquickjs` or
-  teach it to capture equivalent live snapshots from the in-repo QuickJS fork.
-- [x] Install the full non-suspending `chidori` host object on the
-  snapshot-capable `crates/chidori-quickjs` context for the active
-  TypeScript execution path.
-- [x] Complete the remaining server direct live-resume bookkeeping for nested
-  suspending `callAgent()` rejection paths, including `return await
-  chidori.callAgent(...)` and grandchild `input()` rejection propagation through
-  parent `try/catch` handlers.
-- [x] Move recorder/no-context TypeScript agent evaluation from `rquickjs` to
-  `crates/chidori-quickjs`, including deterministic runtime policy prelude.
-- [x] Move TypeScript tool metadata evaluation from `rquickjs` to
-  `crates/chidori-quickjs` so tool discovery exercises the in-repo runtime.
-- [x] Enforce Chidori JSON host-boundary validation in the
-  `crates/chidori-quickjs` wrapper for function and class-instance results.
-- [x] Expose the minimal QuickJS native callback/context-opaque FFI and
-  `SnapshotContext` wrapper API needed to start installing production
-  Rust-backed `chidori` methods in `crates/chidori-quickjs`.
-- [x] Add `SnapshotContext` native object-method installation and callback
-  argument/JSON return helpers, with Rust-backed `chidori.log`-style coverage.
-- [x] Wire native callback/context-opaque helpers through
-  `TypeScriptSnapshotContext`, with TypeScript agent coverage calling a
-  Rust-backed `chidori.log` method.
-- [x] Install `RuntimeContext`/`host_core`-backed native `chidori.log`,
-  `chidori.checkpoint`, `chidori.memory`, and `chidori.template` methods on
-  `TypeScriptSnapshotContext` as the first real snapshot-runtime host method
-  slices.
-- [x] Install `RuntimeContext`/`host_core`-backed native `chidori.execJs`,
-  `chidori.execPython`, and `chidori.execWasm` methods on
-  `TypeScriptSnapshotContext`.
-- [x] Install `RuntimeContext`/`host_core`-backed captured-networking
-  (`fetch`/`node:http`) policy denial and `chidori.input` pause paths on
-  `TypeScriptSnapshotContext`.
-- [x] Install `RuntimeContext`/provider-backed native plain-text
-  `chidori.prompt` on `TypeScriptSnapshotContext`.
-- [x] Run provider-requested `chidori.prompt` tool loops through the native
-  snapshot host path for non-suspending registered TypeScript tools.
-- [x] Install `RuntimeContext`/registry-backed native `chidori.tool` and
-  `chidori.callAgent` paths on `TypeScriptSnapshotContext` for non-suspending
-  TypeScript tools and child agents.
-- [x] Install snapshot-runtime JavaScript helpers for `chidori.tryCall`,
-  `chidori.retry`, and `chidori.parallel`.
-- [x] Persist concrete sandbox host function names in pending host operation
-  metadata so `execJs`, `execPython`, and `execWasm` can be restored without
-  ambiguity.
-- [x] Persist restorable `LiveQuickJsVm` blobs from ordinary TypeScript
-  persisted safepoints by rebuilding the continuation from persisted host
-  promise records, without test-only injected snapshotters.
+Test262 conformance is load-bearing now that there is no fallback engine. Keep
+picking off the cluster table in `docs/conformance.md`. The current top
+clusters:
 
-### Full QuickJS Runtime Snapshot Serialization
+- [ ] **UTF-16 string representation** — the engine's scalar-string model blocks
+  RegExp lone-surrogate matching, the `v`-flag long tail, and String surrogate
+  edge cases. This is the single highest-leverage project; it unlocks the
+  largest RegExp cluster plus String/Array surrogate failures at once.
+- [ ] `language/expressions` corners — dynamic-`import()` semantics and the last
+  class/eval corners.
+- [ ] `language/module-code` — namespace internals, hoisted default-function
+  exports, TLA ordering.
+- [ ] `language/eval-code` / `language/global-code` — eval-created global
+  binding attributes and lexical/var binding interactions.
+- [ ] Sparse-index semantics beyond the dense cap (`built-ins/Object`,
+  `built-ins/Array`).
+- [ ] Resizable-`ArrayBuffer` corners (`built-ins/TypedArray`,
+  `built-ins/ArrayBuffer`): `subarray`/`set`/`slice`/transfer.
 
-The in-repo fork already exercises value/object graph, bytecode, host promise,
-async continuation, and microtask queue snapshots through
-`chidori_quickjs::SnapshotContext`. The context ABI now exposes selected
-Chidori TypeScript roots and the microtask queue through
-`CHIDORI_JS_SnapshotContext` / `CHIDORI_JS_RestoreContext`. Ordinary Chidori
-TypeScript runs use a bundled selected-root module scaffold, so full QuickJS
-`JSModule` record serialization is deferred until the runtime supports a
-broader JavaScript module surface.
+### Product follow-through (from `docs/fable_review.md`)
 
-- [x] Implement `CHIDORI_JS_SnapshotRuntime` as a versioned runtime envelope.
-- [x] Implement `CHIDORI_JS_RestoreRuntime` by restoring a fresh QuickJS
-  runtime for the context payload.
-- [x] Implement `CHIDORI_JS_SnapshotContext` for selected Chidori TypeScript
-  roots and the microtask/job queue.
-- [x] Implement `CHIDORI_JS_RestoreContext` for selected Chidori TypeScript
-  roots and the microtask/job queue.
-- [x] Compose runtime and context payload restore for a suspended Chidori host
-  call completed by host promise id.
-- [x] Preserve selected-root bundled TypeScript module namespace exports through
-  snapshot restore, including exported functions that close over exported
-  constants.
-- [x] Fail selected-root context snapshot creation with path/type detail for
-  unsupported native values.
-- [x] Add fork-level context snapshot tests for suspended async functions and
-  host promise resolution after restore.
-- [x] Add fork-level `CHIDORI_JS_SnapshotContext` /
-  `CHIDORI_JS_RestoreContext` entrypoint coverage for a suspended Chidori host
-  call restored and completed by host promise id.
-- [x] Add fork-level runtime-plus-context entrypoint tests for suspended async
-  functions and host promise resolution after restore.
-- [x] Add ordinary engine persistence coverage that restores a
-  `LiveQuickJsVm` input pause and resolves the suspended host promise.
+- [ ] **SDK publishing** — both SDKs are at 3.0.0 and the README badges
+  npm/PyPI, but there is no publish automation. Wire it up or drop the badges.
+- [ ] **TypeScript SDK tests** — there are none; CI only typechecks and builds
+  the TS SDK. The 8 Python-SDK integration tests against a real server are the
+  template.
+- [ ] **Broader `node:` allowlist** — `stream`, `zlib`, and `child_process`
+  remain unsupported (the current allowlist covers `process`, `buffer`, `util`,
+  `fs`, `fs/promises`, `crypto`, `http`, `https`, `path`, `events`, `url`,
+  `assert`, `os`).
+- [ ] **Providers and modalities** — only Anthropic and OpenAI stream natively
+  (LiteLLM is the escape hatch). No embeddings, image/audio modalities, or
+  JSON-mode/structured-output plumbing beyond tool calls.
+- [ ] **Code-comment doc drift** — several `src/` comments still explain intent
+  by reference to "the QuickJS path" (e.g. `engine.rs`, `bindings.rs`,
+  `rust_engine.rs`, `server.rs`). Low-priority cleanup now that the
+  roadmap docs are corrected.
 
-### Server Resume From Live VM Snapshots
+### Sandbox hardening (from `docs/sandbox-model.md`)
 
-- [x] Remove the server resume validation guard that rejected
-  `LiveQuickJsVm` manifests up front.
-- [x] On `input()` resume, load `runtime.snapshot`, restore the QuickJS
-  runtime/context, resolve the saved host promise id, and use the live result
-  when it completes.
-- [x] Persist a newly reached direct live-VM `input()` pause, including the
-  next pending host operation, host-promise table entry, and updated live
-  snapshot.
-- [x] Execute and record an awaited direct live-VM `log()` host operation
-  without falling back to replay.
-- [x] Execute and record an awaited direct live-VM `template()` host operation
-  without falling back to replay.
-- [x] Execute and record awaited direct live-VM `memory()` host operations
-  without falling back to replay.
-- [x] Execute and record awaited direct live-VM `checkpoint()` host operations
-  without falling back to replay.
-- [x] Execute and record awaited direct live-VM sandbox host operations
-  (`execJs`, `execPython`, `execWasm`) without falling back to replay.
-- [x] Reject failed direct live-VM host promises for handled operations and
-  continue the live VM when agent code catches the error.
-- [x] Reject direct live-VM `http()` calls denied by policy without falling
-  back to replay.
-- [x] Execute and record always-allowed direct live-VM `http()` calls without
-  falling back to replay.
-- [x] Persist direct live-VM `http()` policy approval pauses without falling
-  back to replay.
-- [x] Continue approved policy-gated direct live-VM `http()` calls without
-  falling back to replay.
-- [x] Execute and record direct live-VM TypeScript `tool()` calls without
-  falling back to replay for non-suspending tools.
-- [x] Execute and record direct live-VM TypeScript `callAgent()` calls without
-  falling back to replay for non-suspending child agents.
-- [x] Execute and record direct live-VM plain-text `prompt()` calls without
-  falling back to replay.
-- [x] Execute and record direct live-VM `prompt()` tool loops without falling
-  back to replay for non-suspending tools.
-- [x] Persist and resume direct live-VM `prompt()` tool loops when a
-  TypeScript tool suspends on nested `input()`.
-- [x] Persist and resume top-level direct live-VM TypeScript `tool()` calls
-  that suspend on nested `input()`.
-- [x] Persist and resume top-level direct live-VM TypeScript `callAgent()`
-  calls when the child agent suspends on nested `input()`.
-- [x] Persist and resume nested direct live-VM TypeScript `callAgent()` calls
-  when a grandchild agent suspends on nested `input()`.
-- [x] Preserve top-level suspending `tool()`/`callAgent()` rejection paths
-  after nested `input()` resumes, including parent `try/catch` handlers.
-- [x] Keep replay recovery covered as a fallback for nested suspending
-  `callAgent()` rejection paths.
-- [x] Persist final output for direct live-VM completion.
-- [x] Extend server direct live-VM resume bookkeeping to the nested
-  `callAgent()` rejection path after a grandchild `input()` resumes.
-- [x] Keep replay as an explicit recovery path when direct live-VM resume
-  cannot drive a newly reached production host call.
+- [ ] Per-VM (ownership-attributed) memory accounting — the per-run meter is
+  thread-attributed today, so concurrent runs can still drift.
+- [ ] Per-tenant CPU quota — the opcode budget bounds a run, not a tenant.
+- [ ] Deeper policy matching — `match_args` is shallow; approvals are cached
+  per-session and policy cannot change mid-run.
+- OS-level isolation (seccomp/namespace/process) remains an explicit non-goal;
+  the engine is capability confinement, not a container.
 
-### Tool Metadata Hardening
+### Optional feature extensions
 
-- [x] Replace static text metadata extraction with restricted VM-backed
-  TypeScript metadata evaluation.
-- [x] Capture tool source fingerprints in tool registry entries.
-- [x] Snapshot and directly resume TypeScript tool execution when a tool
-  suspends on nested `input()`, with replay retained as a fallback.
-
-### Quality Gates
-
-- [x] Root Rust test suite passes with TypeScript runtime coverage.
-- [x] Add CI for `cargo fmt --check`.
-- [x] Add CI for `cargo test --workspace`.
-- [x] Add CI for `npm run typecheck` in `sdk/typescript`.
-- [x] Add CI for `npm run build` in `sdk/typescript`.
-- [x] Add CI for Python SDK tests.
-- [x] Add focused integration tests for CLI `.ts` examples.
-- [x] Add end-to-end pause/resume tests that exercise `LiveQuickJsVm` restore.
+- [ ] Branching Phase 3 — the whole-agent replay-prefix model
+  (`docs/branching-execution.md` §8.9); deferred because the §8.2 fork-return
+  model already covers the MVP. Branch merge/promote into the parent run, a
+  tael comparison view, and a programmatic `POST /sessions/{id}/fork` surface
+  are smaller follow-ups.
+- [ ] Signals — per-branch addressing, a typed signal-schema registry, a
+  symmetric `chidori.sendSignal(runId, name, payload)` send side, and
+  broadcast/pub-sub to multiple runs (`docs/signals.md` §17).
+- [ ] Context management — a raw-`Message[]` escape hatch, a typed
+  prompt/segment schema registry, fleet-wide content-addressed cache sharing,
+  and per-provider cache-strategy plugins (`docs/context-management.md` §16).
 
 ## Useful Verification Commands
 
@@ -319,6 +131,7 @@ broader JavaScript module surface.
 cargo fmt --check
 cargo test
 cargo test --workspace
+scripts/test262.sh --gate            # conformance baseline gate
 cd sdk/typescript && npm run build
 cd sdk/typescript && npm run typecheck
 python -m unittest sdk/python/tests/test_session_api.py
@@ -326,16 +139,14 @@ python -m unittest sdk/python/tests/test_session_api.py
 
 ## Deferred Or Descoped
 
-- Visual editor work is not planned for this migration.
-- Automatic `.star` to `.ts` conversion is not required for v1.
-- Node package compatibility inside agents is not required for v1.
-- Arbitrary mid-instruction snapshots for CPU-bound loops are not required for
-  v1.
-- Full QuickJS `JSModule` record serialization beyond Chidori's bundled
-  selected-root TypeScript module scaffold is future runtime generalization
-  work.
-- Promoting the runtime envelope beyond fresh-runtime plus selected context
-  roots is deferred until production host bindings require runtime-global heap
-  state outside those roots.
-- Unsupported-value path/type detail for future runtime roots outside the
-  selected context-root graph is deferred with those roots.
+- Visual editor work is not planned.
+- Automatic `.star` to `.ts` conversion is not required.
+- Node package compatibility (npm) inside agents is not required for v1.
+- Polyglot snippet execution (`execJs`/`execPython`/`execWasm`) was removed with
+  the WASM/Python sandboxes (#39) and has no replacement.
+- VM-image snapshot/restore of suspended continuations is descoped: durability
+  is the deterministic-replay journal. (The QuickJS-era live-VM snapshot design
+  in `docs/typescript-vm-snapshot-runtime.md` is historical.)
+- `Intl`, `Temporal`, `Atomics`/`SharedArrayBuffer`, `WeakRef`/finalizers,
+  `ShadowRealm`, decorators, and iterator helpers are intentionally unsupported
+  and skipped honestly by the conformance runner.

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -139,8 +139,9 @@ struct RuntimeContextInner {
     /// `delivery_seq` matching entry and immediately re-persists the shrunken
     /// inbox so a crash can't double-deliver (see `docs/signals.md` §8.4/§10).
     pub signal_inbox: Vec<QueuedSignal>,
-    /// Durable host-promise bookkeeping. This is snapshot-serializable Rust
-    /// state; the QuickJS fork will bind these ids to real JS promises.
+    /// Durable host-promise bookkeeping: snapshot-serializable Rust state that
+    /// pairs each pending host operation id with its eventual result for the
+    /// deterministic-replay journal.
     #[allow(dead_code)]
     pub host_promises: HostPromiseTable,
     /// Optional live-event sink. When set, every `record_call` is also

--- a/src/runtime/rust_engine.rs
+++ b/src/runtime/rust_engine.rs
@@ -102,12 +102,11 @@ pub fn run_agent(
     run_module(path, source, "agent", inputs, backend)
 }
 
-/// Reframe a chidori-js entrypoint error the way the QuickJS host does, so an
-/// uncaught JS exception surfaces identically on both engines: as
-/// `JavaScript exception: <message>` (see `snapshot_export_error` on the QuickJS
-/// path). chidori-js stringifies a thrown `Error` as `"<Name>: <message>"`; we
-/// strip the standard error-class prefix to recover the bare message and apply
-/// the host framing. Pause sentinels pass through untouched — they are control
+/// Reframe a chidori-js entrypoint error so an uncaught JS exception surfaces
+/// as `JavaScript exception: <message>` — the shape the durable format, the
+/// host-call span tree, and the SDKs expect. chidori-js stringifies a thrown
+/// `Error` as `"<Name>: <message>"`; we strip the standard error-class prefix
+/// to recover the bare message and apply the host framing. Pause sentinels pass through untouched — they are control
 /// flow, not exceptions, and `engine.rs` / `host_core` detect them by substring.
 fn js_exception_message(err: &str) -> String {
     if err.contains(crate::runtime::context::PAUSE_MARKER) {
@@ -133,8 +132,7 @@ fn js_exception_message(err: &str) -> String {
 
 /// Run a nested TypeScript **tool** file natively on the rust engine (G4).
 ///
-/// Re-enters [`run_module`] with the tool's `run(args)` entrypoint instead of
-/// bouncing the nested call back into QuickJS via `TypeScriptVmRuntime`. The
+/// Re-enters [`run_module`] with the tool's `run(args)` entrypoint. The
 /// same `backend` (hence the same `RuntimeContext`) is threaded through, so the
 /// tool's host effects nest under the parent tool call (`parent_seq`) and share
 /// the durable call log, policy, MCP, and OTEL span tree. A suspension inside
@@ -314,8 +312,8 @@ fn panic_payload_message(panic: &(dyn std::any::Any + Send)) -> String {
 /// Transpile `source`, run it as a module on a fresh `chidori-js` engine, and
 /// invoke its entrypoint with `input`. The entrypoint is whatever the module
 /// passed to `run(handler)`, or `fallback_export` (e.g. `agent` for agents). The
-/// VM's `chidori.*` effects are forwarded to `backend.dispatch`, the same
-/// durable host machinery the QuickJS bindings use.
+/// VM's `chidori.*` effects are forwarded to `backend.dispatch`, the durable
+/// host machinery in `host_core`.
 fn run_module(
     path: &Path,
     source: &str,
@@ -325,8 +323,8 @@ fn run_module(
 ) -> Result<Value> {
     // `Node` accepts relative `./foo` imports *and* allowlisted `node:` builtins
     // (the special-cased `chidori` SDK import is stripped by transpilation). This
-    // matches the QuickJS path's durable default so `node:fs`/`crypto`/`timers`
-    // reach the captured-effect natives installed below.
+    // is the durable default so `node:fs`/`crypto`/`timers` reach the
+    // captured-effect natives installed below.
     let opts = TranspileOptions {
         import_policy: TypeScriptImportPolicy::Node,
     };
@@ -358,7 +356,7 @@ fn run_module(
         Rc::new(move |effect: &str, args: &Value| backend.dispatch(effect, args));
     engine.install_chidori_effects(dispatch);
     // Install the JS-level `chidori` SDK sugar (tryCall/retry/parallel + the
-    // memory.set/get/delete/clear wrappers) that the QuickJS path also installs.
+    // memory.set/get/delete/clear wrappers).
     // These are pure-JS helpers layered on top of the native host object, so they
     // must run *after* `install_chidori_effects` (the memory sugar wraps the
     // native `chidori.memory`, and the script's guarded workspace shim no-ops
@@ -491,11 +489,9 @@ fn fs_policy_guard(policy: &RuntimePolicy) -> std::result::Result<(), String> {
     }
 }
 
-/// Captured randomness, replaying byte-for-byte with the QuickJS path: the
-/// result is keyed by the shared call-log sequence and recorded as a
-/// `crypto.random` `CallRecord` (unless `crypto=host`), so a resumed run draws
-/// the identical bytes. Mirrors `execute_captured_random` in the QuickJS
-/// snapshot host.
+/// Captured randomness: the result is keyed by the call-log sequence and
+/// recorded as a `crypto.random` `CallRecord` (unless `crypto=host`), so a
+/// resumed run draws the identical bytes byte-for-byte on replay.
 fn execute_captured_random(
     ctx: &RuntimeContext,
     policy: &RuntimePolicy,
@@ -542,8 +538,8 @@ fn execute_captured_random(
 
 /// Build the `__chidori_*` sync-native dispatcher. Crypto hashing/HMAC are pure
 /// and inline; randomness is captured through the call log; the VFS ops operate
-/// on the same snapshot-resident `RuntimeContext` filesystem the QuickJS path
-/// uses — so a `node:fs`/`node:crypto` agent replays identically on either engine.
+/// on the snapshot-resident `RuntimeContext` filesystem — so a
+/// `node:fs`/`node:crypto` agent records and replays deterministically.
 fn build_sync_native_dispatch(
     ctx: RuntimeContext,
     policy: RuntimePolicy,
@@ -682,9 +678,8 @@ fn build_sync_native_dispatch(
 /// The determinism prelude installed on the rust engine before an agent runs:
 /// the logical clock, `process.env`, UTF-8/base64 text primitives, the Web
 /// Crypto subset, and the virtual timer queue. Date and `Math.random`
-/// determinism are already native to `chidori-js`, so (unlike the QuickJS
-/// prelude) this installs no Date/random shims. The polyfill sources are shared
-/// verbatim with the QuickJS path.
+/// determinism are already native to `chidori-js`, so this installs no
+/// Date/random shims.
 fn rust_engine_prelude(policy: &RuntimePolicy) -> String {
     use crate::runtime::typescript::helpers::{
         chidori_agent_env_json, TEXT_ENCODING_POLYFILL, TIMER_DISABLED_POLYFILL,
@@ -803,7 +798,7 @@ mod tests {
         assert_eq!(output, serde_json::json!({ "value": 42 }));
 
         // The host effect flowed through host_core → the RuntimeContext call log,
-        // exactly like the QuickJS path (so durability + host-call spans work).
+        // so durability + host-call spans work.
         let records = ctx.call_log().into_records();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].function, "log");
@@ -849,7 +844,7 @@ mod tests {
     fn run_agent_nests_tool_internal_calls_under_the_tool_on_rust_engine() {
         // A TypeScript tool whose `run` makes its own chidori.log calls: those
         // must be recorded as CHILDREN of the tool call (parent_seq = tool seq),
-        // exactly like the QuickJS path — so the trace nests on the rust engine.
+        // so the trace nests correctly.
         let ctx = RuntimeContext::new();
         let dir = std::env::temp_dir().join(format!("chidori-rust-tool-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(dir.join("tools")).unwrap();
@@ -971,8 +966,8 @@ mod tests {
     #[test]
     fn run_agent_exposes_chidori_js_sdk_helpers() {
         // The JS-level SDK sugar (tryCall/retry/parallel + memory.set/get/delete/
-        // clear) is shared with the QuickJS path via CHIDORI_JS_HELPERS_SCRIPT and
-        // installed after the native host object. The agent below never defines
+        // clear) is loaded from CHIDORI_JS_HELPERS_SCRIPT and installed after
+        // the native host object. The agent below never defines
         // these itself, so it only passes if the engine layered them on — a
         // regression guard for the meta-agent's `chidori.retry`/`chidori.parallel`
         // calls, which otherwise hit "undefined is not a function".

--- a/src/runtime/snapshot.rs
+++ b/src/runtime/snapshot.rs
@@ -710,8 +710,10 @@ pub enum SnapshotBlobKind {
     /// Current scaffold: a serialized set of TypeScript context roots after
     /// initial module evaluation, not a suspended VM continuation.
     InitialTypeScriptStateScaffold,
-    /// Future production path: a live QuickJS VM snapshot containing async
-    /// continuations, job queues, module records, and heap roots.
+    /// Legacy blob kind for a live VM-image snapshot (async continuations, job
+    /// queues, module records, and heap roots). VM-image snapshots are descoped
+    /// — durability is the deterministic-replay journal — but the variant is
+    /// retained for manifest compatibility (serialized as `live_quick_js_vm`).
     LiveQuickJsVm,
 }
 

--- a/src/runtime/typescript/bindings.rs
+++ b/src/runtime/typescript/bindings.rs
@@ -743,9 +743,8 @@ impl HostBindingBackend {
         host_core::execute_http(tokio_rt, args).map_err(|err| err.to_string())
     }
 
-    /// Build the runtime backend. Shared by the QuickJS bindings and the
-    /// pure-Rust engine's effect dispatcher so both route host effects through
-    /// identical durable machinery.
+    /// Build the runtime backend that the engine's effect dispatcher routes
+    /// host effects through, into the durable host machinery.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn for_runtime(
         runtime_ctx: RuntimeContext,
@@ -810,9 +809,9 @@ impl HostBindingBackend {
         }
     }
 
-    /// The durable runtime policy, when this is the runtime backend. The rust
+    /// The durable runtime policy, when this is the runtime backend. The
     /// engine reads it to install the captured-effect natives (`node:` crypto /
-    /// fs / timers) under the same fs/crypto/timer gates the QuickJS path honors.
+    /// fs / timers) under the fs/crypto/timer gates the policy declares.
     pub(crate) fn runtime_policy(&self) -> Option<crate::runtime::snapshot::RuntimePolicy> {
         match self {
             HostBindingBackend::Runtime { runtime_policy, .. } => Some(runtime_policy.clone()),
@@ -820,10 +819,9 @@ impl HostBindingBackend {
         }
     }
 
-    /// Route one `chidori.<effect>(args)` call from the pure-Rust engine through
-    /// the same durable host machinery the QuickJS bindings use. The arg shapes
-    /// mirror what `chidori-js`'s `install_chidori_effects` forwards, so the two
-    /// engines produce identical call logs.
+    /// Route one `chidori.<effect>(args)` call from the engine through the
+    /// durable host machinery. The arg shapes mirror what `chidori-js`'s
+    /// `install_chidori_effects` forwards.
     pub(crate) fn dispatch(
         &self,
         effect: &str,
@@ -987,9 +985,7 @@ impl HostBindingBackend {
                         .to_string();
                     (url, first.clone())
                 } else {
-                    return Err(
-                        "http request requires a URL string or options object".to_string()
-                    );
+                    return Err("http request requires a URL string or options object".to_string());
                 };
                 let mut method = options
                     .get("method")

--- a/src/runtime/typescript/builtins.rs
+++ b/src/runtime/typescript/builtins.rs
@@ -1452,9 +1452,9 @@ pub fn source_for(path: &Path) -> Option<&'static str> {
 
 /// Return the synthetic builtin source for a `node:` builtin *name* (e.g.
 /// `"crypto"` or `"fs/promises"`), or `None` if the name isn't an allowlisted
-/// builtin. The rust engine's module loader serves `node:` specifiers straight
-/// from this (no synthetic filesystem path), while the QuickJS bundler reaches
-/// it through [`source_for`].
+/// builtin. The module loader serves `node:` specifiers straight from this by
+/// name; [`source_for`] is the by-path wrapper for the synthetic
+/// `__node_builtins__/` resolved paths.
 pub fn shim_source(name: &str) -> Option<&'static str> {
     match name {
         "process" => Some(PROCESS_SHIM),

--- a/src/runtime/typescript/transpile.rs
+++ b/src/runtime/typescript/transpile.rs
@@ -133,7 +133,7 @@ pub fn transpile_module(path: &Path, source: &str, options: &TranspileOptions) -
     // Defaults strip TypeScript syntax (types, interfaces, `as`/`satisfies`,
     // `import type`) and leave modern JS untouched. `enable_all()` would also
     // downlevel async/await, optional chaining, and nullish coalescing into
-    // helper-import-heavy generator code — the quickjs runtime supports the
+    // helper-import-heavy generator code — the engine supports the
     // modern forms natively, so we explicitly avoid that.
     let transform_options = TransformOptions::default();
     let transformer_ret = Transformer::new(&allocator, path, &transform_options)
@@ -471,7 +471,7 @@ pub(crate) fn resolve_relative_import(
     }
     // Bundler-style extension probing. ts-node, Bun, Deno, and the TS Bundler
     // resolver all let `import "./tools/x"` resolve to `./tools/x.ts`; agents
-    // should not have to know our quickjs loader is stricter. If the specifier
+    // should not have to know our module loader is stricter. If the specifier
     // already names a file (with or without a known extension), use it as-is.
     // Otherwise probe `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs` and return the first
     // that exists. If none exist, default to the `.ts` candidate so a missing-

--- a/src/server.rs
+++ b/src/server.rs
@@ -2384,11 +2384,10 @@ async fn approve_session(
         return (StatusCode::OK, Json(session_view(&original))).into_response();
     }
 
-    // Allow path: record the approval. The live-VM resume below handles the
-    // QuickJS path by resuming the frozen VM; if that doesn't apply (e.g. the
-    // rust engine, whose durability is call-log replay), the fallback further
-    // down replays the recorded log with the approval seeded so prior host
-    // calls return their results and only the blocked call re-executes.
+    // Allow path: record the approval. Durability is call-log replay, so the
+    // resume below replays the recorded log with the approval seeded — prior
+    // host calls return their recorded results and only the blocked call
+    // re-executes.
     original
         .approvals
         .push((pending.target.clone(), pending.args.clone()));


### PR DESCRIPTION
## Summary

This PR updates the TODO.md and DESIGN.md documentation to reflect the completion of the JavaScript-engine consolidation work (#39). The docs now accurately describe the current state where all execution (agents, tools, sub-agents, and Test262 conformance) runs on a single in-tree pure-Rust engine (`crates/chidori-js`), with the vendored QuickJS fork, `rquickjs` parity path, and WASM/Python exec sandboxes removed.

## Key Changes

**TODO.md:**
- Removed the "TypeScript-runtime migration" framing; the migration is complete
- Consolidated the "Completed Migration Work" section into a brief summary of what was done
- Clarified that durability is now the deterministic-replay journal, not VM-image snapshots
- Reorganized remaining work into three categories:
  - **Conformance (standing bar)** — Test262 is load-bearing with no fallback engine; detailed clusters to tackle (UTF-16 string representation is highest-leverage)
  - **Product follow-through** — SDK publishing, TypeScript SDK tests, broader `node:` allowlist, providers/modalities, code-comment cleanup
  - **Sandbox hardening** — per-VM memory accounting, per-tenant CPU quota, deeper policy matching
  - **Optional feature extensions** — Branching Phase 3, Signals enhancements, Context management extensions
- Updated the "Deferred Or Descoped" section to reflect that `execJs`/`execPython`/`execWasm` sandboxes were removed and VM-image snapshots are descoped in favor of the journal

**DESIGN.md:**
- Clarified that `crates/chidori-js` is the single pure-Rust JavaScript engine (oxc-based, zero `unsafe`)
- Removed references to the QuickJS fork, `rquickjs`, and WASM/Python sandboxes as active components
- Updated the "Current State" section to describe the actual architecture:
  - `crates/chidori-js` as the engine with its components (parser, bytecode compiler, GC, regex, journal, host seam)
  - `crates/test262-runner` for conformance gating
  - Simplified the TypeScript runtime module descriptions to match the current codebase
- Clarified that durability is the deterministic-replay journal, not VM snapshots
- Updated the "Determinism Policy" table to include filesystem, crypto, and timers policies
- Removed outdated references to "live VM snapshot resume" and "direct live VM continuation"
- Updated the project layout to reflect the actual module structure without QuickJS-related crates

## Notable Details

- The docs now honestly reflect that there is no fallback engine, making Test262 conformance a load-bearing quality gate
- The "Replay And Resume" section now correctly describes the journal-based approach rather than VM-image snapshots
- Removed ~190 lines of completed-work checklist items that are no longer relevant
- Added references to the conformance methodology and sandbox-model docs as the authoritative sources for those topics
- The non-goals section now includes the removal of polyglot snippet execution and clarifies that VM-image snapshots are descoped

https://claude.ai/code/session_01PiApKAcRNmjcm9UYhzCWiL