### PR TITLE
Optimize interpreter hot paths to narrow the cross-runtime benchmark gap

### DIFF
--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -2800,6 +2800,13 @@ impl Vm {
     // =====================================================================
 
     pub fn op_add(&mut self, a: Value, b: Value) -> Result<Value, Value> {
+        // Fast path: Number + Number. Both operands are already primitive
+        // numbers, so ToPrimitive/ToNumeric are identities and the spec result
+        // is simply their f64 sum — skip the coercion ceremony entirely. This
+        // is by far the most common `+` in numeric code (loop counters, sums).
+        if let (Value::Number(x), Value::Number(y)) = (&a, &b) {
+            return Ok(Value::Number(x + y));
+        }
         let pa = self.to_primitive(&a, Hint::Default)?;
         let pb = self.to_primitive(&b, Hint::Default)?;
         if matches!(pa, Value::String(_)) || matches!(pb, Value::String(_)) {
@@ -2860,6 +2867,12 @@ impl Vm {
 
     /// Binary numeric/bigint operation (already-popped operands).
     pub fn arith(&mut self, a: Value, b: Value, kind: ArithKind) -> Result<Value, Value> {
+        // Fast path: Number op Number — already numeric primitives, so
+        // ToNumeric is the identity. Covers the common arithmetic/bitwise mix
+        // in hot loops without the per-operand ToPrimitive/ToNumber detour.
+        if let (Value::Number(x), Value::Number(y)) = (&a, &b) {
+            return Ok(number_arith(*x, *y, kind));
+        }
         let xa = self.to_numeric(&a)?;
         let xb = self.to_numeric(&b)?;
         match (&xa, &xb) {
@@ -2937,6 +2950,16 @@ impl Vm {
 
     /// Unary numeric/bigint operation.
     pub fn unary_arith(&mut self, a: Value, kind: UnaryKind) -> Result<Value, Value> {
+        // Fast path: a Number is already numeric, so ToNumeric is the identity.
+        // `++`/`--` on loop counters route through here every iteration.
+        if let Value::Number(n) = a {
+            return Ok(Value::Number(match kind {
+                UnaryKind::Neg => -n,
+                UnaryKind::Inc => n + 1.0,
+                UnaryKind::Dec => n - 1.0,
+                UnaryKind::BitNot => !crate::vm::to_int32(n) as f64,
+            }));
+        }
         let x = self.to_numeric(&a)?;
         match x {
             Value::BigInt(n) => {
@@ -3010,6 +3033,15 @@ impl Vm {
 
     /// Abstract Relational Comparison `a < b`. Returns None for unordered (NaN).
     pub fn less_than(&mut self, a: &Value, b: &Value) -> Result<Option<bool>, Value> {
+        // Fast path: Number < Number (loop bounds, sorts). NaN is unordered, so
+        // either operand being NaN yields `None` (all of `<`/`>`/`<=`/`>=`
+        // become false at the call site), matching the general path below.
+        if let (Value::Number(x), Value::Number(y)) = (a, b) {
+            if x.is_nan() || y.is_nan() {
+                return Ok(None);
+            }
+            return Ok(Some(x < y));
+        }
         let pa = self.to_primitive(a, Hint::Number)?;
         let pb = self.to_primitive(b, Hint::Number)?;
         if let (Value::String(x), Value::String(y)) = (&pa, &pb) {

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -906,103 +906,117 @@ impl Vm {
                 }
             }
         }
-        // Array exotic: index + length.
+        // Walk the prototype chain. Each level is resolved under a SINGLE
+        // `RefCell` borrow that decides the outcome, then releases the borrow
+        // before any re-entrant call (getter / proxy trap). The decision is
+        // captured in `Step` so the borrow never spans `self.call`/`proxy_get`.
+        enum Step {
+            /// A resolved value (data property, array/string element, namespace
+            /// export, or a missing namespace key → `undefined`).
+            Value(Value),
+            /// An accessor — call this getter with `receiver`.
+            Getter(Value),
+            /// This level is a Proxy — dispatch its `[[Get]]` trap.
+            Proxy,
+            /// A namespace binding read in the Temporal Dead Zone.
+            NsUninitialized,
+            /// Not an own property here — continue to this `[[Prototype]]`
+            /// (`None` ends the chain with `undefined`).
+            Climb(Option<JsObject>),
+        }
+        // Ordinary own-property resolution shared by every (non-exotic) level.
+        // A reified `props` entry shadows any dense array/string element.
+        let ordinary = |b: &ObjectData| -> Step {
+            match b.props.get(key) {
+                Some(prop) => match &prop.kind {
+                    PropertyKind::Data { value, .. } => Step::Value(value.clone()),
+                    PropertyKind::Accessor { get, .. } => match get {
+                        Some(g) => Step::Getter(g.clone()),
+                        None => Step::Value(Value::Undefined),
+                    },
+                },
+                None => Step::Climb(b.proto.clone()),
+            }
+        };
         let mut cur = start.clone();
         loop {
-            // Proxy exotic [[Get]]: dispatch the trap (handles both a proxy base
-            // and a proxy encountered while walking the prototype chain).
-            if matches!(cur.borrow().internal, Internal::Proxy(_)) {
-                return self.proxy_get(&cur, key, receiver);
-            }
-            // Module Namespace exotic [[Get]]: a string key reads the live
-            // export binding (an uninitialized binding throws ReferenceError);
-            // symbols (@@toStringTag) fall through to the ordinary props.
-            {
-                let cell = match &cur.borrow().internal {
-                    Internal::ModuleNamespace(ns) => match key {
-                        PropertyKey::Str(s) => ns.exports.get(s).cloned().map(Some).unwrap_or({
-                            // Unknown string export: namespace proto is null.
-                            None
-                        }),
-                        PropertyKey::Sym(_) => None,
-                    },
-                    _ => None,
-                };
-                if let Some(cell) = cell {
-                    let v = cell.borrow().clone();
-                    if matches!(v, Value::Uninitialized) {
-                        return Err(
-                            self.throw_reference("Cannot access binding before initialization")
-                        );
-                    }
-                    return Ok(v);
-                }
-                let is_ns = matches!(cur.borrow().internal, Internal::ModuleNamespace(_));
-                if is_ns {
-                    if let PropertyKey::Str(_) = key {
-                        return Ok(Value::Undefined);
-                    }
-                }
-            }
-            // Inspect own property without holding the borrow across calls.
-            let found = {
+            let step = {
                 let b = cur.borrow();
-                // array elements. A reified `props` entry for an index/length (a
-                // non-dense descriptor defined via defineProperty) is
-                // authoritative and shadows the dense-Vec slot, so only consult
-                // the Vec when there is no own `props` entry for the key.
-                // Mapped arguments: an aliased index reads the parameter
-                // CELL (live aliasing), not the stale props value.
-                if let Internal::Arguments(map) = &b.internal {
-                    if let Some(idx) = key.array_index() {
-                        if b.props.contains_key(key) {
-                            if let Some(Some(cell)) = map.get(idx as usize) {
-                                return Ok(cell.borrow().clone());
-                            }
-                        }
-                    }
-                }
-                if let Internal::Array(arr) = &b.internal {
-                    if let Some("length") = key.as_str() {
-                        if !b.props.contains_key(key) {
-                            return Ok(Value::Number(arr.len() as f64));
-                        }
-                    } else if let Some(idx) = key.array_index() {
-                        if !b.props.contains_key(key) {
-                            // A hole is an absent index: skip it so the lookup
-                            // continues up the prototype chain (reads undefined).
-                            if let Some(v) = arr.get(idx as usize) {
-                                if !matches!(v, Value::Hole) {
-                                    return Ok(v.clone());
+                match &b.internal {
+                    // Proxy [[Get]] (base or encountered up the chain): trap.
+                    Internal::Proxy(_) => Step::Proxy,
+                    // Module Namespace [[Get]]: a string key reads the live
+                    // export binding (uninitialized → ReferenceError; unknown →
+                    // undefined, the namespace proto is null); symbols
+                    // (@@toStringTag) fall through to ordinary props.
+                    Internal::ModuleNamespace(ns) => match key {
+                        PropertyKey::Str(s) => match ns.exports.get(s) {
+                            Some(cell) => {
+                                let v = cell.borrow().clone();
+                                if matches!(v, Value::Uninitialized) {
+                                    Step::NsUninitialized
+                                } else {
+                                    Step::Value(v)
                                 }
                             }
+                            None => Step::Value(Value::Undefined),
+                        },
+                        PropertyKey::Sym(_) => ordinary(&b),
+                    },
+                    // Mapped arguments: an aliased index reads the live
+                    // parameter CELL, not the stale `props` value.
+                    Internal::Arguments(map) => {
+                        let aliased = key.array_index().and_then(|idx| {
+                            if b.props.contains_key(key) {
+                                map.get(idx as usize).and_then(|c| c.clone())
+                            } else {
+                                None
+                            }
+                        });
+                        match aliased {
+                            Some(cell) => Step::Value(cell.borrow().clone()),
+                            None => ordinary(&b),
                         }
                     }
-                }
-                if let Internal::StringObj(s) = &b.internal {
-                    if let Some(v) = self.string_own_prop(s, key) {
-                        return Ok(v);
+                    // Array exotic: `length` and dense indices. A reified
+                    // `props` entry for the key shadows the dense Vec; a hole is
+                    // an absent index (climb the chain → undefined).
+                    Internal::Array(arr) => {
+                        if let Some("length") = key.as_str() {
+                            if b.props.contains_key(key) {
+                                ordinary(&b)
+                            } else {
+                                Step::Value(Value::Number(arr.len() as f64))
+                            }
+                        } else if let Some(idx) = key.array_index() {
+                            if b.props.contains_key(key) {
+                                ordinary(&b)
+                            } else {
+                                match arr.get(idx as usize) {
+                                    Some(v) if !matches!(v, Value::Hole) => Step::Value(v.clone()),
+                                    _ => ordinary(&b),
+                                }
+                            }
+                        } else {
+                            ordinary(&b)
+                        }
                     }
+                    Internal::StringObj(s) => match self.string_own_prop(s, key) {
+                        Some(v) => Step::Value(v),
+                        None => ordinary(&b),
+                    },
+                    _ => ordinary(&b),
                 }
-                b.props.get(key).cloned()
             };
-            match found {
-                Some(prop) => match prop.kind {
-                    PropertyKind::Data { value, .. } => return Ok(value),
-                    PropertyKind::Accessor { get, .. } => {
-                        return match get {
-                            Some(getter) => self.call(getter, receiver, &[]),
-                            None => Ok(Value::Undefined),
-                        }
-                    }
-                },
-                None => {
-                    let proto = cur.borrow().proto.clone();
-                    match proto {
-                        Some(p) => cur = p,
-                        None => return Ok(Value::Undefined),
-                    }
+            match step {
+                Step::Value(v) => return Ok(v),
+                Step::Getter(g) => return self.call(g, receiver, &[]),
+                Step::Proxy => return self.proxy_get(&cur, key, receiver),
+                Step::NsUninitialized => {
+                    return Err(self.throw_reference("Cannot access binding before initialization"))
                 }
+                Step::Climb(Some(p)) => cur = p,
+                Step::Climb(None) => return Ok(Value::Undefined),
             }
         }
     }


### PR DESCRIPTION
## What

The new cross-runtime benchmark suite (`run.mjs`) showed `chidori-js` trailing Node/Bun by large factors on compute- and property-heavy workloads. Profiling the worst rows (`arith_loop`, `property_access`, `fib_recursive`) pointed at two avoidable interpreter overheads rather than fundamental interpreter cost.

## Changes

**1. Numeric operator fast paths** (`exec.rs`) — `op_add`, `arith`, `unary_arith`, and `less_than` ran the full `ToPrimitive`/`ToNumeric`/`ToNumber` pipeline even when both operands were already `Number`. Since those coercions are the identity on a Number, add a `Number`-`Number` fast path that computes the f64 result directly. This is the overwhelmingly common case in numeric loops, `i++` counters, and loop bounds. NaN ordering is preserved (unordered → `None`, so `<`/`>`/`<=`/`>=` stay false at the call site); BigInt/string/object operands still take the spec path.

**2. Collapsed redundant `RefCell` borrows in property reads** (`vm.rs`) — `get_from_object` re-borrowed the object up to **four times** per prototype-chain level (proxy probe, two namespace probes, then the real lookup). Each level now resolves under a **single** borrow into a `Step` enum, releasing the borrow before any re-entrant call (getter / proxy trap). Exotic behaviors (Proxy, ModuleNamespace, mapped `arguments` aliasing, Array length/index + holes, String) are preserved exactly.

## Results

Execution-only median on the benchmark suite vs. the pre-change binary:

| workload | speedup |
|---|---|
| arith_loop | ~1.55× |
| closures | ~1.23× |
| fib_recursive | ~1.19× |
| property_access | ~1.15× |
| sort | ~1.11× |

## Verification

- Full `chidori-js` test suite passes (all suites, 0 failures).
- Every benchmark workload still cross-checks **identical results** across chidori/node/bun (the suite exits non-zero on any mismatch).
- Manual probes on the touched semantics — prototype-chain getters, array holes climbing to the prototype, string indexing, sloppy `arguments` aliasing, NaN ordering, Proxy traps, TypedArray indexing, BigInt-mixing `TypeError` — all correct.

## Notes

`chidori-js` is a bytecode interpreter and Bun is a JIT, so the absolute gap can be narrowed but not erased without a JIT/shape system. This PR removes pure interpreter waste; the remaining gap is dominated by per-call allocation and the no-inline-cache property model, addressed in a follow-up.

https://claude.ai/code/session_01DdXMBWYsk4Vyn2t3B1HYtz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdXMBWYsk4Vyn2t3B1HYtz)_