### PR TITLE
Replace bare "chidori" SDK import with virtual "chidori:agent" specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ host call:
 
 ```ts
 // summarizer.ts
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { document: string }, chidori: Chidori) {
   const summary = await chidori.prompt("Summarize in 3 bullets:\n" + input.document);

--- a/crates/chidori/src/init.rs
+++ b/crates/chidori/src/init.rs
@@ -13,7 +13,7 @@ use anyhow::{bail, Context, Result};
 /// (written to `agent.ts`) and the fileless `chidori chat` (written to a temp
 /// file). Driven mode (a fixed `messages` list) is how `chidori chat` feeds each
 /// turn; with no messages it reads the terminal interactively.
-pub const CHAT_AGENT_SRC: &str = r#"import type { Chidori } from "chidori";
+pub const CHAT_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
 
 export async function agent(
   input: { messages?: string[]; system?: string; model?: string; tools?: string[] },
@@ -81,7 +81,7 @@ Add your own tools under `tools/` and list their names in the agent's
 /// (scoped to this project — the agent can only see files placed here) plus the
 /// conversation + replay model. The only thing sent to the model is the user's
 /// question and these scaffolded docs; nothing else on the machine is touched.
-const DOCS_AGENT_SRC: &str = r#"import type { Chidori } from "chidori";
+const DOCS_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
 
 /**
  * Chat with the Chidori docs.
@@ -198,7 +198,7 @@ Either way the `chidori` binary lands on your PATH. Check it with
 An agent is a TypeScript file that exports an `agent` function taking the run
 input and the `chidori` host object:
 
-    import type { Chidori } from "chidori";
+    import type { Chidori } from "chidori:agent";
 
     export async function agent(input: { document: string }, chidori: Chidori) {
       const summary = await chidori.prompt("Summarize:\n" + input.document);
@@ -244,7 +244,7 @@ A tool is a TypeScript file in a directory you pass with `--tools`. It exports a
 `tool` definition (name, description, JSON-schema parameters) and a `run`
 function:
 
-    import type { ToolDefinition } from "chidori";
+    import type { ToolDefinition } from "chidori:agent";
 
     export const tool: ToolDefinition = {
       name: "reverse",
@@ -367,7 +367,7 @@ const CHAT: Template = Template {
 // Inlined rather than include_str!'d from examples/ so the crate packages
 // self-contained for crates.io (examples/ lives outside the package root).
 // Mirrors examples/agents/worker.ts and examples/tools/reverse.ts.
-const WORKER_AGENT_SRC: &str = r#"import type { Chidori } from "chidori";
+const WORKER_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
 
 /**
  * An autonomous "worker" agent: it loops — think, call a tool, observe the
@@ -423,7 +423,7 @@ export async function agent(
 }
 "#;
 
-const REVERSE_TOOL_SRC: &str = r#"import type { ToolDefinition } from "chidori";
+const REVERSE_TOOL_SRC: &str = r#"import type { ToolDefinition } from "chidori:agent";
 
 /**
  * A sample tool for the worker agent. Reverses a string. Replace the body (and

--- a/crates/chidori/src/runtime/engine.rs
+++ b/crates/chidori/src/runtime/engine.rs
@@ -879,7 +879,7 @@ mod tests {
         std::fs::write(
             &path,
             r#"
-                import type { Chidori } from "chidori";
+                import type { Chidori } from "chidori:agent";
                 export async function agent(input: { name: string }, chidori: Chidori) {
                     await chidori.log("starting");
                     return { greeting: "Hello, " + input.name };

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -860,7 +860,7 @@ mod tests {
 
     #[test]
     fn run_agent_supports_run_entrypoint_and_import_convention() {
-        // The current convention: `import { chidori, run } from "chidori"` (the
+        // The current convention: `import { chidori, run } from "chidori:agent"` (the
         // import is stripped, both resolve to globals) and `run(handler)` as the
         // entrypoint — no second `chidori` param, no magic `agent` export.
         let ctx = RuntimeContext::new();
@@ -868,7 +868,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("agent.ts");
         let src = r#"
-            import { chidori, run } from "chidori";
+            import { chidori, run } from "chidori:agent";
             run(async (input: { value: number }) => {
                 await chidori.log("via run() entrypoint");
                 return { value: input.value + 1 };
@@ -1678,7 +1678,7 @@ mod tests {
 
         let agent_path = dir.join("agent.ts");
         let agent_src = r#"
-            import { chidori } from "chidori";
+            import { chidori } from "chidori:agent";
             import { triple, BONUS } from "./lib/math";
             export async function agent(input: { value: number }) {
                 chidori.log("computing");

--- a/crates/chidori/src/runtime/typescript/check.rs
+++ b/crates/chidori/src/runtime/typescript/check.rs
@@ -82,7 +82,7 @@ mod tests {
         std::fs::write(
             &path,
             r#"
-                import type { Chidori } from "chidori";
+                import type { Chidori } from "chidori:agent";
                 export async function agent(input: { name: string }, chidori: Chidori) {
                     return { hello: input.name };
                 }

--- a/crates/chidori/src/runtime/typescript/tools.rs
+++ b/crates/chidori/src/runtime/typescript/tools.rs
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn accepts_tool_metadata_and_run_export() {
         let source = r#"
-            import { Chidori, ToolDefinition } from "chidori";
+            import { Chidori, ToolDefinition } from "chidori:agent";
 
             const apiKey = process.env.BRAVE_SEARCH_API_KEY ?? "";
 

--- a/crates/chidori/src/runtime/typescript/transpile.rs
+++ b/crates/chidori/src/runtime/typescript/transpile.rs
@@ -168,11 +168,12 @@ pub fn transpile_module(path: &Path, source: &str, options: &TranspileOptions) -
         })
         .build(&program);
 
-    // The `chidori` SDK import marks host-injected globals (Chidori, ToolDefinition,
-    // etc.) — there's no real module at module-resolution time, so any surviving
-    // `import ... from "chidori"` would crash the loader. oxc's TS pass elides
-    // import-of-type-only specifiers but keeps value imports, so we filter the
-    // remaining `from "chidori"` lines out of the emitted code.
+    // The `chidori:agent` SDK import marks host-injected globals (Chidori,
+    // ToolDefinition, etc.) — there's no real module at module-resolution time,
+    // so any surviving `import ... from "chidori:agent"` would crash the loader.
+    // oxc's TS pass elides import-of-type-only specifiers but keeps value
+    // imports, so we filter the remaining `from "chidori:agent"` lines out of
+    // the emitted code.
     let js = strip_chidori_sdk_imports(&codegen_ret.code);
     // The snapshot bundler line-walks the output to rewrite `import` / `export`
     // statements. oxc splits object literals and function bodies across many
@@ -328,6 +329,20 @@ pub fn validate_imports(
             continue;
         }
 
+        if is_legacy_chidori_specifier(&specifier) {
+            anyhow::bail!(
+                "{}:{}: importing the agent SDK from \"{}\" is no longer supported. \
+                 Import from \"{}\" instead — the bare `chidori` npm name belongs to \
+                 an unrelated package, so the SDK now uses an un-installable virtual \
+                 specifier. (For editor types: `npm install -D @1kbirds/chidori` and \
+                 add `/// <reference types=\"@1kbirds/chidori/agent-env\" />`.)",
+                path.display(),
+                line_no,
+                specifier,
+                CHIDORI_AGENT_SPECIFIER,
+            );
+        }
+
         // Vendored packages (react, react-dom/server, …) are served from the
         // built-in registry, not the filesystem — accept them under any policy.
         if crate::runtime::typescript::builtins::is_vendored_package(&specifier) {
@@ -433,8 +448,28 @@ fn import_specifiers(source: &str) -> Vec<(usize, String)> {
 /// The virtual SDK module has no on-disk form at runtime; the host injects its
 /// exports. Agents may import it by the bare historical name or by the
 /// published npm package name.
+/// The virtual module specifier that marks the host-injected agent SDK
+/// (`Chidori`, `ToolDefinition`, the `chidori`/`run` globals, …). It is
+/// deliberately a URL-style scheme — like `node:fs` or `bun:test` — that can
+/// never be an installable npm package, so there is no third-party package to
+/// confuse it with. The runtime strips this import and supplies the values at
+/// execution time.
+pub(crate) const CHIDORI_AGENT_SPECIFIER: &str = "chidori:agent";
+
+/// Specifiers that used to mark the injected SDK. The bare `chidori` name
+/// belongs to an unrelated npm package — a dependency-confusion hazard, since an
+/// author (or an LLM generating agent code) who tried to `npm install chidori`
+/// for editor types would pull a package we don't control. Agent files must now
+/// import from `chidori:agent`; we still recognize the old spellings so we can
+/// emit a clear migration error rather than an opaque resolution failure.
+const LEGACY_CHIDORI_SPECIFIERS: &[&str] = &["chidori", "@1kbirds/chidori"];
+
 fn is_chidori_sdk_specifier(specifier: &str) -> bool {
-    specifier == "chidori" || specifier == "@1kbirds/chidori"
+    specifier == CHIDORI_AGENT_SPECIFIER
+}
+
+fn is_legacy_chidori_specifier(specifier: &str) -> bool {
+    LEGACY_CHIDORI_SPECIFIERS.contains(&specifier)
 }
 
 fn is_chidori_sdk_import(line: &str) -> bool {
@@ -540,7 +575,7 @@ mod tests {
     #[test]
     fn transpile_strips_basic_type_syntax() {
         let source = r#"
-            import type { Chidori } from "chidori";
+            import type { Chidori } from "chidori:agent";
             type Input = { name: string };
             export async function agent(input: Input, chidori: Chidori): Promise<object> {
                 const greeting: string = input.name;
@@ -566,7 +601,7 @@ mod tests {
     #[test]
     fn transpile_strips_multiline_function_parameter_types() {
         let source = r#"
-            import type { Chidori } from "chidori";
+            import type { Chidori } from "chidori:agent";
             export async function agent(
                 input: { name?: string },
                 chidori: Chidori,
@@ -596,7 +631,7 @@ mod tests {
     #[test]
     fn transpile_strips_multiline_type_and_interface_declarations() {
         let source = r#"
-            import type { Chidori } from "chidori";
+            import type { Chidori } from "chidori:agent";
             export interface Input {
                 topic: string;
                 limit?: number;
@@ -747,7 +782,7 @@ mod tests {
     #[test]
     fn transpile_preserves_object_literal_values() {
         let source = r#"
-            import { Chidori, ToolDefinition } from "chidori";
+            import { Chidori, ToolDefinition } from "chidori:agent";
 
             export const tool: ToolDefinition = {
                 name: "web_search",
@@ -767,7 +802,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(!js.contains("from \"chidori\""));
+        assert!(!js.contains("chidori:agent"));
         assert!(!js.contains(": ToolDefinition"));
         assert!(js.contains(r#"name: "web_search""#));
         assert!(js.contains(r#"type: "object""#));
@@ -776,18 +811,50 @@ mod tests {
     }
 
     #[test]
-    fn transpile_strips_scoped_chidori_sdk_imports() {
-        let source = r#"
-            import { chidori } from "@1kbirds/chidori";
-            import type { Chidori, ToolDefinition } from "@1kbirds/chidori";
+    fn transpile_rejects_legacy_chidori_specifiers_with_migration_error() {
+        // The bare `chidori` name and the `@1kbirds/chidori` scope used to mark
+        // the injected SDK. Both are now rejected in favor of `chidori:agent`,
+        // with an error that names the new specifier.
+        for legacy in ["chidori", "@1kbirds/chidori"] {
+            let source = format!(
+                "import type {{ Chidori }} from \"{legacy}\";\n\
+                 export async function agent(input, chidori: Chidori) {{ return {{ ok: true }}; }}\n"
+            );
 
-            export async function agent(input, chidori: Chidori) {
+            let err = transpile_module(
+                Path::new("/tmp/project/agents/legacy.ts"),
+                &source,
+                &TranspileOptions {
+                    import_policy: TypeScriptImportPolicy::Relative,
+                },
+            )
+            .unwrap_err()
+            .to_string();
+
+            assert!(
+                err.contains("chidori:agent"),
+                "error should point at the new specifier, got: {err}"
+            );
+            assert!(
+                err.contains(legacy),
+                "error should name the legacy specifier {legacy}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn transpile_strips_value_imports_from_virtual_specifier() {
+        let source = r#"
+            import { chidori, run } from "chidori:agent";
+
+            run(async (input) => {
+                await chidori.log("hi");
                 return { ok: true };
-            }
+            });
         "#;
 
         let js = transpile_module(
-            Path::new("/tmp/project/agents/scoped.ts"),
+            Path::new("/tmp/project/agents/inline.ts"),
             source,
             &TranspileOptions {
                 import_policy: TypeScriptImportPolicy::Relative,
@@ -796,16 +863,16 @@ mod tests {
         .unwrap();
 
         assert!(
-            !js.contains("@1kbirds/chidori"),
-            "scoped import survived:\n{js}"
+            !js.contains("chidori:agent"),
+            "virtual SDK import survived:\n{js}"
         );
-        assert!(js.contains("return { ok: true }"));
+        assert!(js.contains("run(async"));
     }
 
     #[test]
     fn transpile_strips_satisfies_and_as_const_assertions() {
         let source = r#"
-            import { ToolDefinition } from "chidori";
+            import { ToolDefinition } from "chidori:agent";
 
             const prompt = "Only call chidori.tool(name, args) directly for deterministic work when the exact args are already known and the tool is either implemented by this project or explicitly described by the user as an available runtime tool. ";
             const template = `Do not strip as const or satisfies ToolDefinition inside templates`;
@@ -842,7 +909,7 @@ mod tests {
     #[test]
     fn transpile_strips_return_type_with_object_literal() {
         let source = r#"
-            import { Chidori } from "chidori";
+            import { Chidori } from "chidori:agent";
 
             export async function run(
                 args: { url: string },

--- a/crates/chidori/src/tools/mod.rs
+++ b/crates/chidori/src/tools/mod.rs
@@ -308,7 +308,7 @@ mod tests {
         std::fs::write(
             dir.join("web_search.ts"),
             r#"
-                import type { Chidori, ToolDefinition } from "chidori";
+                import type { Chidori, ToolDefinition } from "chidori:agent";
 
                 export const tool: ToolDefinition = {
                   name: "web_search",

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -575,7 +575,7 @@ fn cli_stream_accepts_multiline_typed_agent_signature() {
     fs::write(
         &agent,
         r#"
-            import type { Chidori } from "chidori";
+            import type { Chidori } from "chidori:agent";
 
             export async function agent(
                 input: { name?: string },

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -113,7 +113,7 @@ The runtime has these production pieces in place:
 Agents are `.ts` files that export `async function agent(input, chidori)`.
 
 ```ts
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(
   input: { document: string },
@@ -138,7 +138,7 @@ export. Discovery evaluates metadata in a restricted VM context before
 registering the tool.
 
 ```ts
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 export const tool: ToolDefinition = {
   name: "web_search",

--- a/docs/branching-execution.md
+++ b/docs/branching-execution.md
@@ -211,7 +211,7 @@ extra mechanisms (soft divergence + a `fork()`-style return).
 
 ### 6.1 Agent-facing (`chidori.branch`)
 ```ts
-import { chidori } from "chidori";
+import { chidori } from "chidori:agent";
 
 type BranchVariant = {
   /** Branch label (shown in outcomes + trace). */

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -348,7 +348,7 @@ never consults a cache.** Caching lives entirely on the live path.
 ### 6.1 Agent-facing (`chidori.context`)
 
 ```ts
-import { chidori } from "chidori";
+import { chidori } from "chidori:agent";
 
 type Role = "system" | "user" | "assistant" | "tool_result";
 type CacheTtl = "5m" | "1h";
@@ -415,7 +415,7 @@ chidori would re-bill the full ~20K prefix on every single turn.
 ### 7.1 The agent
 
 ```ts
-import { chidori, run } from "chidori";
+import { chidori, run } from "chidori:agent";
 
 type Brief = { corpusPath: string; questions: string[] };
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,15 +24,24 @@ asset-name pattern in `scripts/install.sh` in sync.
 
 The unscoped npm name `chidori` belongs to an unrelated project, so the
 TypeScript SDK publishes under the `@1kbirds` scope (which also carries the
-legacy 0.1.x SDK releases). Agent authors who want the historical
-`import ... from "chidori"` spelling can install via an npm alias:
+legacy 0.1.x SDK releases). The two import contexts use different specifiers,
+and neither can pull the unrelated package:
 
-```bash
-npm install chidori@npm:@1kbirds/chidori
-```
+- **Agent and tool files** (executed by the runtime) import their authoring
+  types from the virtual module `"chidori:agent"`. It is a URL-style scheme —
+  like `node:fs` — with no registry name behind it, so it can never be
+  `npm install`ed by mistake. The runtime strips the import and injects the
+  values at execution time; editor types ship as an ambient declaration in
+  `@1kbirds/chidori` (pulled in with
+  `/// <reference types="@1kbirds/chidori/agent-env" />`). The runtime accepts
+  only `"chidori:agent"`; the old `"chidori"` / `"@1kbirds/chidori"` spellings
+  now fail with a migration error.
+- **Client/driver code** (a normal Node program talking to `chidori serve`)
+  imports the HTTP client from the real package, `"@1kbirds/chidori"`:
 
-The runtime accepts both `"chidori"` and `"@1kbirds/chidori"` as the virtual
-SDK module specifier in agent files.
+  ```bash
+  npm install @1kbirds/chidori
+  ```
 
 ## Cutting a release
 

--- a/docs/running-modes.md
+++ b/docs/running-modes.md
@@ -63,7 +63,7 @@ An agent can handle incoming HTTP events:
 
 ```ts
 // agents/webhook.ts
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(
   input: { url: string; payload?: Record<string, unknown> },

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -215,7 +215,7 @@ call_log; a replay run never re-reads the inbox.
 
 ### 6.1 Agent-facing (`chidori.signal`)
 ```ts
-import { chidori } from "chidori";
+import { chidori } from "chidori:agent";
 
 type Signal<T = Json> = { name: string; payload: T; from: SignalSender };
 type SignalSender = { kind: "human" | "agent"; id: string; runId?: string };
@@ -268,7 +268,7 @@ agent only *consumes* those pushes at the points it declares safe.
 ### 7.2 The agent (`examples/multiplayer-review/policy_doc.ts`)
 
 ```ts
-import { chidori, run } from "chidori";
+import { chidori, run } from "chidori:agent";
 
 type Brief = { topic: string; audience: string };
 type Review = { decision: "approve" | "changes"; notes: string };

--- a/docs/typescript-vm-snapshot-runtime.md
+++ b/docs/typescript-vm-snapshot-runtime.md
@@ -87,7 +87,7 @@ and runtime roots beyond the selected-root scaffold.
 Agents are `.ts` files exporting `async function agent(input, chidori)`.
 
 ```ts
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(
   input: { document: string },
@@ -109,7 +109,7 @@ export async function agent(
 Tools are `.ts` files with explicit metadata and an async `run` export.
 
 ```ts
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 export const tool: ToolDefinition = {
   name: "web_search",

--- a/examples/agents/context_qa.ts
+++ b/examples/agents/context_qa.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Cache-aware multi-turn Q&A over a fixed corpus, using `chidori.context`.

--- a/examples/agents/conversation.ts
+++ b/examples/agents/conversation.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * A multi-turn conversational agent — the "chat assistant" shape — built on

--- a/examples/agents/hello.ts
+++ b/examples/agents/hello.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { name?: string }, chidori: Chidori) {
   const name = input.name ?? "world";

--- a/examples/agents/input_pause.ts
+++ b/examples/agents/input_pause.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { request: string }, chidori: Chidori) {
   const approval = await chidori.input("Approve this request?", {

--- a/examples/agents/parallel.ts
+++ b/examples/agents/parallel.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { topic: string }, chidori: Chidori) {
   const drafts = await chidori.parallel(

--- a/examples/agents/streaming_progress.ts
+++ b/examples/agents/streaming_progress.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { topic: string }, chidori: Chidori) {
   const progress = await chidori.prompt(

--- a/examples/agents/streaming_progress_child.ts
+++ b/examples/agents/streaming_progress_child.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { topic: string }, chidori: Chidori) {
   const note = await chidori.prompt(

--- a/examples/agents/summarizer.ts
+++ b/examples/agents/summarizer.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { document: string }, chidori: Chidori) {
   const summary = await chidori.prompt(

--- a/examples/agents/tool_use.ts
+++ b/examples/agents/tool_use.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { query: string }, chidori: Chidori) {
   const result = await chidori.tool("web_search", { query: input.query });

--- a/examples/agents/value_checkpoint.ts
+++ b/examples/agents/value_checkpoint.ts
@@ -9,7 +9,7 @@
 //
 // The run pauses on `input()`; resume it and the "index" step is served from
 // the journal instead of being recomputed. See docs/value-checkpoints.md.
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { docs?: number }, chidori: Chidori) {
   const docs = input.docs ?? 1000;

--- a/examples/agents/worker.ts
+++ b/examples/agents/worker.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * An autonomous "worker" agent: it loops — think, call a tool, observe the

--- a/examples/branching/agent.ts
+++ b/examples/branching/agent.ts
@@ -1,4 +1,4 @@
-import type { BranchOutcome, Chidori } from "chidori";
+import type { BranchOutcome, Chidori } from "chidori:agent";
 
 /**
  * Branching example (docs/branching-execution.md).

--- a/examples/branching/strategies/draft_direct.ts
+++ b/examples/branching/strategies/draft_direct.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Strategy B: write a flowing draft straight from the research, no outline.

--- a/examples/branching/strategies/outline_first.ts
+++ b/examples/branching/strategies/outline_first.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Strategy A: build an outline from the handed-over research, then expand each

--- a/examples/interactive-pipeline/README.md
+++ b/examples/interactive-pipeline/README.md
@@ -10,7 +10,7 @@ current authoring convention: **import the host object and define the entrypoint
 with `run(handler)`** — no second `chidori` parameter, no magic `agent` export.
 
 ```ts
-import { chidori, run } from "chidori";
+import { chidori, run } from "chidori:agent";
 
 run(async (input) => {
   await chidori.log("hello", { input });
@@ -19,7 +19,7 @@ run(async (input) => {
 });
 ```
 
-The runtime strips the `from "chidori"` import and supplies `chidori` + `run`
+The runtime strips the `from "chidori:agent"` import and supplies `chidori` + `run`
 at execution time. The agent ([`interactive_pipeline.ts`](./interactive_pipeline.ts))
 runs several review stages; each stage delegates a batch to the
 [`review_batch`](./tools/review_batch.ts) tool and then stops at a **checkpoint**

--- a/examples/interactive-pipeline/interactive_pipeline.ts
+++ b/examples/interactive-pipeline/interactive_pipeline.ts
@@ -1,4 +1,4 @@
-import { chidori, run } from "chidori";
+import { chidori, run } from "chidori:agent";
 
 type Input = {
   /** Name shown in logs and as the agent name in the OTEL trace. */

--- a/examples/interactive-pipeline/tools/review_batch.ts
+++ b/examples/interactive-pipeline/tools/review_batch.ts
@@ -1,4 +1,4 @@
-import { chidori } from "chidori";
+import { chidori } from "chidori:agent";
 
 export const tool = {
   name: "review_batch",

--- a/examples/multiplayer-review/README.md
+++ b/examples/multiplayer-review/README.md
@@ -118,7 +118,7 @@ done   = client.signal(paused.id, "review",
 ```
 
 ```ts
-import { AgentClient, isSignalQueued } from "chidori";
+import { AgentClient, isSignalQueued } from "@1kbirds/chidori";
 const client = new AgentClient("http://localhost:8080");
 const res = await client.signal(run, { name: "review", payload: { decision: "approve", notes: "LGTM" } });
 if (isSignalQueued(res)) console.log("queued at", res.delivery_seq);

--- a/examples/multiplayer-review/policy_doc.ts
+++ b/examples/multiplayer-review/policy_doc.ts
@@ -1,4 +1,4 @@
-import type { Chidori, Signal } from "chidori";
+import type { Chidori, Signal } from "chidori:agent";
 
 /**
  * Multiplayer policy-doc drafting agent (docs/signals.md §7).

--- a/examples/record-replay/README.md
+++ b/examples/record-replay/README.md
@@ -20,7 +20,7 @@ The same idea is shown at two layers:
 | Layer | Where | Run without a server? | The primitive |
 |-------|-------|-----------------------|---------------|
 | **`chidori-js` engine (Rust)** | `crates/chidori-js/examples/*.rs` | ✅ yes | `ReplayRuntime::record` / `restore` / `drive` |
-| **TypeScript SDK (`chidori`)** | this directory | needs `chidori run`/`serve` | `chidori.tool` / `input` / `memory` + `AgentClient.replay` |
+| **TypeScript SDK (`@1kbirds/chidori`)** | this directory | needs `chidori run`/`serve` | `chidori.tool` / `input` / `memory` + `AgentClient.replay` |
 
 ---
 
@@ -182,8 +182,8 @@ cargo run -- resume examples/record-replay/exactly_once.ts <run-id> -d examples/
 
 ### Option B — the SDK (`AgentClient`, over HTTP)
 
-This mirrors how you'd use the published `chidori` npm package
-(`import { AgentClient } from "chidori"`). Start a server for one agent, then run
+This mirrors how you'd use the published `@1kbirds/chidori` npm package
+(`import { AgentClient } from "@1kbirds/chidori"`). Start a server for one agent, then run
 the matching driver scenario:
 
 ```bash

--- a/examples/record-replay/deterministic_identity.ts
+++ b/examples/record-replay/deterministic_identity.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Deterministic non-determinism — reproducible ids, clocks, and choices.

--- a/examples/record-replay/driver.mjs
+++ b/examples/record-replay/driver.mjs
@@ -12,7 +12,7 @@
 //   2. Run the matching driver scenario:
 //        node examples/record-replay/driver.mjs --scenario exactly_once
 //
-// In your own code the import is simply `import { AgentClient } from "chidori"`.
+// In your own code the import is simply `import { AgentClient } from "@1kbirds/chidori"`.
 // Here we point at the built SDK in this repo so the example runs in-tree.
 import { AgentClient } from "../../sdk/typescript/dist/index.js";
 

--- a/examples/record-replay/exactly_once.ts
+++ b/examples/record-replay/exactly_once.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Exactly-once side effects — the core durability guarantee for agents.

--- a/examples/record-replay/human_approval.ts
+++ b/examples/record-replay/human_approval.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Durable pause / resume — human-in-the-loop across process restarts.

--- a/examples/record-replay/retry_flaky_tool.ts
+++ b/examples/record-replay/retry_flaky_tool.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Resilient retries with a reproducible history.

--- a/examples/record-replay/tool_pipeline.ts
+++ b/examples/record-replay/tool_pipeline.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 /**
  * Deterministic fan-out + a durable artifact.

--- a/examples/record-replay/tools/flaky_fetch.ts
+++ b/examples/record-replay/tools/flaky_fetch.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // A deliberately flaky tool, deterministic on the attempt number the agent
 // passes in: the first two attempts report failure, the third succeeds. The

--- a/examples/record-replay/tools/fx_rate.ts
+++ b/examples/record-replay/tools/fx_rate.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // Offline stand-in for an FX-rate API. Fixed table keeps the fan-out example
 // deterministic.

--- a/examples/record-replay/tools/geocode.ts
+++ b/examples/record-replay/tools/geocode.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // Offline stand-in for a geocoding API. Returns a fixed lat/lng per city so the
 // fan-out example is deterministic without network access.

--- a/examples/record-replay/tools/mint_id.ts
+++ b/examples/record-replay/tools/mint_id.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // Non-deterministic by nature: a fresh id + wall-clock reading. Because the
 // result is recorded in the call log, every replay reproduces the SAME id and

--- a/examples/record-replay/tools/open_ticket.ts
+++ b/examples/record-replay/tools/open_ticket.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // A side-effecting tool: in a real system this would POST to a ticketing API.
 // Here it just mints a deterministic id so the example runs offline. The point

--- a/examples/record-replay/tools/send_email.ts
+++ b/examples/record-replay/tools/send_email.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // A side-effecting tool. The `chidori.log` line marks where a real send would
 // happen — on replay this tool is NOT re-invoked, so the email is sent exactly

--- a/examples/record-replay/tools/weather.ts
+++ b/examples/record-replay/tools/weather.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 // Offline stand-in for a weather API, keyed on coordinates so it pairs with
 // geocode in the fan-out example.

--- a/examples/tools/reverse.ts
+++ b/examples/tools/reverse.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from "chidori";
+import type { ToolDefinition } from "chidori:agent";
 
 /**
  * A sample tool for the worker agent. Reverses a string. Replace the body (and

--- a/examples/tools/web_search.ts
+++ b/examples/tools/web_search.ts
@@ -1,4 +1,4 @@
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 export const tool: ToolDefinition = {
   name: "web_search",

--- a/llm.txt
+++ b/llm.txt
@@ -13,7 +13,7 @@ and tools.
 An agent is a `.ts` file that exports `agent(input, chidori)`:
 
 ```ts
-import type { Chidori } from "chidori";
+import type { Chidori } from "chidori:agent";
 
 export async function agent(input: { document: string }, chidori: Chidori) {
   const summary = await chidori.prompt(
@@ -393,7 +393,7 @@ A TypeScript tool exports JSON-compatible metadata and an async
 value in a restricted metadata VM context before registration.
 
 ```ts
-import type { Chidori, ToolDefinition } from "chidori";
+import type { Chidori, ToolDefinition } from "chidori:agent";
 
 export const tool: ToolDefinition = {
   name: "web_search",
@@ -481,7 +481,7 @@ restarts.
 ## TypeScript SDK
 
 ```ts
-import { AgentClient, Checkpoint } from "chidori";
+import { AgentClient, Checkpoint } from "@1kbirds/chidori";
 
 const client = new AgentClient("http://localhost:8080");
 const session = await client.run({ document: "Rust is a systems language." });

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -13,24 +13,16 @@ Uses the global `fetch` (Node 18+, browsers). Mirrors the Python SDK.
 ## Install
 
 The package is published to npm as
-[`@1kbirds/chidori`](https://www.npmjs.com/package/@1kbirds/chidori) (the
-unscoped `chidori` npm name belongs to an unrelated project). Installing it
-under the `chidori` alias keeps the historical import spelling working:
-
-```bash
-npm install chidori@npm:@1kbirds/chidori
-```
-
-```ts
-import { AgentClient, Checkpoint } from "chidori";
-```
-
-Or install under the scoped name directly — the Chidori runtime accepts both
-`"chidori"` and `"@1kbirds/chidori"` as the SDK module specifier in agent
-files:
+[`@1kbirds/chidori`](https://www.npmjs.com/package/@1kbirds/chidori). The
+unscoped `chidori` npm name belongs to an unrelated project, so **always import
+the scoped name** — never `npm install chidori`:
 
 ```bash
 npm install @1kbirds/chidori
+```
+
+```ts
+import { AgentClient, Checkpoint } from "@1kbirds/chidori";
 ```
 
 To build from source instead:
@@ -41,16 +33,28 @@ npm install
 npm run build
 ```
 
-Agent and tool authoring types are also exported:
+### Authoring agents and tools
+
+Agent and tool files run *inside* the Chidori runtime, not as a normal Node
+program. They get their authoring types — and the `chidori`/`run` globals — from
+the **virtual** module `chidori:agent`:
 
 ```ts
-import type { Chidori, ToolDefinition } from "chidori";
+/// <reference types="@1kbirds/chidori/agent-env" />
+import type { Chidori, ToolDefinition } from "chidori:agent";
 ```
+
+There is no installable package behind `chidori:agent`; it is a URL-style scheme
+(like `node:fs`) that the runtime strips and injects at execution time, so the
+unrelated `chidori` npm package can never be pulled in by mistake. The
+`/// <reference …>` line (or a `compilerOptions.types: ["@1kbirds/chidori/agent-env"]`
+entry in `tsconfig.json`) gives editors and `tsc` the types while you author;
+the runtime itself needs nothing installed.
 
 ## Usage
 
 ```ts
-import { AgentClient, Checkpoint, isSignalQueued } from "chidori";
+import { AgentClient, Checkpoint, isSignalQueued } from "@1kbirds/chidori";
 
 const client = new AgentClient("http://localhost:8080");
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,6 +18,10 @@
     "./agent": {
       "import": "./dist/agent.js",
       "types": "./dist/agent.d.ts"
+    },
+    "./agent-env": {
+      "import": "./dist/agent-env.js",
+      "types": "./dist/agent-env.d.ts"
     }
   },
   "files": ["dist", "src", "README.md"],

--- a/sdk/typescript/src/agent-env.ts
+++ b/sdk/typescript/src/agent-env.ts
@@ -1,0 +1,43 @@
+/**
+ * Ambient types for the virtual `chidori:agent` module.
+ *
+ * Agent and tool files written for the Chidori runtime import their authoring
+ * types — and, in the global style, the `chidori`/`run` values — from
+ * `chidori:agent`:
+ *
+ * ```ts
+ * import type { Chidori, ToolDefinition } from "chidori:agent";
+ * // …or the global style:
+ * import { chidori, run } from "chidori:agent";
+ * ```
+ *
+ * There is no installable package behind that specifier. It is a virtual module
+ * the runtime injects, much like `node:fs` or `bun:test`: the runtime strips the
+ * import and supplies the real values when it executes the file, so nothing is
+ * resolved from npm. Crucially, the unrelated `chidori` package on npm can never
+ * be pulled in by mistake, because `chidori:agent` is not a registry name at all.
+ *
+ * This file exists only so editors and `tsc` can type agent files. Pull it into
+ * a project with a triple-slash reference at the top of an agent or tool file:
+ *
+ * ```ts
+ * /// <reference types="@1kbirds/chidori/agent-env" />
+ * import type { Chidori } from "chidori:agent";
+ * ```
+ *
+ * or once, project-wide, via tsconfig `compilerOptions.types`:
+ * `["@1kbirds/chidori/agent-env"]`.
+ *
+ * NOTE: this must stay a script file (no top-level `import`/`export`). A bare
+ * `declare module "chidori:agent"` is a *global* ambient declaration; adding a
+ * top-level `export` would turn it into a module augmentation and fail to
+ * resolve, since there is no real `chidori:agent` module to augment.
+ */
+declare module "chidori:agent" {
+  // Re-export every authoring type plus the `chidori`/`run` value globals from
+  // the SDK's agent module. Ambient module declarations may only reference
+  // other modules by a non-relative (package) name, so we use the package's own
+  // public subpath. The package's build resolves it via the `paths` mapping in
+  // tsconfig.json; consumers resolve it from `node_modules`.
+  export * from "@1kbirds/chidori/agent";
+}

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -508,7 +508,7 @@ export type ToolFunction<TArgs extends JsonObject = JsonObject, TResult extends 
  * need for a `(input, chidori)` second parameter):
  *
  * ```ts
- * import { chidori, run } from "chidori";
+ * import { chidori, run } from "chidori:agent";
  * run(async (input: { topic: string }) => {
  *   await chidori.log("starting", { topic: input.topic });
  *   return { ok: true };
@@ -533,7 +533,7 @@ export const chidori: Chidori = new Proxy({} as Chidori, {
  * named `agent`" convention.
  *
  * ```ts
- * import { run } from "chidori";
+ * import { run } from "chidori:agent";
  * run(async (input) => ({ greeting: `hello ${input.name}` }));
  * ```
  */

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -10,7 +10,11 @@
     "rootDir": "src",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@1kbirds/chidori/agent": ["./src/agent.ts"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
The agent-authoring import `from "chidori"` was a virtual/host-injected
import the runtime strips at transpile time — but the unscoped `chidori`
name is a real, unrelated package on npm that we don't own. An author (or
an LLM generating agent code) who tried `npm install chidori` for editor
types would pull a third-party package and run its install scripts: a
dependency-confusion / supply-chain hazard, and confusing besides.

Split the two import contexts so neither can pull the unrelated package:

- Agent and tool files now import from the virtual module `chidori:agent`.
  It is a URL-style scheme (like `node:fs`) with no registry name behind
  it, so it can never be `npm install`ed by mistake. The runtime strips it
  and injects the values at execution time. The old `chidori` /
  `@1kbirds/chidori` agent spellings now fail with a clear migration error
  instead of an opaque module-resolution crash.
- Client/driver code imports the HTTP client from the real, owned package
  `@1kbirds/chidori`.

Editor/`tsc` types for the virtual module ship as an ambient declaration
(`@1kbirds/chidori/agent-env`), pulled in with a triple-slash reference or
a tsconfig `types` entry. Updated the transpiler + tests, the `chidori
init` scaffolder, all examples, docs, llm.txt, and the SDK README.

BREAKING CHANGE: agent/tool files must import from "chidori:agent".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DtXhRqa29YFEUrVxNVJ5hs