### PR TITLE
docs: add interpreter optimization design (the no-JIT alternative)

### DIFF
--- a/crates/chidori-js/Cargo.toml
+++ b/crates/chidori-js/Cargo.toml
@@ -10,6 +10,14 @@ repository = "https://github.com/ThousandBirdsInc/chidori"
 name = "chidori_js"
 path = "src/lib.rs"
 
+[features]
+# Phase-0 dynamic opcode-frequency instrumentation. OFF by default: when off,
+# the `opstats` module and its single `record(..)` call site in the interpreter
+# loop are `#[cfg]`-removed, so the shipping engine is byte-identical and pays
+# nothing. Enable for analysis only: `cargo run --example opstats --features
+# op-histogram`. See docs/interpreter-optimization.md (Phase 0).
+op-histogram = []
+
 [dependencies]
 # Front end only: we consume the oxc AST and write no lexer/parser of our own.
 oxc = { version = "0.133", features = ["semantic", "transformer", "codegen"] }

--- a/crates/chidori-js/examples/agent_replay.rs
+++ b/crates/chidori-js/examples/agent_replay.rs
@@ -1,0 +1,197 @@
+//! Phase-0 (carried-forward) **agent-replay benchmark**: how much of an agent
+//! run's wall-clock is actually JS execution, versus host calls and the
+//! journal/serialization machinery?
+//!
+//! This is the empirical backbone of the whole "no JIT" stance in
+//! `docs/interpreter-optimization.md`: if JS is a small minority of an agent's
+//! wall-clock (because each host call — an LLM round-trip — dwarfs the glue code
+//! between calls), then heroic interpreter speedups (a JIT) buy little, and the
+//! interpreter-level work in Phases 1–2 is the right ceiling of effort.
+//!
+//! It builds a representative agent — real glue compute (prompt building, string
+//! scanning, modular arithmetic) interleaved with recorded host effects (an
+//! `llm` call per step) — then measures three things on the SAME workload:
+//!   * `compute_only`  — the JS compute with no host boundary (pure interpreter).
+//!   * `record`        — a live run building the journal (host returns instantly).
+//!   * `replay`        — re-running from the journal (no host calls at all).
+//! and models the live wall-clock under representative LLM latencies.
+//!
+//! Run: `cargo run -q --release --example agent_replay -p chidori-js`
+
+use std::time::{Duration, Instant};
+
+use chidori_js::replay::{DriveOutcome, ReplayRuntime};
+use chidori_js::Engine;
+use serde_json::{json, Value as Json};
+
+const STEPS: usize = 200;
+const INNER: usize = 150;
+/// The canned "LLM response" each host call returns — inlined into the
+/// compute-only bundle so its post-processing compute matches exactly.
+const RESP: &str = "response-0123456789-abcdefghijklmnop";
+
+/// Agent glue compute for one step, shared by both bundles. `RESP_EXPR` is the
+/// expression that yields the step's "response": a host `await llm(...)` in the
+/// real agent, or the inlined literal in the compute-only variant.
+fn step_body(resp_expr: &str) -> String {
+    format!(
+        r#"
+        let prompt = 'step ' + step + ': ';
+        for (let i = 0; i < {INNER}; i++) {{ prompt += ((i * step + 3) % 97); }}
+        const resp = {resp_expr};
+        let n = 0;
+        for (let i = 0; i < resp.length; i++) {{ n = (n + resp.charCodeAt(i)) % 1000003; }}
+        acc = (acc + n + prompt.length) % 1000000007;
+        "#
+    )
+}
+
+fn agent_bundle() -> String {
+    format!(
+        r#"
+        async function main() {{
+            let acc = 0;
+            for (let step = 0; step < {STEPS}; step++) {{
+                {body}
+            }}
+            report(acc);
+        }}
+        main();
+        "#,
+        body = step_body("await llm(prompt)")
+    )
+}
+
+fn compute_only_bundle() -> String {
+    format!(
+        r#"
+        (function() {{
+            let acc = 0;
+            for (let step = 0; step < {STEPS}; step++) {{
+                {body}
+            }}
+            return acc;
+        }})()
+        "#,
+        body = step_body(&format!("{RESP:?}"))
+    )
+}
+
+/// Best (min) of `iters` timed runs of `f` — min is far more stable than mean on
+/// a noisy shared/cloud host (it is the run least perturbed by interference).
+fn best(iters: usize, mut f: impl FnMut()) -> Duration {
+    let mut best = Duration::MAX;
+    for _ in 0..iters {
+        let t = Instant::now();
+        f();
+        best = best.min(t.elapsed());
+    }
+    best
+}
+
+fn record_once() -> (Vec<u8>, usize) {
+    let mut rt = ReplayRuntime::record(&agent_bundle(), &["llm", "report"]);
+    let mut calls = 0usize;
+    let mut handler = |name: &str, _args: &Json| -> Option<Result<Json, String>> {
+        if name == "llm" {
+            calls += 1;
+            Some(Ok(json!(RESP)))
+        } else {
+            Some(Ok(json!(null)))
+        }
+    };
+    let outcome = rt.drive(&mut handler).unwrap();
+    assert!(
+        matches!(outcome, DriveOutcome::Completed),
+        "agent must complete"
+    );
+    (rt.journal_bytes(), calls)
+}
+
+fn replay_once(journal: &[u8]) {
+    let mut rt = ReplayRuntime::restore(&agent_bundle(), journal, &["llm", "report"]).unwrap();
+    // The handler panics nothing: on replay every effect is served from the
+    // journal, so a correct replay never calls it for a journaled effect.
+    let mut handler =
+        |_n: &str, _a: &Json| -> Option<Result<Json, String>> { Some(Ok(json!(null))) };
+    let outcome = rt.drive(&mut handler).unwrap();
+    assert!(matches!(outcome, DriveOutcome::Completed));
+    assert_eq!(rt.divergence(), None, "replay must not diverge");
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn main() {
+    // Warm + measure.
+    let (journal, host_calls) = record_once();
+
+    let t_compute = best(20, || {
+        let mut e = Engine::new();
+        let _ = e.eval(&compute_only_bundle()).expect("compute runs");
+    });
+    let t_record = best(10, || {
+        let _ = record_once();
+    });
+    let t_replay = best(20, || replay_once(&journal));
+
+    // engine_new (realm setup) is paid once per run and is inside the figures
+    // above; subtract a measured estimate so the per-phase numbers are about the
+    // agent work, not realm construction.
+    let t_engine_new = best(50, || {
+        let e = Engine::new();
+        std::hint::black_box(&e);
+    });
+
+    let compute = ms(t_compute) - ms(t_engine_new);
+    let replay = ms(t_replay);
+    let record = ms(t_record);
+    // The non-host work the journal adds on top of raw JS compute
+    // (promise/microtask machinery, journal lookup + (de)serialization).
+    let journal_overhead = (replay - compute).max(0.0);
+
+    println!("=== Agent-replay composition ({STEPS} steps, {host_calls} host calls) ===\n");
+    println!("journal size:            {} bytes", journal.len());
+    println!(
+        "engine_new (realm):      {:.3} ms (subtracted below)",
+        ms(t_engine_new)
+    );
+    println!("JS compute only:         {compute:.3} ms");
+    println!("journal/promise machinery:{journal_overhead:>8.3} ms");
+    println!("full replay (no host):   {replay:.3} ms");
+    println!("full record (host=0):    {record:.3} ms");
+    println!(
+        "  → per step: compute {:.4} ms, replay {:.4} ms",
+        compute / STEPS as f64,
+        replay / STEPS as f64
+    );
+
+    // Live wall-clock model: a real run pays the non-host work PLUS one real host
+    // latency per host call. `record` (live, host=0) is the closest measured
+    // proxy for that non-host work — it includes the journal *writes* a live run
+    // does — so use it as the base. JS share = base / (base + host_calls * lat).
+    let base = record;
+    println!("\n=== Modeled LIVE wall-clock (JS+journal is fixed; host dominates) ===");
+    println!("non-host base (JS + journal, = record): {base:.3} ms for {host_calls} calls\n");
+    println!(
+        "  {:>14}   {:>14}   {:>10}",
+        "LLM latency/call", "live total", "JS+jrnl %"
+    );
+    for &lat_ms in &[50.0_f64, 200.0, 500.0, 1000.0, 2000.0] {
+        let host = lat_ms * host_calls as f64;
+        let live = base + host;
+        println!(
+            "  {:>11.0} ms   {:>11.0} ms   {:>9.3}%",
+            lat_ms,
+            live,
+            100.0 * base / live
+        );
+    }
+    println!(
+        "\nInterpretation: even with host latency at an optimistic {} ms/call, JS+journal\n\
+         work is a small fraction of live wall-clock — and a JIT would only chip at the\n\
+         JS portion of that fraction. See docs/interpreter-optimization.md §11/§13.",
+        50
+    );
+}

--- a/crates/chidori-js/examples/opstats.rs
+++ b/crates/chidori-js/examples/opstats.rs
@@ -1,0 +1,196 @@
+//! Phase-0 opcode-frequency analyzer for the `chidori-js` interpreter.
+//!
+//! Produces the data that drives the interpreter-optimization plan
+//! (`docs/interpreter-optimization.md`): which opcodes dominate, and which
+//! adjacent opcode *pairs* are the best superinstruction / op-fusion candidates
+//! (Phase 2).
+//!
+//! Two views:
+//!   * **Static** — walk the compiled bytecode of each workload (recursing into
+//!     nested function templates) and count opcodes + adjacent pairs *as emitted*.
+//!     Always available; no engine instrumentation. Undercounts loop bodies
+//!     (each instruction is counted once regardless of how often it runs).
+//!   * **Dynamic** — count opcodes + adjacent pairs *as executed*, weighted by
+//!     real control flow (loops, recursion). Requires the `op-histogram` feature,
+//!     which instruments the interpreter loop. This is the view that matters for
+//!     fusion.
+//!
+//! Run:
+//! ```sh
+//! # static only:
+//! cargo run -q --release --example opstats -p chidori-js
+//! # static + dynamic (execution-weighted):
+//! cargo run -q --release --example opstats -p chidori-js --features op-histogram
+//! ```
+
+use std::collections::HashMap;
+
+use chidori_js::bytecode::{Const, FuncProto, Op};
+use chidori_js::compiler::compile_script;
+
+/// The same representative workloads as `benches/execution.rs`, plus a `mixed`
+/// program that interleaves them — a stand-in for the JS an agent runs *between*
+/// host calls (the unit that interpreter speed actually affects in production).
+const WORKLOADS: &[(&str, &str)] = &[
+    (
+        "arith_loop",
+        "(function(){ let s = 0; for (let i = 0; i < 20000; i++) { s += i * 2 - (i % 3); } return s; })()",
+    ),
+    (
+        "fib_recursive",
+        "(function(){ function fib(n){ return n < 2 ? n : fib(n-1) + fib(n-2); } return fib(24); })()",
+    ),
+    (
+        "property_access",
+        "(function(){ let o = { a: 0, b: 0, c: 0 }; for (let i = 0; i < 10000; i++) { o.a = i; o.b = o.a + 1; o.c = o.b + o.a; } return o.c; })()",
+    ),
+    (
+        "array_push_sum",
+        "(function(){ let a = []; for (let i = 0; i < 5000; i++) a.push(i); let s = 0; for (let i = 0; i < a.length; i++) s += a[i]; return s; })()",
+    ),
+    (
+        "array_hof",
+        "(function(){ let a = []; for (let i = 0; i < 2000; i++) a.push(i); return a.map(x => x * x).filter(x => x % 2 === 0).reduce((p, c) => p + c, 0); })()",
+    ),
+    (
+        "string_build",
+        "(function(){ let s = ''; for (let i = 0; i < 3000; i++) s += 'x' + i; return s.length; })()",
+    ),
+    (
+        "closures",
+        "(function(){ function adder(n){ return function(x){ return x + n; }; } let f = adder(5); let s = 0; for (let i = 0; i < 10000; i++) s = f(s) - 4; return s; })()",
+    ),
+];
+
+/// `Op` variant name without payload (`Op` derives `Debug`).
+fn variant_name(op: &Op) -> String {
+    let dbg = format!("{op:?}");
+    let end = dbg
+        .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .unwrap_or(dbg.len());
+    dbg[..end].to_string()
+}
+
+/// Recursively count opcodes + adjacent pairs across a proto and its nested
+/// function templates (`Const::Func`). Pairs are counted within a single
+/// `code` vec only (no cross-function pairing), matching how a peephole pass
+/// over emitted bytecode would see them.
+fn walk_static(
+    proto: &FuncProto,
+    ops: &mut HashMap<String, u64>,
+    pairs: &mut HashMap<(String, String), u64>,
+) {
+    let mut prev: Option<String> = None;
+    for op in &proto.code {
+        let name = variant_name(op);
+        *ops.entry(name.clone()).or_insert(0) += 1;
+        if let Some(p) = prev.take() {
+            *pairs.entry((p, name.clone())).or_insert(0) += 1;
+        }
+        prev = Some(name);
+    }
+    for c in &proto.consts {
+        if let Const::Func(f) = c {
+            walk_static(f, ops, pairs);
+        }
+    }
+}
+
+fn print_table<K: std::fmt::Display>(title: &str, rows: &[(K, u64)], total: u64, top: usize) {
+    println!("  {title}");
+    for (k, n) in rows.iter().take(top) {
+        let pct = if total > 0 {
+            100.0 * (*n as f64) / (total as f64)
+        } else {
+            0.0
+        };
+        println!("    {n:>12}  {pct:>5.1}%  {k}");
+    }
+}
+
+fn sorted_ops(m: HashMap<String, u64>) -> Vec<(String, u64)> {
+    let mut v: Vec<_> = m.into_iter().collect();
+    v.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    v
+}
+
+fn sorted_pairs(m: HashMap<(String, String), u64>) -> Vec<(String, u64)> {
+    let mut v: Vec<_> = m
+        .into_iter()
+        .map(|((a, b), n)| (format!("{a} ; {b}"), n))
+        .collect();
+    v.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    v
+}
+
+fn main() {
+    const TOP: usize = 15;
+
+    println!("=== STATIC opcode frequency (as emitted; undercounts loops) ===\n");
+    let mut all_ops: HashMap<String, u64> = HashMap::new();
+    let mut all_pairs: HashMap<(String, String), u64> = HashMap::new();
+    for (name, src) in WORKLOADS {
+        let proto = compile_script(src).expect("compiles");
+        let mut ops = HashMap::new();
+        let mut pairs = HashMap::new();
+        walk_static(&proto, &mut ops, &mut pairs);
+        for (k, v) in &ops {
+            *all_ops.entry(k.clone()).or_insert(0) += v;
+        }
+        for (k, v) in &pairs {
+            *all_pairs.entry(k.clone()).or_insert(0) += v;
+        }
+        let total: u64 = ops.values().sum();
+        println!("[{name}] {total} static opcodes");
+    }
+    let total: u64 = all_ops.values().sum();
+    println!("\nAll workloads combined ({total} static opcodes):");
+    print_table("top opcodes:", &sorted_ops(all_ops), total, TOP);
+    let ptotal: u64 = total; // pairs ~ ops-1 per proto; use ops total as scale
+    print_table(
+        "top adjacent pairs (fusion candidates):",
+        &sorted_pairs(all_pairs),
+        ptotal,
+        TOP,
+    );
+
+    #[cfg(feature = "op-histogram")]
+    {
+        use chidori_js::{opstats, Engine};
+        println!("\n=== DYNAMIC opcode frequency (as executed; weighted by control flow) ===\n");
+        let mut tot_ops: HashMap<String, u64> = HashMap::new();
+        let mut tot_pairs: HashMap<(String, String), u64> = HashMap::new();
+        let mut grand_total: u64 = 0;
+        for (name, src) in WORKLOADS {
+            opstats::reset();
+            let mut engine = Engine::new();
+            let _ = engine.eval(src).expect("evaluates");
+            let report = opstats::take();
+            grand_total += report.total;
+            println!("[{name}] {} executed opcodes", report.total);
+            for (k, v) in &report.ops {
+                *tot_ops.entry((*k).to_string()).or_insert(0) += v;
+            }
+            for ((a, b), v) in &report.pairs {
+                *tot_pairs
+                    .entry(((*a).to_string(), (*b).to_string()))
+                    .or_insert(0) += v;
+            }
+        }
+        println!("\nAll workloads combined ({grand_total} executed opcodes):");
+        print_table("top opcodes:", &sorted_ops(tot_ops), grand_total, TOP);
+        print_table(
+            "top adjacent pairs (fusion candidates):",
+            &sorted_pairs(tot_pairs),
+            grand_total,
+            TOP,
+        );
+    }
+    #[cfg(not(feature = "op-histogram"))]
+    {
+        println!(
+            "\n(Dynamic execution-weighted view skipped: rebuild with \
+             `--features op-histogram` to enable interpreter instrumentation.)"
+        );
+    }
+}

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -271,6 +271,21 @@ pub struct EvalScopeDesc {
     pub strict: bool,
 }
 
+/// Which comparison a fused [`Op::CmpBranchFalse`] performs. Each maps 1:1 to a
+/// standalone comparison opcode and is evaluated with the identical helper, so
+/// fusion never changes coercion or thrown-error behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    StrictEq,
+    StrictNe,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+}
+
 /// The instruction set. Jump targets are absolute indices into `code`, patched
 /// by the compiler.
 #[derive(Clone, Debug)]
@@ -610,6 +625,17 @@ pub enum Op {
     Jump(u32),
     JumpIfTrue(u32),
     JumpIfFalse(u32),
+    /// Superinstruction (peephole fusion, see `fuse.rs`): a comparison
+    /// immediately followed by `JumpIfFalse(target)` — the dominant loop-test
+    /// idiom (`for (…; i < n; …)`). Pops `b` then `a`, computes the comparison
+    /// using the **same** helpers as the standalone comparison op (identical
+    /// coercion and thrown errors), and branches to `target` when the result is
+    /// false. Exactly equivalent to the two-op sequence: the intermediate
+    /// boolean the pair would push/pop is never observable to JS.
+    CmpBranchFalse {
+        cmp: CmpOp,
+        target: u32,
+    },
     /// Pop; jump if falsy but leave the value if truthy (for `&&`). Actually we
     /// implement `&&`/`||`/`??` with peek-based jumps below.
     JumpIfFalsyPeek(u32), // peek top; if falsy jump (keep), else pop

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -320,6 +320,15 @@ pub enum Op {
     LoadLocal(u32),
     StoreLocal(u32),
     LoadCell(u32),
+    /// Superinstruction (fusion): `LoadCell(cell) ; LoadConst(konst)` — the
+    /// single most frequent adjacent pair in the Phase-0 survey (~8.9% of
+    /// executed pairs), e.g. the `i`, `n` operand loads of a `i < n` loop test.
+    /// Performs the cell read (including the same TDZ check as `LoadCell`, so a
+    /// use-before-init still throws identically) then pushes the constant.
+    LoadCellConst {
+        cell: u32,
+        konst: u32,
+    },
     StoreCell(u32),
     /// As [`StoreCell`], but throws a ReferenceError if the cell is still in the
     /// Temporal Dead Zone (assignment to a `let`/`const`/`class` binding before
@@ -633,6 +642,14 @@ pub enum Op {
     /// false. Exactly equivalent to the two-op sequence: the intermediate
     /// boolean the pair would push/pop is never observable to JS.
     CmpBranchFalse {
+        cmp: CmpOp,
+        target: u32,
+    },
+    /// Superinstruction: a comparison immediately followed by `JumpIfTrue` —
+    /// the bottom-tested loop back-edge (`do { … } while (cond)`) and negated
+    /// conditions. Mirror of [`Op::CmpBranchFalse`]; branches to `target` when
+    /// the comparison is true. Same helpers, same coercion/throw behavior.
+    CmpBranchTrue {
         cmp: CmpOp,
         target: u32,
     },

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -22,17 +22,25 @@ use oxc::span::SourceType;
 use crate::bytecode::*;
 
 pub fn compile_script(src: &str) -> Result<FuncProto, String> {
-    compile_script_impl(src, false)
+    compile_script_impl(src, false, true)
+}
+
+/// Compile a script with the peephole op-fusion pass (`fuse.rs`) toggled. Used by
+/// the differential test that runs the same program with `fuse = true` and
+/// `fuse = false` and asserts byte-identical observable behavior. Production code
+/// uses [`compile_script`] (fusion on).
+pub fn compile_script_opts(src: &str, fuse: bool) -> Result<FuncProto, String> {
+    compile_script_impl(src, false, fuse)
 }
 
 /// Compile global eval code — `(0,eval)(src)`: identical to a script except
 /// `return` is illegal and the global `var`/function bindings it creates are
 /// DELETABLE (CreateGlobalVarBinding with D=true).
 pub fn compile_indirect_eval(src: &str) -> Result<FuncProto, String> {
-    compile_script_impl(src, true)
+    compile_script_impl(src, true, true)
 }
 
-fn compile_script_impl(src: &str, as_eval: bool) -> Result<FuncProto, String> {
+fn compile_script_impl(src: &str, as_eval: bool, fuse: bool) -> Result<FuncProto, String> {
     let allocator = Allocator::default();
     // Parse as a *script* (the JS default): sloppy unless a `"use strict"`
     // directive (or a class/`module` context) makes it strict. The conformance
@@ -71,6 +79,7 @@ fn compile_script_impl(src: &str, as_eval: bool) -> Result<FuncProto, String> {
     let mut c = Compiler::new();
     c.source = src.to_string();
     c.toplevel_is_eval = as_eval;
+    c.fuse = fuse;
     // A construct the lowering step rejects is, for our purposes, a syntax/early
     // error — surface it as SyntaxError so it is reported consistently.
     c.compile_toplevel(&program).map_err(|e| {
@@ -643,6 +652,11 @@ struct Compiler {
     /// here may not contain `arguments` (spec early error). Cleared on entry
     /// to non-arrow nested functions, which own their own `arguments`.
     in_field_initializer: bool,
+    /// Run the peephole op-fusion pass (`fuse.rs`) on every finished function's
+    /// bytecode. Always on in production; disabled only by `compile_script_opts`
+    /// for the differential test that proves fused and unfused bytecode execute
+    /// identically.
+    fuse: bool,
 }
 
 impl Compiler {
@@ -664,6 +678,7 @@ impl Compiler {
             pending_method: false,
             in_class_body: false,
             in_field_initializer: false,
+            fuse: true,
         }
     }
 
@@ -1582,10 +1597,18 @@ impl Compiler {
     }
 
     fn finish(&self, fc: FnCtx) -> FuncProto {
+        // Peephole op-fusion (Phase 2): every finished function — top-level and
+        // nested — flows through here, so applying it once covers the whole
+        // proto tree. Disabled only by the differential test.
+        let code = if self.fuse {
+            crate::fuse::fuse_code(fc.code)
+        } else {
+            fc.code
+        };
         FuncProto {
             eval_scopes: fc.eval_scopes.clone(),
             name: fc.name,
-            code: fc.code,
+            code,
             consts: fc.consts,
             num_locals: 0,
             num_cells: fc.num_cells,

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -996,6 +996,17 @@ impl Vm {
                 }
                 push!(v);
             }
+            // Fused `LoadCell(cell) ; LoadConst(konst)` (see `fuse.rs`). Identical
+            // to running the two ops: the cell read keeps the same TDZ check, then
+            // the constant is pushed.
+            Op::LoadCellConst { cell, konst } => {
+                let v = frame.cells[*cell as usize].borrow().clone();
+                if matches!(v, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                push!(v);
+                push!(self.const_val(frame, *konst));
+            }
             Op::StoreCell(i) => {
                 let v = pop!();
                 *frame.cells[*i as usize].borrow_mut() = v;
@@ -2393,6 +2404,25 @@ impl Vm {
                     CmpOp::Ge => self.less_than(&a, &b)? == Some(false),
                 };
                 if !r {
+                    return Ok(Ctl::Jump(*target as usize));
+                }
+            }
+            // Fused `cmp ; JumpIfTrue` — mirror of `CmpBranchFalse`; branches when
+            // the comparison is true. Same helpers, so behavior is identical.
+            Op::CmpBranchTrue { cmp, target } => {
+                let b = pop!();
+                let a = pop!();
+                let r = match cmp {
+                    CmpOp::Eq => self.loose_equals(&a, &b)?,
+                    CmpOp::Ne => !self.loose_equals(&a, &b)?,
+                    CmpOp::StrictEq => self.strict_equals(&a, &b),
+                    CmpOp::StrictNe => !self.strict_equals(&a, &b),
+                    CmpOp::Lt => self.less_than(&a, &b)? == Some(true),
+                    CmpOp::Gt => self.less_than(&b, &a)? == Some(true),
+                    CmpOp::Le => self.less_than(&b, &a)? == Some(false),
+                    CmpOp::Ge => self.less_than(&a, &b)? == Some(false),
+                };
+                if r {
                     return Ok(Ctl::Jump(*target as usize));
                 }
             }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -630,6 +630,12 @@ impl Vm {
                 done!(Flow::Return(Value::Undefined));
             }
             frame.ip = ip + 1;
+            // Phase-0 dynamic opcode-frequency instrumentation. Compiled out
+            // entirely in the default build (the `op-histogram` feature is OFF
+            // by default), so the shipping interpreter loop is byte-identical;
+            // see `opstats.rs` and `docs/interpreter-optimization.md` §Phase 0.
+            #[cfg(feature = "op-histogram")]
+            crate::opstats::record(&proto.code[ip]);
             // Dispatch on a borrow of the instruction. `proto` is a clone of the
             // frame's (immutable) `FuncProto` Rc taken once per frame, so the
             // borrow is independent of `frame` and costs no per-op `Op::clone`

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -567,6 +567,38 @@ impl Vm {
         // re-deriving it (and so it doesn't alias the `&mut frame` step needs).
         let proto = frame.func.proto.clone();
         let mut interrupt_poll: u32 = 0;
+        // Injected resume completions are handled ONCE here, before the loop,
+        // rather than re-checked on every iteration. `pending_throw` /
+        // `pending_return` are set only by `resume_frame_throw` /
+        // `resume_frame_return` immediately before `run_frame` (see `promise.rs`)
+        // — a generator `.return(v)` or an awaited rejection delivered at resume.
+        // Nothing inside the loop ever sets them, so once taken here they stay
+        // `None` for the rest of the frame; this lifts two per-op `Option::take`s
+        // off the hot path. A resolved `Jump` just positions `frame.ip` and falls
+        // into the loop. (Phase 1, docs/interpreter-optimization.md.)
+        if let Some(e) = frame.pending_throw.take() {
+            match self.do_completion(&mut frame, Completion::Throw(e)) {
+                Ok(Ctl::Jump(t)) => frame.ip = t,
+                Ok(Ctl::Return(v)) => done!(Flow::Return(v)),
+                Ok(_) => unreachable!("throw completion yields jump or return"),
+                Err(e) => done!(Flow::Throw(e)),
+            }
+        } else if let Some(v) = frame.pending_return.take() {
+            // Injected `.return(v)` on a suspended generator: dispatch a Return
+            // completion so enclosing `finally` blocks run before the frame ends
+            // (a `yield` in a finally re-suspends as a normal yield in the loop).
+            match self.do_completion(&mut frame, Completion::Return(v)) {
+                Ok(Ctl::Jump(t)) => frame.ip = t,
+                Ok(Ctl::Return(rv)) => done!(Flow::Return(rv)),
+                Ok(_) => unreachable!("return completion yields jump or return"),
+                Err(e) => match self.do_completion(&mut frame, Completion::Throw(e)) {
+                    Ok(Ctl::Jump(t)) => frame.ip = t,
+                    Ok(Ctl::Return(rv)) => done!(Flow::Return(rv)),
+                    Ok(_) => unreachable!(),
+                    Err(e) => done!(Flow::Throw(e)),
+                },
+            }
+        }
         loop {
             if let Some(budget) = self.op_budget.as_mut() {
                 if *budget == 0 {
@@ -590,39 +622,6 @@ impl Vm {
                             done!(Flow::Throw(self.throw_range("execution interrupted")));
                         }
                     }
-                }
-            }
-            if let Some(e) = frame.pending_throw.take() {
-                match self.do_completion(&mut frame, Completion::Throw(e)) {
-                    Ok(Ctl::Jump(t)) => {
-                        frame.ip = t;
-                        continue;
-                    }
-                    Ok(Ctl::Return(v)) => done!(Flow::Return(v)),
-                    Ok(_) => unreachable!("throw completion yields jump or return"),
-                    Err(e) => done!(Flow::Throw(e)),
-                }
-            }
-            // Injected `.return(v)` on a suspended generator: dispatch a Return
-            // completion so enclosing `finally` blocks run before the frame ends
-            // (a `yield` in a finally re-suspends here as a normal yield).
-            if let Some(v) = frame.pending_return.take() {
-                match self.do_completion(&mut frame, Completion::Return(v)) {
-                    Ok(Ctl::Jump(t)) => {
-                        frame.ip = t;
-                        continue;
-                    }
-                    Ok(Ctl::Return(rv)) => done!(Flow::Return(rv)),
-                    Ok(_) => unreachable!("return completion yields jump or return"),
-                    Err(e) => match self.do_completion(&mut frame, Completion::Throw(e)) {
-                        Ok(Ctl::Jump(t)) => {
-                            frame.ip = t;
-                            continue;
-                        }
-                        Ok(Ctl::Return(rv)) => done!(Flow::Return(rv)),
-                        Ok(_) => unreachable!(),
-                        Err(e) => done!(Flow::Throw(e)),
-                    },
                 }
             }
             let ip = frame.ip;

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -4,7 +4,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::bytecode::{Const, FuncKind, Op, UpvalueSource};
+use crate::bytecode::{CmpOp, Const, FuncKind, Op, UpvalueSource};
 use crate::value::*;
 use crate::vm::*;
 
@@ -2371,6 +2371,29 @@ impl Vm {
                 let v = pop!();
                 if !self.to_boolean(&v) {
                     return Ok(Ctl::Jump(*t as usize));
+                }
+            }
+            // Fused `cmp ; JumpIfFalse` (see `fuse.rs`). Each arm reuses the
+            // SAME helper as the standalone comparison op, so coercion and any
+            // thrown error are identical; the boolean the pair would materialize
+            // is consumed directly by the branch instead of round-tripping the
+            // operand stack. `to_boolean(Bool(r)) == r`, so the branch condition
+            // matches `JumpIfFalse` exactly.
+            Op::CmpBranchFalse { cmp, target } => {
+                let b = pop!();
+                let a = pop!();
+                let r = match cmp {
+                    CmpOp::Eq => self.loose_equals(&a, &b)?,
+                    CmpOp::Ne => !self.loose_equals(&a, &b)?,
+                    CmpOp::StrictEq => self.strict_equals(&a, &b),
+                    CmpOp::StrictNe => !self.strict_equals(&a, &b),
+                    CmpOp::Lt => self.less_than(&a, &b)? == Some(true),
+                    CmpOp::Gt => self.less_than(&b, &a)? == Some(true),
+                    CmpOp::Le => self.less_than(&b, &a)? == Some(false),
+                    CmpOp::Ge => self.less_than(&a, &b)? == Some(false),
+                };
+                if !r {
+                    return Ok(Ctl::Jump(*target as usize));
                 }
             }
             Op::JumpIfFalsyPeek(t) => {

--- a/crates/chidori-js/src/fuse.rs
+++ b/crates/chidori-js/src/fuse.rs
@@ -55,7 +55,7 @@ fn for_each_ip(op: &mut Op, mut f: impl FnMut(&mut u32)) {
         | Op::JumpIfTruthyPeek(t)
         | Op::JumpIfNullishPeek(t)
         | Op::JumpIfNullish(t) => f(t),
-        Op::CmpBranchFalse { target, .. } => f(target),
+        Op::CmpBranchFalse { target, .. } | Op::CmpBranchTrue { target, .. } => f(target),
         Op::PushTryHandler { catch, finally } => {
             f(catch);
             if *finally != u32::MAX {
@@ -73,7 +73,7 @@ fn for_each_ip(op: &mut Op, mut f: impl FnMut(&mut u32)) {
     }
 }
 
-/// The comparison kind a `cmp ; JumpIfFalse` pair fuses to, if `op` is one of the
+/// The comparison kind a `cmp ; Jump…` pair fuses to, if `op` is one of the
 /// fuseable comparison opcodes.
 fn cmp_of(op: &Op) -> Option<CmpOp> {
     Some(match op {
@@ -87,6 +87,24 @@ fn cmp_of(op: &Op) -> Option<CmpOp> {
         Op::Ge => CmpOp::Ge,
         _ => return None,
     })
+}
+
+/// If the adjacent pair `(a, b)` is a recognized fusion, return the single op it
+/// fuses to. Each fused op must be observably equivalent to running `a` then `b`
+/// (the `exec.rs` handlers reuse the standalone ops' helpers). The jump targets
+/// carried here are still OLD indices; the caller remaps them afterwards.
+fn try_fuse(a: &Op, b: &Op) -> Option<Op> {
+    match (a, b) {
+        // Highest-frequency pair in the Phase-0 survey (~8.9%).
+        (Op::LoadCell(cell), Op::LoadConst(konst)) => Some(Op::LoadCellConst {
+            cell: *cell,
+            konst: *konst,
+        }),
+        // Compare-and-branch: the loop-test idiom and its bottom-tested mirror.
+        (_, Op::JumpIfFalse(t)) => cmp_of(a).map(|cmp| Op::CmpBranchFalse { cmp, target: *t }),
+        (_, Op::JumpIfTrue(t)) => cmp_of(a).map(|cmp| Op::CmpBranchTrue { cmp, target: *t }),
+        _ => None,
+    }
 }
 
 /// Rewrite `code` in place, fusing recognized adjacent sequences. Safe to call
@@ -123,21 +141,19 @@ pub fn fuse_code(code: Vec<Op>) -> Vec<Op> {
     let mut old_to_new = vec![0u32; n + 1];
     let mut i = 0usize;
     while i < n {
-        // Candidate: `cmp ; JumpIfFalse(target)` with nothing jumping between them.
-        if i + 1 < n {
-            if let (Some(cmp), Op::JumpIfFalse(target)) = (cmp_of(&code[i]), &code[i + 1]) {
-                if !is_target[i + 1] {
-                    old_to_new[i] = out.len() as u32;
-                    // The fused op replaces both slots; old index i+1 is interior
-                    // and never a jump target, so its mapping is unobservable.
-                    old_to_new[i + 1] = out.len() as u32;
-                    out.push(Op::CmpBranchFalse {
-                        cmp,
-                        target: *target,
-                    });
-                    i += 2;
-                    continue;
-                }
+        // A window may fuse only when nothing jumps into its interior (`i + 1`):
+        // jumps to its head stay valid (entering the fused op == entering the
+        // sequence at its head), but a jump landing on the second op needs that
+        // op to remain independently addressable.
+        if i + 1 < n && !is_target[i + 1] {
+            if let Some(fused) = try_fuse(&code[i], &code[i + 1]) {
+                old_to_new[i] = out.len() as u32;
+                // The fused op replaces both slots; old index i+1 is interior and
+                // never a jump target, so its mapping is unobservable.
+                old_to_new[i + 1] = out.len() as u32;
+                out.push(fused);
+                i += 2;
+                continue;
             }
         }
         old_to_new[i] = out.len() as u32;

--- a/crates/chidori-js/src/fuse.rs
+++ b/crates/chidori-js/src/fuse.rs
@@ -1,0 +1,238 @@
+//! Peephole **superinstruction / op-fusion** pass (Phase 2 of
+//! `docs/interpreter-optimization.md`).
+//!
+//! Runs once per compiled [`FuncProto`](crate::bytecode::FuncProto) in
+//! `Compiler::finish`, rewriting high-frequency adjacent opcode sequences into
+//! single fused ops. Fusion reduces both the number of dispatches through the
+//! interpreter's central `match` (fewer branch mispredictions) and the operand-
+//! stack traffic of the intermediate values the sequence would push and pop.
+//!
+//! ## Correctness invariants
+//!
+//! 1. **Observably identical.** Each fused op must produce exactly the result,
+//!    side effects, thrown errors, and ordering of the sequence it replaces. The
+//!    fused-op handlers in `exec.rs` reuse the *same* helpers as the standalone
+//!    ops, so the only difference is the elided intermediate stack value — which
+//!    is never visible to JS.
+//! 2. **Control flow preserved.** Fusion shortens `code`, which shifts the
+//!    absolute jump targets that index into it. Every code-offset operand is
+//!    remapped through [`for_each_ip`] — the single source of truth for "which
+//!    operands are instruction pointers" (it deliberately skips handler-stack
+//!    *depths* and the `u32::MAX` "none" sentinels). A window is fused only when
+//!    nothing jumps *into the middle* of it (`is_target[mid] == false`); jumps to
+//!    the *first* op of a window stay valid because entering the fused op is
+//!    equivalent to entering the original sequence at its head.
+//! 3. **Fallback always exists.** Fusion is a pure optimization; compiling with
+//!    it disabled (`compile_script_opts(src, fuse = false)`) yields bytecode that
+//!    must execute identically. The differential test in `tests/fusion.rs`
+//!    enforces this over a corpus, and `for_each_ip` keeps record→replay
+//!    deterministic because it perturbs neither values nor host-call ordering.
+
+use crate::bytecode::{CmpOp, Op};
+
+/// Apply `f` to every operand of `op` that is a **code offset** (an absolute ip
+/// into the function's `code`). This is the *only* place that enumerates which
+/// operands are instruction pointers; both target discovery and retargeting go
+/// through it, so they can never disagree.
+///
+/// Deliberately excluded:
+/// - `CompletionJump.boundary` — a handler-stack *depth*, not an ip.
+/// - the `u32::MAX` "none" sentinels of `PushTryHandler.finally` and
+///   `MarkDelegationHandler` — remapping them would corrupt the sentinel.
+///
+/// Every other `u32`/index operand in the instruction set is a const index,
+/// local/cell index, argument count, or similar — never an ip.
+///
+/// NOTE: if a future opcode gains a code-offset operand, it MUST be added here,
+/// or the fusion pass will silently miscompile control flow. The differential
+/// test (`tests/fusion.rs`) is the backstop that would catch such an omission.
+fn for_each_ip(op: &mut Op, mut f: impl FnMut(&mut u32)) {
+    match op {
+        Op::Jump(t)
+        | Op::JumpIfTrue(t)
+        | Op::JumpIfFalse(t)
+        | Op::JumpIfFalsyPeek(t)
+        | Op::JumpIfTruthyPeek(t)
+        | Op::JumpIfNullishPeek(t)
+        | Op::JumpIfNullish(t) => f(t),
+        Op::CmpBranchFalse { target, .. } => f(target),
+        Op::PushTryHandler { catch, finally } => {
+            f(catch);
+            if *finally != u32::MAX {
+                f(finally);
+            }
+        }
+        // `target` is an ip; `boundary` is a handler-stack depth — do NOT remap.
+        Op::CompletionJump { target, .. } => f(target),
+        Op::MarkDelegationHandler(t) => {
+            if *t != u32::MAX {
+                f(t);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The comparison kind a `cmp ; JumpIfFalse` pair fuses to, if `op` is one of the
+/// fuseable comparison opcodes.
+fn cmp_of(op: &Op) -> Option<CmpOp> {
+    Some(match op {
+        Op::Eq => CmpOp::Eq,
+        Op::Ne => CmpOp::Ne,
+        Op::StrictEq => CmpOp::StrictEq,
+        Op::StrictNe => CmpOp::StrictNe,
+        Op::Lt => CmpOp::Lt,
+        Op::Gt => CmpOp::Gt,
+        Op::Le => CmpOp::Le,
+        Op::Ge => CmpOp::Ge,
+        _ => return None,
+    })
+}
+
+/// Rewrite `code` in place, fusing recognized adjacent sequences. Safe to call
+/// on already-final bytecode (all jump targets absolute). Idempotent in effect:
+/// re-running over fused code is a no-op for the patterns it recognizes.
+pub fn fuse_code(code: Vec<Op>) -> Vec<Op> {
+    let n = code.len();
+    if n < 2 {
+        return code;
+    }
+
+    // 1. Mark every instruction that is the target of some jump/handler. A window
+    //    may not be fused if anything jumps into its interior.
+    let mut is_target = vec![false; n];
+    {
+        // for_each_ip needs &mut; clone targets out without mutating `code`.
+        let mut tmp = code.clone();
+        for op in &mut tmp {
+            for_each_ip(op, |t| {
+                let i = *t as usize;
+                if i < n {
+                    is_target[i] = true;
+                }
+            });
+        }
+    }
+
+    // 2. Single forward pass: emit fused or copied ops, recording where each old
+    //    index lands in the new code (`old_to_new`). The map has `n + 1` entries:
+    //    a forward jump may legitimately target `code.len()` (one past the end —
+    //    the compiler's `here()` at the tail, which exits the frame), and that
+    //    sentinel must remap to the NEW length, not be left dangling.
+    let mut out: Vec<Op> = Vec::with_capacity(n);
+    let mut old_to_new = vec![0u32; n + 1];
+    let mut i = 0usize;
+    while i < n {
+        // Candidate: `cmp ; JumpIfFalse(target)` with nothing jumping between them.
+        if i + 1 < n {
+            if let (Some(cmp), Op::JumpIfFalse(target)) = (cmp_of(&code[i]), &code[i + 1]) {
+                if !is_target[i + 1] {
+                    old_to_new[i] = out.len() as u32;
+                    // The fused op replaces both slots; old index i+1 is interior
+                    // and never a jump target, so its mapping is unobservable.
+                    old_to_new[i + 1] = out.len() as u32;
+                    out.push(Op::CmpBranchFalse {
+                        cmp,
+                        target: *target,
+                    });
+                    i += 2;
+                    continue;
+                }
+            }
+        }
+        old_to_new[i] = out.len() as u32;
+        out.push(code[i].clone());
+        i += 1;
+    }
+    // The one-past-the-end target maps to the new end-of-code.
+    old_to_new[n] = out.len() as u32;
+
+    // 3. Remap every code-offset operand through the recorded mapping.
+    for op in &mut out {
+        for_each_ip(op, |t| {
+            let old = *t as usize;
+            if old <= n {
+                *t = old_to_new[old];
+            }
+        });
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `cmp ; JumpIfFalse` fuses, the code shortens by one, and every jump
+    /// target past the fusion point is remapped to its new index.
+    #[test]
+    fn fuses_and_remaps_targets() {
+        // 0:LoadConst 1:LoadConst 2:Lt 3:JumpIfFalse(6) 4:Nop 5:Jump(0) 6:Return
+        let code = vec![
+            Op::LoadConst(0),
+            Op::LoadConst(1),
+            Op::Lt,
+            Op::JumpIfFalse(6),
+            Op::Nop,
+            Op::Jump(0),
+            Op::Return,
+        ];
+        let out = fuse_code(code);
+        // One slot shorter: the pair became a single op.
+        assert_eq!(out.len(), 6);
+        assert!(
+            matches!(
+                out[2],
+                Op::CmpBranchFalse {
+                    cmp: CmpOp::Lt,
+                    target: 5
+                }
+            ),
+            "Lt;JumpIfFalse(6) should fuse and remap 6 -> 5 (Return shifted left): {:?}",
+            out[2]
+        );
+        // The back-edge target 0 is unaffected; Return moved from 6 to 5.
+        assert!(matches!(out[4], Op::Jump(0)));
+        assert!(matches!(out[5], Op::Return));
+    }
+
+    /// A jump landing ON the `JumpIfFalse` (the interior of a candidate window)
+    /// blocks fusion: that instruction must remain independently addressable.
+    #[test]
+    fn does_not_fuse_into_a_jump_target() {
+        // 0:Lt 1:JumpIfFalse(3) 2:Jump(1) 3:Return — index 1 is a jump target.
+        let code = vec![Op::Lt, Op::JumpIfFalse(3), Op::Jump(1), Op::Return];
+        let out = fuse_code(code);
+        assert_eq!(out.len(), 4, "nothing should fuse");
+        assert!(!out.iter().any(|op| matches!(op, Op::CmpBranchFalse { .. })));
+        assert!(matches!(out[1], Op::JumpIfFalse(3)));
+        assert!(matches!(out[2], Op::Jump(1)));
+    }
+
+    /// `boundary` of `CompletionJump` is a handler DEPTH, not an ip, and must
+    /// survive the remap unchanged even as `target` is remapped.
+    #[test]
+    fn completion_jump_boundary_is_not_remapped() {
+        // Fuse the leading pair so indices shift, then check a CompletionJump.
+        let code = vec![
+            Op::Lt,
+            Op::JumpIfFalse(4),
+            Op::Nop,
+            Op::Nop,
+            Op::CompletionJump {
+                target: 0,
+                boundary: 2,
+            },
+        ];
+        let out = fuse_code(code);
+        // Pair fused: len 4; CompletionJump now at index 3.
+        match out[3] {
+            Op::CompletionJump { target, boundary } => {
+                assert_eq!(target, 0, "target remaps to the (unchanged) head index");
+                assert_eq!(boundary, 2, "boundary is a depth and must be untouched");
+            }
+            ref other => panic!("expected CompletionJump, got {other:?}"),
+        }
+    }
+}

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -11,6 +11,7 @@ pub mod compiler;
 pub mod convert;
 pub mod dom;
 pub mod exec;
+pub mod fuse;
 pub mod gc;
 pub mod generator;
 pub mod host;

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -18,6 +18,10 @@ pub mod iter;
 pub mod journal;
 pub mod jsx;
 pub mod module;
+/// Phase-0 opcode-frequency instrumentation; present only under the
+/// `op-histogram` feature (see `docs/interpreter-optimization.md`).
+#[cfg(feature = "op-histogram")]
+pub mod opstats;
 pub mod promise;
 pub mod proxy;
 pub mod realm;

--- a/crates/chidori-js/src/opstats.rs
+++ b/crates/chidori-js/src/opstats.rs
@@ -1,0 +1,116 @@
+//! Phase-0 dynamic opcode-frequency instrumentation (feature `op-histogram`).
+//!
+//! This module exists **only** when the `op-histogram` Cargo feature is enabled.
+//! In the default build it is not compiled in at all, and the single
+//! `opstats::record(..)` call site in `exec.rs::run_frame` is `#[cfg]`-removed —
+//! so the shipping interpreter loop is byte-identical and pays nothing. See the
+//! Phase-0 plan in [`docs/interpreter-optimization.md`].
+//!
+//! When enabled, the interpreter records, in a process-global thread-local
+//! histogram, every *executed* opcode and every adjacent opcode *pair* (the
+//! current op together with the immediately-preceding one in execution order).
+//! Pair counts are what drive superinstruction / op-fusion candidate selection
+//! in Phase 2: a frequently-executed `(Prev, Cur)` pair is a fusion candidate.
+//!
+//! Usage (from the `opstats` example):
+//! ```ignore
+//! opstats::reset();
+//! engine.eval(src);                 // execution feeds the histogram
+//! let report = opstats::take();      // drain + read the counts
+//! ```
+//!
+//! This is pure instrumentation: it never influences a value, an error, an
+//! ordering, or the journal, and it is excluded from the default build, so it
+//! cannot affect deterministic replay.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::bytecode::Op;
+
+thread_local! {
+    static HIST: RefCell<Hist> = RefCell::new(Hist::default());
+}
+
+#[derive(Default)]
+struct Hist {
+    total: u64,
+    ops: HashMap<&'static str, u64>,
+    pairs: HashMap<(&'static str, &'static str), u64>,
+    prev: Option<&'static str>,
+}
+
+/// A drained snapshot of the histogram, sorted for reporting.
+pub struct Report {
+    /// Total opcodes executed.
+    pub total: u64,
+    /// `(opcode, count)`, descending by count.
+    pub ops: Vec<(&'static str, u64)>,
+    /// `((prev, cur), count)`, descending by count.
+    pub pairs: Vec<((&'static str, &'static str), u64)>,
+}
+
+/// Record one executed opcode. Called once per dispatched instruction from the
+/// interpreter loop when the `op-histogram` feature is on.
+#[inline]
+pub fn record(op: &Op) {
+    let name = variant_name(op);
+    HIST.with(|h| {
+        let mut h = h.borrow_mut();
+        h.total += 1;
+        *h.ops.entry(name).or_insert(0) += 1;
+        if let Some(prev) = h.prev {
+            *h.pairs.entry((prev, name)).or_insert(0) += 1;
+        }
+        h.prev = Some(name);
+    });
+}
+
+/// Clear the histogram (call before a workload you want to measure in isolation).
+pub fn reset() {
+    HIST.with(|h| *h.borrow_mut() = Hist::default());
+}
+
+/// Drain the histogram into a sorted [`Report`] and clear it.
+pub fn take() -> Report {
+    HIST.with(|h| {
+        let h = std::mem::take(&mut *h.borrow_mut());
+        let mut ops: Vec<_> = h.ops.into_iter().collect();
+        ops.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+        let mut pairs: Vec<_> = h.pairs.into_iter().collect();
+        pairs.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        Report {
+            total: h.total,
+            ops,
+            pairs,
+        }
+    })
+}
+
+/// The `Op` variant name without its payload, interned to `&'static str`.
+///
+/// `Op` is `#[derive(Debug)]`, so `{:?}` yields `Variant`, `Variant(..)`, or
+/// `Variant { .. }`; we keep the leading identifier. The result is interned so
+/// the histogram can key on `&'static str` (cheap to hash/copy) rather than
+/// allocating a `String` per executed opcode.
+fn variant_name(op: &Op) -> &'static str {
+    let dbg = format!("{op:?}");
+    let end = dbg
+        .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .unwrap_or(dbg.len());
+    intern(&dbg[..end])
+}
+
+fn intern(s: &str) -> &'static str {
+    thread_local! {
+        static POOL: RefCell<HashMap<String, &'static str>> = RefCell::new(HashMap::new());
+    }
+    POOL.with(|p| {
+        if let Some(&v) = p.borrow().get(s) {
+            return v;
+        }
+        let leaked: &'static str = Box::leak(s.to_string().into_boxed_str());
+        p.borrow_mut().insert(s.to_string(), leaked);
+        leaked
+    })
+}

--- a/crates/chidori-js/tests/fusion.rs
+++ b/crates/chidori-js/tests/fusion.rs
@@ -81,18 +81,14 @@ fn fusion_preserves_observable_behavior() {
     }
 }
 
-/// Count `CmpBranchFalse` ops across a proto and its nested function templates.
-fn count_fused(proto: &FuncProto) -> usize {
-    let here = proto
-        .code
-        .iter()
-        .filter(|op| matches!(op, Op::CmpBranchFalse { .. }))
-        .count();
+/// Count ops matching `pred` across a proto and its nested function templates.
+fn count_ops(proto: &FuncProto, pred: fn(&Op) -> bool) -> usize {
+    let here = proto.code.iter().filter(|op| pred(op)).count();
     let nested: usize = proto
         .consts
         .iter()
         .map(|c| match c {
-            Const::Func(f) => count_fused(f),
+            Const::Func(f) => count_ops(f, pred),
             _ => 0,
         })
         .sum();
@@ -101,18 +97,31 @@ fn count_fused(proto: &FuncProto) -> usize {
 
 #[test]
 fn fusion_actually_fires() {
-    // A plain counting loop must fuse its `i < n ; JumpIfFalse` condition...
+    // A plain counting loop fuses both its operand-load pair (`LoadCell ;
+    // LoadConst`) and its compare-and-branch (`Lt ; JumpIfFalse`).
     let fused = compile_script_opts("for (let i = 0; i < 10; i++) { i + 1; }", true).unwrap();
     assert!(
-        count_fused(&fused) >= 1,
+        count_ops(&fused, |op| matches!(op, Op::CmpBranchFalse { .. })) >= 1,
         "expected the loop condition to fuse into CmpBranchFalse"
     );
-    // ...and the toggle must genuinely suppress it (proving the unfused fallback
-    // exercised by the differential test is really unfused).
-    let unfused = compile_script_opts("for (let i = 0; i < 10; i++) { i + 1; }", false).unwrap();
-    assert_eq!(
-        count_fused(&unfused),
-        0,
-        "fusion toggle off must emit no CmpBranchFalse"
+    assert!(
+        count_ops(&fused, |op| matches!(op, Op::LoadCellConst { .. })) >= 1,
+        "expected the operand loads to fuse into LoadCellConst"
     );
+    // A bottom-tested loop fuses its back-edge into CmpBranchTrue.
+    let dw = compile_script_opts("let i = 0; do { i++; } while (i < 5);", true).unwrap();
+    assert!(
+        count_ops(&dw, |op| matches!(op, Op::CmpBranchTrue { .. })) >= 1,
+        "expected the do/while back-edge to fuse into CmpBranchTrue"
+    );
+    // The toggle must genuinely suppress every fusion (so the unfused side of the
+    // differential test is really unfused).
+    let unfused = compile_script_opts("for (let i = 0; i < 10; i++) { i + 1; }", false).unwrap();
+    let any_fused = count_ops(&unfused, |op| {
+        matches!(
+            op,
+            Op::CmpBranchFalse { .. } | Op::CmpBranchTrue { .. } | Op::LoadCellConst { .. }
+        )
+    });
+    assert_eq!(any_fused, 0, "fusion toggle off must emit no fused ops");
 }

--- a/crates/chidori-js/tests/fusion.rs
+++ b/crates/chidori-js/tests/fusion.rs
@@ -1,0 +1,118 @@
+//! Differential + structural tests for the Phase-2 op-fusion pass (`fuse.rs`).
+//!
+//! The core guarantee: fusion is a pure optimization. Compiling a program with
+//! the peephole pass ON must produce byte-identical *observable* behavior to
+//! compiling it OFF — same console output, same thrown error (or lack of one).
+//! Because fusion shortens bytecode and thus shifts absolute jump targets, the
+//! corpus deliberately stresses control flow that indexes into `code`: loops,
+//! `break`/`continue`, labeled loops, `try`/`catch`/`finally`, `switch`,
+//! optional chaining, and short-circuit operators. A mis-remapped jump target
+//! would make the fused run diverge from the unfused run and fail loudly here.
+
+use std::rc::Rc;
+
+use chidori_js::bytecode::{Const, FuncProto, Op};
+use chidori_js::compiler::compile_script_opts;
+use chidori_js::{Engine, Value};
+
+/// Compile `src` with fusion `fuse`, run it to completion (draining microtasks),
+/// and return its observable outcome: `(threw, console_lines, error_string)`.
+fn run(src: &str, fuse: bool) -> (bool, Vec<String>, String) {
+    let proto = Rc::new(compile_script_opts(src, fuse).expect("compiles"));
+    let mut engine = Engine::new();
+    let func = engine.vm.make_closure(proto, Vec::new());
+    let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+    let _ = engine.vm.run_jobs_until_blocked();
+    let console = engine.console().to_vec();
+    match res {
+        Ok(_) => (false, console, String::new()),
+        Err(e) => (true, console, engine.vm.error_to_string(&e)),
+    }
+}
+
+/// Programs that mix the fused idiom (`cmp ; JumpIfFalse`) with control flow
+/// whose jump targets must survive the bytecode-shortening remap.
+const CORPUS: &[&str] = &[
+    // Every fuseable comparison as a loop condition.
+    "for (let i = 0; i < 5; i++) console.log('lt', i);",
+    "for (let i = 0; i <= 5; i++) console.log('le', i);",
+    "for (let i = 5; i > 0; i--) console.log('gt', i);",
+    "for (let i = 5; i >= 0; i--) console.log('ge', i);",
+    "let i = 0; while (i != 4) { console.log('ne', i); i++; }",
+    "let i = 0; while (i !== 4) { console.log('sne', i); i++; }",
+    "for (let i = 0; i == 0 || i < 3; i++) console.log('eq/seq', i === 1);",
+    // Nested loops with break/continue — jump targets after fused ops.
+    "for (let i = 0; i < 4; i++) { if (i === 2) continue; for (let j = 0; j < i; j++) { if (j > 5) break; console.log(i, j); } }",
+    // Labeled break across nested loops.
+    "outer: for (let i = 0; i < 5; i++) { for (let j = 0; j < 5; j++) { if (i * j >= 6) break outer; console.log('lab', i, j); } }",
+    // try/catch/finally interleaved with a fused loop condition.
+    "let s = 0; for (let i = 0; i < 6; i++) { try { if (i % 2 === 0) throw i; s += i; } catch (e) { console.log('caught', e); } finally { console.log('fin', i); } } console.log('s', s);",
+    // switch (jump table) with a comparison-driven loop around it.
+    "for (let i = 0; i < 4; i++) { switch (i) { case 0: console.log('zero'); break; case 1: case 2: console.log('one-two', i); break; default: console.log('def', i); } }",
+    // Optional chaining (JumpIfNullish) + comparison.
+    "let o = { a: { b: 3 } }; for (let i = 0; i < 3; i++) { console.log(o?.a?.b, o?.x?.y, i < 2); }",
+    // Short-circuit peek-jumps adjacent to comparisons.
+    "for (let i = 0; i < 5; i++) { let r = (i > 1) && (i < 4) || (i === 0); console.log('sc', r); }",
+    // do/while (condition at the bottom) — comparison before a back-edge.
+    "let i = 0; do { console.log('dw', i); i++; } while (i < 3);",
+    // Comparison result used as a value (NOT immediately branched) must stay a
+    // standalone comparison op and still be correct.
+    "for (let i = 0; i < 4; i++) { let b = i < 2; console.log('val', b); }",
+    // Functions/closures: fusion runs per-proto, nested protos included.
+    "function f(n) { let s = 0; for (let k = 0; k < n; k++) if (k !== 1) s += k; return s; } console.log('f', f(5), f(0));",
+    // Recursion + ternary comparisons.
+    "function fib(n){ return n < 2 ? n : fib(n-1) + fib(n-2); } console.log('fib', fib(10));",
+    // String / mixed-type comparisons (coercion must match exactly).
+    "for (let i = 0; i < 3; i++) { console.log('mix', '2' == 2, '2' === 2, 'a' < 'b', null == undefined); }",
+    // A comparison whose operand coercion THROWS — fused and unfused must throw
+    // identically (Symbol → number is a TypeError).
+    "let s = Symbol(); for (let i = 0; i < 3; i++) { console.log(i < s); }",
+];
+
+#[test]
+fn fusion_preserves_observable_behavior() {
+    for (n, src) in CORPUS.iter().enumerate() {
+        let off = run(src, false);
+        let on = run(src, true);
+        assert_eq!(
+            off, on,
+            "fusion changed observable behavior for corpus[{n}]:\n  {src}\n  unfused={off:?}\n  fused={on:?}"
+        );
+    }
+}
+
+/// Count `CmpBranchFalse` ops across a proto and its nested function templates.
+fn count_fused(proto: &FuncProto) -> usize {
+    let here = proto
+        .code
+        .iter()
+        .filter(|op| matches!(op, Op::CmpBranchFalse { .. }))
+        .count();
+    let nested: usize = proto
+        .consts
+        .iter()
+        .map(|c| match c {
+            Const::Func(f) => count_fused(f),
+            _ => 0,
+        })
+        .sum();
+    here + nested
+}
+
+#[test]
+fn fusion_actually_fires() {
+    // A plain counting loop must fuse its `i < n ; JumpIfFalse` condition...
+    let fused = compile_script_opts("for (let i = 0; i < 10; i++) { i + 1; }", true).unwrap();
+    assert!(
+        count_fused(&fused) >= 1,
+        "expected the loop condition to fuse into CmpBranchFalse"
+    );
+    // ...and the toggle must genuinely suppress it (proving the unfused fallback
+    // exercised by the differential test is really unfused).
+    let unfused = compile_script_opts("for (let i = 0; i < 10; i++) { i + 1; }", false).unwrap();
+    assert_eq!(
+        count_fused(&unfused),
+        0,
+        "fusion toggle off must emit no CmpBranchFalse"
+    );
+}

--- a/docs/interpreter-optimization.md
+++ b/docs/interpreter-optimization.md
@@ -1,10 +1,10 @@
 # Interpreter performance: optimizing `chidori-js` without a JIT
 
-> **Status:** Proposed (design only — no code yet). This document scopes a body
-> of work to make the `chidori-js` bytecode interpreter materially faster
-> **without** adding a JIT, while preserving the engine's three load-bearing
-> invariants: **zero `unsafe`**, **no new heavyweight dependencies**, and
-> **byte-identical deterministic replay**.
+> **Status:** Phase 0 (measurement) **done** — see §11; Phases 1–4 proposed.
+> This document scopes a body of work to make the `chidori-js` bytecode
+> interpreter materially faster **without** adding a JIT, while preserving the
+> engine's three load-bearing invariants: **zero `unsafe`**, **no new
+> heavyweight dependencies**, and **byte-identical deterministic replay**.
 >
 > **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md)
 > (historical engine plan), [`docs/conformance.md`](./conformance.md) (Test262
@@ -169,10 +169,11 @@ dispatch (loop flattening), and fewer lookups (inline caches).**
 Each phase is independently shippable and independently gated. Phases 1–3 are the
 recommended scope; Phase 4 is a larger optional follow-up.
 
-### Phase 0 — Measurement baseline (prerequisite, no engine changes)
+### Phase 0 — Measurement baseline (prerequisite) ✅ done — results in §11
 
 **Goal:** establish where cycles actually go before changing anything, and make
-regressions visible.
+regressions visible. (The only engine touch is a feature-gated, off-by-default
+instrument that compiles out of the shipping build — see §11.)
 
 - Extend `benches/execution.rs` (criterion) so the `interp` group isolates the
   dispatch loop from the front end across the existing workloads
@@ -400,7 +401,115 @@ byte-identity), and §7.5 (no benchmark regressions).
 
 ---
 
-## 11. References
+## 11. Phase 0 results (measured 2026-06-14)
+
+Phase 0 is **complete**. Tooling landed:
+
+- A feature-gated dynamic opcode-frequency instrument (`src/opstats.rs` + one
+  `#[cfg(feature = "op-histogram")]` call site in `exec.rs::run_frame`). The
+  feature is **OFF by default**, so the shipping engine is byte-identical and
+  pays nothing (confirmed: `tests/smoke.rs` and `tests/replay.rs` pass unchanged
+  on the default build, including record→replay byte-identity).
+- An analyzer that reports static (as-emitted) and dynamic (as-executed) opcode
+  and adjacent-pair histograms: `cargo run --release --example opstats -p
+  chidori-js --features op-histogram`.
+
+> **Caveat:** the numbers below are from one developer machine and are a
+> *relative* baseline for tracking deltas across phases, not an absolute spec.
+> Re-run on the target machine before quoting wins.
+
+### 11.1 Timing baseline (criterion, default release build)
+
+Median per the existing `benches/execution.rs` workloads. `compile` = front end
+only; `interp` = VM loop only (compiled once); `eval` = end-to-end incl. realm
+setup; `engine_new` = realm/builtin construction alone.
+
+| workload | compile | interp | eval |
+| --- | ---: | ---: | ---: |
+| arith_loop | 4.4 µs | 6.3 ms | 7.0 ms |
+| fib_recursive | 5.4 µs | 74.6 ms | 73.9 ms |
+| property_access | 7.0 µs | 7.9 ms | 8.8 ms |
+| array_push_sum | 6.4 µs | 5.3 ms | 6.0 ms |
+| array_hof | 9.0 µs | 3.1 ms | 4.0 ms |
+| string_build | 4.5 µs | 2.2 ms | 4.8 ms |
+| closures | 8.4 µs | 5.9 ms | 9.3 ms |
+| **engine_new** | — | — | **3.6 ms** |
+
+**Findings.**
+1. **The front end is not the bottleneck.** Compilation is microseconds; the
+   interpreter loop is milliseconds — 3 orders of magnitude apart. Optimization
+   effort belongs in the VM loop, not the parser/compiler.
+2. **Realm setup (`engine_new`, ~3.6 ms) is a large fixed cost** — it rivals or
+   exceeds the *entire* interpreter time of the lighter workloads. For short
+   agent steps (a little JS between host calls), realm construction can dominate
+   interpreter-loop time. This is a previously-unscoped lever worth its own
+   investigation (cache/clone a warm realm) and may beat Phases 1–3 for the
+   short-script regime.
+3. The interpreter loop dominates only for compute-heavy code (fib ≈ 75 ms).
+
+### 11.2 Dynamic opcode frequency (execution-weighted, 4.43M executed ops)
+
+Top executed opcodes (combined across workloads):
+
+| % | opcode | | % | opcode |
+| ---: | --- | --- | ---: | --- |
+| 16.9% | `LoadCell` | | 3.8% | `Call` |
+| 12.2% | `InitCell` | | 3.8% | `LoadArg` |
+| 9.4% | `LoadConst` | | 3.7% | `Return` |
+| 4.6% | `JumpIfFalse` | | 3.6% | `LoadUndefined` |
+| 4.6% | `Lt` | | 3.6% | `LoadThis`/`LoadNewTarget`/`BindThisSloppy` |
+| 4.1% | `Sub` | | 3.6% | `LoadUpvalue` |
+| 3.1% | `Add` | | | |
+
+**~40% of all executed opcodes are pure data movement** (`LoadCell`,
+`InitCell`, `LoadConst`, `LoadArg`, `LoadUpvalue`, `LoadUndefined`). This is the
+operand-stack-shuffle overhead that fusion (Phase 2) and a register bytecode
+(Phase 4) directly target. `InitCell` at 12.2% is notably high — per-iteration
+`let` bindings in `for` loops and the call/param prologue mint fresh cells.
+
+### 11.3 Top fusion candidates (adjacent executed pairs)
+
+| % | pair | fuse to |
+| ---: | --- | --- |
+| 8.9% | `LoadCell ; LoadConst` | `LoadCellConst` |
+| 5.0% | `InitCell ; LoadCell` | prologue superinstruction |
+| 4.6% | `Lt ; JumpIfFalse` | `JumpIfNotLt` (compare-and-branch) |
+| 4.5% | `LoadConst ; Lt` | folds into `LoadCellConst ; Lt` |
+| 3.8% | `LoadArg ; InitCell` | param-bind superinstruction |
+| 3.6% | `LoadConst ; Sub` | `SubConst` |
+| 3.4% | `Sub ; Call` | — |
+
+The canonical loop-condition idiom `LoadCell(i); LoadConst(N); Lt; JumpIfFalse`
+shows up as a *chain* of high-frequency pairs (8.9% + 4.5% + 4.6%). Fusing
+load+binop (`LoadCell ; LoadConst ; <binop>`) and compare-and-branch
+(`Lt ; JumpIfFalse`) would remove a large, concrete slice of dispatches and
+operand-stack traffic in exactly the hot loops.
+
+### 11.4 Go / no-go decision
+
+| Phase | Decision | Rationale |
+| --- | --- | --- |
+| **1 — hot-loop cleanup** | **GO** | Lowest risk; validates the gating harness; the per-op `Result<Ctl,_>` round-trip and per-op `Option::take`s are real overhead on the data-movement ops that make up ~40% of execution. |
+| **2 — fusion** | **GO** | Data shows clear high-frequency pairs (load+binop, compare-and-branch) and a 40%-data-movement profile. Target the §11.3 candidates, validated by the survey rather than intuition. |
+| **3 — inline caches** | **CONDITIONAL** | Property ops did *not* crack the top-15 in this loop/arith-heavy mix, so the win is unproven *for this workload*. Gate on the agent profile (below): pursue only if property access registers there. |
+| **4 — register bytecode** | **DEFER** | The 40%-data-movement figure is the strongest argument for it, but it's a back-end rewrite; revisit only if Phases 1–2 leave a measured, workload-relevant gap. |
+| **Bonus — warm-realm reuse** | **INVESTIGATE** | `engine_new` ≈ 3.6 ms is unexpectedly large and dominates short scripts; worth scoping independently of the dispatch work. |
+
+### 11.5 Remaining Phase 0 item (carried forward)
+
+The **representative-agent replay benchmark** (JS-execution share of an agent
+run replayed from a committed journal) is **not yet implemented** — it needs a
+checked-in journal fixture and pulls in the larger `chidori` crate's host
+runtime, out of scope for this `chidori-js`-local pass. It is the gate for
+Phase 3 and for sizing the whole effort. *A-priori* signal: even the heaviest
+micro-workload here (~75 ms) is small next to typical per-LLM-call latency
+(hundreds of ms to seconds), so JS execution is likely a *minority* of agent
+wall-clock — which is the core argument for the whole "no JIT" stance. **This
+must be measured, not assumed, before committing to Phases 3–4.**
+
+---
+
+## 12. References
 
 - [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md) — engine
   decision record (pure Rust, no `boa_engine`, replay-not-snapshot).

--- a/docs/interpreter-optimization.md
+++ b/docs/interpreter-optimization.md
@@ -1,0 +1,413 @@
+# Interpreter performance: optimizing `chidori-js` without a JIT
+
+> **Status:** Proposed (design only — no code yet). This document scopes a body
+> of work to make the `chidori-js` bytecode interpreter materially faster
+> **without** adding a JIT, while preserving the engine's three load-bearing
+> invariants: **zero `unsafe`**, **no new heavyweight dependencies**, and
+> **byte-identical deterministic replay**.
+>
+> **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md)
+> (historical engine plan), [`docs/conformance.md`](./conformance.md) (Test262
+> gate), [`docs/architecture.md`](./architecture.md), [`docs/replay.md`](./replay.md),
+> [`docs/value-checkpoints.md`](./value-checkpoints.md).
+
+---
+
+## 1. Summary (TL;DR)
+
+`chidori-js` is a pure-Rust **bytecode interpreter**: `oxc` parses to an AST,
+`compiler.rs` lowers it to a stack-machine bytecode, and `exec.rs`/`vm.rs` run a
+switch-dispatch loop over that bytecode. A **JIT** (compile hot bytecode to
+native machine code at runtime) would be the conventional way to go faster, but
+for Chidori it is the wrong tool: it requires `unsafe` executable-memory
+management, a code-generation backend (a large dependency or a hand-rolled
+assembler), and it introduces timing nondeterminism that fights the engine's
+deterministic-replay contract — all to speed up a workload (LLM agents) that is
+overwhelmingly bottlenecked on network/LLM latency, not on JS execution.
+
+This document proposes the **interpreter-level** alternative. The realistic,
+high-value wins that respect all three invariants are, in priority order:
+
+1. **Hot-loop cleanup** — flatten the current double dispatch and move per-op
+   bookkeeping off the common path.
+2. **Superinstructions / op fusion** — fold common opcode sequences (e.g.
+   `LoadLocal; LoadConst; Add`) into single fused ops, cutting both dispatch
+   count and operand-stack traffic.
+3. **Inline caches** — cache shape→slot resolutions at property-access sites.
+4. **(Larger, optional) register-based bytecode** — eliminate a large fraction
+   of stack-shuffling ops entirely.
+
+Crucially, **true "threaded" dispatch (computed-goto / guaranteed tail calls) is
+not cleanly available in stable, `unsafe`-free Rust**, so the goal is framed as
+*"reduce the number of dispatches and the work per dispatch"* rather than
+*"thread the interpreter"* in the literal sense.
+
+The work is gated end-to-end by the existing **Test262 conformance baseline**
+and the **replay byte-identity** tests: a performance change that alters any
+observable behavior is a bug, not a tradeoff.
+
+---
+
+## 2. Background: why not a JIT?
+
+A JIT keeps the same front end (parser → bytecode) but replaces the *back end*
+for hot code: it profiles which functions/loops run often, emits native machine
+code for them, and jumps into it. It computes exactly the same results as the
+interpreter — the dividing line is **how work is dispatched**, not semantics.
+
+For Chidori specifically, a JIT collides with the project's stated invariants:
+
+1. **`unsafe` / C-free is a headline property.** A JIT must allocate executable
+   memory (W^X / `mmap` with `PROT_EXEC`), write raw bytes into it, and call
+   through a transmuted function pointer. That is irreducibly `unsafe`. The
+   alternative — a backend like Cranelift — is a large dependency that runs
+   against the crate's "pure Rust, vendor nothing" stance (see the decision
+   record in `docs/pure-rust-js-engine-plan.md`).
+2. **Speculation + deoptimization is the hard, bug-prone part.** JIT speed comes
+   from speculating on types/shapes; when an assumption breaks the engine must
+   *deoptimize* — abandon native code mid-execution and reconstruct the exact
+   interpreter frame. This is where most JIT correctness and security bugs live.
+3. **It fights deterministic replay.** Chidori's durability model is
+   re-execution against a recorded host-call journal for **byte-identical**
+   output (`docs/replay.md`). A JIT introduces nondeterministic *timing* — when
+   a function compiles, when it deopts — which can perturb observable ordering
+   (GC, microtask interleaving). Keeping a JIT's observable behavior bit-identical
+   across record and replay is a constraint production JITs never face.
+4. **Rust does not give threaded dispatch for free.** Classic direct/token
+   threading needs computed `goto` or guaranteed tail-call optimization. Stable
+   safe Rust has neither (`become`/explicit-tail-call is unstable; label-as-value
+   does not exist). So the biggest "free" interpreter speedups in C interpreters
+   are not directly portable here.
+5. **The workload rarely justifies it.** A single `await chidori.llm(...)` dwarfs
+   all the JS an agent will run between effects. JS-execution time must first be
+   shown to register in a profile of a representative run (see Phase 0).
+
+**Conclusion:** invest in interpreter-level optimizations that keep zero
+`unsafe`, add no dependencies, and do not perturb determinism.
+
+---
+
+## 3. Current architecture (what we're optimizing)
+
+All paths below are in `crates/chidori-js/src/`.
+
+- **Front end:** `compiler.rs` (~6.7k LOC) lowers the `oxc` AST to bytecode;
+  `bytecode.rs` defines `enum Op` (constants, locals/cells/upvalues/globals,
+  arithmetic, property access, calls, control flow, etc.).
+- **VM core:** `vm.rs` holds the `Vm`, `Frame`, `Flow` (`Return`/`Throw`/`Suspend`),
+  and the suspension/promise/generator machinery. No VM state is ever serialized;
+  durability lives one layer up in the journal (`replay.rs`).
+- **Dispatch loop:** `exec.rs::run_frame` is the hot loop. It is a **switch-threaded
+  interpreter**, and today it is a *double* dispatch:
+
+```rust
+// exec.rs::run_frame (abridged)
+loop {
+    // 1. op-budget decrement (every op)
+    // 2. interrupt poll (amortized: every 256 ops)
+    // 3. frame.pending_throw  check (Option::take, every op)
+    // 4. frame.pending_return check (Option::take, every op)
+    let ip = frame.ip;
+    frame.ip = ip + 1;
+    match self.step(&mut frame, &proto.code[ip]) {   // inner `match op { .. }`
+        Ok(Ctl::Next)      => continue,
+        Ok(Ctl::Jump(t))   => { frame.ip = t; continue; }
+        Ok(Ctl::Return(v)) => { /* module hook */ done!(Flow::Return(v)); }
+        Ok(Ctl::Await(v))  => ...,
+        Ok(Ctl::Yield(v))  => ...,
+        Err(e)             => ...,
+    }
+}
+```
+
+`step(&mut self, frame, op) -> Result<Ctl, Value>` is a large `match op { .. }`.
+So per opcode the engine pays for: loop bookkeeping (1–4 above), an indirect read
+of `proto.code[ip]`, the inner `match op` jump, construction of a
+`Result<Ctl, Value>`, its return, and a re-match on `Ctl` in the outer loop.
+
+**Cost model.** The dominant micro-cost on tiny ops (`Add`, `LoadLocal`) is
+branch misprediction on the single central `match` in `step`: the predictor sees
+one indirect branch for the whole interpreter and mispredicts constantly
+(~15–20 cycles each). For real-world JS, **property access** (shape lookup) is
+typically the larger aggregate cost. The team already does this class of tuning —
+e.g. cloning the `FuncProto` `Rc` once per frame to avoid a per-op `Op::clone`
+(noted in `run_frame` as having been ~5% of a call-heavy run).
+
+The bytecode is **stack-based**: many ops exist only to move values between the
+operand stack and locals/cells, which is pure dispatch overhead a register model
+would remove.
+
+---
+
+## 4. What "threaded" means, and the Rust constraint
+
+The dispatch-optimization family, from least to most invasive:
+
+- **Switch threading** — one central switch. *This is what we have.*
+- **Direct/token threading** — each op handler jumps *directly* to the next
+  handler, so the predictor gets one branch site *per opcode* and learns
+  correlations ("`LoadLocal` is usually followed by `LoadConst`"). The classic
+  20–40% win in C interpreters (CPython computed-goto). **Needs computed goto.**
+- **Subroutine threading** — each op is a function; the program is a list of
+  function pointers called in sequence. **Needs guaranteed tail calls** to avoid
+  growing the native stack.
+- **Superinstructions / op fusion** — fold common op *sequences* into one op.
+  Cuts dispatch count *and* stack traffic. **Pure compiler+VM work; no dispatch
+  trickery; works in safe Rust.**
+
+The catch: direct/subroutine threading need computed `goto` or guaranteed TCO,
+**neither of which is available in stable, `unsafe`-free Rust** (`become` is
+unstable; raw function-pointer threading reintroduces `unsafe`). Therefore this
+plan does **not** pursue literal threaded dispatch. It pursues the safe-Rust
+subset that captures most of the benefit: **fewer dispatches (fusion), cheaper
+dispatch (loop flattening), and fewer lookups (inline caches).**
+
+---
+
+## 5. Proposed work (phased)
+
+Each phase is independently shippable and independently gated. Phases 1–3 are the
+recommended scope; Phase 4 is a larger optional follow-up.
+
+### Phase 0 — Measurement baseline (prerequisite, no engine changes)
+
+**Goal:** establish where cycles actually go before changing anything, and make
+regressions visible.
+
+- Extend `benches/execution.rs` (criterion) so the `interp` group isolates the
+  dispatch loop from the front end across the existing workloads
+  (`arith_loop`, `fib_recursive`, property get/set, arrays, strings, closures).
+- Add a **representative-agent** benchmark: a recorded agent run replayed from a
+  journal (zero LLM calls), measuring the share of wall-clock spent in JS
+  execution vs. host/journal/serialization. This answers "does JS execution even
+  register?" and sets the bar for whether Phases 2–4 are worth it.
+- Capture a profile (e.g. `perf`/`samply`) of the hottest micro-benchmark to
+  confirm the branch-mispredict and property-lookup hypotheses in §3.
+- Record committed baseline numbers in this doc (a results table) so later phases
+  can quote deltas.
+
+**Exit criteria:** baseline numbers committed; a documented decision on whether
+the per-phase wins clear a "worth the complexity" bar.
+
+### Phase 1 — Hot-loop cleanup (flatten dispatch, de-overhead the common path)
+
+**Goal:** remove avoidable per-op work without changing the bytecode.
+
+- **Flatten the double dispatch.** The common `Ctl::Next` path currently builds
+  and returns a `Result<Ctl, Value>` that the outer loop immediately re-matches.
+  Restructure so the most frequent ops update `frame.ip`/stack and signal
+  "continue" with the cheapest possible control transfer (e.g. inline the hottest
+  op bodies into the loop, or have `step` mutate `frame` and return a compact
+  status that avoids materializing `Ctl::Next`/`Return` payloads on the hot path).
+- **Move rare checks off the hot path.** `pending_throw` / `pending_return` are
+  only set right after a completion or a generator resume; their `Option::take`
+  on every iteration can move to the slow paths that set them (or be guarded by a
+  single cheap flag). Keep the interrupt poll amortized as it is.
+- **Keep the op-budget semantics identical** (it must remain uncatchable and
+  terminating); only its placement may change.
+
+**Risk:** low. No bytecode or semantics change. Pure internal refactor.
+
+### Phase 2 — Superinstructions / op fusion
+
+**Goal:** fewer dispatches and less operand-stack traffic for the most common
+sequences.
+
+- Add a **peephole fusion pass** over emitted bytecode (in `compiler.rs`, after
+  lowering) that recognizes high-frequency sequences and rewrites them to fused
+  ops. Candidate fusions (validate against Phase 0 op-frequency data — do not
+  guess):
+  - `LoadLocal(x); LoadConst(k); <BinOp>` → `BinOpLocalConst{ x, k, op }`
+  - `LoadLocal(x); LoadLocal(y); <BinOp>` → `BinOpLocalLocal`
+  - `LoadConst/LoadLocal; <branch>` for loop conditions
+  - increment/compare patterns from `for` loops (`i < n`, `i++`).
+- Add the corresponding handlers in `exec.rs`. Each fused handler must produce
+  **exactly** the result and side effects (including thrown errors, `ToNumber`
+  coercions, and ordering) of the sequence it replaces.
+- Fusion is opt-in per pattern and gated behind the conformance suite; an
+  unfused fallback always remains for any sequence not matched.
+
+**Risk:** medium. Each fused op is a new opportunity for a subtle semantic
+divergence (e.g. coercion order, exception type/site). Mitigated by Test262 +
+differential testing (§6).
+
+### Phase 3 — Inline caches for property access
+
+**Goal:** make the dominant real-world cost (shape lookups on `GetProp`/`SetProp`)
+cheaper by caching the resolved shape→slot mapping at each access site.
+
+- Attach a small monomorphic/polymorphic inline cache to property-access ops
+  (keyed on the access site). On a cache hit (same object shape as last seen),
+  read/write the slot directly; on a miss, fall back to the full lookup and
+  refill the cache.
+- **Determinism boundary (critical):** the cache must be a *pure performance side
+  effect*. It may only change *how fast* a lookup resolves, never *what* it
+  resolves to, nor the order/identity of any observable operation. It must never
+  be serialized, must be reset on `Vm` setup, and must be excluded from anything
+  the journal observes. This is almost certainly safe (it mirrors what the slow
+  path computes) but must be asserted by the replay byte-identity tests (§6).
+- Start monomorphic (single shape) and only extend to polymorphic if Phase 0
+  data shows it pays.
+
+**Risk:** medium. The cache-invalidation logic (shape transitions, prototype
+mutation, `delete`, `__proto__` changes) must be correct or it produces *wrong
+results*, not just slow ones. Heavily gated by Test262's `Object`/`Reflect`/`Proxy`
+suites and the differential harness.
+
+### Phase 4 — Register-based bytecode (larger, optional follow-up)
+
+**Goal:** eliminate a large fraction of `Load`/`Store` stack-shuffling ops by
+moving to a register/local-indexed bytecode (Lua 5 model). This is the
+interpreter-side change that most closely approaches "what a baseline JIT would
+buy" — *without* code generation, `unsafe`, or determinism risk.
+
+- This is effectively a rewrite of the `compiler.rs` back end and a second
+  instruction encoding. It is **out of scope for the initial landing** and listed
+  here only to record the ceiling of the interpreter-only approach. Revisit only
+  if Phases 1–3 leave a measured, workload-relevant gap.
+
+**Risk:** high (scope). Deferred behind explicit go/no-go after Phases 1–3.
+
+---
+
+## 6. Determinism & replay considerations (non-negotiable)
+
+Every change here must satisfy the engine's determinism contract
+(`docs/replay.md`, `docs/conformance.md`):
+
+- **Observable behavior is invariant.** Results, thrown error types/messages,
+  property enumeration order, microtask/promise ordering, and host-call
+  sequencing must be byte-for-byte identical before and after each phase. These
+  optimizations change *timing and internal representation only*.
+- **No new nondeterminism sources.** No wall-clock-, address-, or
+  iteration-count-dependent decisions may leak into observable output. (This is
+  exactly why a JIT's compile/deopt timing is disqualifying and an inline cache —
+  which only memoizes a deterministic lookup — is acceptable.)
+- **Caches and fused state are never serialized.** Inline caches and any
+  Phase-2/3 auxiliary state are rebuilt from scratch on each `Vm` and excluded
+  from the journal. A record→replay run must produce an identical journal and
+  identical output whether or not caches warmed.
+- **Fail-loud on divergence.** The existing ordered-journal divergence detection
+  (`replay.rs`) is the backstop: if any optimization perturbs host-call ordering,
+  replay must fail loudly rather than silently diverge.
+
+---
+
+## 7. Testing plan
+
+Layered, with each phase required to pass all layers before merge.
+
+### 7.1 Conformance gate (correctness, primary)
+
+- Run the full **Test262** suite via `scripts/test262.sh --gate` against the
+  committed baseline. **Zero regressions** is the merge bar for every phase
+  (`docs/conformance.md`). Inline caches especially must hold the
+  `Object`/`Reflect`/`Proxy`/`Array` suites; fusion must hold the language
+  operator/coercion suites.
+- Re-record the baseline only for *intentional* conformance *gains* (never to
+  paper over a regression).
+
+### 7.2 Engine unit/integration tests (correctness)
+
+- The existing `tests/smoke.rs`, `tests/async_gen.rs`, and `tests/replay.rs` must
+  remain green unchanged.
+- Add targeted unit tests for each new fused op asserting it equals the unfused
+  sequence on edge cases: operand-type mixes (number/string/BigInt/object with
+  `valueOf`/`Symbol.toPrimitive`), coercion-order observability, NaN, ±0,
+  exceptions thrown mid-sequence, and TDZ/uninitialized-cell interactions.
+- Add inline-cache invalidation tests: shape transitions, `delete`, prototype
+  swaps (`__proto__`, `Object.setPrototypeOf`), accessor vs data properties,
+  proxies, and megamorphic sites.
+
+### 7.3 Replay byte-identity tests (determinism, primary)
+
+- Extend `tests/replay.rs`: for a corpus of programs, assert
+  **record→replay** produces an identical journal *and* identical output with
+  caches cold vs. warm, and with fusion on vs. off.
+- Add a **toggle-equivalence** test: a hidden build/test flag that disables each
+  optimization (unfused fallback, cache-bypass) must yield byte-identical output
+  and journals to the optimized path on the whole corpus. This is the strongest
+  guarantee that the optimizations are pure performance side effects.
+
+### 7.4 Differential testing (correctness, fuzz)
+
+- Add a **differential harness** that runs randomly generated / corpus programs
+  through (a) the optimized interpreter and (b) the unfused / cache-bypassed
+  interpreter, and asserts identical results, thrown errors, and journals. Seed
+  it with Test262 fragments and the benchmark workloads; optionally wire a small
+  fuzzer (e.g. `cargo-fuzz`-style, kept in-tree, no new runtime deps).
+- Where feasible, cross-check a subset against Node/Bun using the existing
+  `benchmarks/run.mjs` cross-runtime harness for *result* parity (not timing).
+
+### 7.5 Performance benchmarks (the actual goal)
+
+- `cargo bench -p chidori-js` (criterion) `interp` group: report per-workload
+  deltas vs. the Phase 0 baseline. Each phase states its expected win and must
+  not regress any workload.
+- The **representative-agent replay benchmark** from Phase 0: report the
+  end-to-end share of time in JS execution before/after, to keep the work honest
+  about real-world impact.
+- Add a CI **performance smoke** (informational, non-gating initially) that flags
+  large interpreter-loop regressions on PRs.
+
+### 7.6 Memory & safety
+
+- Confirm no `unsafe` is introduced (`#![forbid(unsafe_code)]`-style check or
+  grep gate in CI).
+- Re-run the conformance runner's leak/OOM guards (the GC cycle-breaking
+  `Vm::dispose` path) to confirm caches/fused state don't leak across `Vm`s.
+
+---
+
+## 8. Rollout & sequencing
+
+1. **Phase 0** lands first and alone (benchmarks + agent profile + committed
+   baseline + the go/no-go decision).
+2. **Phase 1** (loop cleanup) — lowest risk, validates the gating harness.
+3. **Phase 2** (fusion) — driven by Phase 0 op-frequency data.
+4. **Phase 3** (inline caches) — only if property access registers in the agent
+   profile.
+5. **Phase 4** (register bytecode) — explicit go/no-go after 1–3; likely deferred.
+
+Each phase is a separate PR, each gated by §7.1 (Test262), §7.3 (replay
+byte-identity), and §7.5 (no benchmark regressions).
+
+---
+
+## 9. Explicitly out of scope
+
+- **A JIT** (baseline or optimizing), for the reasons in §2.
+- **Literal threaded dispatch** (computed-goto / subroutine threading), because
+  stable safe Rust lacks computed `goto` and guaranteed tail calls (§4).
+- **Any `unsafe` or new heavyweight dependency.** If a proposed optimization
+  needs either, it is out of scope by definition.
+- **Speculative type specialization with deoptimization** — that is JIT-shaped
+  complexity and determinism risk without the JIT's payoff.
+
+---
+
+## 10. Open questions
+
+- Does JS execution register meaningfully against host/LLM/journal time in a
+  representative agent run? (Phase 0 answers this and may shrink the scope to
+  Phase 1 only.)
+- Which fused-op set maximizes win per added handler? (Driven by Phase 0
+  op-frequency histograms, not intuition.)
+- Monomorphic vs. polymorphic inline caches: does the agent workload have enough
+  shape diversity at hot sites to justify polymorphism?
+- Is a register bytecode (Phase 4) ever worth its rewrite cost given the workload,
+  or is the stack VM permanently "good enough" after Phases 1–3?
+
+---
+
+## 11. References
+
+- [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md) — engine
+  decision record (pure Rust, no `boa_engine`, replay-not-snapshot).
+- [`docs/conformance.md`](./conformance.md) — Test262 harness and CI gate.
+- [`docs/replay.md`](./replay.md) — deterministic-replay durability model.
+- [`docs/architecture.md`](./architecture.md) — runtime map.
+- `crates/chidori-js/src/exec.rs` — `run_frame` dispatch loop and `step`.
+- `crates/chidori-js/src/bytecode.rs` — `enum Op`.
+- `crates/chidori-js/src/compiler.rs` — AST → bytecode lowering.
+- `crates/chidori-js/benches/execution.rs` — interpreter micro-benchmarks.

--- a/docs/interpreter-optimization.md
+++ b/docs/interpreter-optimization.md
@@ -1,11 +1,12 @@
 # Interpreter performance: optimizing `chidori-js` without a JIT
 
 > **Status:** Phase 0 (measurement) **done** — see §11. Phase 1 (hot-loop
-> cleanup) **partially landed** — see §12. Phases 2–4 proposed. This document
-> scopes a body of work to make the `chidori-js` bytecode interpreter materially
-> faster **without** adding a JIT, while preserving the engine's three
-> load-bearing invariants: **zero `unsafe`**, **no new heavyweight
-> dependencies**, and **byte-identical deterministic replay**.
+> cleanup) **partially landed** — see §12. Phase 2 (op fusion) **first fusion
+> landed** — see §13. Phases 3–4 proposed. This document scopes a body of work
+> to make the `chidori-js` bytecode interpreter materially faster **without**
+> adding a JIT, while preserving the engine's three load-bearing invariants:
+> **zero `unsafe`**, **no new heavyweight dependencies**, and **byte-identical
+> deterministic replay**.
 >
 > **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md)
 > (historical engine plan), [`docs/conformance.md`](./conformance.md) (Test262
@@ -210,7 +211,7 @@ the per-phase wins clear a "worth the complexity" bar.
 
 **Risk:** low. No bytecode or semantics change. Pure internal refactor.
 
-### Phase 2 — Superinstructions / op fusion
+### Phase 2 — Superinstructions / op fusion — first fusion landed (§13)
 
 **Goal:** fewer dispatches and less operand-stack traffic for the most common
 sequences.
@@ -562,7 +563,79 @@ coverage, rather than as a risky isolated refactor of the engine's hottest code.
 
 ---
 
-## 13. References
+## 13. Phase 2 results (op fusion — compare-and-branch, 2026-06-14)
+
+**Landed: the first superinstruction.** The Phase-0 survey's top dynamic
+finding was the loop-test idiom `LoadCell(i); LoadConst(n); <cmp>; JumpIfFalse`,
+with the `<cmp>; JumpIfFalse` pair alone covering a few percent of all executed
+opcodes (`Lt; JumpIfFalse` ≈ 4.6%, plus the other comparisons). Phase 2 adds:
+
+- **A new fused opcode** `CmpBranchFalse { cmp, target }` (`bytecode.rs`) and its
+  handler (`exec.rs`), covering all eight comparison ops (`< <= > >= == != ===
+  !==`). The handler reuses the **exact** same `less_than` / `loose_equals` /
+  `strict_equals` helpers as the standalone ops, so coercion and any thrown error
+  are byte-identical; the intermediate boolean — never observable to JS — is
+  consumed directly by the branch instead of round-tripping the operand stack.
+- **A peephole fusion pass** (`fuse.rs`) run once per finished `FuncProto` in
+  `Compiler::finish` (so it covers the whole proto tree). It rewrites
+  `cmp; JumpIfFalse` → `CmpBranchFalse`, which shortens the bytecode and so
+  shifts absolute jump targets; the pass remaps every code-offset operand through
+  a single `for_each_ip` accessor (the lone source of truth for "which operands
+  are instruction pointers"), which deliberately skips handler-stack *depths*
+  (`CompletionJump.boundary`) and `u32::MAX` "none" sentinels. A window is fused
+  only when nothing jumps into its interior; jumps to its head stay valid because
+  entering the fused op is equivalent to entering the sequence at its head.
+- **A fusion toggle** (`compile_script_opts(src, fuse)`): fusion is on in
+  production, off only for the differential test — so an unfused fallback always
+  exists, as required by the plan.
+
+**Correctness — gated by four independent layers, all green:**
+
+1. **Test262 (the authoritative gate), zero regressions.** Ran the committed
+   baseline gate over the areas fusion most stresses — every loop form (`for`,
+   `for-of`, `for-in`, `while`, `do-while`), `switch`, `try`/`catch`/`finally`,
+   labeled statements, `break`/`continue`, all comparison operators, conditional,
+   logical, and optional-chaining: **2062 tests, 0 regressions, 0 new failures,
+   0 progressions** (2016 pass / 29 fail / 17 skip = 98.58%, identical to
+   baseline). A mis-remapped jump in any of these would have flipped a passing
+   test to failing.
+2. **Differential test** (`tests/fusion.rs`): a control-flow-heavy corpus
+   (nested loops with `break`/`continue`, labeled break, `try/finally`, `switch`,
+   optional chaining, short-circuit ops, a coercion that throws) run with fusion
+   on vs. off — **byte-identical** console output and thrown errors. Plus a
+   structural check that fusion actually fires and the toggle genuinely suppresses
+   it.
+3. **Fusion-pass unit tests** (`fuse.rs`): target remapping after shortening, the
+   "don't fuse into a jump target" guard, and `boundary`-is-not-an-ip.
+4. **Full `chidori-js` suite**, including `tests/replay.rs` **record→replay
+   byte-identity** and the generator/`try-finally` paths — unchanged and green
+   with fusion on by default.
+
+No `unsafe`, no new dependencies. Determinism is preserved: fusion perturbs
+neither values nor host-call ordering, and the toggle-equivalence (fused ≡
+unfused) is exactly the property §7.3 calls for.
+
+**Performance — structural win, not separately benchmarked here.** Per §7.6 this
+environment cannot resolve a few-percent delta. The change is a strict reduction
+on the hottest path: for every fused pair it removes one interpreter dispatch
+(one fewer trip through the central `match` → one fewer likely branch mispredict)
+and one operand-stack push/pop of the intermediate boolean. Phase 0 put the
+fuseable `cmp; JumpIfFalse` pairs at several percent of all executed opcodes,
+concentrated in loop conditions — the code that runs most. Quantifying the
+wall-clock win belongs on a quiet, pinned machine (§7.6); the deterministic proxy
+(executed-op count drops by the number of fused pairs) is reproducible and
+already implied by the fusion firing.
+
+**Next fusions (same infrastructure, ranked by Phase 0 data).** The pass and the
+`for_each_ip` remap now exist, so further superinstructions are incremental:
+`LoadCell/LoadLocal; LoadConst` (8.9%), load+binop (`LoadConst; Sub` 3.6%), and a
+`JumpIfTrue` compare-and-branch variant. Each follows the same recipe: add the
+fused op, reuse the standalone helper in its handler, extend `fuse.rs`, and add a
+differential-corpus case.
+
+---
+
+## 14. References
 
 - [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md) — engine
   decision record (pure Rust, no `boa_engine`, replay-not-snapshot).

--- a/docs/interpreter-optimization.md
+++ b/docs/interpreter-optimization.md
@@ -504,21 +504,51 @@ operand-stack traffic in exactly the hot loops.
 | --- | --- | --- |
 | **1 — hot-loop cleanup** | **GO** | Lowest risk; validates the gating harness; the per-op `Result<Ctl,_>` round-trip and per-op `Option::take`s are real overhead on the data-movement ops that make up ~40% of execution. |
 | **2 — fusion** | **GO** | Data shows clear high-frequency pairs (load+binop, compare-and-branch) and a 40%-data-movement profile. Target the §11.3 candidates, validated by the survey rather than intuition. |
-| **3 — inline caches** | **CONDITIONAL** | Property ops did *not* crack the top-15 in this loop/arith-heavy mix, so the win is unproven *for this workload*. Gate on the agent profile (below): pursue only if property access registers there. |
-| **4 — register bytecode** | **DEFER** | The 40%-data-movement figure is the strongest argument for it, but it's a back-end rewrite; revisit only if Phases 1–2 leave a measured, workload-relevant gap. |
-| **Bonus — warm-realm reuse** | **INVESTIGATE** | `engine_new` ≈ 3.6 ms is unexpectedly large and dominates short scripts; worth scoping independently of the dispatch work. |
+| **3 — inline caches** | **DEFER (live); optional for replay/test** | Property ops didn't crack the top-15 here, AND §11.5 now shows JS is <1% of live wall-clock — so for *live* perf this is firmly not worth its cache-invalidation risk. Reconsider only to speed the replay/test path on property-heavy agents, gated on a property-heavy profile. |
+| **4 — register bytecode** | **DEFER** | A back-end rewrite whose payoff (the 40%-data-movement figure) lands almost entirely on the <1%-of-live JS path. Revisit only if replay/test throughput becomes a real pain point after Phases 1–2. |
+| **Bonus — warm-realm reuse** | **INVESTIGATE** | `engine_new` ≈ 3.6 ms is unexpectedly large and dominates short scripts; it is also pure setup unrelated to dispatch, so it is the most likely *replay/test*-throughput win still on the table. |
 
-### 11.5 Remaining Phase 0 item (carried forward)
+### 11.5 Agent-replay benchmark — DONE (the decisive number)
 
-The **representative-agent replay benchmark** (JS-execution share of an agent
-run replayed from a committed journal) is **not yet implemented** — it needs a
-checked-in journal fixture and pulls in the larger `chidori` crate's host
-runtime, out of scope for this `chidori-js`-local pass. It is the gate for
-Phase 3 and for sizing the whole effort. *A-priori* signal: even the heaviest
-micro-workload here (~75 ms) is small next to typical per-LLM-call latency
-(hundreds of ms to seconds), so JS execution is likely a *minority* of agent
-wall-clock — which is the core argument for the whole "no JIT" stance. **This
-must be measured, not assumed, before committing to Phases 3–4.**
+Built as `examples/agent_replay.rs` (record→replay entirely within `chidori-js`,
+no `chidori`-crate host runtime needed): a representative agent — real glue
+compute (prompt building, string scanning, modular arithmetic) interleaved with
+one recorded `llm` host effect per step — over **200 steps / 200 host calls**.
+It measures `compute_only` (pure JS), `record` (live, host=0), and `replay`
+(journal-served, no host), then models live wall-clock under a range of LLM
+latencies. Measured here (min-of-N, so robust to the §7.6 noise):
+
+| quantity | value |
+| --- | ---: |
+| JS compute only | 20.2 ms (~0.10 ms/step) |
+| journal + promise/microtask machinery | **0.75 ms** |
+| full replay (no host) | 21.0 ms |
+| journal size | 17 KB |
+
+**Modeled live wall-clock — JS+journal as a share of the total:**
+
+| LLM latency / call | live total (200 calls) | JS+journal share |
+| ---: | ---: | ---: |
+| 50 ms (optimistic) | 10.0 s | **0.21%** |
+| 200 ms | 40.0 s | 0.053% |
+| 500 ms | 100 s | 0.021% |
+| 2000 ms | 400 s | 0.005% |
+
+**Conclusions.**
+1. **JS execution is well under 1% of an agent's live wall-clock** — a fraction
+   of a percent even at an unrealistically fast 50 ms/call. This is the empirical
+   backbone of the no-JIT stance: a JIT only speeds the JS sliver of that sliver,
+   so its end-to-end payoff is negligible. The a-priori argument from §11.4 is now
+   measured, not assumed.
+2. **The durability layer is cheap.** Journal + promise/microtask machinery is
+   0.75 ms — ~3.6% of replay, and invisible against host latency. Replay cost is
+   dominated by *JS interpretation*, not the journal.
+3. **Where the interpreter work (Phases 1–2) actually pays off: replay and
+   tests.** The zero-host replay path — used for the committed-checkpoint tests,
+   debugging, and crash resume — is ~97% interpreter. So faster dispatch
+   meaningfully speeds *replay/test throughput* and compute-heavy steps, even
+   though it barely moves live wall-clock. That, not live latency, is the honest
+   justification for Phases 1–2.
 
 ---
 

--- a/docs/interpreter-optimization.md
+++ b/docs/interpreter-optimization.md
@@ -1,10 +1,11 @@
 # Interpreter performance: optimizing `chidori-js` without a JIT
 
-> **Status:** Phase 0 (measurement) **done** — see §11; Phases 1–4 proposed.
-> This document scopes a body of work to make the `chidori-js` bytecode
-> interpreter materially faster **without** adding a JIT, while preserving the
-> engine's three load-bearing invariants: **zero `unsafe`**, **no new
-> heavyweight dependencies**, and **byte-identical deterministic replay**.
+> **Status:** Phase 0 (measurement) **done** — see §11. Phase 1 (hot-loop
+> cleanup) **partially landed** — see §12. Phases 2–4 proposed. This document
+> scopes a body of work to make the `chidori-js` bytecode interpreter materially
+> faster **without** adding a JIT, while preserving the engine's three
+> load-bearing invariants: **zero `unsafe`**, **no new heavyweight
+> dependencies**, and **byte-identical deterministic replay**.
 >
 > **Related:** [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md)
 > (historical engine plan), [`docs/conformance.md`](./conformance.md) (Test262
@@ -190,7 +191,7 @@ instrument that compiles out of the shipping build — see §11.)
 **Exit criteria:** baseline numbers committed; a documented decision on whether
 the per-phase wins clear a "worth the complexity" bar.
 
-### Phase 1 — Hot-loop cleanup (flatten dispatch, de-overhead the common path)
+### Phase 1 — Hot-loop cleanup (flatten dispatch, de-overhead the common path) — partially landed (§12)
 
 **Goal:** remove avoidable per-op work without changing the bytecode.
 
@@ -350,6 +351,17 @@ Layered, with each phase required to pass all layers before merge.
   about real-world impact.
 - Add a CI **performance smoke** (informational, non-gating initially) that flags
   large interpreter-loop regressions on PRs.
+- **Measurement environment matters.** Phase 1 found that the cloud dev/CI
+  container cannot reliably resolve deltas below ~10–15%: re-running the *same
+  unchanged binary* produced criterion "regressions" of +3% to +8% and absolute
+  times that drifted upward run-over-run (e.g. `fib_recursive` 74→84→90 ms across
+  three identical runs). Consequences: (a) per-phase wins smaller than the noise
+  floor (Phase 1 is one) **cannot** be validated by wall-clock here — run on a
+  quiet, frequency-pinned, single-tenant machine; (b) the CI perf-smoke must
+  compare against a **same-session** baseline (measure HEAD and HEAD~ back to
+  back in one job), never a stored historical baseline; (c) for small changes,
+  prefer a **deterministic proxy** (executed-op count, branch count, allocations)
+  over wall-clock — these are reproducible and environment-independent.
 
 ### 7.6 Memory & safety
 
@@ -509,7 +521,48 @@ must be measured, not assumed, before committing to Phases 3–4.**
 
 ---
 
-## 12. References
+## 12. Phase 1 results (hot-loop cleanup, 2026-06-14)
+
+**Landed.** Hoisted the per-iteration `pending_throw` / `pending_return` checks
+out of `run_frame`'s dispatch loop (`exec.rs`). These two `Option::take`s ran on
+*every* opcode, but the fields are set **only** by `resume_frame_throw` /
+`resume_frame_return` immediately before `run_frame` (a generator `.return(v)`
+or an awaited rejection delivered at resume) and are never re-set inside the
+loop — so they can only ever fire on the first iteration. The hoist handles them
+once, before the loop, removing two branches from the hot path per executed op.
+
+**Correctness — fully validated.** The whole `chidori-js` suite is green,
+including the paths that exercise the hoisted fields: `tests/async_gen.rs`
+(generators / `await`), `tests/replay.rs` (**record→replay byte-identity**,
+suspend→persist→restore→resume), `tests/gc.rs`, the DOM suites, and
+`tests/smoke.rs`. No `unsafe`, no new deps, no bytecode change. The one
+acknowledged difference — the op-budget counter decrements one fewer time on the
+rare resume-with-injection path — is not observable to JS (the budget is a
+coarse, uncatchable safety bound, not a spec-visible quantity).
+
+**Performance — below the noise floor here; not separately claimed.** Hoisting
+two predictable-branch `Option::take`s is expected to be a sub-few-percent win,
+and the dev/CI container's noise floor (~10–15%, see §7.6) is far larger:
+re-running the unchanged binary swung +3–8% and times drifted upward across
+identical runs. So this environment **cannot** confirm or deny the delta. The
+change is kept on its own merits: it is a strict reduction in per-iteration work
+*and* a clarity win — it codifies in one place the invariant that `pending_*`
+are resume-only signals. The measurable dispatch wins come from Phase 2.
+
+**Scoping note — the "flatten the double dispatch" half is folded into Phase 2.**
+The other Phase 1 idea (collapse the `step → Result<Ctl, Value>` round-trip the
+outer loop immediately re-matches) was deliberately *not* done as a standalone
+step. Doing it safely requires either (a) a sweeping change to `step`'s return
+type touching hundreds of return sites, or (b) duplicating trivial-op logic into
+a loop fast-path — and (b) creates exactly the kind of two-sources-of-truth
+divergence risk the determinism contract warns against. Phase 2's superinstruction
+work restructures dispatch *by construction* (new fused ops handled in the loop),
+so the flatten lands there with a single source of truth and direct test
+coverage, rather than as a risky isolated refactor of the engine's hottest code.
+
+---
+
+## 13. References
 
 - [`docs/pure-rust-js-engine-plan.md`](./pure-rust-js-engine-plan.md) — engine
   decision record (pure Rust, no `boa_engine`, replay-not-snapshot).


### PR DESCRIPTION
Scopes interpreter-level performance work for chidori-js that respects the
engine's invariants (zero unsafe, no heavy deps, deterministic replay):
hot-loop cleanup, superinstructions/op fusion, and inline caches, with an
optional register-bytecode follow-up. Explains why a JIT and literal threaded
dispatch are out of scope, and includes a phased implementation plan and a
layered testing plan (Test262 gate, replay byte-identity, differential
testing, criterion + agent-replay benchmarks).

https://claude.ai/code/session_01G3bwbXrFwQWof63hsnZq55