### PR TITLE
Add cross-runtime benchmark suite for chidori-js

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -1,0 +1,98 @@
+name: JS benchmarks
+
+# Runs the chidori-js cross-runtime benchmark suite (chidori-js vs Node.js vs
+# Bun) on PRs that touch the engine, and posts the results table as a single
+# sticky comment on the PR (updated in place on each run, not re-posted).
+#
+# These numbers come from a shared GitHub-hosted runner, so treat them as
+# ratios for a quick smell-test, not as a precise performance gate — the job
+# never fails the build on timing, only on a correctness mismatch between
+# runtimes (which the harness exits non-zero on).
+on:
+  pull_request:
+    paths:
+      - "crates/chidori-js/**"
+      - ".github/workflows/js-benchmarks.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: js-benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: chidori-js vs Node vs Bun
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Reuse the engine build cache so we don't pay a cold compile every run.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: js-benchmarks
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build chidori-js run example (release)
+        run: cargo build --release -p chidori-js --example run
+
+      - name: Run cross-runtime benchmarks
+        run: |
+          node crates/chidori-js/benchmarks/run.mjs \
+            --no-build \
+            --markdown benchmark-report.md \
+            --json benchmark-report.json
+
+      - name: Upload benchmark report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-benchmark-report
+          path: |
+            benchmark-report.md
+            benchmark-report.json
+
+      # Post/update the sticky PR comment. Skipped for fork PRs (their token is
+      # read-only and can't comment) and for manual workflow_dispatch runs.
+      - name: Comment benchmark results on PR
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- chidori-js-benchmarks -->';
+            const body = fs.readFileSync('benchmark-report.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+              core.info(`Updated benchmark comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+              core.info('Created benchmark comment');
+            }

--- a/crates/chidori-js/benches/execution.rs
+++ b/crates/chidori-js/benches/execution.rs
@@ -11,6 +11,10 @@
 //!                  (isolates the interpreter dispatch loop from the front end).
 //!
 //! Run with: `cargo bench -p chidori-js`
+//!
+//! These isolate chidori-js's own hot paths in-process. For a cross-runtime
+//! comparison of the same workloads against Node.js and Bun, see the harness in
+//! `benchmarks/` (`node crates/chidori-js/benchmarks/run.mjs`).
 
 use std::rc::Rc;
 use std::time::Duration;

--- a/crates/chidori-js/benchmarks/README.md
+++ b/crates/chidori-js/benchmarks/README.md
@@ -58,7 +58,22 @@ Two tables are printed:
   loses the *execution* — this table makes that visible.
 
 Pass `--json PATH` to also dump every sample (min/median/mean/max per runtime)
-for offline analysis.
+for offline analysis, or `--markdown PATH` to write the same two tables as a
+Markdown report.
+
+## CI integration
+
+[`.github/workflows/js-benchmarks.yml`](../../../.github/workflows/js-benchmarks.yml)
+runs this suite on every PR that touches `crates/chidori-js/**` and posts the
+Markdown report (`--markdown`) as a **single sticky comment** on the PR —
+updated in place on each push, never re-posted. The full report is also uploaded
+as a build artifact (`js-benchmark-report`).
+
+The job only fails the build on a **correctness mismatch** between runtimes (the
+harness exits non-zero), never on timing — the numbers come from a shared
+GitHub-hosted runner and are meant as a ratio smell-test, not a hard perf gate.
+The comment step is skipped for fork PRs (their token can't comment) and for
+manual `workflow_dispatch` runs; the artifact is still available in both cases.
 
 ## How it stays honest
 

--- a/crates/chidori-js/benchmarks/README.md
+++ b/crates/chidori-js/benchmarks/README.md
@@ -1,0 +1,114 @@
+# chidori-js cross-runtime benchmarks
+
+A suite that runs the **same JavaScript workloads** under three runtimes and
+compares wall-clock execution time:
+
+| runtime    | what it is                                                            |
+| ---------- | --------------------------------------------------------------------- |
+| `chidori`  | the pure-Rust `chidori-js` engine (via the `run` example binary)      |
+| `node`     | Node.js (V8)                                                          |
+| `bun`      | Bun (JavaScriptCore)                                                  |
+
+This sits alongside the in-process [`benches/execution.rs`](../benches/execution.rs)
+criterion micro-benchmarks. Those isolate chidori-js's own hot paths (compile /
+interpret / realm setup) in-process; **this** suite answers the different
+question "how does chidori-js compare to the JITs people actually ship?" by
+running each workload as a standalone script under all three runtimes.
+
+## Quick start
+
+```sh
+# From the repo root. Builds the chidori `run` example (release) on first run.
+node crates/chidori-js/benchmarks/run.mjs
+
+# Faster smoke run (fewer iterations):
+node crates/chidori-js/benchmarks/run.mjs --quick
+
+# One workload, more samples, save raw data:
+node crates/chidori-js/benchmarks/run.mjs --filter fib --runs 15 --json out.json
+```
+
+Node.js is required to run the harness. Bun is optional — if `bun` isn't on
+`PATH` it is skipped with a warning. The chidori binary is built automatically
+unless you pass `--no-build` (and point at a prebuilt binary via `--chidori-bin`
+or `$CHIDORI_RUN_BIN`).
+
+## What it reports
+
+```
+Execution-only time (subprocess wall-clock minus startup baseline)
+Startup baselines: chidori 3.4ms  node 33.8ms  bun 9.8ms
+
+workload             chidori         node          bun    fastest
+-----------------------------------------------------------------
+arith_loop       727.1ms 167.0x   7.2ms 1.6x        4.4ms        bun
+fib_recursive    2.15s 228.4x  11.8ms 1.3x        9.4ms        bun
+...
+```
+
+Two tables are printed:
+
+- **Execution-only** — raw subprocess time **minus that runtime's startup
+  baseline** (measured separately with `workloads/startup.js`). This is the
+  fairer engine-vs-engine number. The `N.Nx` suffix is the slowdown relative to
+  the fastest runtime on that row.
+- **Total including startup** — the raw `spawn → exit` wall-clock. chidori-js is
+  a small native binary and starts in ~3ms, whereas Node pays ~34ms of V8/runtime
+  startup, so for very short scripts chidori can win the *total* even when it
+  loses the *execution* — this table makes that visible.
+
+Pass `--json PATH` to also dump every sample (min/median/mean/max per runtime)
+for offline analysis.
+
+## How it stays honest
+
+Every workload prints exactly one `RESULT=<value>` line. The harness extracts it
+from each runtime's stdout and **asserts all runtimes produced the same value**
+before reporting timings — a fast-but-wrong engine is not a faster engine. If any
+workload disagrees the row is flagged and the process exits non-zero. The
+`sort` workload seeds a deterministic LCG so all three runtimes sort identical
+input and must agree on the checksum.
+
+## Workloads
+
+Each file in `workloads/` is plain ES that runs unmodified on all three runtimes
+and mirrors (scaled up) an `execution.rs` micro-benchmark where one exists:
+
+| workload          | exercises                                                       |
+| ----------------- | -------------------------------------------------------------- |
+| `arith_loop`      | tight numeric loop — interpreter dispatch + arithmetic         |
+| `fib_recursive`   | recursion + call-frame setup/teardown                          |
+| `property_access` | object property get/set in a loop                              |
+| `array_push_sum`  | array growth + indexed reads                                   |
+| `array_hof`       | `map`/`filter`/`reduce` with per-element closures              |
+| `string_build`    | `+=` string building + number→string coercion                  |
+| `closures`        | closure capture + higher-order calls in a loop                 |
+| `json_roundtrip`  | `JSON.stringify` / `JSON.parse` over a nested object           |
+| `sort`            | `Array.prototype.sort` with a comparator                       |
+| `startup.js`      | near-empty script — used only for the startup baseline         |
+
+Iteration counts are tuned so each workload takes a meaningful-but-bounded time
+on the chidori-js interpreter (~0.2–2s); on the JITs they finish in single-digit
+to low-tens of milliseconds. To stress a runtime harder, bump the `N` / `ROUNDS`
+constant at the top of a workload file — they're deliberately one-liners.
+
+## Adding a workload
+
+1. Drop a `<name>.js` in `workloads/`. It must run on Node, Bun, and chidori-js
+   (the engine is a growing subset of ES — stick to widely-supported syntax and
+   the built-ins chidori-js implements).
+2. End it with `console.log("RESULT=" + <deterministic value>)` so the harness
+   can cross-check correctness. Avoid `Date.now()`, `Math.random()`, or anything
+   else that varies between runs or runtimes in the reported value.
+3. Run `node run.mjs --filter <name>` and confirm it reports `ok` (not a
+   `RESULT MISMATCH`).
+
+## Caveats
+
+- Absolute numbers are machine-, load-, and version-dependent; treat them as
+  ratios on a quiet machine, not as a leaderboard. The sample table above is
+  illustrative.
+- This measures whole-script subprocess runs, so it captures parse + compile +
+  execute, not steady-state JIT throughput. For chidori-js (an interpreter) that
+  is representative; for V8/JSC it understates peak throughput on long-running
+  code because much of the run is spent warming up.

--- a/crates/chidori-js/benchmarks/run.mjs
+++ b/crates/chidori-js/benchmarks/run.mjs
@@ -22,6 +22,7 @@
 //   --chidori-bin PATH  path to the chidori `run` example binary
 //   --no-build          do not `cargo build` the chidori binary first
 //   --json PATH         also write the full results as JSON to PATH
+//   --markdown PATH     also write a Markdown report to PATH (used by CI)
 //   --quick             shorthand for --runs 3 --warmup 0
 //   -h, --help          show this help
 //
@@ -52,6 +53,7 @@ function parseArgs(argv) {
     chidoriBin: process.env.CHIDORI_RUN_BIN || null,
     build: true,
     json: null,
+    markdown: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -64,6 +66,7 @@ function parseArgs(argv) {
       case "--chidori-bin": opts.chidoriBin = next(); break;
       case "--no-build": opts.build = false; break;
       case "--json": opts.json = next(); break;
+      case "--markdown": opts.markdown = next(); break;
       case "--quick": opts.runs = 3; opts.warmup = 0; break;
       case "-h": case "--help": printHelp(); process.exit(0); break;
       default:
@@ -94,6 +97,7 @@ function printHelp() {
       "  --chidori-bin PATH  path to the chidori `run` example binary",
       "  --no-build          do not cargo build the chidori binary first",
       "  --json PATH         also write the full results as JSON to PATH",
+      "  --markdown PATH     also write a Markdown report to PATH (used by CI)",
       "  --quick             shorthand for --runs 3 --warmup 0",
       "  -h, --help          show this help",
     ].join("\n"),
@@ -231,6 +235,23 @@ function padLeft(s, w) {
   return s.length >= w ? s : " ".repeat(w - s.length) + s;
 }
 
+// Execution-only time per runtime for one workload (median minus that runtime's
+// startup baseline), plus which runtime was fastest. The fastest is the
+// reference for the "x" slowdown factors. Shared by the text and Markdown
+// reporters so they can't drift.
+function execTimes(w, rtNames, baselines) {
+  const execByName = {};
+  for (const n of rtNames) {
+    const r = w.byRuntime[n];
+    execByName[n] = r ? Math.max(0, r.median - baselines[n]) : null;
+  }
+  const finite = Object.values(execByName).filter((v) => v != null && v > 0);
+  const best = finite.length ? Math.min(...finite) : null;
+  let fastestName = "";
+  for (const n of rtNames) if (execByName[n] != null && execByName[n] === best) fastestName = n;
+  return { execByName, best, fastestName };
+}
+
 function printTable(workloads, runtimes, baselines) {
   const rtNames = runtimes.map((r) => r.name);
   // Fastest runtime per workload is the reference for the "x" speedup columns.
@@ -250,21 +271,12 @@ function printTable(workloads, runtimes, baselines) {
 
   for (const w of workloads) {
     let row = pad(w.name, nameW);
-    const execByName = {};
-    for (const n of rtNames) {
-      const r = w.byRuntime[n];
-      const exec = r ? Math.max(0, r.median - baselines[n]) : null;
-      execByName[n] = exec;
-    }
-    const finite = Object.values(execByName).filter((v) => v != null && v > 0);
-    const best = finite.length ? Math.min(...finite) : null;
-    let fastestName = "";
+    const { execByName, best, fastestName } = execTimes(w, rtNames, baselines);
     for (const n of rtNames) {
       const exec = execByName[n];
       if (exec == null) { row += "  " + padLeft("—", COL); continue; }
       const factor = best && exec > 0 ? exec / best : 1;
       const cell = factor <= 1.001 ? fmtMs(exec) : `${fmtMs(exec)} ${factor.toFixed(1)}x`;
-      if (exec === best) fastestName = n;
       row += "  " + padLeft(cell, COL);
     }
     row += "  " + padLeft(fastestName, 9);
@@ -284,6 +296,70 @@ function printTable(workloads, runtimes, baselines) {
     }
     console.log(row);
   }
+}
+
+// Stable HTML marker so CI can find-and-update its single sticky comment
+// instead of posting a new one every run.
+const MARKDOWN_MARKER = "<!-- chidori-js-benchmarks -->";
+
+// Render the results as a Markdown report (used for the PR comment).
+function renderMarkdown(workloads, runtimes, baselines, opts) {
+  const rtNames = runtimes.map((r) => r.name);
+  const lines = [];
+  lines.push(MARKDOWN_MARKER);
+  lines.push("## chidori-js cross-runtime benchmarks");
+  lines.push("");
+  lines.push(
+    `Same JS workloads run under **chidori-js**, **Node.js**, and **Bun** ` +
+      `(${opts.runs} timed run(s) + ${opts.warmup} warmup each, median reported). ` +
+      `All workloads cross-checked to produce identical results.`,
+  );
+  lines.push("");
+  lines.push(
+    "**Startup baselines:** " +
+      rtNames.map((n) => `${n} ${fmtMs(baselines[n])}`).join(" · "),
+  );
+  lines.push("");
+
+  // Table 1: execution-only (startup subtracted), with slowdown factors.
+  lines.push("### Execution-only time (startup baseline subtracted)");
+  lines.push("");
+  lines.push(`| workload | ${rtNames.join(" | ")} | fastest |`);
+  lines.push(`|${"---|".repeat(rtNames.length + 2)}`);
+  for (const w of workloads) {
+    const { execByName, best, fastestName } = execTimes(w, rtNames, baselines);
+    const cells = rtNames.map((n) => {
+      const exec = execByName[n];
+      if (exec == null) return "—";
+      const factor = best && exec > 0 ? exec / best : 1;
+      const txt = factor <= 1.001 ? `**${fmtMs(exec)}**` : `${fmtMs(exec)} (${factor.toFixed(1)}×)`;
+      return txt;
+    });
+    const flag = w.agree ? "" : " ⚠️";
+    lines.push(`| ${w.name}${flag} | ${cells.join(" | ")} | ${fastestName} |`);
+  }
+  lines.push("");
+
+  // Table 2: raw total wall-clock including startup.
+  lines.push("### Total time including startup (raw wall-clock)");
+  lines.push("");
+  lines.push(`| workload | ${rtNames.join(" | ")} |`);
+  lines.push(`|${"---|".repeat(rtNames.length + 1)}`);
+  for (const w of workloads) {
+    const cells = rtNames.map((n) => {
+      const r = w.byRuntime[n];
+      return r ? fmtMs(r.median) : "—";
+    });
+    lines.push(`| ${w.name} | ${cells.join(" | ")} |`);
+  }
+  lines.push("");
+  lines.push(
+    "<sub>Numbers are machine- and load-dependent (shared CI runner) — read them " +
+      "as ratios, not absolutes. chidori-js is an interpreter, so it trails the " +
+      "V8/JSC JITs on compute but starts far faster. A ⚠️ marks a workload whose " +
+      "result disagreed across runtimes.</sub>",
+  );
+  return lines.join("\n") + "\n";
 }
 
 // ---------------------------------------------------------------------------
@@ -370,6 +446,11 @@ async function main() {
     };
     writeFileSync(opts.json, JSON.stringify(payload, null, 2));
     console.log(`\nwrote ${opts.json}`);
+  }
+
+  if (opts.markdown) {
+    writeFileSync(opts.markdown, renderMarkdown(workloads, runtimes, baselines, opts));
+    console.log(`\nwrote ${opts.markdown}`);
   }
 
   process.exit(mismatches > 0 ? 1 : 0);

--- a/crates/chidori-js/benchmarks/run.mjs
+++ b/crates/chidori-js/benchmarks/run.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+// Cross-runtime benchmark harness for the chidori-js JavaScript engine.
+//
+// Runs each workload in `workloads/` as a standalone script under chidori-js,
+// Node.js, and Bun, measuring subprocess wall-clock time. The same `.js` file
+// is fed to all three runtimes and every workload prints a single `RESULT=...`
+// line, so the harness can confirm the runtimes agree before trusting the
+// timings (a fast-but-wrong engine is not a faster engine).
+//
+// Each runtime pays a fixed process-startup cost (binary load + realm setup).
+// We measure that separately with `workloads/startup.js` and subtract it to
+// report an execution-only estimate alongside the raw total.
+//
+// Usage:
+//   node benchmarks/run.mjs [options]
+//
+// Options:
+//   --runs N            timed runs per workload (default 5)
+//   --warmup N          untimed warmup runs per workload (default 1)
+//   --filter SUBSTR     only run workloads whose name contains SUBSTR
+//   --runtimes LIST     comma-separated subset of {chidori,node,bun}
+//   --chidori-bin PATH  path to the chidori `run` example binary
+//   --no-build          do not `cargo build` the chidori binary first
+//   --json PATH         also write the full results as JSON to PATH
+//   --quick             shorthand for --runs 3 --warmup 0
+//   -h, --help          show this help
+//
+// Environment:
+//   CHIDORI_RUN_BIN     same as --chidori-bin
+
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileP = promisify(execFile);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..", "..");
+const WORKLOAD_DIR = join(HERE, "workloads");
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = {
+    runs: 5,
+    warmup: 1,
+    filter: null,
+    runtimes: null,
+    chidoriBin: process.env.CHIDORI_RUN_BIN || null,
+    build: true,
+    json: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--runs": opts.runs = Number(next()); break;
+      case "--warmup": opts.warmup = Number(next()); break;
+      case "--filter": opts.filter = next(); break;
+      case "--runtimes": opts.runtimes = next().split(",").map((s) => s.trim()).filter(Boolean); break;
+      case "--chidori-bin": opts.chidoriBin = next(); break;
+      case "--no-build": opts.build = false; break;
+      case "--json": opts.json = next(); break;
+      case "--quick": opts.runs = 3; opts.warmup = 0; break;
+      case "-h": case "--help": printHelp(); process.exit(0); break;
+      default:
+        console.error(`unknown option: ${a}`);
+        printHelp();
+        process.exit(2);
+    }
+  }
+  if (!Number.isFinite(opts.runs) || opts.runs < 1) {
+    console.error("--runs must be a positive integer");
+    process.exit(2);
+  }
+  return opts;
+}
+
+function printHelp() {
+  // The banner comment at the top of this file is the canonical help text.
+  console.log(
+    [
+      "Cross-runtime benchmark harness for chidori-js (vs Node.js and Bun).",
+      "",
+      "Usage: node benchmarks/run.mjs [options]",
+      "",
+      "  --runs N            timed runs per workload (default 5)",
+      "  --warmup N          untimed warmup runs per workload (default 1)",
+      "  --filter SUBSTR     only run workloads whose name contains SUBSTR",
+      "  --runtimes LIST     comma-separated subset of {chidori,node,bun}",
+      "  --chidori-bin PATH  path to the chidori `run` example binary",
+      "  --no-build          do not cargo build the chidori binary first",
+      "  --json PATH         also write the full results as JSON to PATH",
+      "  --quick             shorthand for --runs 3 --warmup 0",
+      "  -h, --help          show this help",
+    ].join("\n"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Runtime discovery
+// ---------------------------------------------------------------------------
+
+function whichSync(cmd) {
+  try {
+    return execFileSync("sh", ["-c", `command -v ${cmd}`], { encoding: "utf8" }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+// Build the chidori `run` example in release mode and return its path. The
+// binary reads a JS file path as argv[1], evaluates it, and prints console
+// output followed by `=> <value>` — we only care about the `RESULT=` line.
+function resolveChidoriBin(opts) {
+  if (opts.chidoriBin) {
+    if (!existsSync(opts.chidoriBin)) {
+      throw new Error(`chidori binary not found: ${opts.chidoriBin}`);
+    }
+    return opts.chidoriBin;
+  }
+  const builtPath = join(REPO_ROOT, "target", "release", "examples", "run");
+  if (opts.build) {
+    process.stderr.write("building chidori-js run example (release)... ");
+    execFileSync("cargo", ["build", "--release", "-q", "-p", "chidori-js", "--example", "run"], {
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    process.stderr.write("done\n");
+  }
+  if (!existsSync(builtPath)) {
+    throw new Error(
+      `chidori binary not found at ${builtPath}. Build it with:\n` +
+        `  cargo build --release -p chidori-js --example run\n` +
+        `or pass --chidori-bin / --no-build with CHIDORI_RUN_BIN.`,
+    );
+  }
+  return builtPath;
+}
+
+function discoverRuntimes(opts) {
+  const names = opts.runtimes ?? ["chidori", "node", "bun"];
+  // Resolve each requested runtime lazily so excluding chidori doesn't force a
+  // Rust build, and a missing optional runtime (bun) is skipped, not fatal.
+  const resolvers = {
+    chidori: () => ({ name: "chidori", cmd: resolveChidoriBin(opts), args: [] }),
+    node: () => ({ name: "node", cmd: process.execPath, args: [] }),
+    bun: () => {
+      const bun = whichSync("bun");
+      return bun ? { name: "bun", cmd: bun, args: [] } : null;
+    },
+  };
+
+  const selected = [];
+  for (const n of names) {
+    const make = resolvers[n];
+    if (!make) {
+      process.stderr.write(`warning: unknown runtime '${n}', skipping\n`);
+      continue;
+    }
+    const rt = make();
+    if (rt) selected.push(rt);
+    else process.stderr.write(`warning: runtime '${n}' not available, skipping\n`);
+  }
+  if (selected.length === 0) throw new Error("no runtimes available to benchmark");
+  return selected;
+}
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
+
+const RESULT_RE = /RESULT=(.*)/;
+
+// Run one workload once under one runtime, returning { ms, result }.
+async function runOnce(runtime, file) {
+  const start = process.hrtime.bigint();
+  let stdout;
+  try {
+    ({ stdout } = await execFileP(runtime.cmd, [...runtime.args, file], {
+      maxBuffer: 64 * 1024 * 1024,
+    }));
+  } catch (err) {
+    throw new Error(`${runtime.name} failed on ${file}: ${err.message}`);
+  }
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  const m = stdout.match(RESULT_RE);
+  if (!m) throw new Error(`${runtime.name} produced no RESULT= line for ${file}`);
+  return { ms, result: m[1].trim() };
+}
+
+async function timeWorkload(runtime, file, runs, warmup) {
+  for (let i = 0; i < warmup; i++) await runOnce(runtime, file);
+  const samples = [];
+  let result = null;
+  for (let i = 0; i < runs; i++) {
+    const r = await runOnce(runtime, file);
+    samples.push(r.ms);
+    result = r.result;
+  }
+  return { samples, result, ...summarize(samples) };
+}
+
+function summarize(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const n = sorted.length;
+  const median = n % 2 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  const mean = sorted.reduce((a, b) => a + b, 0) / n;
+  return { min: sorted[0], max: sorted[n - 1], median, mean };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function fmtMs(ms) {
+  if (ms == null) return "—";
+  if (ms >= 1000) return (ms / 1000).toFixed(2) + "s";
+  return ms.toFixed(1) + "ms";
+}
+
+function pad(s, w) {
+  s = String(s);
+  return s.length >= w ? s : s + " ".repeat(w - s.length);
+}
+function padLeft(s, w) {
+  s = String(s);
+  return s.length >= w ? s : " ".repeat(w - s.length) + s;
+}
+
+function printTable(workloads, runtimes, baselines) {
+  const rtNames = runtimes.map((r) => r.name);
+  // Fastest runtime per workload is the reference for the "x" speedup columns.
+  const COL = 11;
+  const nameW = Math.max(12, ...workloads.map((w) => w.name.length));
+
+  console.log("\nExecution-only time (subprocess wall-clock minus startup baseline)");
+  console.log("Startup baselines: " + rtNames.map((n) => `${n} ${fmtMs(baselines[n])}`).join("  "));
+  console.log("");
+
+  // Header.
+  let header = pad("workload", nameW);
+  for (const n of rtNames) header += "  " + padLeft(n, COL);
+  header += "  " + padLeft("fastest", 9);
+  console.log(header);
+  console.log("-".repeat(header.length));
+
+  for (const w of workloads) {
+    let row = pad(w.name, nameW);
+    const execByName = {};
+    for (const n of rtNames) {
+      const r = w.byRuntime[n];
+      const exec = r ? Math.max(0, r.median - baselines[n]) : null;
+      execByName[n] = exec;
+    }
+    const finite = Object.values(execByName).filter((v) => v != null && v > 0);
+    const best = finite.length ? Math.min(...finite) : null;
+    let fastestName = "";
+    for (const n of rtNames) {
+      const exec = execByName[n];
+      if (exec == null) { row += "  " + padLeft("—", COL); continue; }
+      const factor = best && exec > 0 ? exec / best : 1;
+      const cell = factor <= 1.001 ? fmtMs(exec) : `${fmtMs(exec)} ${factor.toFixed(1)}x`;
+      if (exec === best) fastestName = n;
+      row += "  " + padLeft(cell, COL);
+    }
+    row += "  " + padLeft(fastestName, 9);
+    console.log(row);
+  }
+
+  console.log("\nTotal time including startup (raw subprocess wall-clock, median)");
+  let header2 = pad("workload", nameW);
+  for (const n of rtNames) header2 += "  " + padLeft(n, COL);
+  console.log(header2);
+  console.log("-".repeat(header2.length));
+  for (const w of workloads) {
+    let row = pad(w.name, nameW);
+    for (const n of rtNames) {
+      const r = w.byRuntime[n];
+      row += "  " + padLeft(r ? fmtMs(r.median) : "—", COL);
+    }
+    console.log(row);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const runtimes = discoverRuntimes(opts);
+
+  // Discover workloads (excluding the startup baseline probe).
+  const { readdirSync } = await import("node:fs");
+  let files = readdirSync(WORKLOAD_DIR)
+    .filter((f) => f.endsWith(".js") && f !== "startup.js")
+    .sort();
+  if (opts.filter) files = files.filter((f) => f.includes(opts.filter));
+  if (files.length === 0) throw new Error("no workloads matched");
+
+  console.log(
+    `chidori-js cross-runtime benchmarks\n` +
+      `runtimes: ${runtimes.map((r) => r.name).join(", ")}  |  ` +
+      `runs: ${opts.runs}  warmup: ${opts.warmup}  workloads: ${files.length}`,
+  );
+
+  // Startup baseline per runtime (median of a few extra runs — it's cheap).
+  const baselines = {};
+  const startupFile = join(WORKLOAD_DIR, "startup.js");
+  for (const rt of runtimes) {
+    const { median } = await timeWorkload(rt, startupFile, Math.max(opts.runs, 5), 1);
+    baselines[rt.name] = median;
+  }
+
+  const workloads = [];
+  let mismatches = 0;
+  for (const f of files) {
+    const file = join(WORKLOAD_DIR, f);
+    const name = f.replace(/\.js$/, "");
+    process.stderr.write(`  ${name} ... `);
+    const byRuntime = {};
+    const results = new Set();
+    for (const rt of runtimes) {
+      const r = await timeWorkload(rt, file, opts.runs, opts.warmup);
+      byRuntime[rt.name] = r;
+      results.add(r.result);
+    }
+    const agree = results.size === 1;
+    if (!agree) {
+      mismatches++;
+      process.stderr.write("RESULT MISMATCH\n");
+      for (const rt of runtimes) {
+        process.stderr.write(`      ${rt.name}: ${byRuntime[rt.name].result}\n`);
+      }
+    } else {
+      process.stderr.write("ok\n");
+    }
+    workloads.push({ name, byRuntime, agree, result: [...results][0] });
+  }
+
+  printTable(workloads, runtimes, baselines);
+
+  if (mismatches > 0) {
+    console.log(
+      `\n⚠️  ${mismatches} workload(s) disagreed across runtimes — timings above are not comparable for those rows.`,
+    );
+  }
+
+  if (opts.json) {
+    const payload = {
+      generatedAt: new Date().toISOString(),
+      options: { runs: opts.runs, warmup: opts.warmup },
+      runtimes: runtimes.map((r) => ({ name: r.name, cmd: r.cmd })),
+      baselinesMs: baselines,
+      workloads: workloads.map((w) => ({
+        name: w.name,
+        agree: w.agree,
+        result: w.result,
+        runtimes: Object.fromEntries(
+          Object.entries(w.byRuntime).map(([n, r]) => [
+            n,
+            { median: r.median, min: r.min, max: r.max, mean: r.mean, samples: r.samples },
+          ]),
+        ),
+      })),
+    };
+    writeFileSync(opts.json, JSON.stringify(payload, null, 2));
+    console.log(`\nwrote ${opts.json}`);
+  }
+
+  process.exit(mismatches > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("\nerror: " + err.message);
+  process.exit(1);
+});

--- a/crates/chidori-js/benchmarks/workloads/arith_loop.js
+++ b/crates/chidori-js/benchmarks/workloads/arith_loop.js
@@ -1,0 +1,9 @@
+// Tight numeric loop — interpreter dispatch + integer/float arithmetic.
+// Mirrors the `arith_loop` criterion micro-benchmark, scaled up so execution
+// dominates process startup when run as a standalone script.
+const N = 1_000_000;
+let s = 0;
+for (let i = 0; i < N; i++) {
+  s += i * 2 - (i % 3);
+}
+console.log("RESULT=" + s);

--- a/crates/chidori-js/benchmarks/workloads/array_hof.js
+++ b/crates/chidori-js/benchmarks/workloads/array_hof.js
@@ -1,0 +1,10 @@
+// Higher-order array methods (map/filter/reduce + per-element closures).
+// Mirrors the `array_hof` criterion micro-benchmark, scaled up.
+const N = 200_000;
+const a = [];
+for (let i = 0; i < N; i++) a.push(i);
+const result = a
+  .map((x) => x * x)
+  .filter((x) => x % 2 === 0)
+  .reduce((p, c) => p + c, 0);
+console.log("RESULT=" + result);

--- a/crates/chidori-js/benchmarks/workloads/array_push_sum.js
+++ b/crates/chidori-js/benchmarks/workloads/array_push_sum.js
@@ -1,0 +1,8 @@
+// Array growth + indexed read loop.
+// Mirrors the `array_push_sum` criterion micro-benchmark, scaled up.
+const N = 500_000;
+const a = [];
+for (let i = 0; i < N; i++) a.push(i);
+let s = 0;
+for (let i = 0; i < a.length; i++) s += a[i];
+console.log("RESULT=" + s);

--- a/crates/chidori-js/benchmarks/workloads/closures.js
+++ b/crates/chidori-js/benchmarks/workloads/closures.js
@@ -1,0 +1,12 @@
+// Closures + higher-order calls in a loop (upvalue capture/read).
+// Mirrors the `closures` criterion micro-benchmark, scaled up.
+const N = 1_000_000;
+function adder(n) {
+  return function (x) {
+    return x + n;
+  };
+}
+const f = adder(5);
+let s = 0;
+for (let i = 0; i < N; i++) s = f(s) - 4;
+console.log("RESULT=" + s);

--- a/crates/chidori-js/benchmarks/workloads/fib_recursive.js
+++ b/crates/chidori-js/benchmarks/workloads/fib_recursive.js
@@ -1,0 +1,6 @@
+// Recursion + function-call overhead (frame setup/teardown).
+// Mirrors the `fib_recursive` criterion micro-benchmark, scaled up.
+function fib(n) {
+  return n < 2 ? n : fib(n - 1) + fib(n - 2);
+}
+console.log("RESULT=" + fib(30));

--- a/crates/chidori-js/benchmarks/workloads/json_roundtrip.js
+++ b/crates/chidori-js/benchmarks/workloads/json_roundtrip.js
@@ -1,0 +1,18 @@
+// JSON.stringify / JSON.parse round-trips over a nested object — exercises the
+// serializer, parser, and the object/array allocation paths.
+const N = 20_000;
+const obj = {
+  id: 0,
+  name: "widget",
+  tags: ["a", "b", "c"],
+  nested: { x: 1, y: 2, z: { deep: true, items: [1, 2, 3, 4, 5] } },
+  flag: false,
+};
+let acc = 0;
+for (let i = 0; i < N; i++) {
+  obj.id = i;
+  const s = JSON.stringify(obj);
+  const back = JSON.parse(s);
+  acc += back.id + back.nested.z.items.length + s.length;
+}
+console.log("RESULT=" + acc);

--- a/crates/chidori-js/benchmarks/workloads/property_access.js
+++ b/crates/chidori-js/benchmarks/workloads/property_access.js
@@ -1,0 +1,10 @@
+// Object property get/set in a loop (shape lookups, map access).
+// Mirrors the `property_access` criterion micro-benchmark, scaled up.
+const N = 1_000_000;
+const o = { a: 0, b: 0, c: 0 };
+for (let i = 0; i < N; i++) {
+  o.a = i;
+  o.b = o.a + 1;
+  o.c = o.b + o.a;
+}
+console.log("RESULT=" + o.c);

--- a/crates/chidori-js/benchmarks/workloads/sort.js
+++ b/crates/chidori-js/benchmarks/workloads/sort.js
@@ -1,0 +1,19 @@
+// Array sorting with a comparator — comparator call overhead + the engine's
+// sort implementation. Uses a deterministic LCG so every runtime sorts the
+// same input and must agree on the checksum.
+const N = 50_000;
+const ROUNDS = 6;
+let seed = 123456789;
+function rnd() {
+  // 32-bit LCG (glibc constants), kept in unsigned range.
+  seed = (seed * 1103515245 + 12345) >>> 0;
+  return seed;
+}
+let checksum = 0;
+for (let r = 0; r < ROUNDS; r++) {
+  const a = new Array(N);
+  for (let i = 0; i < N; i++) a[i] = rnd();
+  a.sort((x, y) => x - y);
+  checksum = (checksum + a[0] + a[N - 1] + a[N >> 1]) >>> 0;
+}
+console.log("RESULT=" + checksum);

--- a/crates/chidori-js/benchmarks/workloads/startup.js
+++ b/crates/chidori-js/benchmarks/workloads/startup.js
@@ -1,0 +1,4 @@
+// Near-empty script used to measure each runtime's process-startup baseline
+// (binary load + realm/global setup), which the harness subtracts from the
+// workload totals to estimate execution-only time.
+console.log("RESULT=ok");

--- a/crates/chidori-js/benchmarks/workloads/string_build.js
+++ b/crates/chidori-js/benchmarks/workloads/string_build.js
@@ -1,0 +1,8 @@
+// String building (concatenation + number→string coercion).
+// Mirrors the `string_build` criterion micro-benchmark, scaled up.
+// Kept modest because naive `+=` string building is O(n²) on an engine without
+// rope/cord string representation; chidori-js builds the string eagerly.
+const N = 30_000;
+let s = "";
+for (let i = 0; i < N; i++) s += "x" + i;
+console.log("RESULT=" + s.length);


### PR DESCRIPTION
Introduces a comprehensive benchmarking harness that compares chidori-js against Node.js and Bun by running identical JavaScript workloads across all three runtimes and measuring execution time.

## Summary

This adds a complete cross-runtime benchmarking infrastructure for chidori-js, enabling performance comparisons with production JavaScript engines (V8 and JavaScriptCore). The suite measures both raw wall-clock time and execution-only time (with startup overhead subtracted), and includes CI integration to post results as PR comments.

## Key Changes

- **Benchmark harness** (`benchmarks/run.mjs`): A Node.js script that:
  - Discovers and runs workloads under chidori-js, Node.js, and Bun
  - Measures subprocess wall-clock time with configurable runs/warmup iterations
  - Validates correctness by asserting all runtimes produce identical results
  - Measures startup baselines separately and subtracts them for fair engine-vs-engine comparison
  - Generates text tables, JSON reports, and Markdown output for CI integration

- **10 JavaScript workloads** in `benchmarks/workloads/`:
  - `arith_loop`: tight numeric loop (interpreter dispatch + arithmetic)
  - `fib_recursive`: recursion and call-frame overhead
  - `property_access`: object property get/set in a loop
  - `array_push_sum`: array growth and indexed reads
  - `array_hof`: higher-order array methods (map/filter/reduce)
  - `string_build`: string concatenation and coercion
  - `closures`: closure capture and higher-order calls
  - `json_roundtrip`: JSON serialization/deserialization
  - `sort`: array sorting with a comparator
  - `startup.js`: baseline measurement (near-empty script)

- **GitHub Actions workflow** (`.github/workflows/js-benchmarks.yml`):
  - Runs on PRs touching `crates/chidori-js/**`
  - Builds chidori-js in release mode
  - Executes the benchmark suite with `--markdown` and `--json` output
  - Posts/updates a single sticky PR comment with results (for non-fork PRs)
  - Uploads full report as a build artifact
  - Fails only on correctness mismatches, not timing regressions

- **Documentation** (`benchmarks/README.md`): Comprehensive guide covering:
  - Quick start and usage examples
  - Explanation of reported metrics (execution-only vs. total time)
  - Workload descriptions and iteration tuning
  - Instructions for adding new workloads
  - Caveats about interpreting results

- **Minor update** to `benches/execution.rs`: Added a comment explaining the relationship between in-process criterion micro-benchmarks and the new cross-runtime suite.

## Notable Implementation Details

- **Correctness validation**: Every workload prints `RESULT=<value>` which the harness extracts and cross-checks across runtimes before reporting timings — a fast-but-wrong engine is not a faster engine.
- **Deterministic results**: Workloads use seeded LCGs (e.g., in `sort.js`) to ensure identical input across runs and runtimes.
- **Startup isolation**: Baseline measurement with `startup.js` allows reporting both raw total time and execution-only time (startup subtracted).
- **Flexible filtering**: CLI options for `--filter`, `--runs`, `--warmup`, `--runtimes`, and output formats (`--json`, `--markdown`).
- **CI stability**: Uses a stable HTML marker in Markdown output so the GitHub Actions workflow can find and update the same comment in place rather than posting duplicates.

https://claude.ai/code/session_012e5Wq5Gb8DKR91x6N4Ht9K