### PR TITLE
Add TypeScript SDK test suite with mock HTTP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Test
+        run: npm test
+
   python-sdk:
     name: Python SDK integration
     runs-on: ubuntu-24.04

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -92,11 +92,15 @@ clusters:
 
 ### Product follow-through (from `docs/fable_review.md`)
 
-- [ ] **SDK publishing** — both SDKs are at 3.0.0 and the README badges
-  npm/PyPI, but there is no publish automation. Wire it up or drop the badges.
-- [ ] **TypeScript SDK tests** — there are none; CI only typechecks and builds
-  the TS SDK. The 8 Python-SDK integration tests against a real server are the
-  template.
+- [x] **SDK publishing** — `.github/workflows/release.yml` publishes the
+  TypeScript SDK to npm and the Python SDK to PyPI (both via OIDC trusted
+  publishing), alongside the crates.io and prebuilt-binary jobs, on tag push.
+  The npm/PyPI README badges are now backed by automation.
+- [x] **TypeScript SDK tests** — `sdk/typescript/test/` exercises the HTTP
+  client (run/replay/resume/signal/stream/checkpoint), SSE parsing, and
+  manifest/serialization round-trips against a mock server via Node's built-in
+  test runner (`npm test`), wired into CI. The Python-SDK integration tests
+  against a real server remain the end-to-end complement.
 - [ ] **Broader `node:` allowlist** — `stream`, `zlib`, and `child_process`
   remain unsupported (the current allowlist covers `process`, `buffer`, `util`,
   `fs`, `fs/promises`, `crypto`, `http`, `https`, `path`, `events`, `url`,

--- a/docs/ai-sdk-gap-analysis.md
+++ b/docs/ai-sdk-gap-analysis.md
@@ -248,7 +248,9 @@ Gap:
 - No mock provider API exposed to agent authors beyond environment-level static
   provider behavior.
 - No stream simulation utilities for frontend/client tests.
-- TypeScript SDK tests are still listed as product follow-through work.
+- The TypeScript SDK now has a client test suite (`sdk/typescript/test/`,
+  Node's built-in runner), but there is still no published mock-provider or
+  stream-simulation test-helper package comparable to `ai/test`.
 
 ### 10. Package And Ecosystem Fit
 

--- a/docs/fable_review.md
+++ b/docs/fable_review.md
@@ -305,8 +305,11 @@ fresh clone.
 
 Both SDKs are zero-dependency and mirror each other. Gaps:
 
-- **No npm or PyPI publish automation** despite both SDKs being at 3.0.0 and
-  the README badging npm/PyPI.
+- ~~**No npm or PyPI publish automation** despite both SDKs being at 3.0.0 and
+  the README badging npm/PyPI.~~ *(Update 2026-06-21: resolved —
+  `.github/workflows/release.yml` publishes the TypeScript SDK to npm and the
+  Python SDK to PyPI via OIDC trusted publishing on tag push, alongside the
+  crates.io and binary jobs.)*
 - Both SDK READMEs say checkpoint resume goes through call-log replay
   because "direct live VM continuation … is still gated on the QuickJS
   serializer". That was stale before; it is wrong in a new way now — live-VM
@@ -318,8 +321,10 @@ Both SDKs are zero-dependency and mirror each other. Gaps:
 - Good: engine unit/integration tests (`crates/chidori-js/tests/`), CLI
   integration tests, 8 Python-SDK integration tests against a real server,
   and Test262 in CI.
-- Missing: **any TypeScript SDK tests** (CI only typechecks and builds it);
-  MCP/ACP protocol tests.
+- ~~Missing: **any TypeScript SDK tests** (CI only typechecks and builds
+  it)~~ *(Update 2026-06-21: added — `sdk/typescript/test/` drives the HTTP
+  client against a `node:http` mock via Node's built-in test runner, wired
+  into CI as a `npm test` step)*; MCP/ACP protocol tests remain absent.
 
 ### Examples and docs — the doc-drift list
 
@@ -397,8 +402,12 @@ The original items, for the record:
    configured no `CHIDORI_POLICY*` source (malformed configuration fails
    closed), with `--trusted` as the explicit opt-out; `chidori run` keeps
    the permissive default for local developer-authored code.
-4. ~~Run Test262 in CI~~ — **done** (#41). Add TypeScript SDK tests next.
-5. **Automate SDK publishing** to npm/PyPI, or remove the registry badges.
+4. ~~Run Test262 in CI~~ — **done** (#41). ~~Add TypeScript SDK tests next.~~
+   — **done** (2026-06-21): `sdk/typescript/test/` runs on Node's built-in
+   test runner and is gated in CI.
+5. ~~**Automate SDK publishing** to npm/PyPI, or remove the registry badges.~~
+   — **done**: `.github/workflows/release.yml` publishes both SDKs (npm + PyPI
+   via OIDC trusted publishing) on tag.
 6. ~~**Pay down the doc drift** (the list above): README engine section, SDK
    READMEs, sandbox-model preamble, archive the two migration docs, the
    conformance.sh `ENGINE` knob.~~ — **done**: the README engine/conformance

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -126,3 +126,17 @@ journal/scaffold metadata rather than serialized VM bytes.
 
 Use `client.getSnapshotManifest(sessionId)` when a UI needs only snapshot
 metadata. The endpoint never returns the binary VM snapshot.
+
+## Tests
+
+The SDK ships a dependency-free test suite (Node's built-in `node:test`
+runner) that drives `AgentClient` against a stdlib `node:http` mock server,
+covering run/replay/resume/signal, SSE stream parsing, checkpoint
+serialization, and error handling:
+
+```bash
+npm test   # builds, then runs node --test test/*.test.mjs
+```
+
+End-to-end coverage against a real `chidori serve` binary lives in the Python
+SDK integration tests (`sdk/python/tests/`).

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -27,7 +27,9 @@
   "files": ["dist", "src", "README.md"],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "pretest": "tsc",
+    "test": "node --test test/*.test.mjs"
   },
   "devDependencies": {
     "typescript": "^5.4.0"

--- a/sdk/typescript/test/authoring.test.mjs
+++ b/sdk/typescript/test/authoring.test.mjs
@@ -1,0 +1,20 @@
+// Tests for the authoring entrypoints (`chidori` and `run`). Outside the
+// chidori runtime these are inert stand-ins that throw a helpful error: the
+// runtime strips the import and supplies the real implementations at execution
+// time.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { chidori, run } from "../dist/index.js";
+
+describe("authoring stand-ins", () => {
+  it("accessing any chidori member throws outside the runtime", () => {
+    assert.throws(() => chidori.log, /only available inside the chidori runtime/);
+    assert.throws(() => chidori.prompt, /only available inside the chidori runtime/);
+  });
+
+  it("calling run() throws outside the runtime", () => {
+    assert.throws(() => run(async () => ({ ok: true })), /only available inside the chidori runtime/);
+  });
+});

--- a/sdk/typescript/test/client.test.mjs
+++ b/sdk/typescript/test/client.test.mjs
@@ -1,0 +1,407 @@
+// Tests for the AgentClient HTTP surface, Session/Checkpoint helpers, the
+// signal outcome distinction, SSE stream parsing, and error handling.
+//
+// Run with `npm test` (which builds first) or, after `npm run build`,
+// `node --test test/*.test.mjs`.
+
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, it } from "node:test";
+
+import {
+  AgentClient,
+  Checkpoint,
+  Session,
+  isSignalQueued,
+} from "../dist/index.js";
+
+import {
+  MockServer,
+  callRecord,
+  sendJson,
+  snapshotManifest,
+} from "./helpers.mjs";
+
+let server;
+let client;
+
+before(async () => {
+  server = new MockServer();
+  await server.start();
+  client = new AgentClient(server.baseUrl);
+});
+
+after(async () => {
+  await server.stop();
+});
+
+beforeEach(() => {
+  server.reset();
+});
+
+describe("AgentClient construction", () => {
+  it("strips a trailing slash from the base URL", () => {
+    assert.equal(new AgentClient("http://example.com/").baseUrl, "http://example.com");
+    assert.equal(new AgentClient("http://example.com").baseUrl, "http://example.com");
+  });
+
+  it("defaults to localhost:8080", () => {
+    assert.equal(new AgentClient().baseUrl, "http://localhost:8080");
+  });
+});
+
+describe("health", () => {
+  it("GETs /health and returns the body", async () => {
+    server.on((req, res) => {
+      assert.equal(req.method, "GET");
+      sendJson(res, 200, { status: "ok" });
+    });
+    assert.deepEqual(await client.health(), { status: "ok" });
+    assert.deepEqual(server.requestsFor("/health").length, 1);
+  });
+});
+
+describe("run", () => {
+  it("POSTs the input to /sessions and returns a completed Session", async () => {
+    server.on((req, res, { url }) => {
+      assert.equal(req.method, "POST");
+      assert.equal(url.pathname, "/sessions");
+      sendJson(res, 201, {
+        id: "run-1",
+        status: "completed",
+        output: { answer: "forty-two" },
+        call_log: [callRecord()],
+      });
+    });
+
+    const session = await client.run({ question: "what is the answer" });
+    assert.ok(session instanceof Session);
+    assert.equal(session.id, "run-1");
+    assert.equal(session.status, "completed");
+    assert.equal(session.ok, true);
+    assert.deepEqual(session.output, { answer: "forty-two" });
+    assert.deepEqual(session.input, { question: "what is the answer" });
+
+    const sent = server.requestsFor("/sessions")[0].body;
+    assert.deepEqual(sent, { input: { question: "what is the answer" } });
+  });
+
+  it("sends policy_profile only when a profile is supplied", async () => {
+    server.on((_req, res) => sendJson(res, 201, { id: "r", status: "completed" }));
+
+    await client.run({ q: 1 }, { policyProfile: "untrusted" });
+    assert.deepEqual(server.requestsFor("/sessions")[0].body, {
+      input: { q: 1 },
+      policy_profile: "untrusted",
+    });
+
+    server.reset();
+    server.on((_req, res) => sendJson(res, 201, { id: "r", status: "completed" }));
+    await client.run({ q: 2 });
+    assert.deepEqual(server.requestsFor("/sessions")[0].body, { input: { q: 2 } });
+  });
+
+  it("surfaces a failed run as status=failed with an error", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 201, { id: "r", status: "failed", error: "boom" }),
+    );
+    const session = await client.run({ q: 1 });
+    assert.equal(session.status, "failed");
+    assert.equal(session.ok, false);
+    assert.equal(session.error, "boom");
+  });
+});
+
+describe("replay", () => {
+  it("POSTs the call log as replay_from", async () => {
+    server.on((_req, res) => sendJson(res, 201, { id: "r", status: "completed", output: 1 }));
+    const cp = new Checkpoint("r", { q: 1 }, [callRecord()], null);
+    const replayed = await client.replay(cp);
+    assert.equal(replayed.status, "completed");
+    assert.deepEqual(server.requestsFor("/sessions")[0].body, {
+      input: { q: 1 },
+      replay_from: [callRecord()],
+    });
+  });
+});
+
+describe("resume", () => {
+  it("POSTs the response to /sessions/{id}/resume", async () => {
+    server.on((req, res, { url }) => {
+      assert.equal(url.pathname, "/sessions/run-9/resume");
+      sendJson(res, 200, {
+        id: "run-9",
+        status: "completed",
+        input: { action: "delete" },
+        output: { approved: true },
+      });
+    });
+    const resumed = await client.resume("run-9", "yes");
+    assert.equal(resumed.status, "completed");
+    assert.deepEqual(resumed.output, { approved: true });
+    assert.deepEqual(server.requestsFor("/sessions/run-9/resume")[0].body, {
+      response: "yes",
+    });
+  });
+});
+
+describe("signal", () => {
+  it("returns a resumed Session when the run was waiting on the name (200)", async () => {
+    server.on((req, res, { url }) => {
+      assert.equal(url.pathname, "/sessions/run-3/signal");
+      sendJson(res, 200, {
+        id: "run-3",
+        status: "completed",
+        output: { decision: "approve" },
+      });
+    });
+
+    const result = await client.signal("run-3", {
+      name: "review",
+      payload: { decision: "approve" },
+      from: { kind: "human", id: "mara" },
+    });
+
+    assert.equal(isSignalQueued(result), false);
+    assert.ok(result instanceof Session);
+    assert.equal(result.status, "completed");
+    assert.deepEqual(result.output, { decision: "approve" });
+
+    // payload/from default through even when partially specified.
+    assert.deepEqual(server.requestsFor("/sessions/run-3/signal")[0].body, {
+      name: "review",
+      payload: { decision: "approve" },
+      from: { kind: "human", id: "mara" },
+    });
+  });
+
+  it("returns a SignalQueued descriptor when the signal is enqueued (202)", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 202, {
+        id: "run-3",
+        status: "queued",
+        name: "steer",
+        delivery_seq: 7,
+      }),
+    );
+
+    const result = await client.signal("run-3", { name: "steer" });
+    assert.equal(isSignalQueued(result), true);
+    assert.equal(result instanceof Session, false);
+    assert.equal(result.status, "queued");
+    assert.equal(result.name, "steer");
+    assert.equal(result.delivery_seq, 7);
+
+    // Unspecified payload/from default to null in the request body.
+    assert.deepEqual(server.requestsFor("/sessions/run-3/signal")[0].body, {
+      name: "steer",
+      payload: null,
+      from: null,
+    });
+  });
+
+  it("treats a delivered_live 200 body as queued", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 200, {
+        id: "run-3",
+        status: "delivered_live",
+        name: "steer",
+        delivery_seq: 9,
+      }),
+    );
+    const result = await client.signal("run-3", { name: "steer" });
+    assert.equal(isSignalQueued(result), true);
+    assert.equal(result.status, "delivered_live");
+  });
+
+  it("throws on a terminal run (409)", async () => {
+    server.on((_req, res) => sendJson(res, 409, { error: "run is terminal" }));
+    await assert.rejects(() => client.signal("run-3", { name: "review" }), /HTTP 409/);
+  });
+});
+
+describe("session reads", () => {
+  it("getSession fetches /sessions/{id}", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 200, { id: "s1", status: "paused", input: { a: 1 }, pending_prompt: "ok?" }),
+    );
+    const session = await client.getSession("s1");
+    assert.equal(session.status, "paused");
+    assert.equal(session.pendingPrompt, "ok?");
+    assert.deepEqual(session.input, { a: 1 });
+  });
+
+  it("listSessions returns the summaries array", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 200, { sessions: [{ id: "a", status: "completed" }, { id: "b", status: "failed", error: "x" }] }),
+    );
+    const sessions = await client.listSessions();
+    assert.equal(sessions.length, 2);
+    assert.equal(sessions[0].id, "a");
+    assert.equal(sessions[1].error, "x");
+  });
+
+  it("getCheckpoint returns call log + manifest", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 200, { call_log: [callRecord()], snapshot_manifest: snapshotManifest() }),
+    );
+    const data = await client.getCheckpoint("s1");
+    assert.equal(data.call_log.length, 1);
+    assert.equal(data.snapshot_manifest.run_id, "run-1");
+  });
+
+  it("getSnapshotManifest unwraps the manifest", async () => {
+    server.on((_req, res) =>
+      sendJson(res, 200, { snapshot_manifest: snapshotManifest({ run_id: "abc" }) }),
+    );
+    const manifest = await client.getSnapshotManifest("s1");
+    assert.equal(manifest.run_id, "abc");
+    assert.equal(manifest.snapshot_file, "runtime.snapshot");
+  });
+});
+
+describe("Session helpers", () => {
+  it("checkpoint() lazily fetches the call log when empty", async () => {
+    server.on((req, res, { url }) => {
+      if (req.method === "POST" && url.pathname === "/sessions") {
+        return sendJson(res, 201, { id: "run-7", status: "completed", output: { ok: true } });
+      }
+      if (req.method === "GET" && url.pathname === "/sessions/run-7/checkpoint") {
+        return sendJson(res, 200, { call_log: [callRecord()], snapshot_manifest: snapshotManifest() });
+      }
+      res.writeHead(404).end();
+    });
+
+    const session = await client.run({ q: 1 });
+    assert.equal(session.callLog.length, 0);
+
+    const cp = await session.checkpoint();
+    assert.ok(cp instanceof Checkpoint);
+    assert.equal(cp.sessionId, "run-7");
+    assert.equal(cp.callLog.length, 1);
+    assert.equal(cp.snapshotManifest.run_id, "run-1");
+    assert.equal(server.requestsFor("/sessions/run-7/checkpoint").length, 1);
+  });
+
+  it("replay() round-trips a session through the client", async () => {
+    server.on((req, res, { url }) => {
+      if (req.method === "POST" && url.pathname === "/sessions" && server.requests.length === 1) {
+        // initial run
+        return sendJson(res, 201, {
+          id: "run-8",
+          status: "completed",
+          output: { v: 1 },
+          call_log: [callRecord()],
+          snapshot_manifest: snapshotManifest(),
+        });
+      }
+      if (req.method === "POST" && url.pathname === "/sessions") {
+        // the replay
+        return sendJson(res, 201, { id: "run-8", status: "completed", output: { v: 1 } });
+      }
+      res.writeHead(404).end();
+    });
+
+    const session = await client.run({ q: 1 });
+    const replayed = await session.replay();
+    assert.equal(replayed.status, "completed");
+    const replayReq = server.requestsFor("/sessions")[1].body;
+    assert.deepEqual(replayReq.replay_from, [callRecord()]);
+  });
+
+  it("replay() without a bound client throws", async () => {
+    const orphan = new Session("x", "completed", { q: 1 });
+    await assert.rejects(() => orphan.replay(), /no client bound/);
+  });
+});
+
+describe("Checkpoint serialization", () => {
+  it("round-trips through toJSON / fromJSON", () => {
+    const cp = new Checkpoint("s1", { q: 1 }, [callRecord()], snapshotManifest());
+    const round = Checkpoint.fromJSON(cp.toJSON());
+    assert.deepEqual(round.toJSON(), cp.toJSON());
+    assert.equal(round.sessionId, "s1");
+    assert.equal(round.snapshotManifest.run_id, "run-1");
+  });
+
+  it("omits snapshot_manifest when absent", () => {
+    const cp = new Checkpoint("s1", { q: 1 }, [callRecord()], null);
+    assert.equal("snapshot_manifest" in cp.toJSON(), false);
+    const round = Checkpoint.fromJSON(cp.toJSON());
+    assert.equal(round.snapshotManifest, null);
+  });
+});
+
+describe("error handling", () => {
+  it("throws HTTP <status>: <body> on a non-2xx response", async () => {
+    server.on((_req, res) => sendJson(res, 500, { error: "kaboom" }));
+    await assert.rejects(() => client.health(), (err) => {
+      assert.match(err.message, /HTTP 500/);
+      assert.match(err.message, /kaboom/);
+      return true;
+    });
+  });
+});
+
+describe("stream", () => {
+  it("parses call, prompt lifecycle, and done SSE events", async () => {
+    server.on((req, res, { url }) => {
+      assert.equal(url.pathname, "/sessions/stream");
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      const frame = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+      res.write(frame("call", callRecord({ seq: 1, function: "prompt" })));
+      res.write(frame("prompt_start", { stream_id: "s1", seq: 1, model: "m" }));
+      res.write(frame("prompt_delta", { stream_id: "s1", seq: 1, delta: "forty-" }));
+      res.write(frame("prompt_delta", { stream_id: "s1", seq: 1, delta: "two" }));
+      res.write(frame("prompt_end", { stream_id: "s1", seq: 1 }));
+      res.write(frame("done", { id: "run-1", status: "completed", output: { answer: "forty-two" } }));
+      res.end();
+    });
+
+    const events = [];
+    for await (const evt of client.stream({ question: "stream me" })) {
+      events.push(evt);
+    }
+
+    const calls = events.filter((e) => e.type === "call");
+    const deltas = events.filter((e) => e.type === "prompt_delta");
+    const done = events.filter((e) => e.type === "done");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].record.function, "prompt");
+    assert.equal(calls[0].record.seq, 1);
+    assert.equal(deltas.length, 2);
+    assert.deepEqual(deltas.map((d) => d.delta), ["forty-", "two"]);
+    assert.equal(done.length, 1);
+    assert.equal(done[0].status, "completed");
+    assert.deepEqual(done[0].output, { answer: "forty-two" });
+
+    assert.deepEqual(server.requestsFor("/sessions/stream")[0].body, {
+      input: { question: "stream me" },
+    });
+  });
+
+  it("reassembles an SSE frame split across chunks", async () => {
+    server.on((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      // Deliberately split one done frame across two writes.
+      res.write('event: done\ndata: {"id":"run-1",');
+      res.write('"status":"completed","output":{"v":1}}\n\n');
+      res.end();
+    });
+
+    const events = [];
+    for await (const evt of client.stream({})) events.push(evt);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "done");
+    assert.deepEqual(events[0].output, { v: 1 });
+  });
+
+  it("throws when the stream request fails", async () => {
+    server.on((_req, res) => res.writeHead(500).end());
+    await assert.rejects(async () => {
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of client.stream({})) {
+        // no-op
+      }
+    }, /stream request failed: 500/);
+  });
+});

--- a/sdk/typescript/test/helpers.mjs
+++ b/sdk/typescript/test/helpers.mjs
@@ -1,0 +1,119 @@
+// Shared test helpers: a tiny stdlib-only mock HTTP server and JSON factories.
+//
+// The TypeScript SDK is a thin HTTP client, so the tests drive it against a
+// `node:http` server we control rather than a real `chidori serve` instance.
+// That keeps the suite dependency-free (Node's built-in test runner + http)
+// and fast, while still exercising the real request shapes, response parsing,
+// SSE streaming, and error handling. End-to-end coverage against the actual
+// binary lives in the Python SDK integration tests.
+
+import { createServer } from "node:http";
+
+/**
+ * A configurable mock HTTP server. Each test installs a responder via
+ * `server.on(...)` and inspects `server.requests` afterwards.
+ */
+export class MockServer {
+  constructor() {
+    this._server = null;
+    this.baseUrl = "";
+    this.requests = [];
+    this._responder = (_req, res) => res.writeHead(404).end();
+  }
+
+  async start() {
+    this._server = createServer((req, res) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf8");
+        const url = new URL(req.url ?? "/", "http://localhost");
+        this.requests.push({
+          method: req.method ?? "GET",
+          path: url.pathname,
+          body: raw ? safeJson(raw) : null,
+        });
+        Promise.resolve(this._responder(req, res, { raw, url })).catch(() => {
+          if (!res.writableEnded) res.writeHead(500).end();
+        });
+      });
+    });
+    await new Promise((resolve) => this._server.listen(0, "127.0.0.1", resolve));
+    const { port } = this._server.address();
+    this.baseUrl = `http://127.0.0.1:${port}`;
+  }
+
+  /** Install the responder for the next request(s). */
+  on(responder) {
+    this._responder = responder;
+  }
+
+  /** Clear recorded requests and reset to a 404 responder. */
+  reset() {
+    this.requests = [];
+    this._responder = (_req, res) => res.writeHead(404).end();
+  }
+
+  /** Requests recorded for a given pathname. */
+  requestsFor(path) {
+    return this.requests.filter((r) => r.path === path);
+  }
+
+  async stop() {
+    if (!this._server) return;
+    await new Promise((resolve, reject) =>
+      this._server.close((err) => (err ? reject(err) : resolve())),
+    );
+    this._server = null;
+  }
+}
+
+/** Write a JSON response with a status code. */
+export function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(payload);
+}
+
+/** Parse JSON, falling back to the raw string when it isn't JSON. */
+export function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/** A minimal valid CallRecord. */
+export function callRecord(overrides = {}) {
+  return {
+    seq: 1,
+    function: "prompt",
+    args: { text: "hi" },
+    result: "world",
+    duration_ms: 12,
+    timestamp: "2026-06-21T00:00:00Z",
+    ...overrides,
+  };
+}
+
+/** A minimal valid SnapshotManifest. */
+export function snapshotManifest(overrides = {}) {
+  return {
+    run_id: "run-1",
+    abi: { typescript_runtime: 1, quickjs_snapshot: 1, engine_fork: "chidori-js" },
+    policy: {
+      typescript_imports: "node",
+      date: "fixed",
+      random: "seeded",
+      maps_sets: "reject",
+      deterministic_seed: "0",
+    },
+    entry: { path: "agent.ts", hash: "abc" },
+    modules: [],
+    call_log_len: 1,
+    snapshot_file: "runtime.snapshot",
+    created_at: "2026-06-21T00:00:00Z",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive test suite for the TypeScript SDK that exercises the `AgentClient` HTTP surface, session/checkpoint helpers, SSE stream parsing, and error handling. Tests run against a stdlib-only mock HTTP server via Node's built-in test runner, keeping the suite dependency-free and fast while covering real request shapes and response parsing.

## Key Changes

- **New test files:**
  - `sdk/typescript/test/client.test.mjs` — 407 lines covering AgentClient construction, health checks, run/replay/resume/signal operations, session reads, checkpoint serialization, stream parsing, and error handling
  - `sdk/typescript/test/authoring.test.mjs` — Tests for authoring stand-ins (`chidori` and `run`) that throw helpful errors outside the runtime
  - `sdk/typescript/test/helpers.mjs` — Reusable test utilities including `MockServer` (a configurable `node:http` server), JSON factories (`callRecord`, `snapshotManifest`), and response helpers

- **Test coverage includes:**
  - HTTP method/path validation and request body shape
  - Session status transitions (completed, failed, paused)
  - Signal outcome distinction (202 queued vs. 200 resumed via `isSignalQueued`)
  - SSE frame parsing and reassembly across chunk boundaries
  - Checkpoint lazy-loading and round-trip serialization
  - Error messages on non-2xx responses
  - Optional fields (e.g., `policy_profile`, `snapshot_manifest`)

- **CI integration:**
  - Updated `package.json` with `pretest` (builds) and `test` (runs `node --test test/*.test.mjs`) scripts
  - Added `npm test` step to `.github/workflows/ci.yml`

- **Documentation:**
  - Updated `sdk/typescript/README.md` with test instructions
  - Marked SDK publishing and TypeScript SDK tests as resolved in `docs/fable_review.md` and `docs/TODO.md`
  - Updated `docs/ai-sdk-gap-analysis.md` to reflect test coverage

## Implementation Details

The mock server (`MockServer`) uses only Node's built-in `http` module and provides:
- Request recording with method, path, and parsed body
- Per-test responder installation via `.on()`
- Path-based request filtering via `.requestsFor()`
- Automatic port binding and cleanup

Tests validate both client behavior (correct method/path, proper field mapping like `pending_prompt` → `pendingPrompt`) and server contract (request body shape, status code handling). SSE stream tests verify both normal parsing and edge cases like frames split across TCP chunks.

https://claude.ai/code/session_01Kv6Nu1rwpX58zsJohL6GuF