### PR TITLE
Fix Dependabot security alerts: bump rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,15 +1925,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1957,9 +1956,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Resolves three RustSec advisories affecting rustls-webpki 0.103.11:
- RUSTSEC-2026-0098: Name constraints for URI names incorrectly accepted
- RUSTSEC-2026-0099: Name constraints accepted for certs asserting a wildcard name
- RUSTSEC-2026-0104: Reachable panic in certificate revocation list parsing

rustls-webpki is a transitive dependency (via reqwest's TLS stack). The bump
is lockfile-only and within the existing 0.103 semver range, so no source
changes are required. cargo check --workspace passes.