### PR TITLE
ci: switch crates.io publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,15 @@ name: Release
 #   - the chidori-js and chidori crates to crates.io
 #   - the TypeScript SDK to npm (@1kbirds/chidori)
 #   - the Python SDK to PyPI (chidori)
-# and then creates the matching GitHub release. npm and PyPI use OIDC trusted
-# publishing; crates.io uses the CARGO_REGISTRY_TOKEN secret. Every publish job
-# skips versions already on its registry, so re-running a tag's workflow is safe.
+# and then creates the matching GitHub release. Every publish job uses OIDC
+# trusted publishing — no long-lived registry tokens — and skips versions that
+# are already on its registry, so re-running a tag's workflow is safe.
 #
 # A manual workflow_dispatch run is a dry run: it builds and validates every
 # package but publishes nothing and creates no GitHub release.
 #
-# One-time registry setup (npm/PyPI trusted publishers, the CARGO_REGISTRY_TOKEN
-# secret, and the matching GitHub environments) is documented in
-# docs/releasing.md.
+# One-time registry setup (the npm/PyPI/crates.io trusted publishers and the
+# matching GitHub environments) is documented in docs/releasing.md.
 
 on:
   push:
@@ -129,6 +128,7 @@ jobs:
     environment: crates-io
     permissions:
       contents: read
+      id-token: write # crates.io trusted publishing (OIDC)
     steps:
       - uses: actions/checkout@v4
 
@@ -142,10 +142,15 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: ./scripts/publish.sh --dry-run --skip-tests
 
+      - name: Authenticate to crates.io (OIDC)
+        if: github.ref_type == 'tag'
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish
         if: github.ref_type == 'tag'
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: ./scripts/publish.sh --skip-tests --yes
 
   github-release:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -62,41 +62,41 @@ crates by hand from a tagged commit if CI is unavailable:
 
 ## One-time registry setup
 
-The npm and PyPI jobs authenticate with OIDC trusted publishing — no
-long-lived tokens. The crates.io job uses a `CARGO_REGISTRY_TOKEN` secret. Each
-needs a one-time configuration by an owner of the package:
+Create the three environments under repository Settings → Environments → New
+environment (`npm`, `pypi`, `crates-io`), then configure each registry — done
+by an owner of the package. All three authenticate with OIDC trusted
+publishing, so no long-lived registry tokens are stored.
 
-**npm (`@1kbirds/chidori`)** — on npmjs.com, package → Settings → Trusted
-publisher → GitHub Actions, with:
+**npm (`@1kbirds/chidori`)** → environment `npm`, OIDC trusted publishing (no
+secret). On npmjs.com, package → Settings → Trusted Publisher → GitHub Actions,
+with:
 
 - Organization or user: `ThousandBirdsInc`
 - Repository: `chidori`
 - Workflow filename: `release.yml`
 - Environment: `npm`
 
-**PyPI (`chidori`)** — on pypi.org, project → Manage → Publishing → Add a new
-publisher → GitHub, with:
+**PyPI (`chidori`)** → environment `pypi`, OIDC trusted publishing (no secret).
+On pypi.org, project → Manage → Publishing → Add a new publisher → GitHub, with:
 
 - Owner: `ThousandBirdsInc`
 - Repository name: `chidori`
 - Workflow name: `release.yml`
 - Environment name: `pypi`
 
-**crates.io (`chidori` and `chidori-js`)** — create a crates.io API token at
-<https://crates.io/settings/tokens> (scoped to publish-update, and ideally
-limited to these two crates), then store it as a secret named
-`CARGO_REGISTRY_TOKEN`. Put it on the `crates-io` environment (repository
-Settings → Environments → `crates-io` → Secrets) so it's only exposed to the
-`crates` job, or as a repository secret if you prefer.
+**crates.io (`chidori` and `chidori-js`)** → environment `crates-io`, OIDC
+trusted publishing (no secret). On crates.io, for *each* crate go to Settings →
+Trusted Publishing → Add, with:
 
-**GitHub** — create the `npm`, `pypi`, and `crates-io` environments under
-repository Settings → Environments. The `npm` and `pypi` ones can be empty; the
-`crates-io` one carries the `CARGO_REGISTRY_TOKEN` secret. Add required
-reviewers to any of them if publishes should need manual approval.
+- Repository owner: `ThousandBirdsInc`
+- Repository name: `chidori`
+- Workflow filename: `release.yml`
+- Environment: `crates-io`
 
-Until the OIDC publishers and the crates.io token are configured, tag pushes
-will fail in the publish steps with an authentication error; the verify step
-still runs.
+Add required reviewers to any environment if a publish should need manual
+approval. Until the npm/PyPI/crates.io trusted publishers are configured, tag
+pushes fail in that registry's publish step with an authentication error; the
+verify step still runs.
 
 The GitHub release step needs no setup — it uses the workflow's built-in
 `GITHUB_TOKEN` with `contents: write`.


### PR DESCRIPTION
Follow-up to #77. That PR merged with crates.io still authenticating via the `CARGO_REGISTRY_TOKEN` secret, because crates.io trusted publishing wasn't available at the time. It's now configured for both `chidori` and `chidori-js`, so this moves the `crates` job onto OIDC like npm and PyPI.

## Change
- `release.yml` → `crates` job: add `id-token: write`, mint a short-lived token with `rust-lang/crates-io-auth-action`, and feed it to `scripts/publish.sh` instead of the `CARGO_REGISTRY_TOKEN` secret.
- `docs/releasing.md`: crates.io setup is now a trusted-publisher entry; all three registries documented as OIDC (no stored tokens).

After this, **every** publish job uses OIDC — no long-lived registry tokens in CI.

## Cleanup
- The `CARGO_REGISTRY_TOKEN` secret on the `crates-io` environment can be deleted (the manual `scripts/publish.sh` fallback still accepts it as an env var when run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)