### PR TITLE
docs: design for OS-level isolation (process-per-run, brokered effects)

### DIFF
--- a/.github/workflows/os-isolation.yml
+++ b/.github/workflows/os-isolation.yml
@@ -1,0 +1,58 @@
+name: OS isolation
+
+# Verifies the OS-level isolation worker (docs/os-isolation-plan.md) on both
+# Linux and macOS. The macOS leg is the one that matters most: it is the runtime
+# check of the phase-4 Seatbelt path that the Linux dev/CI hosts cannot perform
+# (`seatbelt_loads_and_enforces_on_macos` fails, rather than skips, if the
+# Seatbelt profile does not load and enforce). The Linux leg exercises the
+# network-namespace + seccomp + (where the kernel provides it) Landlock layers.
+#
+# Runs only when the isolation code, its tests, or this workflow change, since
+# the macOS runners are comparatively scarce.
+on:
+  pull_request:
+    paths:
+      - "crates/chidori/src/runtime/isolate/**"
+      - "crates/chidori/src/runtime/rust_engine.rs"
+      - "crates/chidori/tests/isolate_limits.rs"
+      - ".github/workflows/os-isolation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "crates/chidori/src/runtime/isolate/**"
+      - "crates/chidori/src/runtime/rust_engine.rs"
+      - "crates/chidori/tests/isolate_limits.rs"
+      - ".github/workflows/os-isolation.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: os-isolation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  isolation:
+    name: Isolation tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: os-isolation-${{ matrix.os }}
+
+      # The integration tests spawn the real `chidori` binary as the isolation
+      # worker, so they exercise the per-OS sandbox end to end. `--nocapture`
+      # surfaces the `isolate-selftest:` / `sandbox:` markers in the CI log, which
+      # makes a skip (layer unavailable) easy to tell apart from a real failure.
+      - name: Isolation integration tests
+        run: cargo test -p chidori --test isolate_limits -- --nocapture
+
+      - name: Isolation unit tests
+        run: cargo test -p chidori --lib runtime::isolate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "libc",
  "minijinja",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "rusqlite",
+ "seccompiler",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2637,7 +2638,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2674,7 +2675,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -3000,6 +3001,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "landlock",
  "libc",
  "minijinja",
  "opentelemetry",
@@ -956,6 +957,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1695,6 +1716,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,9 +1740,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -102,6 +102,11 @@ oxc = { version = "0.133", features = ["transformer", "codegen", "semantic"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Linux-only: seccomp-bpf syscall confinement for the isolation worker. See
+# `runtime::isolate::sandbox`.
+[target.'cfg(target_os = "linux")'.dependencies]
+seccompiler = "0.5"
+
 [dev-dependencies]
 tempfile = "3"
 # In-memory span exporter for asserting OTEL span-tree shape in tests. Unions

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -97,6 +97,11 @@ opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
 # AST and emits JS via codegen, so unsupported sugar can't slip through.
 oxc = { version = "0.133", features = ["transformer", "codegen", "semantic"] }
 
+# Unix-only: apply per-process resource limits (setrlimit) and deadline-kill
+# (kill) to the OS-isolation worker child. See `runtime::isolate::limits`.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 # In-memory span exporter for asserting OTEL span-tree shape in tests. Unions

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -102,10 +102,11 @@ oxc = { version = "0.133", features = ["transformer", "codegen", "semantic"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-# Linux-only: seccomp-bpf syscall confinement for the isolation worker. See
-# `runtime::isolate::sandbox`.
+# Linux-only: seccomp-bpf syscall confinement + Landlock filesystem confinement
+# for the isolation worker. See `runtime::isolate::sandbox`.
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = "0.5"
+landlock = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -269,6 +269,12 @@ enum Commands {
         /// Explicit CHIDORI_POLICY* configuration still applies.
         #[arg(long)]
         trusted: bool,
+
+        /// Run each request in an isolated child process, brokering its host
+        /// effects back over a pipe (see docs/os-isolation-plan.md). Equivalent
+        /// to CHIDORI_ISOLATE=process. Composes with --untrusted.
+        #[arg(long)]
+        isolate: bool,
     },
 }
 
@@ -303,8 +309,9 @@ fn main() {
             // `run_agent` reads this env var to decide whether to spawn a worker;
             // setting it here keeps the isolation decision in one place.
             if isolate {
-                std::env::set_var("CHIDORI_ISOLATE", "process");
+                crate::runtime::isolate::enable();
             }
+            crate::runtime::isolate::warn_if_untrusted_without_isolation(untrusted);
             let result = if stream {
                 cmd_run_stream(&file, &input, verbose, &tools, untrusted)
             } else {
@@ -360,7 +367,13 @@ fn main() {
             verbose,
             untrusted,
             trusted,
-        } => (cmd_serve(&file, port, verbose, untrusted, trusted), false),
+            isolate,
+        } => {
+            if isolate {
+                crate::runtime::isolate::enable();
+            }
+            (cmd_serve(&file, port, verbose, untrusted, trusted), false)
+        }
     };
 
     // Flush any buffered OTLP spans before the process exits. No-op when
@@ -1396,6 +1409,10 @@ fn cmd_serve(
     }
 
     eprintln!("Agent: {}", file.display());
+    eprintln!("Isolation: {}", crate::runtime::isolate::describe());
+    // The server is deny-by-default unless explicitly trusted; if it is confining
+    // callers by policy but not by process, point at --isolate.
+    crate::runtime::isolate::warn_if_untrusted_without_isolation(!trusted);
 
     let (policy, policy_posture) = serve_policy(untrusted, trusted);
     let tokio_rt = tokio::runtime::Runtime::new().context("Failed to create server runtime")?;

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -84,7 +84,20 @@ enum Commands {
         /// takes precedence over all CHIDORI_POLICY* env vars.
         #[arg(long)]
         untrusted: bool,
+
+        /// Run the agent in an isolated child process, brokering its host
+        /// effects back over a pipe (see docs/os-isolation-plan.md). Equivalent
+        /// to CHIDORI_ISOLATE=process. Phase 1: process separation + brokering;
+        /// per-OS syscall sandboxing lands in a later phase.
+        #[arg(long)]
+        isolate: bool,
     },
+
+    /// Internal: the isolate worker. Runs one agent over a stdin/stdout frame
+    /// protocol on behalf of a parent supervisor; not meant to be invoked
+    /// directly. See `crate::runtime::isolate`.
+    #[command(name = "__run-worker", hide = true)]
+    RunWorker,
 
     /// Validate a TypeScript agent file without running it
     Check {
@@ -262,6 +275,18 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
 
+    // The isolate worker speaks a binary frame protocol over stdout, so it must
+    // short-circuit before any of the normal startup path can write there.
+    if let Commands::RunWorker = cli.command {
+        std::process::exit(match crate::runtime::isolate::worker::run() {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("isolate worker error: {e}");
+                1
+            }
+        });
+    }
+
     // Commands that only do parsing/validation return exit code 2 on failure;
     // everything else returns 1. Success is 0.
     let (result, parse_only) = match cli.command {
@@ -273,7 +298,13 @@ fn main() {
             tools,
             stream,
             untrusted,
+            isolate,
         } => {
+            // `run_agent` reads this env var to decide whether to spawn a worker;
+            // setting it here keeps the isolation decision in one place.
+            if isolate {
+                std::env::set_var("CHIDORI_ISOLATE", "process");
+            }
             let result = if stream {
                 cmd_run_stream(&file, &input, verbose, &tools, untrusted)
             } else {
@@ -281,6 +312,7 @@ fn main() {
             };
             (result, false)
         }
+        Commands::RunWorker => unreachable!("handled before the dispatch match"),
         Commands::Demo => (cmd_demo(), false),
         Commands::Init { dir, template } => (
             init::run(

--- a/crates/chidori/src/runtime/isolate/limits.rs
+++ b/crates/chidori/src/runtime/isolate/limits.rs
@@ -1,0 +1,193 @@
+//! Per-process resource limits for the OS-isolation worker (phase 2).
+//!
+//! These are the cross-Unix *floor* of the isolation story: cheap, unprivileged
+//! limits the worker applies to itself right after the [`Init`] handoff, before
+//! a single line of agent code runs. They are backstops, not the primary guard —
+//! the opcode budget still bounds compute gracefully in-engine and the
+//! counting-allocator watchdog still bounds the heap. What these add is a *hard*,
+//! kernel-enforced ceiling that does not depend on the engine cooperating:
+//!
+//! * `RLIMIT_CPU` — a hard CPU-seconds cap. Unlike a wall-clock deadline it does
+//!   **not** count time the child spends blocked waiting on a brokered host
+//!   effect (that is not CPU time), so it bounds runaway *compute* without
+//!   penalising a legitimately slow agent. The natural hard backstop to the
+//!   in-engine opcode budget.
+//! * `RLIMIT_FSIZE` — max bytes the child may write to a regular file. The child
+//!   has no filesystem (every `node:fs` op is brokered), so the default of `0`
+//!   costs nothing and slams the door on any stray write. Pipes/sockets are
+//!   exempt, so the stdout protocol channel is unaffected.
+//! * `RLIMIT_CORE` — no core dumps (a crash must not splatter process memory to
+//!   disk).
+//! * `RLIMIT_NOFILE` — a small open-file ceiling.
+//!
+//! Deliberately *not* set here: `RLIMIT_AS` (address-space caps are too blunt —
+//! a multi-threaded VM reserves far more virtual memory than it resides, so an
+//! AS cap kills healthy runs; the heap watchdog and, later, a cgroup
+//! `memory.max` are the right tools) and `RLIMIT_NPROC` (counts every process of
+//! the real uid, so a low cap fails unpredictably under concurrency; blocking
+//! `fork` belongs to the seccomp phase). Both are tracked in
+//! `docs/os-isolation-plan.md`.
+
+use serde::{Deserialize, Serialize};
+
+/// The resource limits a worker applies to itself. Computed in the parent from
+/// the environment and shipped in [`super::protocol::FromParent::Init`] so the
+/// policy lives in one place and the child just enforces what it is told.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceLimits {
+    /// Hard CPU-seconds ceiling (`RLIMIT_CPU`). `None` leaves it unset (the
+    /// default — a hard CPU kill is opt-in, since the opcode budget already
+    /// bounds compute gracefully). Env: `CHIDORI_ISOLATE_CPU_SECS`.
+    pub cpu_secs: Option<u64>,
+    /// Max bytes the child may write to any regular file (`RLIMIT_FSIZE`).
+    /// Defaults to `Some(0)`. Env: `CHIDORI_ISOLATE_FSIZE_BYTES`.
+    pub fsize_bytes: Option<u64>,
+    /// Max open file descriptors (`RLIMIT_NOFILE`), clamped to the inherited hard
+    /// limit. Defaults to `Some(256)`. Env: `CHIDORI_ISOLATE_NOFILE`.
+    pub nofile: Option<u64>,
+    /// Disable core dumps (`RLIMIT_CORE = 0`). Defaults to `true`.
+    pub no_core: bool,
+}
+
+impl Default for ResourceLimits {
+    fn default() -> Self {
+        ResourceLimits {
+            cpu_secs: None,
+            fsize_bytes: Some(0),
+            nofile: Some(256),
+            no_core: true,
+        }
+    }
+}
+
+impl ResourceLimits {
+    /// Resolve the limits to apply from the environment, layering over
+    /// [`Default`]. Parsing is forgiving: a malformed value falls back to the
+    /// default for that field rather than failing the run.
+    pub fn from_env() -> Self {
+        fn env_u64(key: &str) -> Option<u64> {
+            std::env::var(key).ok().and_then(|v| v.trim().parse().ok())
+        }
+        let mut limits = ResourceLimits::default();
+        if let Some(secs) = env_u64("CHIDORI_ISOLATE_CPU_SECS") {
+            limits.cpu_secs = (secs > 0).then_some(secs);
+        }
+        if let Some(bytes) = env_u64("CHIDORI_ISOLATE_FSIZE_BYTES") {
+            limits.fsize_bytes = Some(bytes);
+        }
+        if let Some(n) = env_u64("CHIDORI_ISOLATE_NOFILE") {
+            limits.nofile = (n > 0).then_some(n);
+        }
+        if let Ok(v) = std::env::var("CHIDORI_ISOLATE_NO_CORE") {
+            let v = v.trim().to_ascii_lowercase();
+            limits.no_core = !matches!(v.as_str(), "0" | "off" | "false" | "no");
+        }
+        limits
+    }
+
+    /// Apply every configured limit to the *current* process. Best-effort: a
+    /// failure to set one limit is reported to stderr and skipped, never fatal —
+    /// a missing backstop should degrade isolation, not break the run. No-op on
+    /// non-Unix platforms (the per-OS story there is a later phase).
+    #[cfg(unix)]
+    pub fn apply_to_self(&self) {
+        if let Some(secs) = self.cpu_secs {
+            // Give the *hard* limit one second of headroom over the soft limit so
+            // the soft `RLIMIT_CPU` fires `SIGXCPU` first (whose default action
+            // terminates the process). With soft == hard the kernel jumps
+            // straight to `SIGKILL`, which is indistinguishable from an OOM kill.
+            set_rlimit(libc::RLIMIT_CPU, secs, secs.saturating_add(1), "RLIMIT_CPU");
+        }
+        if let Some(bytes) = self.fsize_bytes {
+            set_rlimit(libc::RLIMIT_FSIZE, bytes, bytes, "RLIMIT_FSIZE");
+        }
+        if self.no_core {
+            set_rlimit(libc::RLIMIT_CORE, 0, 0, "RLIMIT_CORE");
+        }
+        if let Some(n) = self.nofile {
+            // Never try to *raise* NOFILE above the inherited hard limit — that
+            // fails with EPERM for an unprivileged process. Clamp instead.
+            let target = current_hard(libc::RLIMIT_NOFILE).map_or(n, |hard| n.min(hard));
+            set_rlimit(libc::RLIMIT_NOFILE, target, target, "RLIMIT_NOFILE");
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub fn apply_to_self(&self) {}
+}
+
+/// Set the soft (`cur`) and hard (`max`) limit of `resource`. The kernel applies
+/// `RLIM_INFINITY` semantics; we only translate `u64`. The `as rlim_t` casts are
+/// load-bearing for portability — `rlim_t` is not `u64` on every Unix — even
+/// where this target makes them a no-op.
+#[cfg(unix)]
+#[allow(clippy::unnecessary_cast)]
+fn set_rlimit(resource: libc::__rlimit_resource_t, soft: u64, hard: u64, name: &str) {
+    let rlim = libc::rlimit {
+        rlim_cur: soft as libc::rlim_t,
+        rlim_max: hard as libc::rlim_t,
+    };
+    // SAFETY: `setrlimit` reads a single well-formed `rlimit` we own; it only
+    // affects this process and cannot violate Rust's memory model.
+    let rc = unsafe { libc::setrlimit(resource, &rlim) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        eprintln!("isolate worker: failed to set {name} (soft={soft}, hard={hard}): {err}");
+    }
+}
+
+/// The inherited hard limit for `resource`, if it can be read.
+#[cfg(unix)]
+#[allow(clippy::unnecessary_cast)] // `rlim_t` width is platform-dependent
+fn current_hard(resource: libc::__rlimit_resource_t) -> Option<u64> {
+    let mut rlim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `getrlimit` writes into a single `rlimit` we own and borrow mutably.
+    let rc = unsafe { libc::getrlimit(resource, &mut rlim) };
+    (rc == 0).then_some(rlim.rlim_max as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_safe() {
+        let l = ResourceLimits::default();
+        assert_eq!(l.fsize_bytes, Some(0));
+        assert_eq!(l.nofile, Some(256));
+        assert!(l.no_core);
+        assert_eq!(l.cpu_secs, None);
+    }
+
+    #[test]
+    fn from_env_is_forgiving_and_serializes() {
+        // Round-trips through the wire format (it rides the Init frame).
+        let l = ResourceLimits::from_env();
+        let json = serde_json::to_string(&l).unwrap();
+        let back: ResourceLimits = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.no_core, l.no_core);
+        assert_eq!(back.fsize_bytes, l.fsize_bytes);
+    }
+
+    // Applying limits mutates the test process's own rlimits, so keep it to a
+    // raise-the-floor no-op: setting NOFILE to its current hard limit must
+    // succeed and not panic.
+    #[cfg(unix)]
+    #[test]
+    fn apply_nofile_clamps_to_hard_limit() {
+        let hard = current_hard(libc::RLIMIT_NOFILE).unwrap();
+        let limits = ResourceLimits {
+            cpu_secs: None,
+            fsize_bytes: None,
+            nofile: Some(hard.saturating_add(1_000_000)),
+            no_core: false,
+        };
+        // Should clamp to `hard` rather than EPERM-fail; no panic, no change past
+        // the hard cap.
+        limits.apply_to_self();
+        assert_eq!(current_hard(libc::RLIMIT_NOFILE), Some(hard));
+    }
+}

--- a/crates/chidori/src/runtime/isolate/limits.rs
+++ b/crates/chidori/src/runtime/isolate/limits.rs
@@ -121,13 +121,22 @@ impl ResourceLimits {
     pub fn apply_to_self(&self) {}
 }
 
+/// The integer type `setrlimit`/`getrlimit` take for the resource selector:
+/// `__rlimit_resource_t` on glibc/Linux, plain `c_int` everywhere else
+/// (macOS/BSD). Matches the type of the `libc::RLIMIT_*` constants per platform,
+/// so callers pass `libc::RLIMIT_CPU` etc. unchanged.
+#[cfg(target_os = "linux")]
+type RlimitResource = libc::__rlimit_resource_t;
+#[cfg(all(unix, not(target_os = "linux")))]
+type RlimitResource = libc::c_int;
+
 /// Set the soft (`cur`) and hard (`max`) limit of `resource`. The kernel applies
 /// `RLIM_INFINITY` semantics; we only translate `u64`. The `as rlim_t` casts are
 /// load-bearing for portability — `rlim_t` is not `u64` on every Unix — even
 /// where this target makes them a no-op.
 #[cfg(unix)]
 #[allow(clippy::unnecessary_cast)]
-fn set_rlimit(resource: libc::__rlimit_resource_t, soft: u64, hard: u64, name: &str) {
+fn set_rlimit(resource: RlimitResource, soft: u64, hard: u64, name: &str) {
     let rlim = libc::rlimit {
         rlim_cur: soft as libc::rlim_t,
         rlim_max: hard as libc::rlim_t,
@@ -144,7 +153,7 @@ fn set_rlimit(resource: libc::__rlimit_resource_t, soft: u64, hard: u64, name: &
 /// The inherited hard limit for `resource`, if it can be read.
 #[cfg(unix)]
 #[allow(clippy::unnecessary_cast)] // `rlim_t` width is platform-dependent
-fn current_hard(resource: libc::__rlimit_resource_t) -> Option<u64> {
+fn current_hard(resource: RlimitResource) -> Option<u64> {
     let mut rlim = libc::rlimit {
         rlim_cur: 0,
         rlim_max: 0,

--- a/crates/chidori/src/runtime/isolate/limits.rs
+++ b/crates/chidori/src/runtime/isolate/limits.rs
@@ -40,7 +40,12 @@ pub struct ResourceLimits {
     /// bounds compute gracefully). Env: `CHIDORI_ISOLATE_CPU_SECS`.
     pub cpu_secs: Option<u64>,
     /// Max bytes the child may write to any regular file (`RLIMIT_FSIZE`).
-    /// Defaults to `Some(0)`. Env: `CHIDORI_ISOLATE_FSIZE_BYTES`.
+    /// **Off by default** (`None`): a `0` cap is too blunt — it also kills writes
+    /// to an inherited `stderr` that happens to be a *regular file* (redirected
+    /// logs), which the worker legitimately uses for diagnostics. File-write
+    /// confinement is Landlock's job (it blocks *opening* new files while leaving
+    /// inherited fds alone); see [`super::sandbox`]. Opt in via
+    /// `CHIDORI_ISOLATE_FSIZE_BYTES` for workloads with no such stderr.
     pub fsize_bytes: Option<u64>,
     /// Max open file descriptors (`RLIMIT_NOFILE`), clamped to the inherited hard
     /// limit. Defaults to `Some(256)`. Env: `CHIDORI_ISOLATE_NOFILE`.
@@ -53,7 +58,7 @@ impl Default for ResourceLimits {
     fn default() -> Self {
         ResourceLimits {
             cpu_secs: None,
-            fsize_bytes: Some(0),
+            fsize_bytes: None,
             nofile: Some(256),
             no_core: true,
         }
@@ -156,7 +161,9 @@ mod tests {
     #[test]
     fn defaults_are_safe() {
         let l = ResourceLimits::default();
-        assert_eq!(l.fsize_bytes, Some(0));
+        // FSIZE is off by default: a 0 cap also kills writes to a redirected
+        // (regular-file) stderr, which the worker uses for diagnostics.
+        assert_eq!(l.fsize_bytes, None);
         assert_eq!(l.nofile, Some(256));
         assert!(l.no_core);
         assert_eq!(l.cpu_secs, None);

--- a/crates/chidori/src/runtime/isolate/mod.rs
+++ b/crates/chidori/src/runtime/isolate/mod.rs
@@ -1,0 +1,32 @@
+//! OS-level isolation: run an agent in a child process and broker its host
+//! effects back over a pipe.
+//!
+//! The design and rationale live in `docs/os-isolation-plan.md`. The short
+//! version: the host-call boundary (`run_module`'s single `(op, args) -> JSON`
+//! seam) doubles as a serialization boundary, so the JavaScript engine can be
+//! moved into a disposable child process while every powerful effect stays in
+//! the trusted parent. This module is **phase 1** — the worker, the broker, and
+//! the wire protocol. The per-OS sandbox (seccomp / namespaces on Linux,
+//! Seatbelt on macOS) lands in later phases; until then the child is a separate
+//! process with brokered effects but no syscall confinement yet.
+
+pub mod protocol;
+pub mod supervisor;
+pub mod worker;
+
+pub(crate) use supervisor::run_agent_isolated;
+
+/// Whether OS isolation is enabled for this process, controlled by the
+/// `CHIDORI_ISOLATE` environment variable. Any value other than the unset /
+/// empty / explicitly-falsey forms (`0`, `off`, `false`, `no`) turns it on;
+/// `process` is the canonical value. The worker child always has this unset (the
+/// supervisor strips it), so a worker never recursively re-isolates.
+pub fn enabled() -> bool {
+    match std::env::var("CHIDORI_ISOLATE") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && !matches!(v.as_str(), "0" | "off" | "false" | "no")
+        }
+        Err(_) => false,
+    }
+}

--- a/crates/chidori/src/runtime/isolate/mod.rs
+++ b/crates/chidori/src/runtime/isolate/mod.rs
@@ -32,3 +32,39 @@ pub fn enabled() -> bool {
         Err(_) => false,
     }
 }
+
+/// Turn OS isolation on for this process and the workers it spawns, as if
+/// `CHIDORI_ISOLATE=process` were set. Centralizes the env-var name so the CLI
+/// flags (`run --isolate`, `serve --isolate`) and the env path agree.
+pub fn enable() {
+    std::env::set_var("CHIDORI_ISOLATE", "process");
+}
+
+/// A one-line, human-readable description of the isolation posture, for startup
+/// banners. Describes *intent*: the worker applies each layer best-effort and
+/// logs to stderr what actually stuck on this host.
+pub fn describe() -> String {
+    if !enabled() {
+        return "off (agents run in-process)".to_string();
+    }
+    let layers = if cfg!(target_os = "linux") {
+        "Linux: network namespace + Landlock + seccomp"
+    } else if cfg!(target_os = "macos") {
+        "macOS: Seatbelt profile"
+    } else {
+        "no OS sandbox layer on this platform"
+    };
+    format!("on — process-per-run worker ({layers}; best-effort)")
+}
+
+/// If untrusted code is being run without OS isolation, nudge the operator that
+/// `--isolate` is available. No-op when isolation is already on. Per the
+/// orthogonal-but-composable design, this never *enables* isolation itself.
+pub fn warn_if_untrusted_without_isolation(untrusted: bool) {
+    if untrusted && !enabled() {
+        eprintln!(
+            "note: running under the untrusted policy without OS isolation. Pass --isolate \
+             (or set CHIDORI_ISOLATE=process) to also sandbox each run in a confined child process."
+        );
+    }
+}

--- a/crates/chidori/src/runtime/isolate/mod.rs
+++ b/crates/chidori/src/runtime/isolate/mod.rs
@@ -10,6 +10,7 @@
 //! Seatbelt on macOS) lands in later phases; until then the child is a separate
 //! process with brokered effects but no syscall confinement yet.
 
+pub mod limits;
 pub mod protocol;
 pub mod supervisor;
 pub mod worker;

--- a/crates/chidori/src/runtime/isolate/mod.rs
+++ b/crates/chidori/src/runtime/isolate/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod limits;
 pub mod protocol;
+pub mod sandbox;
 pub mod supervisor;
 pub mod worker;
 

--- a/crates/chidori/src/runtime/isolate/protocol.rs
+++ b/crates/chidori/src/runtime/isolate/protocol.rs
@@ -21,6 +21,8 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::limits::ResourceLimits;
+
 /// Hard ceiling on a single frame's body (parent-side hardening: a hostile or
 /// buggy child must not be able to make the parent allocate without bound).
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
@@ -39,6 +41,10 @@ pub enum FromParent {
         /// `Some` for a runtime run (installs captured natives + prelude);
         /// `None` only for backends that wouldn't be isolated in the first place.
         prelude: Option<String>,
+        /// Per-process resource limits the worker applies to itself before
+        /// running the agent (phase 2). Centralised here so the parent owns the
+        /// policy and the child only enforces it.
+        limits: ResourceLimits,
     },
     /// The result of one brokered host op.
     Reply(Outcome),

--- a/crates/chidori/src/runtime/isolate/protocol.rs
+++ b/crates/chidori/src/runtime/isolate/protocol.rs
@@ -1,0 +1,149 @@
+//! Wire protocol for the isolate worker.
+//!
+//! A strictly request/response framing over a pair of byte streams (the child's
+//! stdin/stdout in production, a `socketpair` in tests). Each frame is a
+//! little-endian `u32` length prefix followed by that many bytes of JSON. The
+//! exchange is:
+//!
+//! 1. parent → child: one [`FromParent::Init`].
+//! 2. child runs the agent; for every host op it emits a [`FromChild::Call`] and
+//!    blocks for the matching [`FromParent::Reply`].
+//! 3. child → parent: a final [`FromChild::Done`] carrying the run's result.
+//!
+//! There is no pipelining — the child has exactly one outstanding call at a time
+//! — so the two sides never deadlock as long as each replies before reading the
+//! next frame. JSON (not a binary codec) is deliberate for a first cut: it is
+//! trivially debuggable and the per-effect cost is dwarfed by LLM/tool latency.
+
+use std::io::{self, Read, Write};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Hard ceiling on a single frame's body (parent-side hardening: a hostile or
+/// buggy child must not be able to make the parent allocate without bound).
+pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+
+/// Parent → child messages.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromParent {
+    /// The one-time handoff that starts a run. The child has no filesystem, so
+    /// the entry source and the determinism prelude are shipped inline; sibling
+    /// imports are resolved lazily by brokering `__module_load` back to us.
+    Init {
+        entry_path: String,
+        entry_source: String,
+        fallback_export: String,
+        input: Value,
+        /// `Some` for a runtime run (installs captured natives + prelude);
+        /// `None` only for backends that wouldn't be isolated in the first place.
+        prelude: Option<String>,
+    },
+    /// The result of one brokered host op.
+    Reply(Outcome),
+}
+
+/// Child → parent messages.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromChild {
+    /// A host op the child needs the parent to perform (`chidori.*` effect,
+    /// `__chidori_*` native, `__chidori_dom_render`, or `__module_load`).
+    Call { op: String, args: Value },
+    /// The run finished; `outcome` is the agent's output or the error.
+    Done { outcome: Outcome },
+}
+
+/// A fallible JSON value, serialized as a plain tagged enum so both an `Ok`
+/// payload and an `Err` message survive the round trip.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Outcome {
+    Ok(Value),
+    Err(String),
+}
+
+impl From<Result<Value, String>> for Outcome {
+    fn from(r: Result<Value, String>) -> Self {
+        match r {
+            Ok(v) => Outcome::Ok(v),
+            Err(e) => Outcome::Err(e),
+        }
+    }
+}
+
+impl From<Outcome> for Result<Value, String> {
+    fn from(o: Outcome) -> Self {
+        match o {
+            Outcome::Ok(v) => Ok(v),
+            Outcome::Err(e) => Err(e),
+        }
+    }
+}
+
+/// Write one length-prefixed JSON frame and flush it.
+pub fn write_frame<W: Write, T: Serialize>(w: &mut W, msg: &T) -> io::Result<()> {
+    let body = serde_json::to_vec(msg).map_err(io::Error::other)?;
+    if body.len() > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "frame of {} bytes exceeds the {MAX_FRAME_BYTES} cap",
+                body.len()
+            ),
+        ));
+    }
+    w.write_all(&(body.len() as u32).to_le_bytes())?;
+    w.write_all(&body)?;
+    w.flush()
+}
+
+/// Read one length-prefixed JSON frame. A clean EOF before the length prefix
+/// surfaces as `UnexpectedEof`, which callers treat as "the peer went away".
+pub fn read_frame<R: Read, T: DeserializeOwned>(r: &mut R) -> io::Result<T> {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf)?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame of {len} bytes exceeds the {MAX_FRAME_BYTES} cap"),
+        ));
+    }
+    let mut body = vec![0u8; len];
+    r.read_exact(&mut body)?;
+    serde_json::from_slice(&body).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_round_trips() {
+        let mut buf: Vec<u8> = Vec::new();
+        let msg = FromChild::Call {
+            op: "log".into(),
+            args: serde_json::json!({ "message": "hi" }),
+        };
+        write_frame(&mut buf, &msg).unwrap();
+        let mut cursor = std::io::Cursor::new(buf);
+        let back: FromChild = read_frame(&mut cursor).unwrap();
+        match back {
+            FromChild::Call { op, args } => {
+                assert_eq!(op, "log");
+                assert_eq!(args, serde_json::json!({ "message": "hi" }));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn oversized_length_prefix_is_rejected() {
+        // A length prefix past the cap must error before allocating the body.
+        let mut bytes = ((MAX_FRAME_BYTES + 1) as u32).to_le_bytes().to_vec();
+        bytes.extend_from_slice(b"ignored");
+        let mut cursor = std::io::Cursor::new(bytes);
+        let err = read_frame::<_, FromChild>(&mut cursor).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/chidori/src/runtime/isolate/sandbox.rs
+++ b/crates/chidori/src/runtime/isolate/sandbox.rs
@@ -25,26 +25,66 @@
 /// portable core (seccomp) did not apply.
 #[derive(Debug, Default)]
 pub struct SandboxOutcome {
-    /// The worker runs in its own (empty) network namespace.
+    /// The worker runs in its own (empty) network namespace (Linux).
     pub network_isolated: bool,
-    /// Landlock is enforcing a read-only view of the filesystem.
+    /// Landlock is enforcing a read-only view of the filesystem (Linux).
     pub landlock_enforced: bool,
-    /// The seccomp denylist is installed.
+    /// The seccomp denylist is installed (Linux).
     pub seccomp_applied: bool,
+    /// A Seatbelt profile is confining the worker (macOS). Only ever set/read on
+    /// macOS, so it is dead on other targets.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    pub seatbelt_applied: bool,
     /// Human-readable reasons for any layer that was skipped.
     pub notes: Vec<String>,
 }
 
-/// Apply every confinement layer to the current process, in the order that keeps
-/// each one legal: namespace + Landlock first (they need syscalls — `unshare`,
-/// `landlock_*` — that seccomp then denies), and the seccomp denylist last. Every
-/// layer is best-effort; the returned [`SandboxOutcome`] records what stuck.
+impl SandboxOutcome {
+    /// Whether the platform's *primary* confinement is active — the gate for
+    /// `CHIDORI_ISOLATE_REQUIRE_SANDBOX` (seccomp on Linux, Seatbelt on macOS).
+    /// The namespace/Landlock layers are defense-in-depth on top of this.
+    pub fn core_confined(&self) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            self.seccomp_applied
+        }
+        #[cfg(target_os = "macos")]
+        {
+            self.seatbelt_applied
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            false
+        }
+    }
+}
+
+/// Apply every available confinement layer to the current process, best-effort;
+/// the returned [`SandboxOutcome`] records what stuck. The per-OS work lives in
+/// [`apply_linux`] / [`apply_macos`]; other platforms get nothing (yet).
 ///
 /// Sound only when the caller *is* the dedicated worker process, since each layer
 /// mutates the current process irreversibly.
 pub fn apply() -> SandboxOutcome {
     let mut outcome = SandboxOutcome::default();
 
+    #[cfg(target_os = "linux")]
+    apply_linux(&mut outcome);
+    #[cfg(target_os = "macos")]
+    apply_macos(&mut outcome);
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    outcome
+        .notes
+        .push("no OS sandbox layer is available on this platform".to_string());
+
+    outcome
+}
+
+/// Linux confinement, ordered so each layer is still legal when the next runs:
+/// network namespace + Landlock first (they need `unshare` / `landlock_*`, which
+/// seccomp then denies), and the seccomp denylist last.
+#[cfg(target_os = "linux")]
+fn apply_linux(outcome: &mut SandboxOutcome) {
     match apply_network_namespace() {
         Ok(()) => outcome.network_isolated = true,
         Err(e) => outcome
@@ -62,7 +102,6 @@ pub fn apply() -> SandboxOutcome {
         Ok(()) => outcome.seccomp_applied = true,
         Err(e) => outcome.notes.push(format!("seccomp not applied: {e}")),
     }
-    outcome
 }
 
 /// Move the worker into a fresh, empty network namespace (`unshare(CLONE_NEWNET)`)
@@ -79,11 +118,6 @@ fn apply_network_namespace() -> Result<(), String> {
         return Err(std::io::Error::last_os_error().to_string());
     }
     Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn apply_network_namespace() -> Result<(), String> {
-    Err("network namespaces are only available on Linux".to_string())
 }
 
 /// Enforce a **read-only** view of the filesystem via Landlock: every write-class
@@ -113,11 +147,6 @@ fn apply_landlock_readonly() -> Result<bool, String> {
         .restrict_self()
         .map_err(|e| format!("restrict_self: {e}"))?;
     Ok(!matches!(status.ruleset, RulesetStatus::NotEnforced))
-}
-
-#[cfg(not(target_os = "linux"))]
-fn apply_landlock_readonly() -> Result<bool, String> {
-    Err("landlock is only available on Linux".to_string())
 }
 
 /// Install the worker's seccomp filter on the current thread; every thread or
@@ -158,11 +187,6 @@ pub fn install_seccomp() -> Result<(), String> {
     // `apply_filter` sets `PR_SET_NO_NEW_PRIVS` first, so this works unprivileged.
     seccompiler::apply_filter(&program).map_err(|e| format!("seccomp: applying filter: {e}"))?;
     Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn install_seccomp() -> Result<(), String> {
-    Err("seccomp confinement is only available on Linux".to_string())
 }
 
 /// The denied syscalls. Restricted to numbers that exist on every Linux release
@@ -231,6 +255,73 @@ fn denied_syscalls() -> Vec<i64> {
         libc::SYS_request_key,
     ];
     denied.iter().map(|n| *n as i64).collect()
+}
+
+// ---------------------------------------------------------------------------
+// macOS (Seatbelt) — parity with the Linux posture: no network, no filesystem
+// writes. Implemented behind the same best-effort contract as the Linux layers.
+// ---------------------------------------------------------------------------
+
+/// macOS confinement: apply a Seatbelt profile via `sandbox_init`.
+#[cfg(target_os = "macos")]
+fn apply_macos(outcome: &mut SandboxOutcome) {
+    match apply_seatbelt() {
+        Ok(()) => outcome.seatbelt_applied = true,
+        Err(e) => outcome.notes.push(format!("seatbelt not applied: {e}")),
+    }
+}
+
+/// The Seatbelt profile (SBPL). Allow-default with targeted denies — the same
+/// philosophy as the Linux seccomp denylist + Landlock read-only posture, and
+/// low-risk: a brokered compute worker still reads files and allocates freely,
+/// it just can't reach the network or write to disk. Later rules win in SBPL, so
+/// the denies override `(allow default)` for their operations.
+#[cfg(target_os = "macos")]
+const SEATBELT_PROFILE: &str = "\
+(version 1)
+(allow default)
+(deny network*)
+(deny file-write*)
+";
+
+/// Confine the current process with [`SEATBELT_PROFILE`]. Best-effort: a failure
+/// is returned as a reason (the worker logs it and degrades), never a panic.
+#[cfg(target_os = "macos")]
+fn apply_seatbelt() -> Result<(), String> {
+    use std::ffi::{CStr, CString};
+
+    // `sandbox_init`/`sandbox_free_error` live in libSystem (auto-linked). The API
+    // is deprecated-but-present and stable — it is what Chromium's renderer uses.
+    extern "C" {
+        fn sandbox_init(
+            profile: *const libc::c_char,
+            flags: u64,
+            errorbuf: *mut *mut libc::c_char,
+        ) -> libc::c_int;
+        fn sandbox_free_error(errorbuf: *mut libc::c_char);
+    }
+
+    let profile = CString::new(SEATBELT_PROFILE).map_err(|e| format!("profile CString: {e}"))?;
+    let mut err_ptr: *mut libc::c_char = std::ptr::null_mut();
+    // SAFETY: `profile` is a valid NUL-terminated SBPL string; `flags = 0` selects
+    // an inline (non-named) profile. On failure `sandbox_init` allocates an owned C
+    // string into `err_ptr`, which we read and then free with `sandbox_free_error`.
+    let rc = unsafe { sandbox_init(profile.as_ptr(), 0, &mut err_ptr) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let reason = if err_ptr.is_null() {
+        format!("sandbox_init returned {rc}")
+    } else {
+        // SAFETY: `err_ptr` is a valid C string owned by libSystem; copy it out,
+        // then hand it back to be freed.
+        let msg = unsafe { CStr::from_ptr(err_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { sandbox_free_error(err_ptr) };
+        msg
+    };
+    Err(reason)
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/crates/chidori/src/runtime/isolate/sandbox.rs
+++ b/crates/chidori/src/runtime/isolate/sandbox.rs
@@ -1,0 +1,166 @@
+//! Linux seccomp-bpf syscall confinement for the isolation worker (phase 3).
+//!
+//! This is defense-in-depth *behind* the primary boundary. The engine already
+//! has no ambient authority — there is no socket, no `exec`, no real filesystem
+//! wired into it, and every effect is brokered to the parent — so the realistic
+//! threat seccomp addresses is a hypothetical interpreter RCE that tries to issue
+//! raw syscalls directly. Against that, this filter slams the door on the
+//! highest-value targets: network egress, new-program execution, debugging,
+//! namespace/privilege escalation, and kernel surface.
+//!
+//! **Denylist, not allowlist (for now).** The filter defaults to *allow* and
+//! kills the process on a curated set of dangerous syscalls. A near-empty
+//! allowlist is the stronger end state (and the documented goal — see
+//! `docs/os-isolation-plan.md`), but it risks false-positive kills of the engine
+//! on an unanticipated syscall and is fragile across libc/kernel versions. A
+//! denylist cannot break a healthy run, ships real confinement today, and is a
+//! clean base to tighten from. `fork`/`clone` are intentionally *not* denied —
+//! the engine's watchdog thread needs them and a fork that cannot `exec` gains no
+//! new code — so the `exec*` denial is what actually forecloses code execution.
+
+/// Install the worker's seccomp filter on the current thread; every thread or
+/// child it later spawns inherits it. Returns `Ok(())` on success, or a
+/// human-readable reason it could not be applied (a denied/absent `seccomp`
+/// syscall, an unsupported arch, …) so the caller can decide between degrading
+/// and failing closed.
+#[cfg(target_os = "linux")]
+pub fn install_seccomp() -> Result<(), String> {
+    use std::collections::BTreeMap;
+
+    use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, SeccompRule, TargetArch};
+
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => TargetArch::x86_64,
+        "aarch64" => TargetArch::aarch64,
+        "riscv64" => TargetArch::riscv64,
+        other => return Err(format!("seccomp: unsupported architecture `{other}`")),
+    };
+
+    // An empty rule vec means "match this syscall unconditionally" → `match_action`.
+    let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
+    for sysno in denied_syscalls() {
+        rules.insert(sysno, vec![]);
+    }
+
+    let filter = SeccompFilter::new(
+        rules,
+        SeccompAction::Allow,       // mismatch (everything not listed): allow
+        SeccompAction::KillProcess, // match (a denied syscall): SIGSYS, kill process
+        arch,
+    )
+    .map_err(|e| format!("seccomp: building filter: {e}"))?;
+
+    let program: BpfProgram = filter
+        .try_into()
+        .map_err(|e| format!("seccomp: compiling filter: {e}"))?;
+    // `apply_filter` sets `PR_SET_NO_NEW_PRIVS` first, so this works unprivileged.
+    seccompiler::apply_filter(&program).map_err(|e| format!("seccomp: applying filter: {e}"))?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn install_seccomp() -> Result<(), String> {
+    Err("seccomp confinement is only available on Linux".to_string())
+}
+
+/// The denied syscalls. Restricted to numbers that exist on every Linux release
+/// target (x86_64 and aarch64) so the table compiles on either.
+#[cfg(target_os = "linux")]
+// `c_long as i64` is load-bearing on targets where `c_long` is 32-bit, even
+// though it is a no-op on the 64-bit targets we ship.
+#[allow(clippy::unnecessary_cast)]
+fn denied_syscalls() -> Vec<i64> {
+    let denied: &[libc::c_long] = &[
+        // Network: the worker never legitimately touches a socket — `http` is a
+        // brokered effect performed by the parent.
+        libc::SYS_socket,
+        libc::SYS_socketpair,
+        libc::SYS_connect,
+        libc::SYS_bind,
+        libc::SYS_listen,
+        libc::SYS_accept,
+        libc::SYS_accept4,
+        libc::SYS_getsockname,
+        libc::SYS_getpeername,
+        libc::SYS_setsockopt,
+        libc::SYS_getsockopt,
+        libc::SYS_sendto,
+        libc::SYS_recvfrom,
+        libc::SYS_sendmsg,
+        libc::SYS_recvmsg,
+        libc::SYS_sendmmsg,
+        libc::SYS_recvmmsg,
+        libc::SYS_shutdown,
+        // New-program execution (what actually denies "run arbitrary code").
+        libc::SYS_execve,
+        libc::SYS_execveat,
+        // Debugging / cross-process memory.
+        libc::SYS_ptrace,
+        libc::SYS_process_vm_readv,
+        libc::SYS_process_vm_writev,
+        // Namespace / mount manipulation (sandbox-escape surface).
+        libc::SYS_unshare,
+        libc::SYS_setns,
+        libc::SYS_mount,
+        libc::SYS_umount2,
+        libc::SYS_pivot_root,
+        libc::SYS_chroot,
+        // Privilege changes.
+        libc::SYS_setuid,
+        libc::SYS_setgid,
+        libc::SYS_setreuid,
+        libc::SYS_setregid,
+        libc::SYS_setresuid,
+        libc::SYS_setresgid,
+        libc::SYS_setfsuid,
+        libc::SYS_setfsgid,
+        libc::SYS_setgroups,
+        // Kernel surface / modules / power.
+        libc::SYS_bpf,
+        libc::SYS_perf_event_open,
+        libc::SYS_init_module,
+        libc::SYS_finit_module,
+        libc::SYS_delete_module,
+        libc::SYS_kexec_load,
+        libc::SYS_reboot,
+        // Keyrings.
+        libc::SYS_keyctl,
+        libc::SYS_add_key,
+        libc::SYS_request_key,
+    ];
+    denied.iter().map(|n| *n as i64).collect()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_compiles_for_this_arch() {
+        // Building + compiling the filter must succeed on the host arch; we do not
+        // *apply* it (that would confine the test process for the rest of its run).
+        use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, SeccompRule, TargetArch};
+        use std::collections::BTreeMap;
+
+        let arch = match std::env::consts::ARCH {
+            "x86_64" => TargetArch::x86_64,
+            "aarch64" => TargetArch::aarch64,
+            "riscv64" => TargetArch::riscv64,
+            other => panic!("unexpected test arch {other}"),
+        };
+        let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
+        for sysno in denied_syscalls() {
+            rules.insert(sysno, vec![]);
+        }
+        assert!(!rules.is_empty());
+        let filter = SeccompFilter::new(
+            rules,
+            SeccompAction::Allow,
+            SeccompAction::KillProcess,
+            arch,
+        )
+        .expect("filter builds");
+        let program: BpfProgram = filter.try_into().expect("filter compiles");
+        assert!(!program.is_empty());
+    }
+}

--- a/crates/chidori/src/runtime/isolate/sandbox.rs
+++ b/crates/chidori/src/runtime/isolate/sandbox.rs
@@ -18,6 +18,108 @@
 //! the engine's watchdog thread needs them and a fork that cannot `exec` gains no
 //! new code — so the `exec*` denial is what actually forecloses code execution.
 
+/// What each best-effort confinement layer achieved for a worker. Layers that
+/// could not be applied (older kernel, rootless container, …) leave their flag
+/// `false` and append a human-readable reason to `notes`; the worker logs the
+/// notes and, under `CHIDORI_ISOLATE_REQUIRE_SANDBOX`, fails closed if the
+/// portable core (seccomp) did not apply.
+#[derive(Debug, Default)]
+pub struct SandboxOutcome {
+    /// The worker runs in its own (empty) network namespace.
+    pub network_isolated: bool,
+    /// Landlock is enforcing a read-only view of the filesystem.
+    pub landlock_enforced: bool,
+    /// The seccomp denylist is installed.
+    pub seccomp_applied: bool,
+    /// Human-readable reasons for any layer that was skipped.
+    pub notes: Vec<String>,
+}
+
+/// Apply every confinement layer to the current process, in the order that keeps
+/// each one legal: namespace + Landlock first (they need syscalls — `unshare`,
+/// `landlock_*` — that seccomp then denies), and the seccomp denylist last. Every
+/// layer is best-effort; the returned [`SandboxOutcome`] records what stuck.
+///
+/// Sound only when the caller *is* the dedicated worker process, since each layer
+/// mutates the current process irreversibly.
+pub fn apply() -> SandboxOutcome {
+    let mut outcome = SandboxOutcome::default();
+
+    match apply_network_namespace() {
+        Ok(()) => outcome.network_isolated = true,
+        Err(e) => outcome
+            .notes
+            .push(format!("network namespace not isolated: {e}")),
+    }
+    match apply_landlock_readonly() {
+        Ok(true) => outcome.landlock_enforced = true,
+        Ok(false) => outcome
+            .notes
+            .push("landlock not enforced: no kernel support".to_string()),
+        Err(e) => outcome.notes.push(format!("landlock not enforced: {e}")),
+    }
+    match install_seccomp() {
+        Ok(()) => outcome.seccomp_applied = true,
+        Err(e) => outcome.notes.push(format!("seccomp not applied: {e}")),
+    }
+    outcome
+}
+
+/// Move the worker into a fresh, empty network namespace (`unshare(CLONE_NEWNET)`)
+/// — only loopback, and that down — so network egress is impossible at the kernel
+/// level, belt-and-suspenders with the seccomp socket block. Needs `CAP_SYS_ADMIN`
+/// (root or a privileged container); rootless callers fail with `EPERM` and the
+/// layer is skipped. (Rootless support via an intermediate user namespace is a
+/// future enhancement — see `docs/os-isolation-plan.md`.)
+#[cfg(target_os = "linux")]
+fn apply_network_namespace() -> Result<(), String> {
+    // SAFETY: `unshare` takes a scalar flag and affects only this process.
+    let rc = unsafe { libc::unshare(libc::CLONE_NEWNET) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn apply_network_namespace() -> Result<(), String> {
+    Err("network namespaces are only available on Linux".to_string())
+}
+
+/// Enforce a **read-only** view of the filesystem via Landlock: every write-class
+/// access (create / write / truncate / rename / delete / mkdir / …) is denied,
+/// while reads are left untouched so the C runtime can still load what it needs.
+/// The worker brokers all of its I/O, so it never legitimately writes to disk —
+/// this closes the filesystem-tamper surface the seccomp denylist deliberately
+/// leaves open (it does not block `openat`, to avoid false-positive kills).
+///
+/// Best-effort (`CompatLevel::BestEffort`): on a kernel without Landlock the
+/// ruleset reports `NotEnforced` (returns `Ok(false)`) rather than erroring.
+/// Returns `Ok(true)` when Landlock is enforcing (fully or partially).
+#[cfg(target_os = "linux")]
+fn apply_landlock_readonly() -> Result<bool, String> {
+    use landlock::{AccessFs, CompatLevel, Compatible, Ruleset, RulesetAttr, RulesetStatus, ABI};
+
+    // V5 (Linux 6.10) is a modern baseline; BestEffort downgrades the handled
+    // write-access set to whatever the running kernel actually supports.
+    let abi = ABI::V5;
+    let status = Ruleset::default()
+        .set_compatibility(CompatLevel::BestEffort)
+        .handle_access(AccessFs::from_write(abi))
+        .map_err(|e| format!("handle_access: {e}"))?
+        .create()
+        .map_err(|e| format!("create: {e}"))?
+        // No path rules are granted, so every handled (write) access is denied.
+        .restrict_self()
+        .map_err(|e| format!("restrict_self: {e}"))?;
+    Ok(!matches!(status.ruleset, RulesetStatus::NotEnforced))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn apply_landlock_readonly() -> Result<bool, String> {
+    Err("landlock is only available on Linux".to_string())
+}
+
 /// Install the worker's seccomp filter on the current thread; every thread or
 /// child it later spawns inherits it. Returns `Ok(())` on success, or a
 /// human-readable reason it could not be applied (a denied/absent `seccomp`

--- a/crates/chidori/src/runtime/isolate/supervisor.rs
+++ b/crates/chidori/src/runtime/isolate/supervisor.rs
@@ -1,0 +1,105 @@
+//! The supervisor half of OS isolation — the parent-side broker.
+//!
+//! [`run_agent_isolated`] spawns the worker (`chidori __run-worker`), ships it
+//! the [`FromParent::Init`] handoff, then services every host op the child sends
+//! by routing it through the *same* [`route_host_op`] the in-process host uses.
+//! The durable call log, policy, MCP, providers, and OTEL all stay here in the
+//! trusted parent; the child only computes JavaScript.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+
+use crate::runtime::rust_engine::{build_sync_native_dispatch, route_host_op, rust_engine_prelude};
+use crate::runtime::typescript::bindings::HostBindingBackend;
+
+use super::protocol::{read_frame, write_frame, FromChild, FromParent, Outcome};
+
+/// Run `source` (the agent at `path`) in a sandboxed child process, brokering its
+/// host effects back through `backend`. Returns the agent's output, or an error
+/// if the worker failed, crashed, or was killed.
+pub(crate) fn run_agent_isolated(
+    path: &Path,
+    source: &str,
+    input: &Value,
+    backend: &HostBindingBackend,
+) -> Result<Value> {
+    let exe = std::env::current_exe().context("locating the chidori worker binary")?;
+    let mut child = Command::new(&exe)
+        .arg("__run-worker")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        // The child must not re-enter isolation (it runs the agent directly); make
+        // that impossible regardless of how this process's env was configured.
+        .env_remove("CHIDORI_ISOLATE")
+        .spawn()
+        .with_context(|| format!("spawning isolate worker `{} __run-worker`", exe.display()))?;
+
+    let mut to_child = child.stdin.take().expect("worker stdin was piped");
+    let mut from_child = child.stdout.take().expect("worker stdout was piped");
+
+    let init = FromParent::Init {
+        entry_path: path.to_string_lossy().into_owned(),
+        entry_source: source.to_string(),
+        fallback_export: "agent".to_string(),
+        input: input.clone(),
+        prelude: backend.runtime_policy().map(|p| rust_engine_prelude(&p)),
+    };
+
+    let result = broker(&mut from_child, &mut to_child, backend, init);
+
+    // Drop our pipe ends so the worker sees EOF, then reap it to avoid a zombie.
+    // The `Done` frame (or its absence) is authoritative for the run's outcome;
+    // the exit status is only used to enrich a missing-result error.
+    drop(to_child);
+    drop(from_child);
+    let status = child.wait();
+    match result {
+        Ok(v) => Ok(v),
+        Err(e) => match status {
+            Ok(s) if !s.success() => {
+                Err(e.context(format!("isolate worker exited with status {s}")))
+            }
+            _ => Err(e),
+        },
+    }
+}
+
+/// The broker loop: send `init`, then service `Call` frames until the worker
+/// reports `Done`. Generic over the transport so tests can drive it over an
+/// in-process socket pair. `pub(crate)` for that reason.
+pub(crate) fn broker<R: Read, W: Write>(
+    from_child: &mut R,
+    to_child: &mut W,
+    backend: &HostBindingBackend,
+    init: FromParent,
+) -> Result<Value> {
+    // The captured-effect native dispatch (VFS / crypto / timers), built once and
+    // shared across every brokered op — identical to what the in-process host
+    // constructs, so brokered and inline runs hit the same handlers.
+    let sync = match (backend.runtime_policy(), backend.runtime_ctx()) {
+        (Some(policy), Some(ctx)) => Some(build_sync_native_dispatch(ctx.clone(), policy)),
+        _ => None,
+    };
+
+    write_frame(to_child, &init).context("sending Init to the isolate worker")?;
+
+    loop {
+        let msg: FromChild = read_frame(from_child)
+            .context("isolate worker terminated before returning a result")?;
+        match msg {
+            FromChild::Call { op, args } => {
+                let outcome: Outcome = route_host_op(backend, sync.as_ref(), &op, &args).into();
+                write_frame(to_child, &FromParent::Reply(outcome))
+                    .context("replying to the isolate worker")?;
+            }
+            FromChild::Done { outcome } => {
+                return Result::<Value, String>::from(outcome).map_err(|e| anyhow!(e));
+            }
+        }
+    }
+}

--- a/crates/chidori/src/runtime/isolate/supervisor.rs
+++ b/crates/chidori/src/runtime/isolate/supervisor.rs
@@ -209,6 +209,9 @@ fn exit_cause(status: &std::process::ExitStatus) -> Option<String> {
     use std::os::unix::process::ExitStatusExt;
     let sig = status.signal()?;
     Some(match sig {
+        libc::SIGSYS => {
+            "isolate worker attempted a blocked syscall and was killed (seccomp/SIGSYS)".to_string()
+        }
         libc::SIGKILL => {
             "isolate worker was killed (out of memory, or an external SIGKILL)".to_string()
         }

--- a/crates/chidori/src/runtime/isolate/supervisor.rs
+++ b/crates/chidori/src/runtime/isolate/supervisor.rs
@@ -5,10 +5,21 @@
 //! by routing it through the *same* [`route_host_op`] the in-process host uses.
 //! The durable call log, policy, MCP, providers, and OTEL all stay here in the
 //! trusted parent; the child only computes JavaScript.
+//!
+//! Phase 2 adds the parent-side hard backstops that the child cannot evade: a
+//! wall-clock **deadline-kill** (a watchdog thread that `SIGKILL`s a wedged
+//! child) and **signal-aware failure mapping** so an OS kill — CPU limit, file
+//! limit, OOM, deadline — surfaces as a precise error instead of an opaque
+//! "worker terminated". The per-process `setrlimit` floor is applied by the
+//! child itself (see [`super::limits`]).
 
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
@@ -16,11 +27,25 @@ use serde_json::Value;
 use crate::runtime::rust_engine::{build_sync_native_dispatch, route_host_op, rust_engine_prelude};
 use crate::runtime::typescript::bindings::HostBindingBackend;
 
+use super::limits::ResourceLimits;
 use super::protocol::{read_frame, write_frame, FromChild, FromParent, Outcome};
+
+/// Optional parent-side wall-clock deadline, in milliseconds, from
+/// `CHIDORI_ISOLATE_DEADLINE_MS`. Distinct from the in-engine
+/// `CHIDORI_JS_DEADLINE_MS` (which the child enforces cooperatively): this is the
+/// hard backstop that reclaims a child which has stopped cooperating entirely.
+/// Off (`None`) unless set to a positive value.
+fn deadline_from_env() -> Option<Duration> {
+    std::env::var("CHIDORI_ISOLATE_DEADLINE_MS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .map(Duration::from_millis)
+}
 
 /// Run `source` (the agent at `path`) in a sandboxed child process, brokering its
 /// host effects back through `backend`. Returns the agent's output, or an error
-/// if the worker failed, crashed, or was killed.
+/// if the worker failed, crashed, hit a resource limit, or blew the deadline.
 pub(crate) fn run_agent_isolated(
     path: &Path,
     source: &str,
@@ -48,24 +73,42 @@ pub(crate) fn run_agent_isolated(
         fallback_export: "agent".to_string(),
         input: input.clone(),
         prelude: backend.runtime_policy().map(|p| rust_engine_prelude(&p)),
+        limits: ResourceLimits::from_env(),
     };
+
+    // Arm the deadline watchdog (if configured) before brokering: it SIGKILLs the
+    // child if the run outlasts the deadline, which unblocks the broker's read.
+    let deadline = deadline_from_env();
+    let watchdog = deadline.map(|d| DeadlineWatchdog::arm(child.id(), d));
 
     let result = broker(&mut from_child, &mut to_child, backend, init);
 
-    // Drop our pipe ends so the worker sees EOF, then reap it to avoid a zombie.
-    // The `Done` frame (or its absence) is authoritative for the run's outcome;
-    // the exit status is only used to enrich a missing-result error.
+    // Disarm the watchdog (a no-op if it already fired), then drop our pipe ends
+    // so the worker sees EOF, and reap the child to avoid a zombie. The `Done`
+    // frame is authoritative for the outcome; the exit status only *enriches* an
+    // error with the OS-level cause.
+    let killed_by_deadline = watchdog.map(|w| w.disarm()).unwrap_or(false);
     drop(to_child);
     drop(from_child);
     let status = child.wait();
+
     match result {
-        Ok(v) => Ok(v),
-        Err(e) => match status {
-            Ok(s) if !s.success() => {
-                Err(e.context(format!("isolate worker exited with status {s}")))
+        Ok(value) => Ok(value),
+        Err(e) => {
+            if killed_by_deadline {
+                let ms = deadline.map(|d| d.as_millis()).unwrap_or(0);
+                return Err(e.context(format!(
+                    "isolate worker exceeded the {ms} ms wall-clock deadline and was killed"
+                )));
             }
-            _ => Err(e),
-        },
+            match status {
+                Ok(s) if !s.success() => match exit_cause(&s) {
+                    Some(cause) => Err(e.context(cause)),
+                    None => Err(e.context(format!("isolate worker exited with status {s}"))),
+                },
+                _ => Err(e),
+            }
+        }
     }
 }
 
@@ -102,4 +145,81 @@ pub(crate) fn broker<R: Read, W: Write>(
             }
         }
     }
+}
+
+/// A background thread that `SIGKILL`s the worker if the run outlasts the
+/// deadline. [`disarm`](DeadlineWatchdog::disarm) returns whether it fired, and
+/// blocks until the thread has exited so no kill can land after the call returns.
+struct DeadlineWatchdog {
+    stop: mpsc::Sender<()>,
+    fired: Arc<AtomicBool>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl DeadlineWatchdog {
+    /// Start watching `pid`. On Unix the kill is a `SIGKILL` by pid (the child is
+    /// not yet reaped, so the pid is unambiguous); on other platforms the
+    /// watchdog degrades to a no-op (Windows isolation is a later phase).
+    fn arm(pid: u32, deadline: Duration) -> Self {
+        let (stop, rx) = mpsc::channel::<()>();
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_thread = fired.clone();
+        let handle = std::thread::spawn(move || {
+            // Wake either when the run completes (a send/disconnect) or when the
+            // deadline elapses (timeout) — only the timeout triggers a kill.
+            if let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(deadline) {
+                fired_thread.store(true, Ordering::Release);
+                kill_pid(pid);
+            }
+        });
+        DeadlineWatchdog {
+            stop,
+            fired,
+            handle,
+        }
+    }
+
+    /// Stop the watchdog and report whether it fired. Joins the thread, so once
+    /// this returns the watchdog can no longer issue a kill.
+    fn disarm(self) -> bool {
+        let _ = self.stop.send(());
+        let _ = self.handle.join();
+        self.fired.load(Ordering::Acquire)
+    }
+}
+
+/// Send `SIGKILL` to `pid`. A failure (e.g. the child already exited) is ignored.
+#[cfg(unix)]
+fn kill_pid(pid: u32) {
+    // SAFETY: `kill` takes scalar arguments and has no memory-safety contract;
+    // targeting an already-exited pid simply returns `ESRCH`, which we ignore.
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_pid(_pid: u32) {}
+
+/// Describe why a non-success worker exit happened, when the OS tells us via a
+/// terminating signal. `None` for a plain nonzero exit (the caller adds the
+/// generic status context).
+#[cfg(unix)]
+fn exit_cause(status: &std::process::ExitStatus) -> Option<String> {
+    use std::os::unix::process::ExitStatusExt;
+    let sig = status.signal()?;
+    Some(match sig {
+        libc::SIGKILL => {
+            "isolate worker was killed (out of memory, or an external SIGKILL)".to_string()
+        }
+        libc::SIGXCPU => "isolate worker exceeded its CPU-time limit (RLIMIT_CPU)".to_string(),
+        libc::SIGXFSZ => "isolate worker exceeded its file-size limit (RLIMIT_FSIZE)".to_string(),
+        libc::SIGSEGV => "isolate worker crashed (SIGSEGV)".to_string(),
+        other => format!("isolate worker was terminated by signal {other}"),
+    })
+}
+
+#[cfg(not(unix))]
+fn exit_cause(_status: &std::process::ExitStatus) -> Option<String> {
+    None
 }

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -6,8 +6,10 @@
 //! back to the parent over the pipe via [`BrokeredHost`]. It never touches the
 //! filesystem, the network, or a clock of its own — those live behind the seam.
 //!
-//! Phase 1 wires the broker but applies no sandbox yet; the seccomp / namespace
-//! confinement lands in a later phase (see `docs/os-isolation-plan.md`).
+//! Before running the agent the worker seals itself in: the `setrlimit` floor
+//! ([`super::limits`]) then the best-effort confinement layers — network
+//! namespace, Landlock, and the seccomp denylist ([`super::sandbox`]). See
+//! `docs/os-isolation-plan.md`.
 
 use std::cell::RefCell;
 use std::io::{self, Read, Write};
@@ -122,43 +124,44 @@ fn serve_inner<R: Read + 'static, W: Write + 'static>(
         }
     };
 
-    // Slam the resource floor shut, then the syscall door — before any agent code
-    // runs, and only in a real worker process (see `serve_inner`'s `apply_limits`;
-    // these mutate the *current* process, which is sound only when it is a
-    // dedicated worker). Both are best-effort: a limit or filter that can't be
+    // Slam the resource floor shut, then the confinement layers — before any agent
+    // code runs, and only in a real worker process (see `serve_inner`'s
+    // `apply_limits`; these mutate the *current* process, which is sound only when
+    // it is a dedicated worker). Every layer is best-effort: one that can't be
     // installed degrades isolation but never fails the run, unless the operator
-    // demands `CHIDORI_ISOLATE_REQUIRE_SANDBOX`, in which case we fail closed.
-    let seccomp_applied = if apply_limits {
+    // demands `CHIDORI_ISOLATE_REQUIRE_SANDBOX`, in which case a missing seccomp
+    // core fails closed.
+    let sandbox = if apply_limits {
         limits.apply_to_self();
-        match super::sandbox::install_seccomp() {
-            Ok(()) => true,
-            Err(reason) => {
-                eprintln!("isolate worker: seccomp not applied: {reason}");
-                if env_truthy("CHIDORI_ISOLATE_REQUIRE_SANDBOX") {
-                    let mut guard = io.borrow_mut();
-                    return write_frame(
-                        &mut guard.writer,
-                        &FromChild::Done {
-                            outcome: Outcome::Err(format!(
-                                "isolation sandbox required but unavailable: {reason}"
-                            )),
-                        },
-                    );
-                }
-                false
-            }
-        }
+        super::sandbox::apply()
     } else {
         let _ = &limits;
-        false
+        super::sandbox::SandboxOutcome::default()
     };
+    for note in &sandbox.notes {
+        eprintln!("isolate worker: sandbox: {note}");
+    }
+    if apply_limits && env_truthy("CHIDORI_ISOLATE_REQUIRE_SANDBOX") && !sandbox.seccomp_applied {
+        let mut guard = io.borrow_mut();
+        return write_frame(
+            &mut guard.writer,
+            &FromChild::Done {
+                outcome: Outcome::Err(
+                    "isolation sandbox required but the seccomp core could not be applied"
+                        .to_string(),
+                ),
+            },
+        );
+    }
 
-    // Test-only probe: once the sandbox is in place, attempt a denied syscall to
-    // prove the filter blocks it (the process is killed by SIGSYS and never
-    // returns). Gated behind an env var so it is inert in normal operation.
+    // Test-only probes: once the sandbox is in place, attempt an operation a given
+    // layer must forbid, to prove it does. Gated behind an env var so it is inert
+    // in normal operation.
     #[cfg(unix)]
-    if std::env::var_os("CHIDORI_ISOLATE_SELFTEST_SOCKET").is_some() {
-        selftest_denied_socket(seccomp_applied);
+    if apply_limits {
+        if let Some(mode) = std::env::var_os("CHIDORI_ISOLATE_SELFTEST") {
+            run_selftest(&mode.to_string_lossy(), &sandbox);
+        }
     }
 
     let host: Rc<dyn RunHost> = Rc::new(BrokeredHost {
@@ -193,21 +196,56 @@ fn env_truthy(key: &str) -> bool {
     }
 }
 
-/// Self-test for the seccomp denylist (driven by `isolate_limits` integration
-/// tests). With the filter active, `socket()` must trigger `SIGSYS` and kill the
-/// process before it returns — so this function never returns in that case. If
-/// seccomp could not be applied (e.g. a kernel/container that forbids it), it
-/// says so and exits cleanly so the test can *skip* rather than fail.
+/// Dispatch a sandbox self-test probe (driven by `isolate_limits` integration
+/// tests via `CHIDORI_ISOLATE_SELFTEST`). Each probe attempts an operation the
+/// named layer must forbid and reports the result on stderr; if the relevant
+/// layer wasn't applied in this environment it prints an `*-unavailable` marker
+/// so the test can *skip* rather than fail. Always terminates the process.
 #[cfg(unix)]
-fn selftest_denied_socket(seccomp_applied: bool) -> ! {
-    if !seccomp_applied {
-        eprintln!("isolate-selftest: seccomp-unavailable");
-        std::process::exit(0);
+fn run_selftest(mode: &str, sandbox: &crate::runtime::isolate::sandbox::SandboxOutcome) -> ! {
+    match mode {
+        // seccomp: `socket()` must raise SIGSYS and kill us before it returns.
+        "socket" => {
+            if !sandbox.seccomp_applied {
+                eprintln!("isolate-selftest: seccomp-unavailable");
+                std::process::exit(0);
+            }
+            // SAFETY: `socket` takes scalar args. With the filter active the call
+            // never returns (the kernel raises SIGSYS); if it does, the filter
+            // failed to block it — a real test failure.
+            let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+            eprintln!("isolate-selftest: socket-not-blocked (fd={fd})");
+            std::process::exit(97);
+        }
+        // Landlock: creating a file must be denied (EACCES) under the read-only
+        // policy. Distinct from RLIMIT_FSIZE, which blocks the *write*, not the open.
+        "fs-write" => {
+            if !sandbox.landlock_enforced {
+                eprintln!("isolate-selftest: landlock-unavailable");
+                std::process::exit(0);
+            }
+            let path = c"/tmp/chidori-landlock-selftest";
+            // SAFETY: `open` takes a valid NUL-terminated path and scalar flags.
+            let fd = unsafe {
+                libc::open(
+                    path.as_ptr(),
+                    libc::O_CREAT | libc::O_WRONLY | libc::O_TRUNC,
+                    0o600,
+                )
+            };
+            if fd >= 0 {
+                // SAFETY: closing an fd we just opened.
+                unsafe { libc::close(fd) };
+                eprintln!("isolate-selftest: fs-write-not-blocked");
+                std::process::exit(96);
+            }
+            let err = std::io::Error::last_os_error();
+            eprintln!("isolate-selftest: fs-write-blocked ({err})");
+            std::process::exit(0);
+        }
+        other => {
+            eprintln!("isolate-selftest: unknown mode `{other}`");
+            std::process::exit(95);
+        }
     }
-    // SAFETY: `socket` takes scalar args and has no memory-safety contract. With
-    // the filter active the call never returns (the kernel raises SIGSYS); if it
-    // *does* return, the filter failed to block it — a real test failure.
-    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
-    eprintln!("isolate-selftest: socket-not-blocked (fd={fd})");
-    std::process::exit(97);
 }

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -122,13 +122,43 @@ fn serve_inner<R: Read + 'static, W: Write + 'static>(
         }
     };
 
-    // Slam the resource floor shut before any agent code runs — but only in a
-    // real worker process (see `serve_inner`'s `apply_limits`). Best-effort: a
-    // limit that can't be set degrades isolation but never fails the run.
-    if apply_limits {
+    // Slam the resource floor shut, then the syscall door — before any agent code
+    // runs, and only in a real worker process (see `serve_inner`'s `apply_limits`;
+    // these mutate the *current* process, which is sound only when it is a
+    // dedicated worker). Both are best-effort: a limit or filter that can't be
+    // installed degrades isolation but never fails the run, unless the operator
+    // demands `CHIDORI_ISOLATE_REQUIRE_SANDBOX`, in which case we fail closed.
+    let seccomp_applied = if apply_limits {
         limits.apply_to_self();
+        match super::sandbox::install_seccomp() {
+            Ok(()) => true,
+            Err(reason) => {
+                eprintln!("isolate worker: seccomp not applied: {reason}");
+                if env_truthy("CHIDORI_ISOLATE_REQUIRE_SANDBOX") {
+                    let mut guard = io.borrow_mut();
+                    return write_frame(
+                        &mut guard.writer,
+                        &FromChild::Done {
+                            outcome: Outcome::Err(format!(
+                                "isolation sandbox required but unavailable: {reason}"
+                            )),
+                        },
+                    );
+                }
+                false
+            }
+        }
     } else {
         let _ = &limits;
+        false
+    };
+
+    // Test-only probe: once the sandbox is in place, attempt a denied syscall to
+    // prove the filter blocks it (the process is killed by SIGSYS and never
+    // returns). Gated behind an env var so it is inert in normal operation.
+    #[cfg(unix)]
+    if std::env::var_os("CHIDORI_ISOLATE_SELFTEST_SOCKET").is_some() {
+        selftest_denied_socket(seccomp_applied);
     }
 
     let host: Rc<dyn RunHost> = Rc::new(BrokeredHost {
@@ -150,4 +180,34 @@ fn serve_inner<R: Read + 'static, W: Write + 'static>(
 
     let mut guard = io.borrow_mut();
     write_frame(&mut guard.writer, &FromChild::Done { outcome })
+}
+
+/// Whether an env var holds a truthy value (set and not `0`/`off`/`false`/`no`).
+fn env_truthy(key: &str) -> bool {
+    match std::env::var(key) {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && !matches!(v.as_str(), "0" | "off" | "false" | "no")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Self-test for the seccomp denylist (driven by `isolate_limits` integration
+/// tests). With the filter active, `socket()` must trigger `SIGSYS` and kill the
+/// process before it returns — so this function never returns in that case. If
+/// seccomp could not be applied (e.g. a kernel/container that forbids it), it
+/// says so and exits cleanly so the test can *skip* rather than fail.
+#[cfg(unix)]
+fn selftest_denied_socket(seccomp_applied: bool) -> ! {
+    if !seccomp_applied {
+        eprintln!("isolate-selftest: seccomp-unavailable");
+        std::process::exit(0);
+    }
+    // SAFETY: `socket` takes scalar args and has no memory-safety contract. With
+    // the filter active the call never returns (the kernel raises SIGSYS); if it
+    // *does* return, the filter failed to block it — a real test failure.
+    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+    eprintln!("isolate-selftest: socket-not-blocked (fd={fd})");
+    std::process::exit(97);
 }

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -1,0 +1,121 @@
+//! The worker half of OS isolation — the code that runs in the sandboxed child.
+//!
+//! The child holds *only* the JavaScript engine. It reads an [`FromParent::Init`]
+//! handoff, runs the agent through the ordinary [`run_module`] path, and routes
+//! every host op (`chidori.*` effect, captured native, DOM flush, module load)
+//! back to the parent over the pipe via [`BrokeredHost`]. It never touches the
+//! filesystem, the network, or a clock of its own — those live behind the seam.
+//!
+//! Phase 1 wires the broker but applies no sandbox yet; the seccomp / namespace
+//! confinement lands in a later phase (see `docs/os-isolation-plan.md`).
+
+use std::cell::RefCell;
+use std::io::{self, Read, Write};
+use std::path::Path;
+use std::rc::Rc;
+
+use serde_json::Value;
+
+use crate::runtime::rust_engine::{run_module, RunHost};
+
+use super::protocol::{read_frame, write_frame, FromChild, FromParent, Outcome};
+
+/// The duplex the worker speaks over: replies/Init arrive on `reader`, calls/Done
+/// go out on `writer`. Wrapped in a single cell so the run thread can borrow both
+/// for one request/response exchange.
+struct WorkerIo<R: Read, W: Write> {
+    reader: R,
+    writer: W,
+}
+
+/// A [`RunHost`] that satisfies every op by a blocking round trip to the parent.
+/// Mirrors the engine's existing synchronous dispatch, so to the VM this is
+/// indistinguishable from the in-process host.
+struct BrokeredHost<R: Read, W: Write> {
+    io: Rc<RefCell<WorkerIo<R, W>>>,
+    prelude: Option<String>,
+}
+
+impl<R: Read, W: Write> RunHost for BrokeredHost<R, W> {
+    fn call(&self, op: &str, args: &Value) -> Result<Value, String> {
+        let mut io = self.io.borrow_mut();
+        let io = &mut *io;
+        write_frame(
+            &mut io.writer,
+            &FromChild::Call {
+                op: op.to_string(),
+                args: args.clone(),
+            },
+        )
+        .map_err(|e| format!("isolate worker: writing host call `{op}`: {e}"))?;
+        let reply: FromParent = read_frame(&mut io.reader)
+            .map_err(|e| format!("isolate worker: reading reply for `{op}`: {e}"))?;
+        match reply {
+            FromParent::Reply(outcome) => outcome.into(),
+            FromParent::Init { .. } => {
+                Err("isolate worker: unexpected Init while awaiting a reply".to_string())
+            }
+        }
+    }
+
+    fn prelude(&self) -> Option<String> {
+        self.prelude.clone()
+    }
+}
+
+/// Entry point for the hidden `chidori __run-worker` subcommand: drive the
+/// protocol over this process's stdin/stdout. stderr is left untouched for
+/// diagnostics — nothing but frames may go to stdout or the stream desyncs.
+pub fn run() -> io::Result<()> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    serve(stdin.lock(), stdout.lock())
+}
+
+/// Run one agent to completion over an arbitrary reader/writer pair. Factored out
+/// of [`run`] so tests can drive it over an in-process socket without spawning a
+/// subprocess. Always reports the run outcome as a final [`FromChild::Done`];
+/// protocol/IO failures (a dead parent) surface as the returned `io::Result`.
+pub fn serve<R: Read + 'static, W: Write + 'static>(reader: R, writer: W) -> io::Result<()> {
+    let io = Rc::new(RefCell::new(WorkerIo { reader, writer }));
+
+    let init: FromParent = {
+        let mut guard = io.borrow_mut();
+        read_frame(&mut guard.reader)?
+    };
+    let (entry_path, entry_source, fallback_export, input, prelude) = match init {
+        FromParent::Init {
+            entry_path,
+            entry_source,
+            fallback_export,
+            input,
+            prelude,
+        } => (entry_path, entry_source, fallback_export, input, prelude),
+        FromParent::Reply(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "isolate worker: expected Init as the first frame",
+            ));
+        }
+    };
+
+    let host: Rc<dyn RunHost> = Rc::new(BrokeredHost {
+        io: io.clone(),
+        prelude,
+    });
+    // `run_module` already contains the opcode-budget guard and a `catch_unwind`
+    // boundary, so an interpreter panic comes back here as `Err`, not an unwind.
+    let outcome: Outcome = match run_module(
+        Path::new(&entry_path),
+        &entry_source,
+        &fallback_export,
+        &input,
+        host,
+    ) {
+        Ok(value) => Outcome::Ok(value),
+        Err(e) => Outcome::Err(e.to_string()),
+    };
+
+    let mut guard = io.borrow_mut();
+    write_frame(&mut guard.writer, &FromChild::Done { outcome })
+}

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -66,31 +66,54 @@ impl<R: Read, W: Write> RunHost for BrokeredHost<R, W> {
 /// Entry point for the hidden `chidori __run-worker` subcommand: drive the
 /// protocol over this process's stdin/stdout. stderr is left untouched for
 /// diagnostics — nothing but frames may go to stdout or the stream desyncs.
+///
+/// This is the only caller that applies the `setrlimit` floor, because the
+/// limits are applied to the *current process* — sound only when that process is
+/// a dedicated worker. The in-process [`serve`] path (used by tests) must never
+/// self-limit, or it would mutate the limits of whatever process is hosting it.
 pub fn run() -> io::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
-    serve(stdin.lock(), stdout.lock())
+    serve_inner(stdin.lock(), stdout.lock(), true)
 }
 
-/// Run one agent to completion over an arbitrary reader/writer pair. Factored out
-/// of [`run`] so tests can drive it over an in-process socket without spawning a
-/// subprocess. Always reports the run outcome as a final [`FromChild::Done`];
-/// protocol/IO failures (a dead parent) surface as the returned `io::Result`.
+/// Run one agent to completion over an arbitrary reader/writer pair *without*
+/// applying any per-process resource limits. Factored out of [`run`] so tests
+/// can drive the worker over an in-process socket without a subprocess — and
+/// without the worker's `setrlimit` floor leaking onto the test process.
 pub fn serve<R: Read + 'static, W: Write + 'static>(reader: R, writer: W) -> io::Result<()> {
+    serve_inner(reader, writer, false)
+}
+
+/// Shared worker body. `apply_limits` gates the per-process `setrlimit` floor —
+/// see [`run`] vs [`serve`].
+fn serve_inner<R: Read + 'static, W: Write + 'static>(
+    reader: R,
+    writer: W,
+    apply_limits: bool,
+) -> io::Result<()> {
     let io = Rc::new(RefCell::new(WorkerIo { reader, writer }));
 
     let init: FromParent = {
         let mut guard = io.borrow_mut();
         read_frame(&mut guard.reader)?
     };
-    let (entry_path, entry_source, fallback_export, input, prelude) = match init {
+    let (entry_path, entry_source, fallback_export, input, prelude, limits) = match init {
         FromParent::Init {
             entry_path,
             entry_source,
             fallback_export,
             input,
             prelude,
-        } => (entry_path, entry_source, fallback_export, input, prelude),
+            limits,
+        } => (
+            entry_path,
+            entry_source,
+            fallback_export,
+            input,
+            prelude,
+            limits,
+        ),
         FromParent::Reply(_) => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -98,6 +121,15 @@ pub fn serve<R: Read + 'static, W: Write + 'static>(reader: R, writer: W) -> io:
             ));
         }
     };
+
+    // Slam the resource floor shut before any agent code runs — but only in a
+    // real worker process (see `serve_inner`'s `apply_limits`). Best-effort: a
+    // limit that can't be set degrades isolation but never fails the run.
+    if apply_limits {
+        limits.apply_to_self();
+    } else {
+        let _ = &limits;
+    }
 
     let host: Rc<dyn RunHost> = Rc::new(BrokeredHost {
         io: io.clone(),

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -218,14 +218,17 @@ fn run_selftest(mode: &str, sandbox: &crate::runtime::isolate::sandbox::SandboxO
             eprintln!("isolate-selftest: socket-not-blocked (fd={fd})");
             std::process::exit(97);
         }
-        // Landlock: creating a file must be denied (EACCES) under the read-only
-        // policy. Distinct from RLIMIT_FSIZE, which blocks the *write*, not the open.
+        // Filesystem-write confinement: creating a file must be denied — by
+        // Landlock's read-only policy on Linux, or the Seatbelt `(deny
+        // file-write*)` rule on macOS. Distinct from RLIMIT_FSIZE, which blocks
+        // the *write*, not the *open*. This is the cross-platform proof that the
+        // OS sandbox actually loaded and is enforcing.
         "fs-write" => {
-            if !sandbox.landlock_enforced {
-                eprintln!("isolate-selftest: landlock-unavailable");
+            if !(sandbox.landlock_enforced || sandbox.seatbelt_applied) {
+                eprintln!("isolate-selftest: fs-write-confinement-unavailable");
                 std::process::exit(0);
             }
-            let path = c"/tmp/chidori-landlock-selftest";
+            let path = c"/tmp/chidori-fs-write-selftest";
             // SAFETY: `open` takes a valid NUL-terminated path and scalar flags.
             let fd = unsafe {
                 libc::open(

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -141,13 +141,14 @@ fn serve_inner<R: Read + 'static, W: Write + 'static>(
     for note in &sandbox.notes {
         eprintln!("isolate worker: sandbox: {note}");
     }
-    if apply_limits && env_truthy("CHIDORI_ISOLATE_REQUIRE_SANDBOX") && !sandbox.seccomp_applied {
+    if apply_limits && env_truthy("CHIDORI_ISOLATE_REQUIRE_SANDBOX") && !sandbox.core_confined() {
         let mut guard = io.borrow_mut();
         return write_frame(
             &mut guard.writer,
             &FromChild::Done {
                 outcome: Outcome::Err(
-                    "isolation sandbox required but the seccomp core could not be applied"
+                    "isolation sandbox required but the platform's core confinement \
+                     (seccomp on Linux, Seatbelt on macOS) could not be applied"
                         .to_string(),
                 ),
             },

--- a/crates/chidori/src/runtime/mod.rs
+++ b/crates/chidori/src/runtime/mod.rs
@@ -6,6 +6,9 @@ pub mod crypto;
 pub mod engine;
 pub mod host_branch;
 pub mod host_core;
+/// OS-level isolation: run an agent in a sandboxed child process and broker its
+/// host effects back over a pipe (see `docs/os-isolation-plan.md`).
+pub mod isolate;
 pub mod memory;
 pub mod native;
 pub mod otel;

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -97,9 +97,23 @@ pub fn run_agent(
     inputs: &Value,
     backend: &HostBindingBackend,
 ) -> Result<Value> {
+    // When OS isolation is enabled, run the agent in a sandboxed child process
+    // and broker its host effects back here over a pipe (see
+    // `crate::runtime::isolate` and `docs/os-isolation-plan.md`). Only the
+    // runtime backend is isolated — the recorder/metadata backend has no live
+    // host machinery to broker into.
+    if crate::runtime::isolate::enabled() && backend.runtime_ctx().is_some() {
+        return crate::runtime::isolate::run_agent_isolated(path, source, inputs, backend);
+    }
     // Agents define their entrypoint with `run(handler)`; fall back to a legacy
     // `agent` export if `run(...)` wasn't called.
-    run_module(path, source, "agent", inputs, backend)
+    run_module(
+        path,
+        source,
+        "agent",
+        inputs,
+        Rc::new(InProcessHost::new(backend.clone())),
+    )
 }
 
 /// Reframe a chidori-js entrypoint error so an uncaught JS exception surfaces
@@ -145,7 +159,13 @@ pub(crate) fn run_tool_file(
 ) -> Result<Value> {
     let source = std::fs::read_to_string(path)
         .map_err(|e| anyhow::anyhow!("reading tool {}: {e}", path.display()))?;
-    run_module(path, &source, "run", kwargs, backend)
+    run_module(
+        path,
+        &source,
+        "run",
+        kwargs,
+        Rc::new(InProcessHost::new(backend.clone())),
+    )
 }
 
 /// Run a nested TypeScript **sub-agent** file natively on the rust engine (G4).
@@ -157,7 +177,121 @@ pub(crate) fn run_agent_file(
 ) -> Result<Value> {
     let source = std::fs::read_to_string(path)
         .map_err(|e| anyhow::anyhow!("reading sub-agent {}: {e}", path.display()))?;
-    run_module(path, &source, "agent", input, backend)
+    run_module(
+        path,
+        &source,
+        "agent",
+        input,
+        Rc::new(InProcessHost::new(backend.clone())),
+    )
+}
+
+/// The host surface [`run_module`] needs, routed by op name. This is the single
+/// seam that the OS-isolation worker replaces with a pipe (see
+/// [`crate::runtime::isolate`] and `docs/os-isolation-plan.md`): in-process it is
+/// [`InProcessHost`] (which forwards straight to the durable host machinery);
+/// in the worker it is a `BrokeredHost` that serializes each call over to the
+/// parent. Because every `chidori.*` effect and captured native already flows
+/// through one synchronous `(name, args) -> JSON` call, brokering is a drop-in.
+pub(crate) trait RunHost {
+    /// Route a single host op to its handler and return the JSON result. `op` is
+    /// a `chidori.*` effect name (`log`, `prompt`, `http`, …), a `__chidori_*`
+    /// captured native, `"__chidori_dom_render"` (args = the drained DOM batch),
+    /// or `"__module_load"` (`{specifier, importer}` → `{key, source}`).
+    fn call(&self, op: &str, args: &Value) -> std::result::Result<Value, String>;
+
+    /// The determinism prelude to `eval` before user code, or `None` to install
+    /// neither the prelude nor the captured-effect sync natives (the recorder
+    /// backend, which has no runtime policy/context).
+    fn prelude(&self) -> Option<String>;
+
+    /// An optional JS-level trace observer to install on the VM for this run.
+    fn trace_sink(&self, _js: &str) -> Option<Box<dyn chidori_js::TraceObserver>> {
+        None
+    }
+}
+
+/// Route a host op against an in-process [`HostBindingBackend`]. Shared by
+/// [`InProcessHost`] and the isolate broker loop
+/// ([`crate::runtime::isolate::supervisor`]) so both reach the identical
+/// handlers — the only difference is whether the call arrived inline or over a
+/// pipe. `sync` is the captured-effect native dispatch
+/// ([`build_sync_native_dispatch`]), present only for the runtime backend.
+pub(crate) fn route_host_op(
+    backend: &HostBindingBackend,
+    sync: Option<&Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>>>,
+    op: &str,
+    args: &Value,
+) -> std::result::Result<Value, String> {
+    if op == "__module_load" {
+        let specifier = args
+            .get("specifier")
+            .and_then(|v| v.as_str())
+            .ok_or("__module_load: missing `specifier`")?;
+        let importer = args
+            .get("importer")
+            .and_then(|v| v.as_str())
+            .ok_or("__module_load: missing `importer`")?;
+        let (key, source) = load_module_source(specifier, importer)?;
+        return Ok(serde_json::json!({ "key": key, "source": source }));
+    }
+    if op == "__chidori_dom_render" {
+        let ctx = backend
+            .runtime_ctx()
+            .ok_or("dom_render: no runtime context")?;
+        return crate::runtime::host_core::execute_durable_json_call(
+            ctx,
+            "dom_render",
+            Value::Null,
+            || Ok(args.clone()),
+        )
+        .map_err(|e| e.to_string());
+    }
+    // The captured natives are matched by exact name (not the `__chidori_` prefix)
+    // so sibling host ops that share the prefix — e.g. the `__chidori_http` op the
+    // fetch polyfill calls — still fall through to the async effect dispatch.
+    if SYNC_NATIVE_NAMES.iter().any(|(n, _)| *n == op) {
+        let sync = sync.ok_or("captured natives unavailable on this backend")?;
+        return sync(op, args);
+    }
+    backend.dispatch(op, args)
+}
+
+/// The in-process [`RunHost`]: forwards every op straight into the durable host
+/// machinery on the same thread (the historical behaviour, now behind the trait).
+pub(crate) struct InProcessHost {
+    backend: HostBindingBackend,
+    sync: Option<Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>>>,
+}
+
+impl InProcessHost {
+    pub(crate) fn new(backend: HostBindingBackend) -> Self {
+        let sync = match (backend.runtime_policy(), backend.runtime_ctx()) {
+            (Some(policy), Some(ctx)) => Some(build_sync_native_dispatch(ctx.clone(), policy)),
+            _ => None,
+        };
+        InProcessHost { backend, sync }
+    }
+}
+
+impl RunHost for InProcessHost {
+    fn call(&self, op: &str, args: &Value) -> std::result::Result<Value, String> {
+        route_host_op(&self.backend, self.sync.as_ref(), op, args)
+    }
+
+    fn prelude(&self) -> Option<String> {
+        self.backend
+            .runtime_policy()
+            .map(|policy| rust_engine_prelude(&policy))
+    }
+
+    fn trace_sink(&self, js: &str) -> Option<Box<dyn chidori_js::TraceObserver>> {
+        if !js_tracing_enabled() {
+            return None;
+        }
+        let run = self.backend.runtime_ctx()?.otel_run()?;
+        Some(Box::new(run.js_trace_observer(js, JS_TRACE_MAX_DEPTH)))
+    }
 }
 
 /// Resource limits applied to every rust-engine agent run, read from the
@@ -314,12 +448,12 @@ fn panic_payload_message(panic: &(dyn std::any::Any + Send)) -> String {
 /// passed to `run(handler)`, or `fallback_export` (e.g. `agent` for agents). The
 /// VM's `chidori.*` effects are forwarded to `backend.dispatch`, the durable
 /// host machinery in `host_core`.
-fn run_module(
+pub(crate) fn run_module(
     path: &Path,
     source: &str,
     fallback_export: &str,
     input: &Value,
-    backend: &HostBindingBackend,
+    host: Rc<dyn RunHost>,
 ) -> Result<Value> {
     // `Node` accepts relative `./foo` imports *and* allowlisted `node:` builtins
     // (the special-cased `chidori` SDK import is stripped by transpilation). This
@@ -331,30 +465,29 @@ fn run_module(
     let js = transpile_module(path, source, &opts)?;
 
     let mut engine = chidori_js::Engine::new();
-    if js_tracing_enabled() {
-        if let Some(ctx) = backend.runtime_ctx() {
-            if let Some(run) = ctx.otel_run() {
-                engine.vm.trace_sink =
-                    Some(Box::new(run.js_trace_observer(&js, JS_TRACE_MAX_DEPTH)));
-            }
-        }
+    if let Some(sink) = host.trace_sink(&js) {
+        engine.vm.trace_sink = Some(sink);
     }
     // Captured-effect natives (`node:` crypto/fs) + the determinism prelude
     // (process env, TextEncoder/atob, Web Crypto, virtual timers). Installed only
-    // for the runtime backend — the recorder/metadata backend has no policy or
-    // call log to capture into, and `node:`-using agent code doesn't run there.
-    if let (Some(policy), Some(ctx)) = (backend.runtime_policy(), backend.runtime_ctx()) {
-        let sync = build_sync_native_dispatch(ctx.clone(), policy.clone());
+    // when the host exposes a runtime policy — the recorder/metadata backend has
+    // none, and its `node:`-using agent code doesn't run there. The sync natives
+    // are routed back through `host.call`, so the in-process host reaches
+    // `build_sync_native_dispatch` while the isolate worker brokers them to the
+    // parent process (where the VFS / captured-crypto state lives).
+    if let Some(prelude) = host.prelude() {
+        let h = host.clone();
+        let sync: Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>> =
+            Rc::new(move |name, args| h.call(name, args));
         engine.install_sync_natives(SYNC_NATIVE_NAMES, sync);
-        let prelude = rust_engine_prelude(&policy);
         engine
             .eval(&prelude)
             .map_err(|e| anyhow::anyhow!("installing node: builtin prelude: {e}"))?;
     }
-    let backend_for_dom = backend.clone();
-    let backend = backend.clone();
-    let dispatch: Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>> =
-        Rc::new(move |effect: &str, args: &Value| backend.dispatch(effect, args));
+    let dispatch: Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>> = {
+        let h = host.clone();
+        Rc::new(move |effect: &str, args: &Value| h.call(effect, args))
+    };
     engine.install_chidori_effects(dispatch);
     // Install the JS-level `chidori` SDK sugar (tryCall/retry/parallel + the
     // memory.set/get/delete/clear wrappers).
@@ -385,28 +518,21 @@ fn run_module(
     // re-run, so node ids stay deterministic across replay.
     let dom_handle = engine.install_dom();
     {
-        let backend_dom = backend_for_dom;
+        let h = host.clone();
         let dom = dom_handle.clone();
+        // Drain the pending DOM mutation batch in the engine's process, then hand
+        // it to the host to journal: the in-process host runs it through
+        // `execute_durable_json_call`; the isolate worker ships the batch over the
+        // pipe and the parent journals it. Either way the rendered output is
+        // recorded live and served from the journal on replay.
         let dom_dispatch: Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>> =
-            Rc::new(move |name: &str, _args: &Value| {
-                let ctx = backend_dom
-                    .runtime_ctx()
-                    .ok_or_else(|| "dom: no runtime context".to_string())?;
-                match name {
-                    "__chidori_dom_render" => {
-                        crate::runtime::host_core::execute_durable_json_call(
-                            ctx,
-                            "dom_render",
-                            Value::Null,
-                            || {
-                                Ok(serde_json::to_value(dom.drain_render_batch())
-                                    .unwrap_or(Value::Null))
-                            },
-                        )
-                        .map_err(|e| e.to_string())
-                    }
-                    _ => Ok(Value::Null),
+            Rc::new(move |name: &str, _args: &Value| match name {
+                "__chidori_dom_render" => {
+                    let batch =
+                        serde_json::to_value(dom.drain_render_batch()).unwrap_or(Value::Null);
+                    h.call("__chidori_dom_render", &batch)
                 }
+                _ => Ok(Value::Null),
             });
         engine.install_sync_natives(&[("__chidori_dom_render", 0)], dom_dispatch);
     }
@@ -421,7 +547,11 @@ fn run_module(
     let entry_key = path.to_string_lossy().to_string();
     // Resolve each `(specifier, importer)` to a sibling `.ts`/`.js` file (or, for
     // `node:` specifiers, the synthetic builtin shim) and hand the linker its
-    // transpiled ES module source.
+    // transpiled ES module source. `node:` shims and vendored packages are pure
+    // string lookups resolved here (identically in-process and in the worker);
+    // only the disk-reading sibling resolution is routed through `host.call` so
+    // the isolate worker — which has no filesystem — brokers it to the parent.
+    let load_host = host.clone();
     let mut load = |specifier: &str,
                     importer_key: &str|
      -> std::result::Result<(String, String), String> {
@@ -439,7 +569,19 @@ fn run_module(
         if let Some(resolved) = crate::runtime::typescript::builtins::vendored_module(specifier) {
             return Ok(resolved);
         }
-        load_module_source(specifier, importer_key)
+        let resolved = load_host.call(
+            "__module_load",
+            &serde_json::json!({ "specifier": specifier, "importer": importer_key }),
+        )?;
+        let key = resolved
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "__module_load: response missing `key`".to_string())?;
+        let src = resolved
+            .get("source")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "__module_load: response missing `source`".to_string())?;
+        Ok((key.to_string(), src.to_string()))
     };
 
     // Install per-run resource limits (opcode budget + memory/deadline watchdog)
@@ -588,7 +730,7 @@ fn execute_captured_random(
 /// and inline; randomness is captured through the call log; the VFS ops operate
 /// on the snapshot-resident `RuntimeContext` filesystem — so a
 /// `node:fs`/`node:crypto` agent records and replays deterministically.
-fn build_sync_native_dispatch(
+pub(crate) fn build_sync_native_dispatch(
     ctx: RuntimeContext,
     policy: RuntimePolicy,
 ) -> Rc<dyn Fn(&str, &Value) -> std::result::Result<Value, String>> {
@@ -728,7 +870,7 @@ fn build_sync_native_dispatch(
 /// Crypto subset, and the virtual timer queue. Date and `Math.random`
 /// determinism are already native to `chidori-js`, so this installs no
 /// Date/random shims.
-fn rust_engine_prelude(policy: &RuntimePolicy) -> String {
+pub(crate) fn rust_engine_prelude(policy: &RuntimePolicy) -> String {
     use crate::runtime::typescript::helpers::{
         chidori_agent_env_json, TEXT_ENCODING_POLYFILL, TIMER_DISABLED_POLYFILL,
         TIMER_VIRTUAL_POLYFILL, WEB_CRYPTO_POLYFILL,
@@ -821,6 +963,102 @@ mod tests {
             tools,
             Arc::new(McpManager::new()),
         )
+    }
+
+    /// An agent run via the isolate broker must produce byte-identical output and
+    /// host-call records to the same agent run in-process. Exercises the three
+    /// brokered surfaces at once: a `chidori.log` effect (async dispatch), a
+    /// `node:crypto` hash (a `__chidori_*` captured native), and a sibling
+    /// `./helper.ts` import (a brokered `__module_load`), plus the determinism
+    /// prelude that `createHash` relies on. Runs the broker over an in-process
+    /// `socketpair` so the real protocol/worker/parent loop are exercised without
+    /// the cost (or flakiness) of spawning a subprocess.
+    #[cfg(unix)]
+    #[test]
+    fn isolated_run_matches_in_process_byte_for_byte() {
+        use std::os::unix::net::UnixStream;
+
+        use crate::runtime::isolate::protocol::FromParent;
+        use crate::runtime::isolate::supervisor::broker;
+
+        let dir = std::env::temp_dir().join(format!("chidori-isolate-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            dir.join("helper.ts"),
+            "export function bump(n: number): number { return n + 1; }\n",
+        )
+        .unwrap();
+        let src = r#"
+            import { chidori, run } from "chidori:agent";
+            import { bump } from "./helper.ts";
+            import { createHash } from "node:crypto";
+            run(async (input: { value: number }) => {
+                await chidori.log("isolation parity check");
+                const h = createHash("sha256").update("chidori").digest("hex");
+                return { value: bump(input.value), hash: h };
+            });
+        "#;
+        std::fs::write(&path, src).unwrap();
+        let input = serde_json::json!({ "value": 41 });
+
+        // Host calls are compared by (function, args) — the durable shape — rather
+        // than the whole record, which carries non-semantic fields like sequence.
+        let host_calls = |ctx: &RuntimeContext| -> Vec<(String, Value)> {
+            ctx.call_log()
+                .into_records()
+                .into_iter()
+                .map(|r| (r.function, r.args))
+                .collect()
+        };
+
+        // 1) In-process baseline.
+        let ctx_inproc = RuntimeContext::new();
+        let backend_inproc = test_backend(ctx_inproc.clone(), Arc::new(ToolRegistry::new()));
+        let out_inproc = run_agent(&path, src, &input, &backend_inproc).unwrap();
+
+        // 2) Brokered run: a worker thread on one socket end, the parent broker on
+        //    the other, with its own context so the two logs can be compared.
+        let (parent_sock, child_sock) = UnixStream::pair().unwrap();
+        let worker = std::thread::spawn(move || {
+            let reader = child_sock.try_clone().unwrap();
+            crate::runtime::isolate::worker::serve(reader, child_sock)
+        });
+
+        let ctx_brokered = RuntimeContext::new();
+        let backend_brokered = test_backend(ctx_brokered.clone(), Arc::new(ToolRegistry::new()));
+        let init = FromParent::Init {
+            entry_path: path.to_string_lossy().into_owned(),
+            entry_source: src.to_string(),
+            fallback_export: "agent".to_string(),
+            input: input.clone(),
+            prelude: backend_brokered
+                .runtime_policy()
+                .map(|p| rust_engine_prelude(&p)),
+        };
+        let mut to_child = parent_sock.try_clone().unwrap();
+        let mut from_child: UnixStream = parent_sock;
+        let out_brokered = broker(&mut from_child, &mut to_child, &backend_brokered, init).unwrap();
+        worker.join().unwrap().unwrap();
+
+        // The whole point: identical output and identical host-call log.
+        assert_eq!(
+            out_brokered, out_inproc,
+            "isolated output must match in-process"
+        );
+        assert_eq!(
+            host_calls(&ctx_brokered),
+            host_calls(&ctx_inproc),
+            "isolated host-call log must match in-process"
+        );
+        // Sanity: the agent's compute (sibling import) and captured crypto landed.
+        assert_eq!(out_brokered.get("value"), Some(&serde_json::json!(42)));
+        assert!(out_brokered
+            .get("hash")
+            .and_then(|v| v.as_str())
+            .is_some_and(|h| h.len() == 64));
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -1035,6 +1035,7 @@ mod tests {
             prelude: backend_brokered
                 .runtime_policy()
                 .map(|p| rust_engine_prelude(&p)),
+            limits: crate::runtime::isolate::limits::ResourceLimits::default(),
         };
         let mut to_child = parent_sock.try_clone().unwrap();
         let mut from_child: UnixStream = parent_sock;

--- a/crates/chidori/tests/isolate_limits.rs
+++ b/crates/chidori/tests/isolate_limits.rs
@@ -129,13 +129,16 @@ fn seccomp_blocks_a_denied_syscall() {
 }
 
 #[test]
-fn landlock_blocks_file_creation() {
-    // Probe a file create once the sandbox is in place. Under the Landlock
-    // read-only policy the `open(O_CREAT)` is denied with EACCES; if Landlock
-    // isn't enforced in this environment (older kernel, or the LSM isn't in the
-    // active set) the worker says so and we skip rather than fail.
+fn filesystem_writes_are_blocked_when_confined() {
+    // Probe a file create once the sandbox is in place. The OS filesystem-write
+    // confinement — Landlock read-only on Linux, the Seatbelt `(deny file-write*)`
+    // rule on macOS — must deny the `open(O_CREAT)`. This is the cross-platform
+    // proof the sandbox actually loaded and enforces; in particular it is how the
+    // macOS Seatbelt path is verified at runtime in CI. If no such layer is
+    // active in this environment (older Linux kernel without Landlock, etc.) the
+    // worker says so and we skip rather than fail.
     let agent = write_agent(
-        "landlock",
+        "fs-write",
         r#"
         import { run } from "chidori:agent";
         run(async () => ({}));
@@ -144,19 +147,68 @@ fn landlock_blocks_file_creation() {
     let out = run_isolated(&agent, &[("CHIDORI_ISOLATE_SELFTEST", "fs-write")]);
     let stderr = String::from_utf8_lossy(&out.stderr);
 
-    if stderr.contains("landlock-unavailable") {
-        eprintln!("skipping landlock test: not enforced in this environment");
+    if stderr.contains("fs-write-confinement-unavailable") {
+        eprintln!("skipping fs-write test: no filesystem-write confinement in this environment");
         let _ = fs::remove_dir_all(agent.parent().unwrap());
         return;
     }
     assert!(
         !stderr.contains("fs-write-not-blocked"),
-        "file creation was NOT blocked by Landlock; stderr={stderr}"
+        "file creation was NOT blocked by the OS sandbox; stderr={stderr}"
     );
     assert!(
         stderr.contains("fs-write-blocked"),
-        "expected the Landlock-blocked marker; stderr={stderr}"
+        "expected the sandbox-blocked marker; stderr={stderr}"
     );
+    let _ = fs::remove_dir_all(agent.parent().unwrap());
+}
+
+/// macOS-only: the runtime verification of the phase-4 Seatbelt FFI that a Linux
+/// dev/CI host cannot perform. Unlike the skip-aware test above, this one *fails*
+/// (not skips) if Seatbelt does not load and enforce, so the macOS CI job catches
+/// a regression in `sandbox_init` / the SBPL profile. It asserts: the worker did
+/// not report the profile as unapplied, the normal isolated run still works
+/// (i.e. `(deny file-write*)` did not also wedge the broker pipe), and a file
+/// create is denied.
+#[cfg(target_os = "macos")]
+#[test]
+fn seatbelt_loads_and_enforces_on_macos() {
+    let agent = write_agent(
+        "seatbelt",
+        r#"
+        import { chidori, run } from "chidori:agent";
+        run(async (input: { value: number }) => {
+            await chidori.log("seatbelt smoke");
+            return { value: (input?.value ?? 0) + 1 };
+        });
+        "#,
+    );
+
+    // 1) A normal isolated run must still succeed — proves the Seatbelt profile
+    //    didn't also block the worker's stdout broker pipe.
+    let ok = run_isolated(&agent, &[]);
+    let ok_err = String::from_utf8_lossy(&ok.stderr);
+    assert!(
+        ok.status.success(),
+        "isolated run failed under Seatbelt; stderr={ok_err}"
+    );
+    assert!(
+        !ok_err.contains("seatbelt not applied"),
+        "Seatbelt profile failed to load; stderr={ok_err}"
+    );
+
+    // 2) The fs-write probe must be blocked (Seatbelt is actually enforcing).
+    let probe = run_isolated(&agent, &[("CHIDORI_ISOLATE_SELFTEST", "fs-write")]);
+    let probe_err = String::from_utf8_lossy(&probe.stderr);
+    assert!(
+        !probe_err.contains("fs-write-confinement-unavailable"),
+        "Seatbelt reported no filesystem-write confinement; stderr={probe_err}"
+    );
+    assert!(
+        probe_err.contains("fs-write-blocked"),
+        "Seatbelt did not block a file create; stderr={probe_err}"
+    );
+
     let _ = fs::remove_dir_all(agent.parent().unwrap());
 }
 

--- a/crates/chidori/tests/isolate_limits.rs
+++ b/crates/chidori/tests/isolate_limits.rs
@@ -92,6 +92,43 @@ fn parent_deadline_kills_a_wedged_worker() {
 }
 
 #[test]
+fn seccomp_blocks_a_denied_syscall() {
+    // A normal agent, but the worker is told to probe `socket()` once the seccomp
+    // filter is installed. With the filter active that syscall raises SIGSYS and
+    // kills the worker, which the parent maps to a seccomp error. If seccomp can't
+    // be installed in this environment, the worker says so and we skip rather than
+    // report a false failure.
+    let agent = write_agent(
+        "seccomp",
+        r#"
+        import { chidori, run } from "chidori:agent";
+        run(async () => { await chidori.log("unreachable: killed before running"); return {}; });
+        "#,
+    );
+    let out = run_isolated(&agent, &[("CHIDORI_ISOLATE_SELFTEST_SOCKET", "1")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    if stderr.contains("seccomp-unavailable") {
+        eprintln!("skipping seccomp test: seccomp could not be applied in this environment");
+        let _ = fs::remove_dir_all(agent.parent().unwrap());
+        return;
+    }
+    assert!(
+        !stderr.contains("socket-not-blocked"),
+        "socket() was NOT blocked by the seccomp filter; stderr={stderr}"
+    );
+    assert!(
+        !out.status.success(),
+        "worker probing a denied syscall should fail the run; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("seccomp"),
+        "error should name the seccomp violation; stderr={stderr}"
+    );
+    let _ = fs::remove_dir_all(agent.parent().unwrap());
+}
+
+#[test]
 fn cpu_limit_terminates_a_busy_worker() {
     // With compute bounds disabled, a busy loop burns CPU until RLIMIT_CPU fires
     // (SIGXCPU), which the parent maps to a CPU-time error. No deadline set, so

--- a/crates/chidori/tests/isolate_limits.rs
+++ b/crates/chidori/tests/isolate_limits.rs
@@ -105,7 +105,7 @@ fn seccomp_blocks_a_denied_syscall() {
         run(async () => { await chidori.log("unreachable: killed before running"); return {}; });
         "#,
     );
-    let out = run_isolated(&agent, &[("CHIDORI_ISOLATE_SELFTEST_SOCKET", "1")]);
+    let out = run_isolated(&agent, &[("CHIDORI_ISOLATE_SELFTEST", "socket")]);
     let stderr = String::from_utf8_lossy(&out.stderr);
 
     if stderr.contains("seccomp-unavailable") {
@@ -124,6 +124,38 @@ fn seccomp_blocks_a_denied_syscall() {
     assert!(
         stderr.contains("seccomp"),
         "error should name the seccomp violation; stderr={stderr}"
+    );
+    let _ = fs::remove_dir_all(agent.parent().unwrap());
+}
+
+#[test]
+fn landlock_blocks_file_creation() {
+    // Probe a file create once the sandbox is in place. Under the Landlock
+    // read-only policy the `open(O_CREAT)` is denied with EACCES; if Landlock
+    // isn't enforced in this environment (older kernel, or the LSM isn't in the
+    // active set) the worker says so and we skip rather than fail.
+    let agent = write_agent(
+        "landlock",
+        r#"
+        import { run } from "chidori:agent";
+        run(async () => ({}));
+        "#,
+    );
+    let out = run_isolated(&agent, &[("CHIDORI_ISOLATE_SELFTEST", "fs-write")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    if stderr.contains("landlock-unavailable") {
+        eprintln!("skipping landlock test: not enforced in this environment");
+        let _ = fs::remove_dir_all(agent.parent().unwrap());
+        return;
+    }
+    assert!(
+        !stderr.contains("fs-write-not-blocked"),
+        "file creation was NOT blocked by Landlock; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("fs-write-blocked"),
+        "expected the Landlock-blocked marker; stderr={stderr}"
     );
     let _ = fs::remove_dir_all(agent.parent().unwrap());
 }

--- a/crates/chidori/tests/isolate_limits.rs
+++ b/crates/chidori/tests/isolate_limits.rs
@@ -1,0 +1,124 @@
+//! End-to-end tests for the OS-isolation resource floor (phase 2), driven
+//! through the real `chidori` binary so the actual worker subprocess, its
+//! `setrlimit` floor, and the parent's deadline-kill / signal mapping are all
+//! exercised. Unix-only: the limits and the kill path are Unix primitives.
+#![cfg(unix)]
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn chidori_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_chidori")
+}
+
+fn write_agent(name: &str, src: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "chidori-isolate-{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("agent.ts");
+    fs::write(&path, src).unwrap();
+    path
+}
+
+/// Run `chidori run <agent> --isolate` with extra env, returning the output.
+fn run_isolated(agent: &PathBuf, env: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(chidori_bin());
+    cmd.arg("run").arg(agent).arg("--isolate");
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    cmd.output().unwrap()
+}
+
+#[test]
+fn isolated_run_succeeds_under_the_default_resource_floor() {
+    // The default rlimits (no-core, fsize=0, nofile=256) must not break a normal
+    // run — they only close doors the agent never uses.
+    let agent = write_agent(
+        "ok",
+        r#"
+        import { chidori, run } from "chidori:agent";
+        run(async () => {
+            await chidori.log("isolated and limited");
+            return { ok: true };
+        });
+        "#,
+    );
+    let out = run_isolated(&agent, &[]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected success; stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.contains("\"ok\""), "stdout missing result: {stdout}");
+    let _ = fs::remove_dir_all(agent.parent().unwrap());
+}
+
+#[test]
+fn parent_deadline_kills_a_wedged_worker() {
+    // A busy loop with the in-engine opcode budget disabled never self-terminates,
+    // so only the parent's wall-clock deadline can reclaim it. (No CPU limit set,
+    // so the deadline — not RLIMIT_CPU — is unambiguously the cause.)
+    let agent = write_agent(
+        "deadline",
+        r#"
+        import { run } from "chidori:agent";
+        run(async () => { while (true) {} });
+        "#,
+    );
+    let out = run_isolated(
+        &agent,
+        &[
+            ("CHIDORI_JS_OP_BUDGET", "0"),   // disable the in-engine compute bound
+            ("CHIDORI_JS_DEADLINE_MS", "0"), // disable the in-engine deadline
+            ("CHIDORI_ISOLATE_DEADLINE_MS", "500"), // parent hard backstop
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "wedged worker should fail the run");
+    assert!(
+        stderr.contains("deadline"),
+        "error should name the deadline; stderr={stderr}"
+    );
+    let _ = fs::remove_dir_all(agent.parent().unwrap());
+}
+
+#[test]
+fn cpu_limit_terminates_a_busy_worker() {
+    // With compute bounds disabled, a busy loop burns CPU until RLIMIT_CPU fires
+    // (SIGXCPU), which the parent maps to a CPU-time error. No deadline set, so
+    // the CPU limit is the sole cause.
+    let agent = write_agent(
+        "cpu",
+        r#"
+        import { run } from "chidori:agent";
+        run(async () => { while (true) {} });
+        "#,
+    );
+    let out = run_isolated(
+        &agent,
+        &[
+            ("CHIDORI_JS_OP_BUDGET", "0"),
+            ("CHIDORI_JS_DEADLINE_MS", "0"),
+            ("CHIDORI_ISOLATE_CPU_SECS", "1"),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "CPU-bound worker should fail the run"
+    );
+    assert!(
+        stderr.contains("CPU"),
+        "error should name the CPU limit; stderr={stderr}"
+    );
+    let _ = fs::remove_dir_all(agent.parent().unwrap());
+}

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,7 +1,8 @@
 # OS-level isolation: process-per-run with brokered effects
 
-> **Status:** Phase 1 implemented (`crates/chidori/src/runtime/isolate/`); phases
-> 2–5 (resource floor + per-OS sandbox) not yet started.
+> **Status:** Phases 1–2 implemented (`crates/chidori/src/runtime/isolate/`):
+> process-per-run brokering + the rlimits/deadline-kill resource floor. Phases
+> 3–5 (cgroup memory ceiling + per-OS syscall sandbox) not yet started.
 > **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
 > isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
 > precision and cross-run heap hygiene).
@@ -302,8 +303,21 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
    log) against the in-process path
    (`rust_engine::tests::isolated_run_matches_in_process_byte_for_byte`). No
    sandbox yet — the child is a separate process with brokered effects only.
-2. **Resource floor.** rlimits + cgroup `memory.max`; move the memory ceiling off
-   the in-process watchdog for the isolated path; deadline-kill from the parent.
+2. **Resource floor.** ✅ **Done (rlimits + deadline-kill)** —
+   `runtime::isolate::limits` applies a per-process `setrlimit` floor in the
+   worker before any agent code runs (`RLIMIT_CPU` hard CPU-seconds backstop to
+   the opcode budget — ignores broker-wait time; `RLIMIT_FSIZE=0` since the child
+   has no filesystem; `RLIMIT_CORE=0`; `RLIMIT_NOFILE`), and the supervisor adds
+   a `SIGKILL` **deadline-kill** watchdog (`CHIDORI_ISOLATE_DEADLINE_MS`) plus
+   **signal-aware failure mapping** (CPU/file/OOM/deadline → precise errors).
+   Limits ride the `Init` frame so the parent owns the policy; the in-process
+   `serve` path never self-limits. Note: running the engine in its own process
+   *already* makes the existing heap watchdog a clean per-run ceiling (no
+   cross-tenant attribution drift — gaps #2/#3). **Remaining (deferred):** a hard
+   memory ceiling via cgroup v2 `memory.max` (needs delegation; `RLIMIT_AS` is
+   too blunt — a multi-threaded VM over-reserves virtual memory) and `RLIMIT_NPROC`
+   (fragile under shared-uid concurrency; blocking `fork` belongs to the seccomp
+   phase). Env: `CHIDORI_ISOLATE_{CPU_SECS,FSIZE_BYTES,NOFILE,NO_CORE,DEADLINE_MS}`.
 3. **Linux syscall confinement.** seccomp allowlist + empty netns + mount ns +
    Landlock; negative tests (a worker that calls `socket()`/`open("/etc/passwd")`
    is killed).

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,8 +1,10 @@
 # OS-level isolation: process-per-run with brokered effects
 
-> **Status:** Phases 1–2 implemented (`crates/chidori/src/runtime/isolate/`):
-> process-per-run brokering + the rlimits/deadline-kill resource floor. Phases
-> 3–5 (cgroup memory ceiling + per-OS syscall sandbox) not yet started.
+> **Status:** Phases 1–3 implemented (`crates/chidori/src/runtime/isolate/`):
+> process-per-run brokering, the rlimits/deadline-kill resource floor, and a
+> Linux seccomp denylist. Remaining: the namespace/cgroup layer (deferred — needs
+> privilege/delegation), tightening seccomp toward an allowlist, and macOS
+> Seatbelt (phase 4).
 > **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
 > isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
 > precision and cross-run heap hygiene).
@@ -318,9 +320,24 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
    too blunt — a multi-threaded VM over-reserves virtual memory) and `RLIMIT_NPROC`
    (fragile under shared-uid concurrency; blocking `fork` belongs to the seccomp
    phase). Env: `CHIDORI_ISOLATE_{CPU_SECS,FSIZE_BYTES,NOFILE,NO_CORE,DEADLINE_MS}`.
-3. **Linux syscall confinement.** seccomp allowlist + empty netns + mount ns +
-   Landlock; negative tests (a worker that calls `socket()`/`open("/etc/passwd")`
-   is killed).
+3. **Linux syscall confinement.** ⏳ **Partly done (seccomp denylist)** —
+   `runtime::isolate::sandbox` installs a seccomp-bpf filter in the worker (via
+   `seccompiler`) before any agent code runs: default-allow, `KILL_PROCESS` on a
+   curated denylist (the whole socket family, `exec*`, `ptrace`/`process_vm_*`,
+   namespace/mount, privilege-change, kernel-module/`bpf`/`perf_event_open`, and
+   keyring syscalls). `apply_filter` sets `NO_NEW_PRIVS`, so it works rootless.
+   Best-effort by default (degrades to brokering + rlimits where seccomp is
+   unavailable); `CHIDORI_ISOLATE_REQUIRE_SANDBOX=1` fails closed. A SIGSYS kill
+   maps to a precise "blocked syscall (seccomp/SIGSYS)" error. Verified: a normal
+   isolated run is unaffected (no false positives), and a worker probing
+   `socket()` post-filter is killed (`isolate_limits::seccomp_blocks_a_denied_syscall`,
+   skip-aware). **Chosen denylist over allowlist** deliberately — it cannot
+   false-positive-kill the engine and the primary boundary is still
+   capability-confinement + brokering; the near-empty allowlist remains the end
+   goal. **Deferred:** empty net namespace + mount/pid/user namespaces + Landlock
+   and cgroup v2 `memory.max` — all need privilege or cgroup delegation that many
+   deploy targets (rootless containers, CI) lack, so they need a capability probe
+   + graceful fallback before they can ship without regressing the common case.
 4. **macOS Seatbelt** profile + the `Sandbox` trait FFI; CI parity.
 5. **Polish:** `--isolate` UX, policy-profile coupling, docs, optional warm pool.
 

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,0 +1,333 @@
+# OS-level isolation: process-per-run with brokered effects
+
+> **Status:** Design / proposal. Not yet implemented.
+> **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
+> isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
+> precision and cross-run heap hygiene).
+> **Related:** [`docs/sandbox-model.md`](./sandbox-model.md),
+> [`docs/captured-effects-vfs-crypto-timers.md`](./captured-effects-vfs-crypto-timers.md),
+> [`docs/running-modes.md`](./running-modes.md).
+
+## TL;DR
+
+Today the `chidori-js` VM runs **in-process** with the host: strong
+capability-confinement + Rust memory safety, but no OS boundary
+([`sandbox-model.md`](./sandbox-model.md) gap #4). This doc specifies an
+**additive** isolation mode that runs the VM in a **disposable child process per
+run**, with the child holding *only* the JavaScript engine. Every `chidori.*`
+effect — and every captured sync native (VFS, crypto, DOM) — is **RPC'd back to
+the parent over a pipe**; the parent keeps doing all real I/O (LLM, HTTP, disk,
+MCP) and owns the durable call log. The child runs under a **near-empty syscall
+allowlist** (Linux seccomp) / OS sandbox (macOS Seatbelt), so even a total
+compromise of the interpreter cannot touch the network, the filesystem, or
+another run.
+
+Three existing design properties make this unusually cheap:
+
+1. **The host-call boundary is already a serialization seam.** Effects flow
+   through a single synchronous function — `backend.dispatch(effect, args) ->
+   Result<Value, String>` (`rust_engine.rs:356`) — whose entire interface is
+   `(name: &str, args: &Value) -> JSON`. That *is* the wire format. Brokering is
+   a drop-in replacement of one closure.
+2. **The engine has no ambient authority.** It makes essentially no syscalls of
+   its own (alloc + futex), so the child's seccomp allowlist can be far tighter
+   than any Node/Python sandbox.
+3. **Durability is deterministic-replay, not VM-image snapshot.** Pause = kill
+   the child; resume = spawn a fresh child and fast-forward through the journal
+   (zero LLM calls). The child is **fully disposable** — no child-memory
+   checkpointing is ever needed.
+
+Agent code, the SDKs, the durable format, and replay semantics are **unchanged**.
+Brokering is invisible above the seam.
+
+## Why process-per-run (vs process-per-session, effects-in-child)
+
+The sibling design (process-per-session with the host backend living *inside* the
+child) needs the child to keep network/disk/MCP, so its seccomp profile must stay
+wide. Process-per-run with brokered effects is strictly stronger: the untrusted
+process literally cannot name a syscall that reaches the outside world, because
+every powerful effect is performed on the *other* side of the pipe by trusted
+code that already validates it (policy gate, workspace path sanitization, JSON
+deserialization). The cost is one IPC hop per effect — negligible, since effects
+are already `await`ed and dominated by LLM/tool latency.
+
+## Architecture
+
+```
+┌─────────────────────────────── PARENT (trusted) ───────────────────────────────┐
+│  chidori serve / run                                                            │
+│   • transpile + resolve the full module graph (filesystem)                      │
+│   • spawn + sandbox the child, set up pipe + cgroup/rlimits                      │
+│   • BROKER LOOP: read (effect, args) ─► HostBindingBackend.dispatch ─► write JSON│
+│        - chidori.*  : log, prompt, tool, callAgent, http, memory, template,      │
+│                       checkpoint, input, workspace.*                             │
+│        - __chidori_*: VFS read/write/append, crypto hash/hmac/random, dom_render │
+│   • owns: durable call log / journal, policy, MCP, OTEL, captured determinism    │
+│   • enforces wall-clock deadline (kill child); reaps child; maps exit → error    │
+└───────────────────────────────────▲──────────────┬─────────────────────────────┘
+                                     │ result JSON  │ (effect, args)
+                            length-prefixed frames over a socketpair fd
+                                     │              ▼
+┌─────────────────────────────── CHILD (untrusted) ──────────────────────────────┐
+│  chidori __run-worker   (seccomp / Seatbelt; own cgroup; rlimits; no_new_privs)  │
+│   • chidori-js Engine: parse (oxc) → compile → stack VM                          │
+│   • opcode budget (VM counter), regex/stack caps  ← stay in-child                │
+│   • dispatch closure = blocking pipe round-trip (replaces backend.dispatch)      │
+│   • fetch polyfill / node: shims / DOM build → emit __chidori_* over the pipe    │
+│   • NO fs, NO net, NO clock, NO child processes — nothing is wired               │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### What moves, what stays
+
+| Concern | Today (in-process) | Proposed (isolated) |
+|---|---|---|
+| JS parse / compile / execute | `run_module` (`rust_engine.rs:317`) | **child** (same code, worker entrypoint) |
+| Opcode budget | VM counter (`exec.rs`) | **child** (unchanged) |
+| `chidori.*` effects | `backend.dispatch` inline | **parent** via broker; child closure = pipe RTT |
+| Sync natives (VFS / crypto / DOM) | `install_sync_natives` inline | **parent** via broker (state lives in `RuntimeContext`) |
+| Transpile + import resolution | `transpile_module` + `load` closure (reads sibling `.ts` from disk) | **parent** ships the fully-linked graph; child never touches disk |
+| Module loader `load` (`rust_engine.rs:425`) | reads files in-process | **parent**; child receives prelinked sources |
+| Memory ceiling | `CountingAllocator` watchdog (`mem_guard.rs`) | **OS**: cgroup `memory.max` / `RLIMIT_AS` (hard, not polled) |
+| Wall-clock deadline | watchdog trips `vm.interrupt` | **parent** kills child (or keep in-child too) |
+| Panic containment | `catch_unwind` (`rust_engine.rs:449`) | child still catches, writes error frame, exits cleanly |
+| Durable call log / replay / policy / MCP / OTEL | parent (`HostBindingBackend`) | **parent** (unchanged) |
+
+Note the bonus: moving the JS heap into its own process replaces the *polled,
+thread-attributed* memory meter with a *hard, kernel-enforced* per-run ceiling —
+which is exactly what gaps #2 and #3 of `sandbox-model.md` ask for. And because
+the child exits after one run, the `Rc<RefCell>` cycle-leak concern across runs
+(gap #6) disappears for the isolated path.
+
+### The seam, concretely
+
+`run_module` installs effects with:
+
+```rust
+let dispatch: Rc<dyn Fn(&str, &Value) -> Result<Value, String>> =
+    Rc::new(move |effect, args| backend.dispatch(effect, args));
+engine.install_chidori_effects(dispatch);                 // rust_engine.rs:356
+engine.install_sync_natives(SYNC_NATIVE_NAMES, sync);     // rust_engine.rs:348
+```
+
+In the worker, `backend.dispatch` (and the sync-native dispatch) are replaced by
+a blocking call that writes a request frame and reads the response frame:
+
+```rust
+// worker side — same Fn signature, so install_chidori_effects is untouched
+let broker = PipeBroker::from_fd(effect_fd);
+let dispatch = Rc::new(move |effect: &str, args: &Value| {
+    broker.call(effect, args)   // write (effect,args); block; read Result<Value,String>
+});
+```
+
+Because the engine already drives effects synchronously on the run thread (it
+blocks in `dispatch` today), the child blocking on a pipe read is semantically
+identical — no change to the VM, the SDK, or determinism.
+
+On the **parent** side the broker is one task per run:
+
+```rust
+loop {
+    let (effect, args) = read_frame(&mut pipe)?;           // untrusted bytes
+    let result = backend.dispatch(&effect, &args);         // existing validated path
+    write_frame(&mut pipe, &result)?;
+}
+```
+
+`backend.dispatch` is *already* the trust boundary — it enforces policy, sanitizes
+workspace paths, and deserializes JSON into typed handlers (`bindings.rs:841`).
+Brokering does not widen it; it makes it a process boundary too.
+
+### `callAgent` and nested tools
+
+Today a sub-agent / TS tool re-enters `run_module` on the same engine, sharing the
+backend so its effects nest under the parent (`run_tool_file` /
+`run_agent_file`, `rust_engine.rs:141`). Under isolation, `callAgent` and a TS
+`tool` become **brokered effects the parent satisfies by spawning a nested child**
+(process-per-run, recursively), threading the same `parent_seq` so nesting,
+journaling, and OTEL spans are preserved. Depth is bounded by the existing call
+depth. MCP tools already run as external processes (`mcp/client.rs`) — unchanged.
+
+### Pause / resume / replay
+
+`chidori.input()` and signals already suspend by **unwinding** with `PAUSE_MARKER`
+and resuming via a *fresh engine that replays the journal to the pause point*
+(`rust_engine.rs:109`, `host.rs`). That maps onto process-per-run for free:
+
+- **Pause** → the child returns the pause sentinel and exits; the parent persists
+  as it does today.
+- **Resume / replay / branch** → the parent spawns a fresh worker and the journal
+  is replayed (the parent serves recorded effect results over the same pipe; the
+  child cannot tell record from replay). **Zero** child-state serialization.
+
+## Wire protocol
+
+A minimal, length-prefixed framing over a single `socketpair(2)` fd (Unix) /
+anonymous pipe (Windows). Keep it dumb so the child's seccomp allowlist stays at
+`read`/`write`/`futex`/`mmap`/`exit`.
+
+- Frame = `u32 length` (LE) + body. Body is `postcard`/`bincode` (compact, safe
+  Rust) or JSON; recommend a binary codec to avoid re-stringifying large blobs.
+- Request: `{ effect: String, args: Value }`. Response: `{ ok: Value } | { err: String }`.
+- **Parent hardening:** enforce a max frame size (reject → kill the run) so a
+  hostile child cannot OOM the parent with a giant `args`; treat EOF / decode
+  error / child death as a run failure; never block past the run deadline on a
+  read.
+- A second control channel (or a tagged frame kind) carries the initial
+  `{ bundle, prelinked_modules, input, limits }` handoff and the final
+  `{ result | error }`.
+
+Throughput: a pipe round-trip is microseconds; effects are ms–seconds. The only
+chatty surface is captured sync natives (VFS reads, crypto) inside hot loops — if
+profiling shows it, ship a **read-only VFS snapshot** into the child (writes still
+broker) as a later optimization. Not needed for v1.
+
+## Cross-platform isolation
+
+Brokering means the child needs *no* outward capability on **any** platform, so
+even a weak per-OS sandbox is meaningfully strong (there is nothing wired for it
+to abuse). We tier the **kernel-enforced** guarantee and keep a common floor.
+
+### Common floor (all platforms)
+
+- **Separate process**, no inherited fds except the broker socket + stderr.
+- **rlimits**: `RLIMIT_AS` (address space), `RLIMIT_CPU`, `RLIMIT_NOFILE` (tiny),
+  `RLIMIT_NPROC` (0–1, block `fork`), `RLIMIT_FSIZE = 0`, core dumps off.
+- **`no_new_privs`** equivalent; clear the environment; chdir to an empty dir.
+- A `trait Sandbox { fn pre_exec(&self) -> io::Result<()>; }` with per-OS impls;
+  the parent supervisor and worker entry are platform-agnostic above it.
+
+### Tier 1 — Linux (primary target)
+
+Strongest guarantee, no daemon required on modern kernels:
+
+- **seccomp-bpf** allowlist via the `seccompiler` crate (safe Rust, from the
+  Firecracker project — fits the engine's zero-`unsafe` ethos). Allowed:
+  `read, write, close, mmap, munmap, mremap, brk, madvise, futex,
+  rt_sigreturn, rt_sigaction, rt_sigprocmask, sched_yield, exit, exit_group`,
+  plus `clock_gettime`/`getrandom` if std needs them (see notes). Default action
+  `SECCOMP_RET_KILL_PROCESS` in production (`RET_ERRNO(EPERM)` + log in dev).
+- **Namespaces** (unprivileged user namespace as the entry): `user, mount, pid,
+  net (empty — no interfaces), ipc, uts, cgroup`. An empty net namespace makes
+  network egress impossible even if a syscall slipped through.
+- **cgroup v2** `memory.max` (hard per-run heap ceiling — replaces the polled
+  watchdog), `pids.max`, optional `cpu.max`. Delegation may need systemd/root;
+  document the unprivileged fallback (rlimits-only) when cgroup delegation is
+  unavailable.
+- **Landlock** (via the `landlock` crate) as defense-in-depth on the filesystem
+  for kernels ≥ 5.13, even though brokering already means the child opens nothing.
+- Crates: `seccompiler`, `landlock`, `rustix`/`nix` (clone/unshare/rlimit),
+  `cgroups-rs` or direct cgroupfs writes.
+
+**Notes / decisions to nail down:** Rust's `HashMap` seeds `RandomState` via
+`getrandom` at startup — either allow `getrandom` (a capability-free
+non-determinism source the engine never exposes to JS) or pre-seed before
+sandbox lock-in. JS `Date`/`performance.now`/`Math.random` are already
+virtualized through captured effects, so the child needs no real clock or RNG of
+its own.
+
+### Tier 2 — macOS (parity target; shipped binary)
+
+- **Seatbelt** via `sandbox_init()` with a `(deny default)` SBPL profile that
+  allows only the broker fd and process basics — the same mechanism Chrome's
+  renderer uses. The API is deprecated-but-present and stable; isolate the one
+  bit of `libc` FFI behind the `Sandbox` trait (the only `unsafe` in the
+  feature, kept out of the engine crate).
+- **rlimits** as above; `posix_spawn` with a closed-fd policy.
+- Evaluate the `birdcage` crate (cross-platform Landlock+seccomp / Seatbelt
+  wrapper) to share code — but it targets "allow these paths/hosts," whereas our
+  child wants "allow almost nothing," so a hand-rolled minimal profile is likely
+  cleaner. Decide during the spike.
+
+### Tier 3 — Windows (not a shipped target today)
+
+Documented for completeness; implement only if Windows becomes a target. Job
+Object (kill-on-job-close, `JOB_OBJECT_LIMIT_PROCESS_MEMORY`, active-process cap)
++ a restricted/low-integrity token or AppContainer. No syscall-filter equivalent;
+the guarantee is process isolation + resource caps + restricted token, leaning on
+brokering for the rest. Mark clearly as the weakest tier.
+
+### Guarantee matrix
+
+| Mechanism | Linux | macOS | Windows |
+|---|---|---|---|
+| Separate process + closed fds | ✅ | ✅ | ✅ |
+| rlimits (AS/CPU/NPROC/FSIZE) | ✅ | ✅ | partial (Job Object) |
+| Hard memory ceiling | cgroup `memory.max` | `RLIMIT_AS` | Job Object |
+| Syscall allowlist | ✅ seccomp | ⚠️ Seatbelt (coarser) | ❌ |
+| Network egress blocked at OS | ✅ empty netns | ✅ Seatbelt deny | ⚠️ token/firewall |
+| Filesystem blocked at OS | ✅ mount ns + Landlock | ✅ Seatbelt deny | ⚠️ token |
+
+## Failure mapping
+
+The parent translates child exit into a host error, surfacing the structured
+error frame the child writes from its `catch_unwind` boundary before exiting:
+
+| Child outcome | Host error |
+|---|---|
+| seccomp kill (`SIGSYS`) | `sandbox violation: disallowed syscall` |
+| cgroup OOM / `RLIMIT_AS` | `memory limit exceeded` |
+| parent deadline kill | `wall-clock deadline exceeded` |
+| opcode budget (in-child `RangeError`) | `JavaScript exception: …` (unchanged) |
+| panic → error frame, exit | `rust engine panicked: …` (unchanged shape) |
+| pipe EOF / oversized frame | `isolated run failed: worker terminated` |
+
+## Configuration & rollout
+
+- **Off by default**; in-process stays the default for trusted local dev.
+- New worker subcommand `chidori __run-worker` (hidden), added to the clap
+  `Commands` enum (`main.rs:44`); the parent `exec`s its own binary in this mode.
+- Opt-in: `--isolate` flag on `run`/`serve` and `CHIDORI_ISOLATE=process` (env).
+  Naturally pairs with `--untrusted` — consider having the `untrusted` /
+  `supervised` policy profiles *imply* isolation when the platform supports it.
+- The server already runs each request under `tokio::task::spawn_blocking`
+  (`server.rs:977` et al.); the broker loop slots in there as one task per run,
+  so concurrency = many children + many broker tasks, exactly as today.
+- **Spawn-per-run by default** (clean, disposable, leak-free — and it resolves
+  gaps #2/#3/#6 for the isolated path). An optional **warm worker pool** (fork a
+  pre-sandboxed worker, hand it a bundle per run) is a latency optimization for
+  high-throughput servers, but only with a proven cross-run reset; defer to v2.
+
+## Phasing
+
+1. **Worker mode + broker, no sandbox.** Add `__run-worker`, the pipe protocol,
+   the prelinked-graph handoff, the parent broker loop, and failure mapping. Get
+   byte-identical results vs in-process across the existing test suite. *This is
+   the bulk of the work and is independently testable.*
+2. **Resource floor.** rlimits + cgroup `memory.max`; move the memory ceiling off
+   the in-process watchdog for the isolated path; deadline-kill from the parent.
+3. **Linux syscall confinement.** seccomp allowlist + empty netns + mount ns +
+   Landlock; negative tests (a worker that calls `socket()`/`open("/etc/passwd")`
+   is killed).
+4. **macOS Seatbelt** profile + the `Sandbox` trait FFI; CI parity.
+5. **Polish:** `--isolate` UX, policy-profile coupling, docs, optional warm pool.
+
+## Verification
+
+- **Parity:** every existing rust-engine test passes through the worker with
+  identical output (drive the suite in both modes behind a test flag).
+- **Protocol:** frame round-trip; oversized-frame rejection; child-crash → run
+  error; deadline interrupts a blocked read.
+- **Confinement (negative):** a worker bundle that attempts a raw `socket`,
+  `connect`, `open` of a real path, or `fork` is killed by seccomp/Seatbelt; an
+  agent that tries `node:fs` host mode still hits the VFS (brokered) and never
+  real disk; network is blocked at the OS even with a deliberately broken policy.
+- **Resource:** Map-of-8MB-strings agent is OOM-killed by cgroup at a 64 MB cap
+  and returns `memory limit exceeded`; `while(true){}` still terminates via the
+  in-child opcode budget; a long sleep trips the parent deadline.
+- **CI matrix:** Linux (full tiers) + macOS (Seatbelt) on the existing targets.
+
+## Open questions
+
+- **getrandom / clock at startup:** allow narrowly, or pre-seed and forbid? (Lean
+  pre-seed for the tightest profile; measure std's needs first.)
+- **cgroup without root:** require systemd delegation, or ship rlimits-only as the
+  unprivileged fallback and document the reduced guarantee?
+- **birdcage vs hand-rolled:** adopt for macOS+Linux to cut code, or keep a
+  minimal hand-rolled profile for the near-empty allowlist? (Spike both.)
+- **Sync-native chattiness:** is a read-only VFS snapshot in-child worth it, or do
+  real agents make few enough captured fs/crypto calls that brokering them is
+  free? (Profile before optimizing.)
+- **Default coupling:** should `--untrusted` auto-enable `--isolate` where
+  supported, or keep them orthogonal so the operator opts in explicitly?

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,12 +1,12 @@
 # OS-level isolation: process-per-run with brokered effects
 
-> **Status:** Phases 1–4 implemented (`crates/chidori/src/runtime/isolate/`):
+> **Status:** Phases 1–5 implemented (`crates/chidori/src/runtime/isolate/`):
 > process-per-run brokering, the rlimits/deadline-kill resource floor, a Linux
-> confinement stack (network namespace + Landlock + seccomp), and a macOS Seatbelt
-> profile — each best-effort with graceful fallback, behind a per-OS `apply()`
-> dispatch. Remaining: cgroup v2 `memory.max` (needs delegation), tightening
-> seccomp toward an allowlist, rootless net-ns via user namespaces, and phase-5
-> polish.
+> confinement stack (network namespace + Landlock + seccomp), a macOS Seatbelt
+> profile, and the `--isolate` CLI/UX — each best-effort with graceful fallback,
+> behind a per-OS `apply()` dispatch. Smaller follow-ups remain: cgroup v2
+> `memory.max` (needs delegation), tightening seccomp toward an allowlist,
+> rootless net-ns via user namespaces, and a macOS CI gate for the Seatbelt path.
 > **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
 > isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
 > precision and cross-run heap hygiene).
@@ -365,7 +365,30 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
    link) but **runtime-unverified** — no macOS host in this environment; the
    best-effort design means a profile/load failure degrades to a logged skip
    rather than breaking a run.
-5. **Polish:** `--isolate` UX, policy-profile coupling, docs, optional warm pool.
+5. **Polish.** ✅ **Done (warm pool deliberately skipped)** — `--isolate` on both
+   `chidori run` and `chidori serve` (and `CHIDORI_ISOLATE=process`); a startup
+   `Isolation:` banner line describing the posture; and an `--untrusted`→isolation
+   hint. Per the chosen design the two stay **orthogonal but composable**:
+   `--untrusted` (policy) and `--isolate` (process sandbox) are independent, and
+   running untrusted without isolation prints a nudge rather than silently
+   changing behavior. The **warm worker pool is intentionally not built**:
+   spawn-per-run is what makes the child disposable and leak-free (it is what
+   resolves the memory-accounting/cycle-leak gaps #2/#3/#6 for the isolated path),
+   and a pool would reintroduce cross-run state hygiene concerns for a latency win
+   that the LLM/tool-dominated workload doesn't need. Revisit only if a
+   high-throughput, compute-bound deployment shows worker spawn as a real cost.
+
+### Configuration reference
+
+| Env var | Default | Effect |
+|---|---|---|
+| `CHIDORI_ISOLATE` | unset (off) | `process` runs each agent in a confined child worker. Set by `--isolate`. |
+| `CHIDORI_ISOLATE_REQUIRE_SANDBOX` | off | Fail the run closed if the platform's core confinement (seccomp/Seatbelt) can't be applied. |
+| `CHIDORI_ISOLATE_DEADLINE_MS` | off | Parent-side wall-clock `SIGKILL` of a wedged worker. |
+| `CHIDORI_ISOLATE_CPU_SECS` | off | Hard `RLIMIT_CPU` ceiling on worker compute. |
+| `CHIDORI_ISOLATE_NOFILE` | 256 | `RLIMIT_NOFILE` (clamped to the inherited hard limit). |
+| `CHIDORI_ISOLATE_FSIZE_BYTES` | off | `RLIMIT_FSIZE` (opt-in; off because a `0` cap also kills a redirected regular-file stderr). |
+| `CHIDORI_ISOLATE_NO_CORE` | on | Disable core dumps (`RLIMIT_CORE=0`). |
 
 ## Verification
 

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,11 +1,12 @@
 # OS-level isolation: process-per-run with brokered effects
 
-> **Status:** Phases 1–3b implemented (`crates/chidori/src/runtime/isolate/`):
-> process-per-run brokering, the rlimits/deadline-kill resource floor, and a
-> Linux confinement stack — empty network namespace + Landlock read-only
-> filesystem + seccomp denylist, each best-effort with graceful fallback.
-> Remaining: cgroup v2 `memory.max` (needs delegation), tightening seccomp toward
-> an allowlist, rootless net-ns via user namespaces, and macOS Seatbelt (phase 4).
+> **Status:** Phases 1–4 implemented (`crates/chidori/src/runtime/isolate/`):
+> process-per-run brokering, the rlimits/deadline-kill resource floor, a Linux
+> confinement stack (network namespace + Landlock + seccomp), and a macOS Seatbelt
+> profile — each best-effort with graceful fallback, behind a per-OS `apply()`
+> dispatch. Remaining: cgroup v2 `memory.max` (needs delegation), tightening
+> seccomp toward an allowlist, rootless net-ns via user namespaces, and phase-5
+> polish.
 > **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
 > isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
 > precision and cross-run heap hygiene).
@@ -351,7 +352,19 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
    **Deferred:** cgroup v2 `memory.max` (needs delegation — the per-process heap
    watchdog from phase 2 is the graceful stand-in), rootless net-ns via an
    intermediate user namespace, and mount/pid namespaces.
-4. **macOS Seatbelt** profile + the `Sandbox` trait FFI; CI parity.
+4. **macOS Seatbelt.** ✅ **Done** — `sandbox::apply()` dispatches per-OS
+   (`apply_linux` vs `apply_macos`); on macOS it confines the worker with a
+   Seatbelt profile via `sandbox_init` (the deprecated-but-stable libSystem FFI
+   Chromium's renderer uses). The SBPL is **allow-default with targeted denies**
+   (`(deny network*)` + `(deny file-write*)`) — the same posture as the Linux
+   seccomp denylist + Landlock read-only, and low-risk: a brokered compute worker
+   still reads files and allocates freely. Best-effort with the same graceful-skip
+   contract; `SandboxOutcome::core_confined()` abstracts the per-OS "primary
+   layer" (seccomp on Linux, Seatbelt on macOS) for the `REQUIRE_SANDBOX` gate.
+   The FFI is type-checked on the Linux host (via `cargo check`, which doesn't
+   link) but **runtime-unverified** — no macOS host in this environment; the
+   best-effort design means a profile/load failure degrades to a logged skip
+   rather than breaking a run.
 5. **Polish:** `--isolate` UX, policy-profile coupling, docs, optional warm pool.
 
 ## Verification

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,6 +1,7 @@
 # OS-level isolation: process-per-run with brokered effects
 
-> **Status:** Design / proposal. Not yet implemented.
+> **Status:** Phase 1 implemented (`crates/chidori/src/runtime/isolate/`); phases
+> 2–5 (resource floor + per-OS sandbox) not yet started.
 > **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
 > isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
 > precision and cross-run heap hygiene).
@@ -291,10 +292,16 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
 
 ## Phasing
 
-1. **Worker mode + broker, no sandbox.** Add `__run-worker`, the pipe protocol,
-   the prelinked-graph handoff, the parent broker loop, and failure mapping. Get
-   byte-identical results vs in-process across the existing test suite. *This is
-   the bulk of the work and is independently testable.*
+1. **Worker mode + broker, no sandbox.** ✅ **Done** —
+   `crates/chidori/src/runtime/isolate/` (`protocol`, `worker`, `supervisor`).
+   `run_module` now routes every host op through a single `RunHost` seam
+   (`InProcessHost` in-process; `BrokeredHost` in the worker); `chidori run
+   --isolate` / `CHIDORI_ISOLATE=process` spawns `chidori __run-worker` and
+   brokers `chidori.*` effects, captured natives, DOM flushes, and module loads
+   over stdin/stdout. Parity is asserted byte-for-byte (output **and** host-call
+   log) against the in-process path
+   (`rust_engine::tests::isolated_run_matches_in_process_byte_for_byte`). No
+   sandbox yet — the child is a separate process with brokered effects only.
 2. **Resource floor.** rlimits + cgroup `memory.max`; move the memory ceiling off
    the in-process watchdog for the isolated path; deadline-kill from the parent.
 3. **Linux syscall confinement.** seccomp allowlist + empty netns + mount ns +

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -1,10 +1,11 @@
 # OS-level isolation: process-per-run with brokered effects
 
-> **Status:** Phases 1–3 implemented (`crates/chidori/src/runtime/isolate/`):
+> **Status:** Phases 1–3b implemented (`crates/chidori/src/runtime/isolate/`):
 > process-per-run brokering, the rlimits/deadline-kill resource floor, and a
-> Linux seccomp denylist. Remaining: the namespace/cgroup layer (deferred — needs
-> privilege/delegation), tightening seccomp toward an allowlist, and macOS
-> Seatbelt (phase 4).
+> Linux confinement stack — empty network namespace + Landlock read-only
+> filesystem + seccomp denylist, each best-effort with graceful fallback.
+> Remaining: cgroup v2 `memory.max` (needs delegation), tightening seccomp toward
+> an allowlist, rootless net-ns via user namespaces, and macOS Seatbelt (phase 4).
 > **Closes:** [`docs/sandbox-model.md`](./sandbox-model.md) gap #4 ("No process / OS-level
 > isolation"), and as a side effect tightens gaps #2, #3, #6 (memory accounting
 > precision and cross-run heap hygiene).
@@ -308,8 +309,10 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
 2. **Resource floor.** ✅ **Done (rlimits + deadline-kill)** —
    `runtime::isolate::limits` applies a per-process `setrlimit` floor in the
    worker before any agent code runs (`RLIMIT_CPU` hard CPU-seconds backstop to
-   the opcode budget — ignores broker-wait time; `RLIMIT_FSIZE=0` since the child
-   has no filesystem; `RLIMIT_CORE=0`; `RLIMIT_NOFILE`), and the supervisor adds
+   the opcode budget — ignores broker-wait time; `RLIMIT_CORE=0`; `RLIMIT_NOFILE`;
+   `RLIMIT_FSIZE` opt-in only — a `0` cap also kills writes to a redirected
+   regular-file `stderr`, so file-write confinement is Landlock's job instead),
+   and the supervisor adds
    a `SIGKILL` **deadline-kill** watchdog (`CHIDORI_ISOLATE_DEADLINE_MS`) plus
    **signal-aware failure mapping** (CPU/file/OOM/deadline → precise errors).
    Limits ride the `Init` frame so the parent owns the policy; the in-process
@@ -320,7 +323,7 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
    too blunt — a multi-threaded VM over-reserves virtual memory) and `RLIMIT_NPROC`
    (fragile under shared-uid concurrency; blocking `fork` belongs to the seccomp
    phase). Env: `CHIDORI_ISOLATE_{CPU_SECS,FSIZE_BYTES,NOFILE,NO_CORE,DEADLINE_MS}`.
-3. **Linux syscall confinement.** ⏳ **Partly done (seccomp denylist)** —
+3. **Linux syscall confinement.** ✅ **Done (seccomp denylist)** —
    `runtime::isolate::sandbox` installs a seccomp-bpf filter in the worker (via
    `seccompiler`) before any agent code runs: default-allow, `KILL_PROCESS` on a
    curated denylist (the whole socket family, `exec*`, `ptrace`/`process_vm_*`,
@@ -334,10 +337,20 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
    skip-aware). **Chosen denylist over allowlist** deliberately — it cannot
    false-positive-kill the engine and the primary boundary is still
    capability-confinement + brokering; the near-empty allowlist remains the end
-   goal. **Deferred:** empty net namespace + mount/pid/user namespaces + Landlock
-   and cgroup v2 `memory.max` — all need privilege or cgroup delegation that many
-   deploy targets (rootless containers, CI) lack, so they need a capability probe
-   + graceful fallback before they can ship without regressing the common case.
+   goal (a future tightening).
+3b. **Namespaces + Landlock + cgroup.** ⏳ **Partly done (net-ns + Landlock)** —
+   `sandbox::apply()` now layers, before seccomp (so `unshare`/`landlock_*` are
+   still legal): an **empty network namespace** (`unshare(CLONE_NEWNET)` —
+   belt-and-suspenders with the socket block; needs `CAP_SYS_ADMIN`, skipped
+   rootless) and a **Landlock read-only filesystem** (deny every write-class
+   access, leave reads for the C runtime; closes the `openat`-write surface
+   seccomp leaves open, and unlike `RLIMIT_FSIZE` it spares inherited fds like a
+   redirected `stderr`). Both best-effort with graceful skip + a `notes` log; a
+   single `SandboxOutcome` drives `REQUIRE_SANDBOX` (seccomp is the required
+   core) and the skip-aware self-tests (`isolate_limits::landlock_blocks_file_creation`).
+   **Deferred:** cgroup v2 `memory.max` (needs delegation — the per-process heap
+   watchdog from phase 2 is the graceful stand-in), rootless net-ns via an
+   intermediate user namespace, and mount/pid namespaces.
 4. **macOS Seatbelt** profile + the `Sandbox` trait FFI; CI parity.
 5. **Polish:** `--isolate` UX, policy-profile coupling, docs, optional warm pool.
 

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -367,9 +367,17 @@ If you intend to run code you do not trust on this engine today:
    (and tighten `CHIDORI_JS_MEM_POLL_MS` alongside a small cap), and enable
    `CHIDORI_JS_DEADLINE_MS` (acceptable because untrusted code should not be
    making slow trusted host calls).
-3. Run each agent in its own process (or container) so the lack of OS isolation
-   (gap 4) does not allow a true breakout; per-run memory accounting (gap 2)
-   already keeps co-tenant caps separate within one process.
+3. Add OS isolation with `--isolate` (`chidori run --isolate`, `chidori serve
+   --isolate`, or `CHIDORI_ISOLATE=process`): each run executes in a confined
+   child process and brokers its effects back over a pipe, so a breakout has no
+   ambient process to land in. On Linux the child runs under a network namespace
+   + Landlock read-only filesystem + a seccomp denylist; on macOS under a
+   Seatbelt profile; everywhere it gets a `setrlimit` floor (`CHIDORI_ISOLATE_*`)
+   and a parent-side deadline-kill. Layers are best-effort — set
+   `CHIDORI_ISOLATE_REQUIRE_SANDBOX=1` to fail closed if the platform's core
+   confinement can't be applied. See
+   [`docs/os-isolation-plan.md`](./os-isolation-plan.md). (Running each agent in
+   its own container is still complementary.)
 4. Keep `node:fs` on `FsPolicy::Captured` (the VFS) and avoid `workspace.*`.
 
 ## Verification

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -235,7 +235,9 @@ resource-precision gaps.
    there is no seccomp, namespace, or separate-process boundary. Isolation is
    purely capability-confinement plus Rust memory safety. A panic is contained
    (gap-free via `catch_unwind`), but this is not a substitute for OS containment
-   when running genuinely hostile code.
+   when running genuinely hostile code. A proposed additive fix —
+   process-per-run with brokered effects + per-OS sandboxing — is specified in
+   [`docs/os-isolation-plan.md`](./os-isolation-plan.md).
 
 5. **Container element counts beyond arrays are uncapped.** Arrays are bounded by
    `MAX_DENSE_ARRAY` (1M), but `Map`/`Set`/object property counts are not


### PR DESCRIPTION
Specify an additive isolation mode that runs the chidori-js VM in a
disposable child process per run, with every chidori.* effect and captured
sync native brokered back to the parent over a pipe. The child runs under a
near-empty syscall allowlist (Linux seccomp) / OS sandbox (macOS Seatbelt),
so an interpreter compromise cannot reach the network, disk, or other runs.

Leans on three existing properties: the host-call boundary is already a
(name, args) -> JSON serialization seam; the engine has no ambient authority;
and deterministic-replay makes the child fully disposable (pause kills it,
resume replays the journal). Closes sandbox-model gap #4 and tightens the
memory-accounting gaps. Covers cross-platform tiers (Linux/macOS/Windows),
wire protocol, failure mapping, phasing, and verification.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019zoxzZENSmUiRee7UZxg9Q