### PR TITLE
JS runtime performance: call-ceremony elimination, typed kernel tiers (loops/functions/recursion/closures), JSON fast paths

### DIFF
--- a/crates/chidori-js/benchmarks/workloads/array_sum.js
+++ b/crates/chidori-js/benchmarks/workloads/array_sum.js
@@ -1,0 +1,38 @@
+// Dense-array traversal with index arithmetic — the `s += a[i]` class the
+// typed loop kernels' element access targets: reads, in-place writes, a
+// two-array dot product, and a nested 2D walk. Deterministic fill (no RNG)
+// so every runtime computes the same checksum.
+const N = 200_000;
+const ROUNDS = 5;
+const a = new Array(N);
+const b = new Array(N);
+for (let i = 0; i < N; i++) {
+  a[i] = (i * 7919) % 10007;
+  b[i] = (i * 104729) % 7919;
+}
+let checksum = 0;
+for (let r = 0; r < ROUNDS; r++) {
+  // read + accumulate
+  let s = 0;
+  for (let i = 0; i < a.length; i++) {
+    s += a[i];
+  }
+  // dot product
+  let d = 0;
+  for (let i = 0; i < a.length; i++) {
+    d += a[i] * b[i];
+  }
+  // in-place transform
+  for (let i = 0; i < a.length; i++) {
+    a[i] = (a[i] + b[i]) % 10007;
+  }
+  checksum = (checksum + s + d) % 9007199254740991;
+}
+// nested 2D walk
+let m = 0;
+for (let i = 0; i < 500; i++) {
+  for (let j = 0; j < 500; j++) {
+    m += (i * j) % 13;
+  }
+}
+console.log("RESULT=" + (checksum + m));

--- a/crates/chidori-js/examples/dump_ops.rs
+++ b/crates/chidori-js/examples/dump_ops.rs
@@ -1,0 +1,26 @@
+//! Dev-only bytecode disassembler: `cargo run --example dump_ops -- file.js`
+//! Prints each compiled function's ops with indices, for inspecting what the
+//! kernel pass will see. Not part of the public surface.
+
+fn dump(proto: &chidori_js::bytecode::FuncProto, depth: usize) {
+    let pad = "  ".repeat(depth);
+    println!(
+        "{pad}fn {:?} locals={} cells={} strict={}",
+        proto.name, proto.num_locals, proto.num_cells, proto.is_strict
+    );
+    for (i, op) in proto.code.iter().enumerate() {
+        println!("{pad}  {i:4}  {op:?}");
+    }
+    for c in &proto.consts {
+        if let chidori_js::bytecode::Const::Func(p) = c {
+            dump(p, depth + 1);
+        }
+    }
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: dump_ops <file.js>");
+    let src = std::fs::read_to_string(&path).unwrap();
+    let proto = chidori_js::compiler::compile_script(&src).unwrap();
+    dump(&proto, 0);
+}

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -277,6 +277,32 @@ fn create_data_elem(vm: &mut Vm, target: &Value, idx: f64, v: Value) -> Result<(
     create_data_property_or_throw(vm, &o, &elem_key(idx), v)
 }
 
+/// `Set(O, ToString(k), V, Throw=true)` for the mutating builtins' write-back
+/// loops, with the dense fast path of `Op::SetPropDynamic`: overwriting an
+/// EXISTING in-bounds non-hole element of an unshadowed dense array in place.
+/// Such a slot is a plain writable data property (per the array exotic
+/// [[Set]]), so no setter, no length change, and no extensibility interaction
+/// is observable. Appends, holes, out-of-bounds indices, shadowed elements,
+/// and array-likes take the exact spec path.
+fn set_elem(vm: &mut Vm, base: &Value, idx: f64, v: Value) -> Result<(), Value> {
+    if idx >= 0.0 && idx <= u32::MAX as f64 {
+        if let Value::Object(o) = base {
+            let mut b = o.borrow_mut();
+            if b.props.is_empty() {
+                if let Internal::Array(arr) = &mut b.internal {
+                    if let Some(slot) = arr.get_mut(idx as usize) {
+                        if !matches!(slot, Value::Hole) {
+                            *slot = v;
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    vm.set_prop_strict(base, &elem_key(idx), v)
+}
+
 /// `DeletePropertyOrThrow(O, key)`: a failed delete (non-configurable property)
 /// raises a TypeError instead of silently succeeding.
 fn delete_or_throw(vm: &mut Vm, o: &Value, key: &PropertyKey) -> Result<(), Value> {
@@ -1135,28 +1161,28 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
-            let key = elem_key(k);
-            if vm.has_prop(&ov, &key)? {
-                items.push(vm.get_prop(&ov, &key)?);
+            // Dense fast path (`has_get_elem`): no idx→String key, no hashing,
+            // no prototype walk for an unshadowed dense element; everything
+            // else takes the exact HasProperty/Get spec sequence.
+            if let Some(v) = has_get_elem(vm, &ov, k)? {
+                items.push(v);
             }
             k += 1.0;
         }
         let item_count = items.len();
         // Undefineds sort to the end without the comparator ever seeing them.
-        let mut defined: Vec<Value> = items
-            .iter()
-            .filter(|v| !v.is_undefined())
-            .cloned()
-            .collect();
+        // (Values MOVE out of the snapshot — no clone pass.)
+        let mut defined = items;
+        defined.retain(|v| !v.is_undefined());
         let undef_count = item_count - defined.len();
         merge_sort(vm, &mut defined, &cmp, has_cmp)?;
         let mut j = 0.0;
         for v in defined {
-            vm.set_prop_strict(&ov, &elem_key(j), v)?;
+            set_elem(vm, &ov, j, v)?;
             j += 1.0;
         }
         for _ in 0..undef_count {
-            vm.set_prop_strict(&ov, &elem_key(j), Value::Undefined)?;
+            set_elem(vm, &ov, j, Value::Undefined)?;
             j += 1.0;
         }
         // Indices [itemCount, len) were holes (absent) — delete them.
@@ -1187,12 +1213,10 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
             items.push(vm.get_prop(&ov, &elem_key(k))?);
             k += 1.0;
         }
-        let mut defined: Vec<Value> = items
-            .iter()
-            .filter(|v| !v.is_undefined())
-            .cloned()
-            .collect();
-        let undef_count = items.len() - defined.len();
+        let item_count = items.len();
+        let mut defined = items;
+        defined.retain(|v| !v.is_undefined());
+        let undef_count = item_count - defined.len();
         merge_sort(vm, &mut defined, &cmp, has_cmp)?;
         defined.extend(std::iter::repeat(Value::Undefined).take(undef_count));
         Ok(Value::Object(vm.new_array(defined)))
@@ -1425,41 +1449,68 @@ fn merge_sort(
     cmp: &Value,
     has_cmp: bool,
 ) -> Result<(), Value> {
+    if items.len() <= 1 {
+        return Ok(());
+    }
+    // One scratch buffer for the whole sort (max use: the larger half) instead
+    // of two fresh Vec clones per recursion node — the naive version's
+    // malloc/free + refcount churn was a measurable slice of sort-heavy runs.
+    let mut aux: Vec<Value> = Vec::with_capacity(items.len() / 2 + 1);
     let n = items.len();
+    merge_sort_range(vm, items, &mut aux, 0, n, cmp, has_cmp)
+}
+
+/// Sort `items[lo..hi]` in place. Identical recursion structure and stable
+/// merge order as the previous out-of-place version, so the comparator sees
+/// the exact same call sequence (observable via side effects); only the
+/// buffer management changed. On a comparator throw the scratch's contents
+/// are abandoned mid-merge — harmless, because every caller sorts a detached
+/// scratch list and only writes back to the array on success.
+fn merge_sort_range(
+    vm: &mut Vm,
+    items: &mut [Value],
+    aux: &mut Vec<Value>,
+    lo: usize,
+    hi: usize,
+    cmp: &Value,
+    has_cmp: bool,
+) -> Result<(), Value> {
+    let n = hi - lo;
     if n <= 1 {
         return Ok(());
     }
-    let mid = n / 2;
-    let mut left = items[..mid].to_vec();
-    let mut right = items[mid..].to_vec();
-    merge_sort(vm, &mut left, cmp, has_cmp)?;
-    merge_sort(vm, &mut right, cmp, has_cmp)?;
-    let mut i = 0;
-    let mut j = 0;
-    let mut k = 0;
-    // Stable merge: take from `left` on ties (order <= 0) so equal elements
-    // preserve their original relative order.
-    while i < left.len() && j < right.len() {
-        let order = compare_values(vm, &left[i], &right[j], cmp, has_cmp)?;
+    let mid = lo + n / 2;
+    merge_sort_range(vm, items, aux, lo, mid, cmp, has_cmp)?;
+    merge_sort_range(vm, items, aux, mid, hi, cmp, has_cmp)?;
+    // Move the left run into the scratch (no clones; the vacated slots are
+    // overwritten before they are ever read), then merge back into
+    // `items[lo..]`. Take from the left on ties (order <= 0) so equal
+    // elements keep their original relative order (stable sort).
+    aux.clear();
+    for slot in &mut items[lo..mid] {
+        aux.push(std::mem::replace(slot, Value::Undefined));
+    }
+    let mut i = 0; // over aux (left run)
+    let mut j = mid; // over items (right run)
+    let mut k = lo; // write cursor; k <= j always, so unread right
+                    // elements are never overwritten
+    while i < aux.len() && j < hi {
+        let order = compare_values(vm, &aux[i], &items[j], cmp, has_cmp)?;
         if order <= 0 {
-            items[k] = left[i].clone();
+            items[k] = std::mem::replace(&mut aux[i], Value::Undefined);
             i += 1;
         } else {
-            items[k] = right[j].clone();
+            items.swap(k, j);
             j += 1;
         }
         k += 1;
     }
-    while i < left.len() {
-        items[k] = left[i].clone();
+    while i < aux.len() {
+        items[k] = std::mem::replace(&mut aux[i], Value::Undefined);
         i += 1;
         k += 1;
     }
-    while j < right.len() {
-        items[k] = right[j].clone();
-        j += 1;
-        k += 1;
-    }
+    // Any right-run tail is already in place.
     Ok(())
 }
 
@@ -1472,8 +1523,13 @@ fn compare_values(
 ) -> Result<i32, Value> {
     if has_cmp {
         // SortCompare with a user comparator: call it, coerce the result via
-        // ToNumber, and treat NaN as 0 (spec). Errors propagate.
-        let r = vm.call(cmp.clone(), Value::Undefined, &[a.clone(), b.clone()])?;
+        // ToNumber, and treat NaN as 0 (spec). Errors propagate. Owned-args
+        // path: the pooled buffer moves straight into the callee frame instead
+        // of being copied a second time by the slice path's make_frame.
+        let mut argv = vm.take_value_vec();
+        argv.push(a.clone());
+        argv.push(b.clone());
+        let r = vm.call_valuevec(cmp.clone(), Value::Undefined, argv)?;
         let n = vm.to_number(&r)?;
         Ok(if n < 0.0 {
             -1

--- a/crates/chidori-js/src/builtins/mod.rs
+++ b/crates/chidori-js/src/builtins/mod.rs
@@ -12,7 +12,7 @@ mod disposable;
 mod date;
 pub(crate) mod fundamental;
 mod intl;
-mod numbers;
+pub(crate) mod numbers;
 
 mod regexp_builtin;
 

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -933,9 +933,19 @@ fn install_json(vm: &mut Vm) {
             .borrow_mut()
             .props
             .insert(PropertyKey::str(""), Property::data(value));
-        match json_stringify(vm, &Value::Object(holder), "", "", &mut state)? {
-            Some(s) => Ok(Value::str(s)),
-            None => Ok(Value::Undefined),
+        let mut out = String::with_capacity(128);
+        let root_key = JsString::from("");
+        if json_stringify(
+            vm,
+            &Value::Object(holder),
+            &root_key,
+            "",
+            &mut state,
+            &mut out,
+        )? {
+            Ok(Value::str(out))
+        } else {
+            Ok(Value::Undefined)
         }
     });
     // JSON[Symbol.toStringTag] = "JSON" (non-writable, non-enumerable, configurable).
@@ -957,7 +967,7 @@ fn install_json(vm: &mut Vm) {
 struct StringifyState {
     indent: String,
     rep_fn: Option<Value>,
-    rep_list: Option<Vec<String>>,
+    rep_list: Option<Vec<JsString>>,
     seen: Vec<usize>,
 }
 
@@ -966,7 +976,7 @@ struct StringifyState {
 fn json_build_replacer(
     vm: &mut Vm,
     replacer: &Value,
-) -> Result<(Option<Value>, Option<Vec<String>>), Value> {
+) -> Result<(Option<Value>, Option<Vec<JsString>>), Value> {
     if vm.is_callable(replacer) {
         return Ok((Some(replacer.clone()), None));
     }
@@ -977,18 +987,18 @@ fn json_build_replacer(
         if is_array {
             let len_v = vm.get_prop(replacer, &PropertyKey::str("length"))?;
             let len = vm.to_length(&len_v)?;
-            let mut list: Vec<String> = Vec::new();
+            let mut list: Vec<JsString> = Vec::new();
             for i in 0..len {
                 let el = vm.get_prop(replacer, &PropertyKey::from_index(i as u32))?;
                 // A property name is added for String/Number entries (and the
                 // boxed forms thereof).
                 let name = match &el {
-                    Value::String(s) => Some(s.as_str().to_string()),
-                    Value::Number(n) => Some(number_to_string(*n)),
+                    Value::String(s) => Some(s.clone()),
+                    Value::Number(n) => Some(JsString::from(number_to_string(*n))),
                     Value::Object(obj) => {
                         let cls = obj.borrow().class_name();
                         if cls == "String" || cls == "Number" {
-                            Some(vm.to_js_string(&el)?.as_str().to_string())
+                            Some(vm.to_js_string(&el)?)
                         } else {
                             None
                         }
@@ -1198,7 +1208,26 @@ impl<'a> JsonParser<'a> {
     }
     fn parse_string(&mut self, vm: &mut Vm) -> Result<String, Value> {
         self.pos += 1; // opening quote
-        let mut s = String::new();
+                       // Fast path: a string with no escapes and no control characters —
+                       // the overwhelmingly common case — is ONE slice copy instead of
+                       // per-char pushes. (Multi-byte UTF-8 passes through: continuation
+                       // bytes are ≥ 0x80 and match none of the terminators.)
+        let start = self.pos;
+        let mut i = self.pos;
+        while i < self.bytes.len() {
+            match self.bytes[i] {
+                b'"' => {
+                    self.pos = i + 1;
+                    return Ok(self.src[start..i].to_string());
+                }
+                b'\\' | 0x00..=0x1f => break,
+                _ => i += 1,
+            }
+        }
+        // Slow path: seed with the clean prefix, continue escape-aware.
+        let mut s = String::with_capacity((i - start) + 16);
+        s.push_str(&self.src[start..i]);
+        self.pos = i;
         while self.pos < self.bytes.len() {
             let c = self.bytes[self.pos];
             match c {
@@ -1350,37 +1379,54 @@ impl<'a> JsonParser<'a> {
     }
 }
 
-fn json_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
+/// QuoteJSONString, appended to `out`. Only `"`, `\` and control characters
+/// need escaping — all single ASCII bytes — so the scan copies maximal
+/// clean RUNS (multi-byte UTF-8 included wholesale; every continuation byte
+/// is ≥ 0x80 and never matches) instead of pushing char by char.
+fn json_quote_into(s: &str, out: &mut String) {
     out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\u{08}' => out.push_str("\\b"),
-            '\u{0c}' => out.push_str("\\f"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
+    let bytes = s.as_bytes();
+    let mut run = 0usize;
+    for (i, &c) in bytes.iter().enumerate() {
+        if c == b'"' || c == b'\\' || c < 0x20 {
+            out.push_str(&s[run..i]);
+            match c {
+                b'"' => out.push_str("\\\""),
+                b'\\' => out.push_str("\\\\"),
+                b'\n' => out.push_str("\\n"),
+                b'\r' => out.push_str("\\r"),
+                b'\t' => out.push_str("\\t"),
+                0x08 => out.push_str("\\b"),
+                0x0c => out.push_str("\\f"),
+                c => {
+                    use std::fmt::Write;
+                    let _ = write!(out, "\\u{:04x}", c);
+                }
+            }
+            run = i + 1;
         }
     }
+    out.push_str(&s[run..]);
     out.push('"');
-    out
 }
 
-/// SerializeJSONProperty: stringify `holder[key]`, applying toJSON and the
-/// function replacer (which both observe `key`). Returns `None` when the value
-/// is to be omitted (undefined / function / symbol after transforms).
+/// SerializeJSONProperty: stringify `holder[key]` APPENDED to `out`,
+/// applying toJSON and the function replacer (which both observe `key`).
+/// Returns `false` when the value is to be omitted (undefined / function /
+/// symbol after transforms) — the caller then truncates whatever prefix it
+/// wrote. One shared buffer for the whole tree: no per-node Strings, no
+/// joins, no format! assembly (the old shape was ~40% of the round-trip
+/// profile in allocator + fmt machinery). Every spec-visible effect
+/// ([[Get]] order, toJSON/replacer calls, proxy traps) is unchanged.
 fn json_stringify(
     vm: &mut Vm,
     holder: &Value,
-    key: &str,
+    key: &JsString,
     cur_indent: &str,
     state: &mut StringifyState,
-) -> Result<Option<String>, Value> {
-    let mut value = vm.get_prop(holder, &PropertyKey::str(key))?;
+    out: &mut String,
+) -> Result<bool, Value> {
+    let mut value = vm.get_prop(holder, &PropertyKey::Str(key.clone()))?;
 
     // toJSON: looked up for an Object OR a BigInt value (spec
     // SerializeJSONProperty step 2), called with the value as `this`.
@@ -1388,14 +1434,14 @@ fn json_stringify(
         let to_json = vm.get_prop(&value, &PropertyKey::str("toJSON"))?;
         if vm.is_callable(&to_json) {
             let this = value.clone();
-            value = vm.call(to_json, this, &[Value::str(key)])?;
+            value = vm.call(to_json, this, &[Value::String(key.clone())])?;
         }
     }
 
     // Function replacer.
     if let Some(rep) = &state.rep_fn {
         let rep = rep.clone();
-        value = vm.call(rep, holder.clone(), &[Value::str(key), value])?;
+        value = vm.call(rep, holder.clone(), &[Value::String(key.clone()), value])?;
     }
 
     // Unwrap boxed primitives (Number/String/Boolean) to their primitive value.
@@ -1441,18 +1487,30 @@ fn json_stringify(
         | Value::Uninitialized
         | Value::Hole
         | Value::Symbol(_)
-        | Value::BigInt(_) => None,
-        Value::Null => Some("null".into()),
-        Value::Bool(b) => Some(b.to_string()),
-        Value::Number(n) => Some(if n.is_finite() {
-            number_to_string(*n)
-        } else {
-            "null".into()
-        }),
-        Value::String(s) => Some(json_quote(s.as_str())),
+        | Value::BigInt(_) => false,
+        Value::Null => {
+            out.push_str("null");
+            true
+        }
+        Value::Bool(b) => {
+            out.push_str(if *b { "true" } else { "false" });
+            true
+        }
+        Value::Number(n) => {
+            if n.is_finite() {
+                crate::vm::push_number_string(*n, out);
+            } else {
+                out.push_str("null");
+            }
+            true
+        }
+        Value::String(s) => {
+            json_quote_into(s.as_str(), out);
+            true
+        }
         Value::Object(o) => {
             if o.borrow().is_callable() {
-                return Ok(None);
+                return Ok(false);
             }
             let id = o.ptr_id();
             if state.seen.contains(&id) {
@@ -1460,39 +1518,39 @@ fn json_stringify(
             }
             state.seen.push(id);
             let is_array = crate::builtins::fundamental::is_array_exotic(vm, o)?;
-            let indent = state.indent.clone();
-            let new_indent = format!("{cur_indent}{indent}");
-            let (nl, sp) = if indent.is_empty() {
-                (String::new(), String::new())
+            // Pretty-print separators — ALL empty in the common compact
+            // mode, so assembly below is pure buffer pushes.
+            let (new_indent, nl, close_nl, sp) = if state.indent.is_empty() {
+                (String::new(), String::new(), String::new(), "")
             } else {
-                (format!("\n{new_indent}"), " ".to_string())
+                let ni = format!("{cur_indent}{}", state.indent);
+                let nl = format!("\n{ni}");
+                (ni, nl, format!("\n{cur_indent}"), " ")
             };
-            let result = if is_array {
+            if is_array {
                 // SerializeJSONArray reads `length` via [[Get]] (a proxy trap
                 // fires) and ToLength; elements go through [[Get]] too.
                 let len_v = vm.get_prop(&value, &PropertyKey::str("length"))?;
                 let len = vm.to_length(&len_v)?;
-                if len == 0 {
-                    "[]".to_string()
-                } else {
-                    let mut parts = Vec::new();
+                out.push('[');
+                if len != 0 {
                     for i in 0..len {
-                        let k = i.to_string();
-                        let s = json_stringify(vm, &value, &k, &new_indent, state)?
-                            .unwrap_or_else(|| "null".into());
-                        parts.push(s);
+                        if i > 0 {
+                            out.push(',');
+                        }
+                        out.push_str(&nl);
+                        let k = JsString::from(i.to_string());
+                        if !json_stringify(vm, &value, &k, &new_indent, state, out)? {
+                            out.push_str("null");
+                        }
                     }
-                    let close_nl = if indent.is_empty() {
-                        String::new()
-                    } else {
-                        format!("\n{cur_indent}")
-                    };
-                    format!("[{nl}{}{close_nl}]", parts.join(&format!(",{nl}")))
+                    out.push_str(&close_nl);
                 }
+                out.push(']');
             } else {
                 // Property key list: the allowlist if present, else all enumerable
                 // own string keys.
-                let keys: Vec<String> = if let Some(list) = &state.rep_list {
+                let keys: Vec<JsString> = if let Some(list) = &state.rep_list {
                     list.clone()
                 } else {
                     // EnumerableOwnPropertyNames via [[OwnPropertyKeys]] +
@@ -1500,30 +1558,39 @@ fn json_stringify(
                     vm.enumerable_own_keys_dyn(o)?
                         .into_iter()
                         .filter_map(|k| match k {
-                            PropertyKey::Str(s) => Some(s.as_str().to_string()),
+                            PropertyKey::Str(s) => Some(s),
                             PropertyKey::Sym(_) => None,
                         })
                         .collect()
                 };
-                let mut parts = Vec::new();
+                out.push('{');
+                let mut first = true;
                 for k in keys {
-                    if let Some(s) = json_stringify(vm, &value, &k, &new_indent, state)? {
-                        parts.push(format!("{}:{sp}{s}", json_quote(&k)));
+                    // Write the member prefix, then the value; an OMITTED
+                    // member (undefined/function/symbol) truncates the
+                    // prefix back off. Side effects (getters, toJSON, the
+                    // replacer) still ran — exactly as the spec orders.
+                    let mark = out.len();
+                    if !first {
+                        out.push(',');
+                    }
+                    out.push_str(&nl);
+                    json_quote_into(k.as_str(), out);
+                    out.push(':');
+                    out.push_str(sp);
+                    if json_stringify(vm, &value, &k, &new_indent, state, out)? {
+                        first = false;
+                    } else {
+                        out.truncate(mark);
                     }
                 }
-                if parts.is_empty() {
-                    "{}".to_string()
-                } else {
-                    let close_nl = if indent.is_empty() {
-                        String::new()
-                    } else {
-                        format!("\n{cur_indent}")
-                    };
-                    format!("{{{nl}{}{close_nl}}}", parts.join(&format!(",{nl}")))
+                if !first {
+                    out.push_str(&close_nl);
                 }
-            };
+                out.push('}');
+            }
             state.seen.pop();
-            Some(result)
+            true
         }
     })
 }

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -720,12 +720,76 @@ fn install_math(vm: &mut Vm) {
         },
     );
 
+    // Register the canonical Math object and the kernel-supported methods so
+    // the typed loop kernels (`kernel.rs`) can identity-check them at entry:
+    // a kernel using `Math.max` runs only while the global `Math` binding and
+    // the method are still these exact objects (methods are writable).
+    vm.realm.math_object = Some(math.clone());
+    vm.realm.math_kernel = crate::bytecode::KMath::ALL
+        .iter()
+        .map(|k| {
+            match math
+                .borrow()
+                .props
+                .get(&PropertyKey::str(k.name()))
+                .and_then(|p| p.value().cloned())
+            {
+                Some(Value::Object(o)) => o,
+                _ => unreachable!("Math.{} installed above", k.name()),
+            }
+        })
+        .collect();
     vm.define_value(&vm.realm.global.clone(), "Math", Value::Object(math));
 }
 
 /// Math.round: round half toward +Infinity, preserving the sign of zero and the
 /// edge case where the result is in `(-1, -0]` (e.g. `round(-0.5) === -0`).
-fn math_round(n: f64) -> f64 {
+/// The 2-argument folds of `Math.max`/`Math.min` — EXACTLY the builtin
+/// closures' logic over two elements, shared with the typed loop kernels so
+/// kernel results are bit-identical (NaN poisoning, +0 beats -0, etc.).
+pub(crate) fn math_max2(a: f64, b: f64) -> f64 {
+    let mut m = f64::NEG_INFINITY;
+    for n in [a, b] {
+        if n.is_nan() {
+            return f64::NAN;
+        }
+        if n > m || (n == 0.0 && m == 0.0 && n.is_sign_positive()) {
+            m = n;
+        }
+    }
+    m
+}
+
+pub(crate) fn math_min2(a: f64, b: f64) -> f64 {
+    let mut m = f64::INFINITY;
+    for n in [a, b] {
+        if n.is_nan() {
+            return f64::NAN;
+        }
+        if n < m || (n == 0.0 && m == 0.0 && n.is_sign_negative()) {
+            m = n;
+        }
+    }
+    m
+}
+
+pub(crate) fn math_imul2(a: f64, b: f64) -> f64 {
+    crate::vm::to_int32(a).wrapping_mul(crate::vm::to_int32(b)) as f64
+}
+
+pub(crate) fn math_sign(n: f64) -> f64 {
+    f64::signum_js(n)
+}
+
+pub(crate) fn math_fround(n: f64) -> f64 {
+    if n.is_nan() {
+        f64::NAN
+    } else {
+        n as f32 as f64
+    }
+}
+
+pub(crate) fn math_round(n: f64) -> f64 {
     if n.is_nan() || n.is_infinite() || n == 0.0 {
         return n;
     }
@@ -746,7 +810,7 @@ fn math_round(n: f64) -> f64 {
 
 /// Math.pow with ECMAScript exponentiation special cases that `f64::powf` does
 /// not match (notably `pow(1, ±Inf)` and `pow(±1, NaN)` -> NaN).
-fn math_pow(base: f64, exp: f64) -> f64 {
+pub(crate) fn math_pow(base: f64, exp: f64) -> f64 {
     if exp.is_nan() {
         return f64::NAN;
     }

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -109,6 +109,13 @@ pub struct FuncProto {
     /// §6.5): an [`Op::LoopKernel`] at a loop header indexes into this table.
     /// Empty for functions with no eligible loops.
     pub kernels: Vec<Kernel>,
+    /// FUNCTION kernel (docs/js-performance-roadmap.md §6.5): the ENTIRE body
+    /// as a register program, executed FRAMELESS by the call paths when the
+    /// entry guard passes (every consumed argument a `Number`, captured
+    /// upvalues `Number`s, no op budget, no trace sink). Guard failure takes
+    /// the ordinary frame path. `None` for anything but tiny pure-scalar
+    /// bodies (sort comparators, map/filter/reduce callbacks).
+    pub fn_kernel: Option<Kernel>,
     /// Number of plain (non-captured) local slots.
     pub num_locals: u32,
     /// Number of cell (captured-by-closure) slots.
@@ -202,6 +209,7 @@ impl FuncProto {
             code: Vec::new(),
             consts: Vec::new(),
             kernels: Vec::new(),
+            fn_kernel: None,
             num_locals: 0,
             num_cells: 0,
             num_params: 0,
@@ -1025,14 +1033,22 @@ pub enum KOp {
     /// registers, objects from object slots), and resume the bytecode
     /// interpreter at `resume_ip`.
     Exit { resume_ip: u32, shape: u16 },
+    /// FUNCTION kernels only (`FuncProto::fn_kernel`): finish the frameless
+    /// call, yielding `regs[src]` as the call's result — `Value::Bool` when
+    /// the register is statically boolean-typed, else `Value::Number`. Never
+    /// emitted for loop kernels (their region has no `Return` on the
+    /// allowlist).
+    Ret { src: u16, boolean: bool },
 }
 
-/// A numeric register's source: a frame local (read/write) or a captured
-/// upvalue cell (read-only snapshot).
+/// A numeric register's source: a frame local (read/write), a captured
+/// upvalue cell (read-only snapshot), or — FUNCTION kernels only — a call
+/// argument (read-only; the entry guard requires it present and a `Number`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KSlot {
     Local(u32),
     Upvalue(u32),
+    Arg(u32),
 }
 
 /// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read
@@ -1141,6 +1157,12 @@ pub struct Kernel {
     /// inside a kernel, so nothing can write a captured cell mid-activation;
     /// in-region upvalue WRITES reject at translation). The guard requires
     /// `Value::Number` in every one; only `Local` slots write back.
+    ///
+    /// FUNCTION kernels additionally use `Arg` slots (read-only; the guard
+    /// requires the argument present and a `Number`), and their `Local` slots
+    /// are pure register scratch — no frame exists, so they are neither
+    /// guarded nor written back (translation proves store-before-read on
+    /// every path).
     pub locals: Box<[KSlot]>,
     /// `frame.locals` indices statically typed BOOLEAN, mirrored into the
     /// registers right after the numeric ones (as 0.0/1.0). The guard

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1000,6 +1000,17 @@ pub enum KOp {
     /// `regs[dst] = <length>` of the dense array in object slot `obj`
     /// (unshadowed only — a reified `length` marker bails).
     LoadLen { dst: u16, obj: u16, bail: u16 },
+    /// Materialize a comparison as a BOOLEAN register (`0.0`/`1.0`): the
+    /// translator types the destination as Bool, so it writes back as
+    /// `Value::Bool` and never feeds an array index.
+    CmpSet {
+        cmp: CmpOp,
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
+    /// `regs[dst] = ToBoolean(regs[src]) ? 0.0 : 1.0` (JS `!x` on a scalar).
+    BoolNot { dst: u16, src: u16 },
     /// `regs[dst] = Math.<kind>(regs[src])` via the builtin's own core fn.
     Math1 { kind: KMath, dst: u16, src: u16 },
     /// `regs[dst] = Math.<kind>(regs[a], regs[b])`.
@@ -1016,6 +1027,14 @@ pub enum KOp {
     Exit { resume_ip: u32, shape: u16 },
 }
 
+/// A numeric register's source: a frame local (read/write) or a captured
+/// upvalue cell (read-only snapshot).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KSlot {
+    Local(u32),
+    Upvalue(u32),
+}
+
 /// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read
 /// from a register, an object read from an object slot, or a canonical Math
 /// intrinsic (the entry guard proved the live values ARE the canonicals, so a
@@ -1023,6 +1042,9 @@ pub enum KOp {
 #[derive(Clone, Copy, Debug)]
 pub enum KShapeSlot {
     Num(u16),
+    /// A register statically typed BOOLEAN (holds exactly 0.0/1.0):
+    /// materialized as `Value::Bool` — `typeof` must not see a number.
+    Bool(u16),
     Obj(u16),
     MathObj,
     MathFn(KMath),
@@ -1114,8 +1136,17 @@ impl KMath {
 #[derive(Clone, Debug)]
 pub struct Kernel {
     pub code: Box<[KOp]>,
-    /// `frame.locals` indices mirrored into registers `0..locals.len()`.
-    pub locals: Box<[u32]>,
+    /// Numeric slots mirrored into registers `0..locals.len()`: frame locals
+    /// (read/write) and UPVALUES (read-only snapshots — no call can run
+    /// inside a kernel, so nothing can write a captured cell mid-activation;
+    /// in-region upvalue WRITES reject at translation). The guard requires
+    /// `Value::Number` in every one; only `Local` slots write back.
+    pub locals: Box<[KSlot]>,
+    /// `frame.locals` indices statically typed BOOLEAN, mirrored into the
+    /// registers right after the numeric ones (as 0.0/1.0). The guard
+    /// requires `Value::Bool`; write-back restores `Value::Bool` — a kernel
+    /// must never turn a boolean binding into a number (`typeof`).
+    pub bool_locals: Box<[u32]>,
     /// `frame.locals` indices of ARRAY BASES (`a` in `a[i]`/`a.length`):
     /// object slot `s` caches that local's `JsObject` at kernel entry. The
     /// guard requires each to hold an object; per-access checks do the rest.

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -105,6 +105,10 @@ pub struct FuncProto {
     pub name: String,
     pub code: Vec<Op>,
     pub consts: Vec<Const>,
+    /// Typed loop kernels compiled by `kernel.rs` (docs/js-performance-roadmap.md
+    /// §6.5): an [`Op::LoopKernel`] at a loop header indexes into this table.
+    /// Empty for functions with no eligible loops.
+    pub kernels: Vec<Kernel>,
     /// Number of plain (non-captured) local slots.
     pub num_locals: u32,
     /// Number of cell (captured-by-closure) slots.
@@ -197,6 +201,7 @@ impl FuncProto {
             name: name.to_string(),
             code: Vec::new(),
             consts: Vec::new(),
+            kernels: Vec::new(),
             num_locals: 0,
             num_cells: 0,
             num_params: 0,
@@ -901,4 +906,103 @@ pub enum Op {
     Nop,
     /// Create the `arguments` object from current frame.
     LoadArguments,
+    /// A typed loop kernel sits at this loop header (see [`Kernel`] and
+    /// `kernel.rs`). The payload indexes [`FuncProto::kernels`]. Placed by the
+    /// kernelization pass REPLACING the original header op (which is preserved
+    /// as [`Kernel::fallback`]), so every other instruction index — and every
+    /// jump target — in the function is unchanged.
+    LoopKernel(u32),
+}
+
+// =============================================================================
+// Typed loop kernels
+// =============================================================================
+
+/// The kernel register machine's instruction set: unboxed `f64` registers, no
+/// operand stack, no heap values. Produced by `kernel.rs` from an eligible
+/// loop region's bytecode; executed by `Vm::run_kernel`. `target` fields index
+/// [`Kernel::code`]. Numeric semantics are shared with the interpreter
+/// (`number_arith_raw`, `js_mod`, `to_int32`, …) so results are bit-identical
+/// to the generic path on `Number` inputs — which the entry guard establishes
+/// and the (closed-under-arithmetic) op set preserves.
+#[derive(Clone, Copy, Debug)]
+pub enum KOp {
+    /// `regs[dst] = regs[src]`
+    Mov { dst: u16, src: u16 },
+    /// `regs[dst] = k`
+    Const { dst: u16, k: f64 },
+    /// `regs[dst] = regs[a] + regs[b]` (numeric `+`; strings can't occur here)
+    Add { dst: u16, a: u16, b: u16 },
+    /// `regs[dst] = regs[a] + k`
+    AddK { dst: u16, a: u16, k: f64 },
+    /// `regs[dst] = regs[a] <kind> regs[b]` (same table as `number_arith`)
+    Arith {
+        kind: crate::exec::ArithKind,
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
+    /// `regs[dst] = regs[a] <kind> k`
+    ArithK {
+        kind: crate::exec::ArithKind,
+        dst: u16,
+        a: u16,
+        k: f64,
+    },
+    /// `regs[dst] = -regs[src]`
+    Neg { dst: u16, src: u16 },
+    /// `regs[dst] = ~ToInt32(regs[src])`
+    BitNot { dst: u16, src: u16 },
+    /// unconditional jump
+    Br { target: u16 },
+    /// numeric compare-and-branch: jump when `cmp(a, b) == if_true`
+    BrCmp {
+        cmp: CmpOp,
+        a: u16,
+        b: u16,
+        if_true: bool,
+        target: u16,
+    },
+    /// as [`KOp::BrCmp`] with a constant right operand
+    BrCmpK {
+        cmp: CmpOp,
+        a: u16,
+        k: f64,
+        if_true: bool,
+        target: u16,
+    },
+    /// jump when `regs[src]` is falsy (`0`, `-0`, or NaN)
+    BrFalsy { src: u16, target: u16 },
+    /// jump when `regs[src]` is truthy
+    BrTruthy { src: u16, target: u16 },
+    /// Leave the kernel: write every mapped local back to `frame.locals`, push
+    /// registers `S0..S(stack-1)` onto the operand stack (as Numbers), and
+    /// resume the bytecode interpreter at `resume_ip`.
+    Exit { resume_ip: u32, stack: u16 },
+}
+
+/// One compiled loop kernel: the register program for a bytecode loop region
+/// whose every op is numeric and whose every binding is a `frame.locals` slot.
+///
+/// Register file layout: registers `0..locals.len()` mirror the mapped frame
+/// locals (`regs[r]` ↔ `frame.locals[locals[r]]`); registers above that are
+/// the canonical operand-stack slots (`S(d) = locals.len() + d`).
+///
+/// The runtime contract lives in `Vm::run_kernel`: the kernel runs only when
+/// no op budget is installed, and only after verifying every mapped local
+/// currently holds a `Number` (the GUARD). A guard failure executes
+/// `fallback` — the original loop-header op — so the loop proceeds generically
+/// for that iteration and the kernel retries at the next back-edge arrival
+/// (late entry: a `let x;` warming to a number on iteration 1 enters the
+/// kernel from iteration 2).
+#[derive(Clone, Debug)]
+pub struct Kernel {
+    pub code: Box<[KOp]>,
+    /// `frame.locals` indices mirrored into registers `0..locals.len()`.
+    pub locals: Box<[u32]>,
+    /// Total register count (mapped locals + canonical stack slots).
+    pub n_regs: u16,
+    /// The original loop-header op this kernel replaced; executed verbatim
+    /// when the guard declines.
+    pub fallback: Box<Op>,
 }

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -975,10 +975,44 @@ pub enum KOp {
     BrFalsy { src: u16, target: u16 },
     /// jump when `regs[src]` is truthy
     BrTruthy { src: u16, target: u16 },
-    /// Leave the kernel: write every mapped local back to `frame.locals`, push
-    /// registers `S0..S(stack-1)` onto the operand stack (as Numbers), and
-    /// resume the bytecode interpreter at `resume_ip`.
-    Exit { resume_ip: u32, stack: u16 },
+    /// `regs[dst] = <element>` of the dense array in object slot `obj` at
+    /// index `regs[idx]` — IF the index is a non-negative integral f64, the
+    /// array is unshadowed (`props` empty), the element is in bounds, not a
+    /// hole, and a `Number`. Anything else jumps to the [`KOp::Exit`] at
+    /// kernel pc `bail`, which resumes the generic interpreter AT the access
+    /// op with the operand stack reconstructed — the slow path then performs
+    /// the exact spec semantics (prototype walk, holes, getters, strings).
+    LoadElem {
+        dst: u16,
+        obj: u16,
+        idx: u16,
+        bail: u16,
+    },
+    /// In-place dense element overwrite (the `Op::SetPropDynamic` fast-path
+    /// conditions exactly: unshadowed dense array, integral in-bounds index,
+    /// existing non-hole slot). Everything else bails like [`KOp::LoadElem`].
+    StoreElem {
+        obj: u16,
+        idx: u16,
+        val: u16,
+        bail: u16,
+    },
+    /// `regs[dst] = <length>` of the dense array in object slot `obj`
+    /// (unshadowed only — a reified `length` marker bails).
+    LoadLen { dst: u16, obj: u16, bail: u16 },
+    /// Leave the kernel: write every mapped local back to `frame.locals`,
+    /// materialize the operand stack from `shapes[shape]` (Numbers from
+    /// registers, objects from object slots), and resume the bytecode
+    /// interpreter at `resume_ip`.
+    Exit { resume_ip: u32, shape: u16 },
+}
+
+/// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read
+/// from a register, or an object read from an object slot.
+#[derive(Clone, Copy, Debug)]
+pub enum KShapeSlot {
+    Num(u16),
+    Obj(u16),
 }
 
 /// One compiled loop kernel: the register program for a bytecode loop region
@@ -1000,6 +1034,13 @@ pub struct Kernel {
     pub code: Box<[KOp]>,
     /// `frame.locals` indices mirrored into registers `0..locals.len()`.
     pub locals: Box<[u32]>,
+    /// `frame.locals` indices of ARRAY BASES (`a` in `a[i]`/`a.length`):
+    /// object slot `s` caches that local's `JsObject` at kernel entry. The
+    /// guard requires each to hold an object; per-access checks do the rest.
+    /// Disjoint from `locals`, and never stored to inside the region.
+    pub oslots: Box<[u32]>,
+    /// Operand-stack shapes for [`KOp::Exit`] (bottom-up).
+    pub shapes: Box<[Box<[KShapeSlot]>]>,
     /// Total register count (mapped locals + canonical stack slots).
     pub n_regs: u16,
     /// The original loop-header op this kernel replaced; executed verbatim

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1039,6 +1039,22 @@ pub enum KOp {
     /// emitted for loop kernels (their region has no `Return` on the
     /// allowlist).
     Ret { src: u16, boolean: bool },
+    /// Named own-property READ (`o.a`) on the pinned object in
+    /// [`Kernel::props_used`] entry `prop`. No per-access check and no bail:
+    /// the kernel ENTRY resolved the property to a raw slot index and proved
+    /// it a `Number`-holding own data property on an `Internal::Ordinary`
+    /// object — and nothing inside a kernel region can restructure a
+    /// property map (no calls, no property creation/deletion; the only
+    /// in-kernel property writes are [`KOp::StoreProp`]'s in-place `Number`
+    /// overwrites), so the slot and its Number-ness hold for the whole
+    /// activation. Any entry-time surprise declines the activation into the
+    /// generic fallback iteration instead.
+    LoadProp { dst: u16, prop: u16 },
+    /// Named own-property WRITE (`o.a = v`) — the in-place overwrite of the
+    /// entry-resolved WRITABLE own data property (exactly the interpreter's
+    /// `Op::SetProp` fast-path conditions). See [`KOp::LoadProp`] for why no
+    /// per-access check is needed.
+    StoreProp { prop: u16, src: u16 },
     /// FUNCTION kernels only: a DIRECT SELF-RECURSIVE call (`fib(n - 1)`
     /// inside `fib`), executed as a fresh register WINDOW running the same
     /// kernel code from pc 0 — no frame, no `Value`s, just an explicit
@@ -1063,6 +1079,22 @@ pub enum KSlot {
     Local(u32),
     Upvalue(u32),
     Arg(u32),
+}
+
+/// One named-property access class in a kernel (`o.a` / `o.a = v` sites over
+/// the pinned base object in oslot `oslot`): resolved ONCE per kernel
+/// activation to a raw property-map slot index. The entry check requires an
+/// [`crate::value::Internal::Ordinary`] receiver whose OWN data property
+/// `key` exists — holding a `Number` when `load` (reads must produce what
+/// the guard typed), writable when `store` — and declines the activation
+/// otherwise. Slot indices are stable for the activation because kernel
+/// regions contain no calls and no property creation/deletion.
+#[derive(Clone, Debug)]
+pub struct KProp {
+    pub oslot: u16,
+    pub key: Box<str>,
+    pub load: bool,
+    pub store: bool,
 }
 
 /// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read
@@ -1190,6 +1222,9 @@ pub struct Kernel {
     pub oslots: Box<[u32]>,
     /// Operand-stack shapes for [`KOp::Exit`] (bottom-up).
     pub shapes: Box<[Box<[KShapeSlot]>]>,
+    /// Named-property access classes ([`KOp::LoadProp`]/[`KOp::StoreProp`]),
+    /// entry-resolved to raw slot indices. See [`KProp`].
+    pub props_used: Box<[KProp]>,
     /// Math intrinsics this kernel executes: the entry guard identity-checks
     /// the global `Math` binding and each of these methods against the
     /// realm's canonical objects before running.

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1055,6 +1055,25 @@ pub enum KOp {
     /// `Op::SetProp` fast-path conditions). See [`KOp::LoadProp`] for why no
     /// per-access check is needed.
     StoreProp { prop: u16, src: u16 },
+    /// LOOP kernels only: call the PINNED CLOSURE in oslot
+    /// [`Kernel::callee_slots`]`[fslot]` — a plain bytecode function whose
+    /// proto carries a (non-recursive, Number-returning) function kernel —
+    /// by running that kernel's register program on a dedicated window above
+    /// the caller's registers. The window's upvalue registers were loaded
+    /// ONCE at entry (the callee local is an oslot: in-region stores to it
+    /// reject, so the closure identity is pinned); per call only the `argc`
+    /// argument registers at `base..` copy in, and the callee's `Ret` value
+    /// copies out to `dst`. The entry guard verified everything a per-call
+    /// `run_fn_kernel` guard would (arguments are statically Numbers here),
+    /// plus one depth check for the whole activation (the loop calls at a
+    /// CONSTANT depth). No trace sink may be active (it would see an
+    /// enter/exit per call on the generic path).
+    CallKernel {
+        dst: u16,
+        fslot: u16,
+        base: u16,
+        argc: u16,
+    },
     /// FUNCTION kernels only: a DIRECT SELF-RECURSIVE call (`fib(n - 1)`
     /// inside `fib`), executed as a fresh register WINDOW running the same
     /// kernel code from pc 0 — no frame, no `Value`s, just an explicit
@@ -1095,6 +1114,17 @@ pub struct KProp {
     pub key: Box<str>,
     pub load: bool,
     pub store: bool,
+}
+
+/// One pinned CALLEE of a loop kernel (see [`KOp::CallKernel`]): the oslot
+/// local holding the closure, and the smallest `argc` any call site in the
+/// region supplies — the entry guard requires the callee's function kernel
+/// to consume no argument index at or beyond it (a shorter call would need
+/// the generic `undefined` parameter).
+#[derive(Clone, Debug)]
+pub struct KCallee {
+    pub oslot: u16,
+    pub min_argc: u16,
 }
 
 /// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read
@@ -1225,6 +1255,9 @@ pub struct Kernel {
     /// Named-property access classes ([`KOp::LoadProp`]/[`KOp::StoreProp`]),
     /// entry-resolved to raw slot indices. See [`KProp`].
     pub props_used: Box<[KProp]>,
+    /// Pinned closure callees ([`KOp::CallKernel`]), entry-verified. See
+    /// [`KCallee`].
+    pub callee_slots: Box<[KCallee]>,
     /// Math intrinsics this kernel executes: the entry guard identity-checks
     /// the global `Math` binding and each of these methods against the
     /// realm's canonical objects before running.

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1000,6 +1000,15 @@ pub enum KOp {
     /// `regs[dst] = <length>` of the dense array in object slot `obj`
     /// (unshadowed only — a reified `length` marker bails).
     LoadLen { dst: u16, obj: u16, bail: u16 },
+    /// `regs[dst] = Math.<kind>(regs[src])` via the builtin's own core fn.
+    Math1 { kind: KMath, dst: u16, src: u16 },
+    /// `regs[dst] = Math.<kind>(regs[a], regs[b])`.
+    Math2 {
+        kind: KMath,
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
     /// Leave the kernel: write every mapped local back to `frame.locals`,
     /// materialize the operand stack from `shapes[shape]` (Numbers from
     /// registers, objects from object slots), and resume the bytecode
@@ -1008,11 +1017,84 @@ pub enum KOp {
 }
 
 /// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read
-/// from a register, or an object read from an object slot.
+/// from a register, an object read from an object slot, or a canonical Math
+/// intrinsic (the entry guard proved the live values ARE the canonicals, so a
+/// bail can reconstruct them from the realm).
 #[derive(Clone, Copy, Debug)]
 pub enum KShapeSlot {
     Num(u16),
     Obj(u16),
+    MathObj,
+    MathFn(KMath),
+}
+
+/// The `Math` methods the loop kernels can execute directly. Every kind maps
+/// to the SAME core function its builtin uses (`builtins::numbers`), so
+/// results are bit-identical; the kernel entry guard identity-checks the
+/// global `Math` binding and each used method against the realm's canonical
+/// objects (methods are writable — a monkeypatched `Math.max` makes the
+/// kernel decline, it never runs the stale intrinsic).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KMath {
+    Abs,
+    Floor,
+    Ceil,
+    Round,
+    Trunc,
+    Sign,
+    Sqrt,
+    Fround,
+    Min2,
+    Max2,
+    Pow2,
+    Imul2,
+}
+
+impl KMath {
+    pub const ALL: [KMath; 12] = [
+        KMath::Abs,
+        KMath::Floor,
+        KMath::Ceil,
+        KMath::Round,
+        KMath::Trunc,
+        KMath::Sign,
+        KMath::Sqrt,
+        KMath::Fround,
+        KMath::Min2,
+        KMath::Max2,
+        KMath::Pow2,
+        KMath::Imul2,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            KMath::Abs => "abs",
+            KMath::Floor => "floor",
+            KMath::Ceil => "ceil",
+            KMath::Round => "round",
+            KMath::Trunc => "trunc",
+            KMath::Sign => "sign",
+            KMath::Sqrt => "sqrt",
+            KMath::Fround => "fround",
+            KMath::Min2 => "min",
+            KMath::Max2 => "max",
+            KMath::Pow2 => "pow",
+            KMath::Imul2 => "imul",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<KMath> {
+        KMath::ALL.iter().copied().find(|k| k.name() == name)
+    }
+
+    /// Call arity the kernel translates (`Math.min`/`max` are variadic; only
+    /// the 2-argument form is kernelized).
+    pub fn arity(self) -> usize {
+        match self {
+            KMath::Min2 | KMath::Max2 | KMath::Pow2 | KMath::Imul2 => 2,
+            _ => 1,
+        }
+    }
 }
 
 /// One compiled loop kernel: the register program for a bytecode loop region
@@ -1041,6 +1123,10 @@ pub struct Kernel {
     pub oslots: Box<[u32]>,
     /// Operand-stack shapes for [`KOp::Exit`] (bottom-up).
     pub shapes: Box<[Box<[KShapeSlot]>]>,
+    /// Math intrinsics this kernel executes: the entry guard identity-checks
+    /// the global `Math` binding and each of these methods against the
+    /// realm's canonical objects before running.
+    pub math_used: Box<[KMath]>,
     /// Total register count (mapped locals + canonical stack slots).
     pub n_regs: u16,
     /// The original loop-header op this kernel replaced; executed verbatim

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1039,6 +1039,20 @@ pub enum KOp {
     /// emitted for loop kernels (their region has no `Return` on the
     /// allowlist).
     Ret { src: u16, boolean: bool },
+    /// FUNCTION kernels only: a DIRECT SELF-RECURSIVE call (`fib(n - 1)`
+    /// inside `fib`), executed as a fresh register WINDOW running the same
+    /// kernel code from pc 0 — no frame, no `Value`s, just an explicit
+    /// (return-pc, dst, window) stack in the executor. `argc` argument
+    /// registers sit contiguously at `base..`; the callee's `Ret` lands in
+    /// `regs[dst]` of the calling window (always a Number — recursive
+    /// kernels reject boolean returns). Only emitted when the body's callee
+    /// is `LoadGlobal` of the function's OWN name; the entry guard then
+    /// verifies that global binding still holds the very closure being
+    /// invoked ([`Kernel::self_global`]), so a rebound name declines to the
+    /// generic path. Depth is tracked against the interpreter's limit; an
+    /// overflow ABANDONS the (pure, side-effect-free) kernel activation and
+    /// reruns the whole call generically, which raises the spec RangeError.
+    SelfCall { dst: u16, base: u16, argc: u16 },
 }
 
 /// A numeric register's source: a frame local (read/write), a captured
@@ -1182,6 +1196,13 @@ pub struct Kernel {
     pub math_used: Box<[KMath]>,
     /// Total register count (mapped locals + canonical stack slots).
     pub n_regs: u16,
+    /// FUNCTION kernels containing [`KOp::SelfCall`]: the GLOBAL name the
+    /// body's recursive callee resolves through. The entry guard requires
+    /// the global binding to be a plain data property holding the very
+    /// closure being invoked (pointer identity) — a shadowed/rebound/
+    /// accessor'd name declines the kernel and the call runs generically.
+    /// `None` for loop kernels and non-recursive function kernels.
+    pub self_global: Option<Box<str>>,
     /// The original loop-header op this kernel replaced; executed verbatim
     /// when the guard declines.
     pub fallback: Box<Op>,

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -1789,10 +1789,24 @@ impl Compiler {
         } else {
             (code, Vec::new())
         };
+        // Function kernels (kernel.rs): a tiny pure-scalar body — a sort
+        // comparator, a map/filter/reduce callback — additionally compiles to
+        // a register program the call paths execute FRAMELESS when its entry
+        // guard passes. Plain sync functions only; `arguments` (and every
+        // construct off the allowlist, `this` included) needs a real frame.
+        let fn_kernel = if self.kernelize
+            && matches!(fc.kind, FuncKind::Normal | FuncKind::Arrow)
+            && !fc.uses_arguments
+        {
+            crate::kernel::kernelize_function(&code, &fc.consts, &kernels)
+        } else {
+            None
+        };
         FuncProto {
             eval_scopes: fc.eval_scopes.clone(),
             name: fc.name,
             kernels,
+            fn_kernel,
             ic: code
                 .iter()
                 .map(|_| crate::bytecode::IcEntry {

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -1798,7 +1798,15 @@ impl Compiler {
             && matches!(fc.kind, FuncKind::Normal | FuncKind::Arrow)
             && !fc.uses_arguments
         {
-            crate::kernel::kernelize_function(&code, &fc.consts, &kernels)
+            // The function's own (non-empty) name lets a direct recursive
+            // call fuse to `KOp::SelfCall` — validity is the RUNTIME guard's
+            // problem (the global binding must hold the invoked closure).
+            let self_name = if fc.name.is_empty() {
+                None
+            } else {
+                Some(fc.name.as_str())
+            };
+            crate::kernel::kernelize_function(&code, &fc.consts, &kernels, self_name)
         } else {
             None
         };

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -110,6 +110,48 @@ pub fn compile_script_passes(src: &str, fuse: bool, localize: bool) -> Result<Fu
     compile_script_impl(src, false, fuse, localize)
 }
 
+/// Compile with the loop-kernel pass toggled — used by the kernel differential
+/// test (`tests/kernels.rs`), which asserts kernelized and generic execution
+/// are byte-identical. Production uses [`compile_script`] (kernels on).
+pub fn compile_script_kernels(src: &str, kernels: bool) -> Result<FuncProto, String> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::script();
+    let ret = Parser::new(&allocator, src, source_type).parse();
+    if !ret.errors.is_empty() {
+        let msg = ret
+            .errors
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(format!("SyntaxError: {msg}"));
+    }
+    let program = ret.program;
+    let sem = oxc::semantic::SemanticBuilder::new()
+        .with_check_syntax_error(true)
+        .build(&program);
+    if !sem.errors.is_empty() {
+        return Err(format!(
+            "SyntaxError: {}",
+            sem.errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    }
+    let mut c = Compiler::new();
+    c.source = src.to_string();
+    c.kernelize = kernels;
+    c.compile_toplevel(&program).map_err(|e| {
+        if e.starts_with("SyntaxError") {
+            e
+        } else {
+            format!("SyntaxError: {e}")
+        }
+    })
+}
+
 /// Compile global eval code — `(0,eval)(src)`: identical to a script except
 /// `return` is illegal and the global `var`/function bindings it creates are
 /// DELETABLE (CreateGlobalVarBinding with D=true).
@@ -744,6 +786,10 @@ struct Compiler {
     /// function. Always on in production; disabled only for the differential
     /// test that proves localized and cell-only bytecode execute identically.
     localize: bool,
+    /// Compile typed loop kernels (`kernel.rs`) for eligible numeric loops.
+    /// Always on in production; disabled for the kernel differential test and
+    /// under the `op-histogram` feature (kernels would hide per-op counts).
+    kernelize: bool,
 }
 
 impl Compiler {
@@ -767,6 +813,7 @@ impl Compiler {
             in_field_initializer: false,
             fuse: true,
             localize: true,
+            kernelize: !cfg!(feature = "op-histogram"),
         }
     }
 
@@ -1733,9 +1780,19 @@ impl Compiler {
         } else {
             loc.code
         };
+        // Typed loop kernels (docs/js-performance-roadmap.md §6.5): translate
+        // eligible numeric loops into unboxed register programs. Runs LAST so
+        // it sees the final (localized + fused) op stream; it replaces loop
+        // header ops in place, so no jump target shifts.
+        let (code, kernels) = if self.kernelize {
+            crate::kernel::kernelize(code, &fc.consts)
+        } else {
+            (code, Vec::new())
+        };
         FuncProto {
             eval_scopes: fc.eval_scopes.clone(),
             name: fc.name,
+            kernels,
             ic: code
                 .iter()
                 .map(|_| crate::bytecode::IcEntry {

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -226,6 +226,15 @@ impl Vm {
             self.recycle_value_vec(args);
             return r;
         }
+        // Function kernel (kernel.rs): a tiny pure-scalar body executes
+        // FRAMELESS when the entry guard passes. Only plain sync functions
+        // ever carry one, so this can't intercept async/generator callees.
+        if bf.proto.fn_kernel.is_some() {
+            if let Some(r) = self.run_fn_kernel(&bf, &args) {
+                self.recycle_value_vec(args);
+                return r;
+            }
+        }
         let uses_arguments = bf.proto.uses_arguments;
         let mut frame = self.make_frame_owned(bf, this, args, new_target);
         // `func_obj` has exactly one consumer — the `arguments` object's
@@ -275,6 +284,19 @@ impl Vm {
         if self.call_depth > self.max_call_depth {
             self.call_depth -= 1;
             return Err(self.throw_range("Maximum call stack size exceeded"));
+        }
+        // Function kernel: run frameless straight off the caller's operand
+        // stack (the arguments sit at `at..`), then pop the ceremony.
+        if bf.proto.fn_kernel.is_some() {
+            if let Some(r) = self.run_fn_kernel(&bf, &caller.stack[at..]) {
+                caller.stack.truncate(at);
+                if has_this {
+                    caller.stack.pop();
+                }
+                caller.stack.pop(); // the function value
+                self.call_depth -= 1;
+                return r;
+            }
         }
         let mut callee = self.take_frame();
         callee.args.extend(caller.stack.drain(at..));
@@ -368,6 +390,8 @@ impl Vm {
                 crate::bytecode::KSlot::Upvalue(u) => {
                     matches!(*frame.func.upvalues[*u as usize].borrow(), Value::Number(_))
                 }
+                // Function-kernel-only slot; loop translation never maps one.
+                crate::bytecode::KSlot::Arg(_) => false,
             };
             if !ok {
                 return self.step(frame, &k.fallback);
@@ -404,6 +428,7 @@ impl Vm {
                 crate::bytecode::KSlot::Upvalue(u) => {
                     frame.func.upvalues[*u as usize].borrow().clone()
                 }
+                crate::bytecode::KSlot::Arg(_) => unreachable!("declined by the guard"),
             };
             if let Value::Number(n) = v {
                 regs[r] = n;
@@ -625,6 +650,8 @@ impl Vm {
                     }
                 }
                 KOp::Exit { resume_ip, shape } => break (resume_ip, shape),
+                // Function-kernel-only op; loop translation never emits it.
+                KOp::Ret { .. } => unreachable!("Ret in a loop kernel"),
             }
             pc += 1;
         };
@@ -664,6 +691,169 @@ impl Vm {
         objs.clear();
         self.kernel_objs = objs;
         Ok(Ctl::Jump(resume_ip as usize))
+    }
+
+    /// Execute a FUNCTION kernel (`FuncProto::fn_kernel`): the entire call
+    /// runs in unboxed registers with no frame at all. `None` = the entry
+    /// guard declined (an op budget installed — per-op counts are observable;
+    /// a trace sink active — it must see an enter/exit per call; a consumed
+    /// argument or captured upvalue not a `Number`; a monkeypatched `Math`) —
+    /// the caller proceeds down the ordinary frame path. `Some` is the call's
+    /// exact result, bit-identical to the generic path by the loop-kernel
+    /// argument (shared numeric cores, an op set closed over numbers, typed
+    /// returns). Callers have already applied the depth guard, so the
+    /// max-call-depth RangeError fires identically on both paths.
+    fn run_fn_kernel(
+        &mut self,
+        bf: &BytecodeFunction,
+        args: &[Value],
+    ) -> Option<Result<Value, Value>> {
+        let k = bf.proto.fn_kernel.as_ref()?;
+        if self.op_budget.is_some() || self.trace_sink.is_some() {
+            return None;
+        }
+        let mut regs = std::mem::take(&mut self.kernel_regs);
+        regs.clear();
+        regs.resize(k.n_regs as usize, 0.0);
+        for (r, slot) in k.locals.iter().enumerate() {
+            match slot {
+                crate::bytecode::KSlot::Arg(a) => match args.get(*a as usize) {
+                    Some(Value::Number(n)) => regs[r] = *n,
+                    _ => {
+                        self.kernel_regs = regs;
+                        return None;
+                    }
+                },
+                // Internal locals are pure register scratch: translation
+                // proved a store dominates every read, so no frame slot is
+                // needed (and none exists).
+                crate::bytecode::KSlot::Local(_) => {}
+                crate::bytecode::KSlot::Upvalue(u) => match &*bf.upvalues[*u as usize].borrow() {
+                    Value::Number(n) => regs[r] = *n,
+                    _ => {
+                        self.kernel_regs = regs;
+                        return None;
+                    }
+                },
+            }
+        }
+        if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
+            self.kernel_regs = regs;
+            return None;
+        }
+        let interrupt = self.interrupt.clone();
+        let mut poll: u32 = 0;
+        let code = &k.code;
+        let mut pc = 0usize;
+        let ret = loop {
+            // Back-edges poll the cooperative interrupt flag, as in
+            // `run_kernel_op`; registers are pure scratch, nothing to write
+            // back on the unwind.
+            macro_rules! branch {
+                ($t:expr) => {{
+                    let t = $t as usize;
+                    if t <= pc {
+                        poll = poll.wrapping_add(1);
+                        if poll & 0xFF == 0 {
+                            if let Some(flag) = &interrupt {
+                                if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                    self.kernel_regs = regs;
+                                    self.op_budget = Some(0);
+                                    return Some(Err(self.throw_range("execution interrupted")));
+                                }
+                            }
+                        }
+                    }
+                    pc = t;
+                    continue;
+                }};
+            }
+            match code[pc] {
+                KOp::Mov { dst, src } => regs[dst as usize] = regs[src as usize],
+                KOp::Const { dst, k } => regs[dst as usize] = k,
+                KOp::Add { dst, a, b } => regs[dst as usize] = regs[a as usize] + regs[b as usize],
+                KOp::AddK { dst, a, k } => regs[dst as usize] = regs[a as usize] + k,
+                KOp::Arith { kind, dst, a, b } => {
+                    regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind)
+                }
+                KOp::ArithK { kind, dst, a, k } => {
+                    regs[dst as usize] = number_arith_raw(regs[a as usize], k, kind)
+                }
+                KOp::Neg { dst, src } => regs[dst as usize] = -regs[src as usize],
+                KOp::BitNot { dst, src } => {
+                    regs[dst as usize] = !crate::vm::to_int32(regs[src as usize]) as f64
+                }
+                KOp::Br { target } => branch!(target),
+                KOp::BrCmp {
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target,
+                } => {
+                    if knum_cmp(cmp, regs[a as usize], regs[b as usize]) == if_true {
+                        branch!(target)
+                    }
+                }
+                KOp::BrCmpK {
+                    cmp,
+                    a,
+                    k,
+                    if_true,
+                    target,
+                } => {
+                    if knum_cmp(cmp, regs[a as usize], k) == if_true {
+                        branch!(target)
+                    }
+                }
+                KOp::BrFalsy { src, target } => {
+                    if !knum_truthy(regs[src as usize]) {
+                        branch!(target)
+                    }
+                }
+                KOp::BrTruthy { src, target } => {
+                    if knum_truthy(regs[src as usize]) {
+                        branch!(target)
+                    }
+                }
+                KOp::CmpSet { cmp, dst, a, b } => {
+                    regs[dst as usize] = if knum_cmp(cmp, regs[a as usize], regs[b as usize]) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                }
+                KOp::BoolNot { dst, src } => {
+                    regs[dst as usize] = if knum_truthy(regs[src as usize]) {
+                        0.0
+                    } else {
+                        1.0
+                    }
+                }
+                KOp::Math1 { kind, dst, src } => {
+                    regs[dst as usize] = kmath1(kind, regs[src as usize])
+                }
+                KOp::Math2 { kind, dst, a, b } => {
+                    regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
+                }
+                KOp::Ret { src, boolean } => {
+                    break if boolean {
+                        Value::Bool(regs[src as usize] != 0.0)
+                    } else {
+                        Value::Number(regs[src as usize])
+                    }
+                }
+                // A frameless kernel has no bytecode frame to bail into;
+                // fn-mode translation rejects anything needing one.
+                KOp::LoadElem { .. }
+                | KOp::StoreElem { .. }
+                | KOp::LoadLen { .. }
+                | KOp::Exit { .. } => unreachable!("bail op in a function kernel"),
+            }
+            pc += 1;
+        };
+        self.kernel_regs = regs;
+        Some(Ok(ret))
     }
 
     fn describe(&self, v: &Value) -> String {
@@ -753,6 +943,12 @@ impl Vm {
         }
         if kind.is_generator() {
             return self.make_generator(func_obj, bf, this, args, new_target);
+        }
+        // Function kernel: frameless fast path (see `call_bytecode_vec`).
+        if bf.proto.fn_kernel.is_some() {
+            if let Some(r) = self.run_fn_kernel(&bf, args) {
+                return r;
+            }
         }
         let uses_arguments = bf.proto.uses_arguments;
         let mut frame = self.make_frame(bf, this, args, new_target);

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -8,6 +8,25 @@ use crate::bytecode::{CmpOp, Const, FuncKind, Op, UpvalueSource};
 use crate::value::*;
 use crate::vm::*;
 
+/// Peek a call op's callee: `Some(bf)` when it is a PLAIN bytecode function —
+/// synchronous, not a generator, not a class constructor — i.e. the class the
+/// interpreter can run via [`Vm::call_direct`] without any of the generic
+/// path's special-casing. Everything else (native, bound, proxy, async,
+/// generator, class ctor, non-callable) returns `None` and takes the generic
+/// path, which owns the error reporting for the non-callable case.
+#[inline]
+fn peek_plain_bytecode(v: &Value) -> Option<Rc<BytecodeFunction>> {
+    if let Value::Object(o) = v {
+        if let Internal::Function(FunctionInner::Bytecode(bf)) = &o.borrow().internal {
+            let k = bf.proto.kind;
+            if !bf.is_class_ctor && !k.is_generator() && !k.is_async() {
+                return Some(bf.clone());
+            }
+        }
+    }
+    None
+}
+
 /// Control-flow signal from a single opcode step.
 enum Ctl {
     Next,
@@ -54,26 +73,75 @@ impl Vm {
     /// path copies the arguments a second time in make_frame. Native/bound/
     /// proxy callees borrow the vec and recycle it; every early error simply
     /// drops it (a pool miss, never a leak).
+    ///
+    /// This is the interpreter's hottest call entry, so the callable check and
+    /// the dispatch extraction are ONE object borrow (the layered
+    /// `call_object_vec` path borrows once for `is_callable` and again for the
+    /// dispatch), and the depth guard is applied here directly.
     pub(crate) fn call_valuevec(
         &mut self,
         func: Value,
         this: Value,
         args: Vec<Value>,
     ) -> Result<Value, Value> {
+        enum Disp {
+            Native(NativeFn),
+            Bytecode(Rc<BytecodeFunction>),
+            Bound(JsObject, Value, Vec<Value>),
+            Proxy,
+            NotCallable,
+        }
         if let Value::Object(o) = &func {
-            let o = o.clone();
-            let (callable, is_proxy) = {
+            let disp = {
                 let b = o.borrow();
-                (b.is_callable(), matches!(b.internal, Internal::Proxy(_)))
+                match &b.internal {
+                    Internal::Function(FunctionInner::Native(nf)) => Disp::Native(nf.func.clone()),
+                    Internal::Function(FunctionInner::Bytecode(bf)) => Disp::Bytecode(bf.clone()),
+                    Internal::Function(FunctionInner::Bound(bound)) => Disp::Bound(
+                        bound.target.clone(),
+                        bound.bound_this.clone(),
+                        bound.bound_args.clone(),
+                    ),
+                    Internal::Proxy(p) if p.callable => Disp::Proxy,
+                    _ => Disp::NotCallable,
+                }
             };
-            if is_proxy {
-                if callable {
+            match disp {
+                Disp::NotCallable => {}
+                Disp::Proxy => {
+                    let o = o.clone();
                     let r = self.proxy_call(&o, this, &args);
                     self.recycle_value_vec(args);
                     return r;
                 }
-            } else if callable {
-                return self.call_object_vec(&o, this, args, Value::Undefined);
+                disp => {
+                    self.call_depth += 1;
+                    if self.call_depth > self.max_call_depth {
+                        self.call_depth -= 1;
+                        return Err(self.throw_range("Maximum call stack size exceeded"));
+                    }
+                    let r = match disp {
+                        Disp::Bytecode(bf) => {
+                            let o = o.clone();
+                            self.call_bytecode_vec(&o, bf, this, args, Value::Undefined)
+                        }
+                        Disp::Native(f) => {
+                            let r = f(self, this, &args);
+                            self.recycle_value_vec(args);
+                            r
+                        }
+                        Disp::Bound(target, bthis, bargs) => {
+                            let mut all = bargs;
+                            let mut args = args;
+                            all.append(&mut args);
+                            self.recycle_value_vec(args);
+                            self.call_object_vec(&target, bthis, all, Value::Undefined)
+                        }
+                        Disp::Proxy | Disp::NotCallable => unreachable!(),
+                    };
+                    self.call_depth -= 1;
+                    return r;
+                }
             }
         }
         let desc = self.describe(&func);
@@ -158,8 +226,14 @@ impl Vm {
             self.recycle_value_vec(args);
             return r;
         }
+        let uses_arguments = bf.proto.uses_arguments;
         let mut frame = self.make_frame_owned(bf, this, args, new_target);
-        frame.func_obj = Some(func_obj.clone());
+        // `func_obj` has exactly one consumer — the `arguments` object's
+        // `callee` — so the per-call `Rc` round-trip is skipped for the
+        // overwhelming majority of functions that never materialize it.
+        if uses_arguments {
+            frame.func_obj = Some(func_obj.clone());
+        }
         let token = self.trace_enter(&frame.func.proto);
         frame.trace_token = token;
         if kind.is_async() {
@@ -180,6 +254,58 @@ impl Vm {
                 }
             }
         }
+    }
+
+    /// The interpreter call ops' fast path (see `Op::Call`): the callee was
+    /// already peeked as a plain (non-generator, non-async, non-class-ctor)
+    /// bytecode function sitting on the caller's operand stack under `n`
+    /// arguments at `at..`. Moves the arguments straight off the caller stack
+    /// into the pooled callee frame — no intermediate pooled Vec round-trip —
+    /// and reuses the popped function VALUE as the callee's `func_obj` (no
+    /// refcount traffic). Behavior is identical to the generic
+    /// `call_valuevec` → `call_bytecode_vec` chain for this callee class.
+    fn call_direct(
+        &mut self,
+        caller: &mut Frame,
+        at: usize,
+        bf: Rc<BytecodeFunction>,
+        has_this: bool,
+    ) -> Result<Value, Value> {
+        self.call_depth += 1;
+        if self.call_depth > self.max_call_depth {
+            self.call_depth -= 1;
+            return Err(self.throw_range("Maximum call stack size exceeded"));
+        }
+        let mut callee = self.take_frame();
+        callee.args.extend(caller.stack.drain(at..));
+        let this = if has_this {
+            caller.stack.pop().unwrap_or(Value::Undefined)
+        } else {
+            Value::Undefined
+        };
+        let func_v = caller.stack.pop().unwrap_or(Value::Undefined);
+        let uses_arguments = bf.proto.uses_arguments;
+        self.init_frame(&mut callee, bf, this, Value::Undefined);
+        if uses_arguments {
+            if let Value::Object(o) = func_v {
+                callee.func_obj = Some(o);
+            }
+        }
+        let token = self.trace_enter(&callee.func.proto);
+        callee.trace_token = token;
+        let r = match self.run_frame(callee) {
+            Flow::Return(v) => {
+                self.trace_exit(token, false);
+                Ok(v)
+            }
+            Flow::Throw(e) => {
+                self.trace_exit(token, true);
+                Err(e)
+            }
+            Flow::Suspend(_) => Err(self.throw_type("internal: sync function suspended")),
+        };
+        self.call_depth -= 1;
+        r
     }
 
     fn describe(&self, v: &Value) -> String {
@@ -270,8 +396,12 @@ impl Vm {
         if kind.is_generator() {
             return self.make_generator(func_obj, bf, this, args, new_target);
         }
+        let uses_arguments = bf.proto.uses_arguments;
         let mut frame = self.make_frame(bf, this, args, new_target);
-        frame.func_obj = Some(func_obj.clone());
+        // See `call_bytecode_vec`: `func_obj` only feeds `arguments.callee`.
+        if uses_arguments {
+            frame.func_obj = Some(func_obj.clone());
+        }
         let token = self.trace_enter(&frame.func.proto);
         frame.trace_token = token;
         if kind.is_async() {
@@ -425,13 +555,15 @@ impl Vm {
     const VALUE_VEC_POOL_CAP: usize = 4096;
 
     /// Pull a cleared `Vec<Value>` from the pool, or allocate a fresh one.
-    fn take_value_vec(&mut self) -> Vec<Value> {
+    #[inline]
+    pub(crate) fn take_value_vec(&mut self) -> Vec<Value> {
         self.value_vec_pool.pop().unwrap_or_default()
     }
 
     /// Return a buffer to the pool for reuse (clearing it drops any residual
     /// values). A never-grown (capacity 0) buffer isn't worth pooling; the list
     /// is size-capped so it can't retain memory without bound.
+    #[inline]
     fn recycle_value_vec(&mut self, mut v: Vec<Value>) {
         if v.capacity() == 0 || self.value_vec_pool.len() >= Self::VALUE_VEC_POOL_CAP {
             return;
@@ -440,23 +572,50 @@ impl Vm {
         self.value_vec_pool.push(v);
     }
 
-    /// Reclaim a synchronously-finished frame's reusable buffers into the pool.
-    /// Only called on `Return`/`Throw` exits — a suspended frame keeps its
-    /// buffers (they ride inside the `Suspension`/generator state).
-    fn recycle_frame(&mut self, frame: &mut Frame) {
-        let stack = std::mem::take(&mut frame.stack);
-        let locals = std::mem::take(&mut frame.locals);
-        let args = std::mem::take(&mut frame.args);
-        self.recycle_value_vec(stack);
-        self.recycle_value_vec(locals);
-        self.recycle_value_vec(args);
-        let mut cells = std::mem::take(&mut frame.cells);
-        for cell in cells.drain(..) {
+    /// Reclaim a synchronously-finished frame WHOLE into the frame pool: every
+    /// value-bearing field is cleared (the pool must never extend a value's
+    /// lifetime — same discipline as the cell pool), while the stack / locals /
+    /// cells / args buffers keep their capacity for the next call. Only called
+    /// on `Return`/`Throw` exits — a suspended frame keeps its box (it rides
+    /// inside the `Suspension`/generator state).
+    #[inline]
+    fn recycle_frame(&mut self, mut frame: Box<Frame>) {
+        if self.frame_pool.len() >= Self::VALUE_VEC_POOL_CAP {
+            // Over cap: fall back to recycling the inner buffers individually.
+            let stack = std::mem::take(&mut frame.stack);
+            let locals = std::mem::take(&mut frame.locals);
+            let args = std::mem::take(&mut frame.args);
+            self.recycle_value_vec(stack);
+            self.recycle_value_vec(locals);
+            self.recycle_value_vec(args);
+            for cell in frame.cells.drain(..) {
+                self.recycle_cell(cell);
+            }
+            return;
+        }
+        frame.func = self.dummy_bf.clone();
+        frame.stack.clear();
+        frame.locals.clear();
+        for cell in frame.cells.drain(..) {
             self.recycle_cell(cell);
         }
-        if cells.capacity() > 0 && self.cells_vec_pool.len() < Self::VALUE_VEC_POOL_CAP {
-            self.cells_vec_pool.push(cells);
-        }
+        frame.this = Value::Undefined;
+        frame.new_target = Value::Undefined;
+        frame.handlers.clear();
+        frame.pending_completion = None;
+        frame.pending_throw = None;
+        frame.pending_return = None;
+        frame.args.clear();
+        frame.func_obj = None;
+        frame.dispose_scopes.clear();
+        frame.completion = Value::Undefined;
+        frame.enumerators.clear();
+        frame.with_scope.clear();
+        frame.trace_token = None;
+        frame.skip_delegation_throw = false;
+        frame.eval_vars = None;
+        frame.priv_env = None;
+        self.frame_pool.push(frame);
     }
 
     /// Pull a binding cell holding `v` from the pool, or allocate a fresh one.
@@ -487,7 +646,7 @@ impl Vm {
         this: Value,
         args: &[Value],
         new_target: Value,
-    ) -> Frame {
+    ) -> Box<Frame> {
         let mut args_buf = self.take_value_vec();
         args_buf.extend_from_slice(args);
         self.make_frame_owned(bf, this, args_buf, new_target)
@@ -495,16 +654,71 @@ impl Vm {
 
     /// As [`Vm::make_frame`], but adopts an already-owned argument buffer
     /// (the interpreter's pooled call-op buffer) as `frame.args` directly,
-    /// skipping the copy. `recycle_frame` returns it to the pool at exit.
+    /// skipping the copy.
+    ///
+    /// The frame itself comes from the frame pool when one is available: a
+    /// recycled frame arrives scrubbed (see [`Vm::recycle_frame`]) with its
+    /// four buffers' capacities intact, so this only re-initializes fields in
+    /// place — no buffer pool round-trips, no ~400-byte struct move.
     pub fn make_frame_owned(
         &mut self,
         bf: Rc<BytecodeFunction>,
         this: Value,
         args: Vec<Value>,
         new_target: Value,
-    ) -> Frame {
-        let proto = bf.proto.clone();
-        let mut cells = self.cells_vec_pool.pop().unwrap_or_default();
+    ) -> Box<Frame> {
+        let mut f = self.take_frame();
+        self.init_frame(&mut f, bf, this, new_target);
+        let old_args = std::mem::replace(&mut f.args, args);
+        self.recycle_value_vec(old_args);
+        f
+    }
+
+    /// Pop a scrubbed frame from the pool, or allocate a fresh (equally blank)
+    /// one. Every field of a pooled frame was reset by [`Vm::recycle_frame`].
+    #[inline]
+    fn take_frame(&mut self) -> Box<Frame> {
+        match self.frame_pool.pop() {
+            Some(f) => f,
+            None => Box::new(Frame {
+                func: self.dummy_bf.clone(),
+                ip: 0,
+                stack: Vec::with_capacity(8),
+                locals: Vec::new(),
+                cells: Vec::new(),
+                this: Value::Undefined,
+                new_target: Value::Undefined,
+                handlers: Vec::new(),
+                pending_completion: None,
+                pending_throw: None,
+                pending_return: None,
+                args: Vec::new(),
+                func_obj: None,
+                dispose_scopes: Vec::new(),
+                completion: Value::Undefined,
+                enumerators: Vec::new(),
+                with_scope: Vec::new(),
+                trace_token: None,
+                skip_delegation_throw: false,
+                eval_vars: None,
+                priv_env: None,
+            }),
+        }
+    }
+
+    /// Initialize a blank (fresh or pool-scrubbed) frame's per-call fields in
+    /// place. The caller provides `args` separately (either an owned buffer
+    /// swapped in, or values moved straight off its operand stack).
+    #[inline]
+    fn init_frame(
+        &mut self,
+        f: &mut Frame,
+        bf: Rc<BytecodeFunction>,
+        this: Value,
+        new_target: Value,
+    ) {
+        f.ip = 0;
+        let proto = &bf.proto;
         for i in 0..proto.num_cells as usize {
             // A localized index lives in `frame.locals`; its cell slot is a
             // shared never-read placeholder (`Rc` bump, no pool round-trip).
@@ -513,43 +727,17 @@ impl Vm {
             } else {
                 self.take_cell(Value::Undefined)
             };
-            cells.push(c);
+            f.cells.push(c);
         }
+        f.locals.resize(proto.num_locals as usize, Value::Undefined);
         // A closure created inside `with (o) { … }` carries the with-object
         // chain; seed the frame's with-scope stack with it so the body's
         // dynamic name ops resolve against it (under any with the body enters).
-        let with_scope = bf.captured_with.clone();
-        let priv_env = bf.captured_priv_env.clone();
-        // Reuse pooled buffers for the three per-call vectors (operand stack,
-        // locals, args) instead of allocating each one fresh.
-        let mut stack = self.take_value_vec();
-        stack.reserve(8);
-        let mut locals = self.take_value_vec();
-        locals.resize(proto.num_locals as usize, Value::Undefined);
-        let args_buf = args;
-        Frame {
-            func: bf,
-            ip: 0,
-            stack,
-            locals,
-            cells,
-            this,
-            new_target,
-            handlers: Vec::new(),
-            pending_completion: None,
-            pending_throw: None,
-            pending_return: None,
-            args: args_buf,
-            func_obj: None,
-            dispose_scopes: Vec::new(),
-            completion: Value::Undefined,
-            enumerators: Vec::new(),
-            with_scope,
-            trace_token: None,
-            skip_delegation_throw: false,
-            eval_vars: None,
-            priv_env,
-        }
+        f.with_scope.extend_from_slice(&bf.captured_with);
+        f.priv_env = bf.captured_priv_env.clone();
+        f.func = bf;
+        f.this = this;
+        f.new_target = new_target;
     }
 
     // =====================================================================
@@ -735,15 +923,15 @@ impl Vm {
     // The interpreter loop
     // =====================================================================
 
-    pub fn run_frame(&mut self, mut frame: Frame) -> Flow {
-        // Recycle this frame's pooled buffers into the free-list, then return the
+    pub fn run_frame(&mut self, mut frame: Box<Frame>) -> Flow {
+        // Recycle this frame whole into the frame pool, then return the
         // (already-owned) outcome. Used only on synchronous Return/Throw exits;
         // the Suspend paths move the whole frame (buffers included) into the
         // Suspension/generator state, so they must NOT recycle here.
         macro_rules! done {
             ($flow:expr) => {{
                 let outcome = $flow;
-                self.recycle_frame(&mut frame);
+                self.recycle_frame(frame);
                 return outcome;
             }};
         }
@@ -784,27 +972,40 @@ impl Vm {
                 },
             }
         }
+        // Budget/interrupt accounting hoisted to ONE register-friendly bool: in
+        // the common case (no op budget, no interrupt flag — every production
+        // run) the per-op cost is a single predicted-not-taken branch instead
+        // of two `Option` loads through `self`. Sampled once per frame entry;
+        // both are only ever installed BEFORE execution starts (the conformance
+        // runner, untrusted eval), never from inside a running frame, so no
+        // frame can miss a budget that applies to it. The interrupt latch below
+        // zeroes the budget of an already-`counting` frame, and every frame
+        // entered afterwards re-samples.
+        let counting = self.op_budget.is_some() || self.interrupt.is_some();
         loop {
-            if let Some(budget) = self.op_budget.as_mut() {
-                if *budget == 0 {
-                    // Uncatchable so execution is guaranteed to terminate.
-                    done!(Flow::Throw(self.throw_range("execution budget exceeded")));
+            if counting {
+                if let Some(budget) = self.op_budget.as_mut() {
+                    if *budget == 0 {
+                        // Uncatchable so execution is guaranteed to terminate.
+                        done!(Flow::Throw(self.throw_range("execution budget exceeded")));
+                    }
+                    *budget -= 1;
                 }
-                *budget -= 1;
-            }
-            // Cooperative cancellation: poll the interrupt flag every 256 ops to
-            // keep the atomic load off the hot per-op path while still reacting
-            // promptly even when individual ops are expensive (e.g. O(n) string
-            // concatenation in a loop). Once observed, latch it by zeroing the op
-            // budget so a JS `try/catch` around the slow loop can't resume
-            // execution — guaranteeing a prompt, terminating unwind.
-            if self.interrupt.is_some() {
-                interrupt_poll = interrupt_poll.wrapping_add(1);
-                if interrupt_poll & 0xFF == 0 {
-                    if let Some(flag) = &self.interrupt {
-                        if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                            self.op_budget = Some(0);
-                            done!(Flow::Throw(self.throw_range("execution interrupted")));
+                // Cooperative cancellation: poll the interrupt flag every 256
+                // ops to keep the atomic load off the hot per-op path while
+                // still reacting promptly even when individual ops are expensive
+                // (e.g. O(n) string concatenation in a loop). Once observed,
+                // latch it by zeroing the op budget so a JS `try/catch` around
+                // the slow loop can't resume execution — guaranteeing a prompt,
+                // terminating unwind.
+                if self.interrupt.is_some() {
+                    interrupt_poll = interrupt_poll.wrapping_add(1);
+                    if interrupt_poll & 0xFF == 0 {
+                        if let Some(flag) = &self.interrupt {
+                            if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                self.op_budget = Some(0);
+                                done!(Flow::Throw(self.throw_range("execution interrupted")));
+                            }
                         }
                     }
                 }
@@ -842,25 +1043,25 @@ impl Vm {
                 }
                 Ok(Ctl::Await(v)) => {
                     return Flow::Suspend(Suspension {
-                        frame: Box::new(frame),
+                        frame,
                         kind: SuspendKind::Await(v),
                     })
                 }
                 Ok(Ctl::Yield(v)) => {
                     return Flow::Suspend(Suspension {
-                        frame: Box::new(frame),
+                        frame,
                         kind: SuspendKind::Yield(v),
                     })
                 }
                 Ok(Ctl::YieldStar(v)) => {
                     return Flow::Suspend(Suspension {
-                        frame: Box::new(frame),
+                        frame,
                         kind: SuspendKind::YieldStar(v),
                     })
                 }
                 Ok(Ctl::GeneratorStart) => {
                     return Flow::Suspend(Suspension {
-                        frame: Box::new(frame),
+                        frame,
                         kind: SuspendKind::GeneratorStart,
                     })
                 }
@@ -2636,26 +2837,40 @@ impl Vm {
             Op::Call(argc) => {
                 let n = *argc as usize;
                 let at = frame.stack.len() - n;
-                // Move the argument values into a pooled buffer rather than
-                // `split_off` (which allocates a fresh Vec on every call).
-                let mut args = self.take_value_vec();
-                args.extend(frame.stack.drain(at..));
-                let this = pop!();
-                let func = pop!();
-                // Owned-args path: the pooled buffer moves into the callee
-                // frame (recycled by its recycle_frame), skipping the second
-                // copy make_frame's slice path would do.
-                let r = self.call_valuevec(func, this, args);
-                push!(r?);
+                // Stack layout: [func, this, a0..]. A plain sync bytecode
+                // callee takes the direct path: its args MOVE straight from
+                // this operand stack into the pooled callee frame.
+                if let Some(bf) = peek_plain_bytecode(&frame.stack[at - 2]) {
+                    let r = self.call_direct(frame, at, bf, true)?;
+                    push!(r);
+                } else {
+                    // Move the argument values into a pooled buffer rather than
+                    // `split_off` (which allocates a fresh Vec on every call).
+                    let mut args = self.take_value_vec();
+                    args.extend(frame.stack.drain(at..));
+                    let this = pop!();
+                    let func = pop!();
+                    // Owned-args path: the pooled buffer moves into the callee
+                    // frame (recycled by its recycle_frame), skipping the second
+                    // copy make_frame's slice path would do.
+                    let r = self.call_valuevec(func, this, args);
+                    push!(r?);
+                }
             }
             Op::CallMethodless(argc) => {
                 let n = *argc as usize;
                 let at = frame.stack.len() - n;
-                let mut args = self.take_value_vec();
-                args.extend(frame.stack.drain(at..));
-                let func = pop!();
-                let r = self.call_valuevec(func, Value::Undefined, args);
-                push!(r?);
+                // Stack layout: [func, a0..] — no explicit `this`.
+                if let Some(bf) = peek_plain_bytecode(&frame.stack[at - 1]) {
+                    let r = self.call_direct(frame, at, bf, false)?;
+                    push!(r);
+                } else {
+                    let mut args = self.take_value_vec();
+                    args.extend(frame.stack.drain(at..));
+                    let func = pop!();
+                    let r = self.call_valuevec(func, Value::Undefined, args);
+                    push!(r?);
+                }
             }
             Op::CallSpread => {
                 let args_arr = pop!();

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -1316,6 +1316,15 @@ impl Vm {
         }
     }
 
+    /// One opcode. Split in two for the sake of the NATIVE stack: the hot
+    /// ops (loads/stores, arithmetic, comparisons, branches, calls, property
+    /// access, the fused superinstructions) are handled inline here, and every
+    /// other op delegates to the `#[inline(never)]` [`Vm::step_cold`]. With
+    /// one giant match, LLVM's imperfect stack coloring gave `step` a ~4 KB
+    /// stack frame -- the UNION of ~190 arms' locals -- which is what a JS
+    /// call's native-stack footprint is mostly made of (deep JS recursion
+    /// must exhaust `max_call_depth` before the native stack). Each op has
+    /// exactly ONE implementation: here, or in `step_cold`, never both.
     fn step(&mut self, frame: &mut Frame, op: &Op) -> Result<Ctl, Value> {
         macro_rules! pop {
             () => {
@@ -1336,40 +1345,12 @@ impl Vm {
             Op::LoadTrue => push!(Value::Bool(true)),
             Op::LoadFalse => push!(Value::Bool(false)),
             Op::LoadThis => push!(frame.this.clone()),
-            Op::RequireObjectCoercible => {
-                if frame.stack.last().map(|v| v.is_nullish()).unwrap_or(true) {
-                    return Err(self.throw_type("Cannot destructure a null or undefined value"));
-                }
-            }
-            Op::BindThisSloppy => {
-                let t = pop!();
-                let bound = match t {
-                    Value::Undefined | Value::Null => Value::Object(self.realm.global.clone()),
-                    Value::Object(_) => t,
-                    // A primitive `this` is boxed (ToObject) in sloppy mode.
-                    other => Value::Object(self.to_object(&other)?),
-                };
-                push!(bound);
-            }
             Op::LoadNewTarget => push!(frame.new_target.clone()),
             Op::LoadArg(i) => push!(frame
                 .args
                 .get(*i as usize)
                 .cloned()
                 .unwrap_or(Value::Undefined)),
-            Op::LoadRestArgs(n) => {
-                let rest: Vec<Value> = if (*n as usize) < frame.args.len() {
-                    frame.args[*n as usize..].to_vec()
-                } else {
-                    Vec::new()
-                };
-                push!(Value::Object(self.new_array(rest)));
-            }
-            Op::LoadArguments => {
-                let o = self.make_arguments_object(frame);
-                push!(o);
-            }
-
             Op::LoadLocal(i) => {
                 let v = frame.locals[*i as usize].clone();
                 if matches!(v, Value::Uninitialized) {
@@ -1607,13 +1588,6 @@ impl Vm {
                 };
                 push!(v);
             }
-            Op::LoadGlobalTypeof(i) => {
-                let name = self.const_name(frame, *i);
-                let key = PropertyKey::Str(name);
-                let g = self.realm.global.clone();
-                let v = self.get_prop(&Value::Object(g), &key)?;
-                push!(v);
-            }
             Op::StoreGlobal(i) => {
                 let name = self.const_name(frame, *i);
                 let v = pop!();
@@ -1628,6 +1602,822 @@ impl Vm {
                     return Err(self.throw_reference(&format!("{} is not defined", name.as_str())));
                 }
                 self.put_value(&Value::Object(g), &key, v, strict)?;
+            }
+            Op::Pop => {
+                frame.stack.pop();
+            }
+            Op::Dup => {
+                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
+                push!(v);
+            }
+            Op::Swap => {
+                let n = frame.stack.len();
+                if n >= 2 {
+                    frame.stack.swap(n - 1, n - 2);
+                }
+            }
+            Op::Rot3 => {
+                let n = frame.stack.len();
+                if n >= 3 {
+                    // a b c -> b c a
+                    frame.stack[n - 3..].rotate_left(1);
+                }
+            }
+
+            Op::NewObject => push!(Value::Object(self.new_object())),
+            Op::NewArray(n) => {
+                let n = *n as usize;
+                let at = frame.stack.len() - n;
+                let elems = frame.stack.split_off(at);
+                push!(Value::Object(self.new_array(elems)));
+            }
+            Op::GetProp(i) => {
+                let name = self.const_name(frame, *i);
+                let obj = pop!();
+                // Inline cache (key-verified hints; see `FuncProto::ic`).
+                // Two levels:
+                //  - `holder == None`: the receiver's OWN data property at
+                //    `slot` (ordinary objects).
+                //  - `holder == Some(p)`: a data property at `slot` on `p`,
+                //    verified to still be the receiver's DIRECT prototype and
+                //    not shadowed by an own property — the method-lookup
+                //    pattern (`arr.push`, class instances calling prototype
+                //    methods). Array receivers exclude keys with exotic own
+                //    behavior (`length`, indices). Deeper chains, accessors,
+                //    proxies, and every other exotic fall to the unchanged
+                //    slow path.
+                if let Value::Object(o) = &obj {
+                    if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
+                        let b = o.borrow();
+                        let (is_ord, is_arr) = (
+                            matches!(b.internal, Internal::Ordinary),
+                            matches!(b.internal, Internal::Array(_)),
+                        );
+                        // Array exotics: `length` and index keys never take
+                        // the IC (they don't live in the props map).
+                        let plain_key = !is_arr
+                            || (name.as_str() != "length"
+                                && crate::value::canonical_index(name.as_str()).is_none());
+                        if (is_ord || is_arr) && plain_key {
+                            // Own-property hit: never touches the holder cell.
+                            if is_ord {
+                                if let Some((PropertyKey::Str(k), prop)) =
+                                    b.props.get_index(ic.own_slot.get() as usize)
+                                {
+                                    if let PropertyKind::Data { value, .. } = &prop.kind {
+                                        if k == &name {
+                                            let v = value.clone();
+                                            drop(b);
+                                            push!(v);
+                                            return Ok(Ctl::Next);
+                                        }
+                                    }
+                                }
+                            }
+                            // Proto hit: valid only when the receiver has no
+                            // own props (nothing can shadow) and its CURRENT
+                            // direct proto is the cached holder.
+                            if b.props.is_empty() {
+                                let holder = ic.holder.borrow();
+                                if let Some(h) = &*holder {
+                                    if b.proto.as_ref().is_some_and(|p| p.ptr_eq(h)) {
+                                        let hb = h.borrow();
+                                        if let Some((PropertyKey::Str(k), prop)) =
+                                            hb.props.get_index(ic.proto_slot.get() as usize)
+                                        {
+                                            if let PropertyKind::Data { value, .. } = &prop.kind {
+                                                if k == &name {
+                                                    let v = value.clone();
+                                                    drop(hb);
+                                                    drop(holder);
+                                                    drop(b);
+                                                    push!(v);
+                                                    return Ok(Ctl::Next);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            // Refill: own data property first (ordinary only),
+                            // then a one-level proto data property when no own
+                            // props can shadow.
+                            let key = PropertyKey::Str(name.clone());
+                            if is_ord {
+                                if let Some((idx, _, prop)) = b.props.get_full(&key) {
+                                    if let PropertyKind::Data { value, .. } = &prop.kind {
+                                        ic.own_slot.set(idx as u32);
+                                        let v = value.clone();
+                                        drop(b);
+                                        push!(v);
+                                        return Ok(Ctl::Next);
+                                    }
+                                }
+                            }
+                            if b.props.is_empty() {
+                                if let Some(p) = &b.proto {
+                                    let pb = p.borrow();
+                                    if matches!(pb.internal, Internal::Ordinary)
+                                        || matches!(pb.internal, Internal::Array(_))
+                                    {
+                                        if let Some((idx, _, prop)) = pb.props.get_full(&key) {
+                                            if let PropertyKind::Data { value, .. } = &prop.kind {
+                                                ic.proto_slot.set(idx as u32);
+                                                let v = value.clone();
+                                                let holder_obj = p.clone();
+                                                drop(pb);
+                                                *ic.holder.borrow_mut() = Some(holder_obj);
+                                                drop(b);
+                                                push!(v);
+                                                return Ok(Ctl::Next);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                let v = self.get_prop(&obj, &PropertyKey::Str(name))?;
+                push!(v);
+            }
+            Op::SetProp(i) => {
+                let name = self.const_name(frame, *i);
+                let value = pop!();
+                let obj = pop!();
+                // Inline cache (key-verified slot hint; see `FuncProto::ic`).
+                // Fast path only when the receiver is an ordinary object whose
+                // OWN property at the hinted slot is a WRITABLE data property —
+                // per OrdinarySetWithOwnDescriptor that assignment updates the
+                // value in place (attributes and slot order preserved, no
+                // prototype setter can intervene). Everything else (missing own
+                // key → proto-chain setters/read-only checks, accessors,
+                // non-writable → strict TypeError, exotics) takes the
+                // unchanged put_value path, which also refills the hint.
+                if let Value::Object(o) = &obj {
+                    if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
+                        let mut b = o.borrow_mut();
+                        if matches!(b.internal, Internal::Ordinary) {
+                            if let Some((PropertyKey::Str(k), prop)) =
+                                b.props.get_index_mut(ic.own_slot.get() as usize)
+                            {
+                                if k == &name {
+                                    if let PropertyKind::Data {
+                                        value: slot,
+                                        writable: true,
+                                    } = &mut prop.kind
+                                    {
+                                        *slot = value.clone();
+                                        drop(b);
+                                        push!(value);
+                                        return Ok(Ctl::Next);
+                                    }
+                                }
+                            }
+                            let key = PropertyKey::Str(name.clone());
+                            if let Some((idx, _, prop)) = b.props.get_full_mut(&key) {
+                                if let PropertyKind::Data {
+                                    value: slot,
+                                    writable: true,
+                                } = &mut prop.kind
+                                {
+                                    ic.own_slot.set(idx as u32);
+                                    *slot = value.clone();
+                                    drop(b);
+                                    push!(value);
+                                    return Ok(Ctl::Next);
+                                }
+                            }
+                        }
+                    }
+                }
+                let strict = frame.func.proto.is_strict;
+                self.put_value(&obj, &PropertyKey::Str(name), value.clone(), strict)?;
+                push!(value);
+            }
+            Op::GetPropDynamic => {
+                let key_v = pop!();
+                let obj = pop!();
+                // Integer fast path: `a[i]` on a dense array with an integral
+                // Number key reads the element directly — skipping
+                // ToPropertyKey's Number→String conversion (a float-format +
+                // heap allocation per access!), the reparse back to an index,
+                // and the property-map machinery. Only when no reified props
+                // entry can shadow the dense element (`props.is_empty()`) and
+                // the slot is a real element (in bounds, not a hole);
+                // everything else takes the unchanged spec path.
+                if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
+                    if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
+                        let b = o.borrow();
+                        if let Internal::Array(arr) = &b.internal {
+                            if b.props.is_empty() {
+                                if let Some(v) = arr.get(*n as usize) {
+                                    if !matches!(v, Value::Hole) {
+                                        let v = v.clone();
+                                        drop(b);
+                                        push!(v);
+                                        return Ok(Ctl::Next);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                // GetValue: RequireObjectCoercible(base) (via ToObject) throws
+                // BEFORE ToPropertyKey coerces the key expression's value.
+                self.require_object_coercible(&obj, "read properties of")?;
+                let key = self.to_property_key(&key_v)?;
+                let v = self.get_prop(&obj, &key)?;
+                push!(v);
+            }
+            Op::SetPropDynamic => {
+                let value = pop!();
+                let key_v = pop!();
+                let obj = pop!();
+                // Integer fast path mirroring `GetPropDynamic`: overwrite an
+                // EXISTING dense element in place. An in-bounds non-hole dense
+                // slot is a plain writable data property (per the array exotic
+                // [[Set]]), so no setter, no length change, and no
+                // extensibility interaction is observable. Appends, holes,
+                // out-of-bounds, and shadowed elements take the spec path.
+                if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
+                    if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
+                        let mut b = o.borrow_mut();
+                        if b.props.is_empty() {
+                            if let Internal::Array(arr) = &mut b.internal {
+                                let i = *n as usize;
+                                if let Some(slot) = arr.get_mut(i) {
+                                    if !matches!(slot, Value::Hole) {
+                                        *slot = value.clone();
+                                        drop(b);
+                                        push!(value);
+                                        return Ok(Ctl::Next);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                self.require_object_coercible(&obj, "set properties of")?;
+                let key = self.to_property_key(&key_v)?;
+                let strict = frame.func.proto.is_strict;
+                self.put_value(&obj, &key, value.clone(), strict)?;
+                push!(value);
+            }
+            Op::HasProp => {
+                let obj = pop!();
+                let key_v = pop!();
+                let key = self.to_property_key(&key_v)?;
+                let r = self.has_prop(&obj, &key)?;
+                push!(Value::Bool(r));
+            }
+            Op::JumpIfNullish(t) => {
+                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
+                if v.is_nullish() {
+                    // An optional chain short-circuits to `undefined` even when
+                    // the base was `null` (the other emit sites pop the value).
+                    if let Some(top) = frame.stack.last_mut() {
+                        *top = Value::Undefined;
+                    }
+                    return Ok(Ctl::Jump(*t as usize));
+                }
+            }
+
+            Op::Call(argc) => {
+                let n = *argc as usize;
+                let at = frame.stack.len() - n;
+                // Stack layout: [func, this, a0..]. A plain sync bytecode
+                // callee takes the direct path: its args MOVE straight from
+                // this operand stack into the pooled callee frame.
+                if let Some(bf) = peek_plain_bytecode(&frame.stack[at - 2]) {
+                    let r = self.call_direct(frame, at, bf, true)?;
+                    push!(r);
+                } else {
+                    // Move the argument values into a pooled buffer rather than
+                    // `split_off` (which allocates a fresh Vec on every call).
+                    let mut args = self.take_value_vec();
+                    args.extend(frame.stack.drain(at..));
+                    let this = pop!();
+                    let func = pop!();
+                    // Owned-args path: the pooled buffer moves into the callee
+                    // frame (recycled by its recycle_frame), skipping the second
+                    // copy make_frame's slice path would do.
+                    let r = self.call_valuevec(func, this, args);
+                    push!(r?);
+                }
+            }
+            Op::CallMethodless(argc) => {
+                let n = *argc as usize;
+                let at = frame.stack.len() - n;
+                // Stack layout: [func, a0..] — no explicit `this`.
+                if let Some(bf) = peek_plain_bytecode(&frame.stack[at - 1]) {
+                    let r = self.call_direct(frame, at, bf, false)?;
+                    push!(r);
+                } else {
+                    let mut args = self.take_value_vec();
+                    args.extend(frame.stack.drain(at..));
+                    let func = pop!();
+                    let r = self.call_valuevec(func, Value::Undefined, args);
+                    push!(r?);
+                }
+            }
+            Op::CallSpread => {
+                let args_arr = pop!();
+                let this = pop!();
+                let func = pop!();
+                let args = self.iterate_to_vec(&args_arr)?;
+                let r = self.call(func, this, &args)?;
+                push!(r);
+            }
+            Op::New(argc) => {
+                let n = *argc as usize;
+                let at = frame.stack.len() - n;
+                let args = frame.stack.split_off(at);
+                let ctor = pop!();
+                let r = self.construct(&ctor, &args, &ctor)?;
+                push!(r);
+            }
+            Op::NewSpread => {
+                let args_arr = pop!();
+                let ctor = pop!();
+                let args = self.iterate_to_vec(&args_arr)?;
+                let r = self.construct(&ctor, &args, &ctor)?;
+                push!(r);
+            }
+            Op::Return => {
+                let v = pop!();
+                // Route through any enclosing `finally` blocks before returning.
+                return self.do_completion(frame, Completion::Return(v));
+            }
+            Op::ReturnUndefined => {
+                let v = frame.completion.clone();
+                return self.do_completion(frame, Completion::Return(v));
+            }
+
+            Op::Closure(i) => {
+                let proto = match &frame.func.proto.consts[*i as usize] {
+                    Const::Func(p) => p.clone(),
+                    _ => return Err(self.throw_type("internal: bad closure const")),
+                };
+                let upvalues = proto
+                    .upvalues
+                    .iter()
+                    .map(|src| match src {
+                        UpvalueSource::ParentCell(idx) => frame.cells[*idx as usize].clone(),
+                        UpvalueSource::ParentUpvalue(idx) => {
+                            frame.func.upvalues[*idx as usize].clone()
+                        }
+                    })
+                    .collect();
+                let inherit_home = proto.kind.is_arrow() || proto.inherit_home;
+                let f = self.make_closure(proto, upvalues);
+                // Capture the active with-scope chain (closures defined inside
+                // `with` resolve free identifiers against it after the block)
+                // and the active private-environment chain (methods and
+                // initializers defined inside class bodies resolve `#x`
+                // against it). Arrows (and synthetic in-class closures) also
+                // inherit the creating frame's [[HomeObject]], so `super.x`
+                // inside them resolves like the enclosing method.
+                if !frame.with_scope.is_empty()
+                    || frame.priv_env.is_some()
+                    || (inherit_home && frame.func.home_object.is_some())
+                {
+                    if let Internal::Function(FunctionInner::Bytecode(bf)) =
+                        &mut f.borrow_mut().internal
+                    {
+                        let bf = Rc::make_mut(bf);
+                        bf.captured_with = frame.with_scope.clone();
+                        bf.captured_priv_env = frame.priv_env.clone();
+                        if inherit_home {
+                            bf.home_object = frame.func.home_object.clone();
+                        }
+                    }
+                }
+                push!(Value::Object(f));
+            }
+
+            // ---- arithmetic ----
+            Op::Add => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.op_add(a, b)?;
+                push!(r);
+            }
+            Op::Sub => bin_arith(self, frame, ArithKind::Sub)?,
+            Op::Mul => bin_arith(self, frame, ArithKind::Mul)?,
+            Op::Div => bin_arith(self, frame, ArithKind::Div)?,
+            Op::Mod => bin_arith(self, frame, ArithKind::Mod)?,
+            Op::Pow => bin_arith(self, frame, ArithKind::Pow)?,
+            Op::Neg => {
+                let a = pop!();
+                push!(self.unary_arith(a, UnaryKind::Neg)?);
+            }
+            Op::Pos => {
+                // ToNumber throws TypeError for BigInt (unary + is invalid on it).
+                let a = pop!();
+                let n = self.to_number(&a)?;
+                push!(Value::Number(n));
+            }
+            Op::ToNumeric => {
+                // ToNumeric: like ToNumber but keeps BigInt (used by ++/-- to
+                // produce the coerced old value).
+                let a = pop!();
+                push!(self.to_numeric(&a)?);
+            }
+            Op::Inc => {
+                let a = pop!();
+                push!(self.unary_arith(a, UnaryKind::Inc)?);
+            }
+            Op::Dec => {
+                let a = pop!();
+                push!(self.unary_arith(a, UnaryKind::Dec)?);
+            }
+            Op::BitNot => {
+                let a = pop!();
+                push!(self.unary_arith(a, UnaryKind::BitNot)?);
+            }
+            Op::Not => {
+                let a = pop!();
+                push!(Value::Bool(!self.to_boolean(&a)));
+            }
+            Op::BitAnd => bin_arith(self, frame, ArithKind::BitAnd)?,
+            Op::BitOr => bin_arith(self, frame, ArithKind::BitOr)?,
+            Op::BitXor => bin_arith(self, frame, ArithKind::BitXor)?,
+            Op::Shl => bin_arith(self, frame, ArithKind::Shl)?,
+            Op::Shr => bin_arith(self, frame, ArithKind::Shr)?,
+            Op::UShr => bin_arith(self, frame, ArithKind::UShr)?,
+            Op::TypeofExpr => {
+                let a = pop!();
+                push!(Value::str(a.type_of()));
+            }
+
+            // ---- comparison ----
+            Op::Eq => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.loose_equals(&a, &b)?;
+                push!(Value::Bool(r));
+            }
+            Op::Ne => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.loose_equals(&a, &b)?;
+                push!(Value::Bool(!r));
+            }
+            Op::StrictEq => {
+                let b = pop!();
+                let a = pop!();
+                push!(Value::Bool(self.strict_equals(&a, &b)));
+            }
+            Op::StrictNe => {
+                let b = pop!();
+                let a = pop!();
+                push!(Value::Bool(!self.strict_equals(&a, &b)));
+            }
+            Op::Lt => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.less_than(&a, &b)?;
+                push!(Value::Bool(r == Some(true)));
+            }
+            Op::Gt => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.less_than(&b, &a)?;
+                push!(Value::Bool(r == Some(true)));
+            }
+            Op::Le => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.less_than(&b, &a)?;
+                push!(Value::Bool(r == Some(false)));
+            }
+            Op::Ge => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.less_than(&a, &b)?;
+                push!(Value::Bool(r == Some(false)));
+            }
+            Op::InstanceOf => {
+                let ctor = pop!();
+                let obj = pop!();
+                let r = self.instance_of(&obj, &ctor)?;
+                push!(Value::Bool(r));
+            }
+
+            // ---- control flow ----
+            Op::Jump(t) => return Ok(Ctl::Jump(*t as usize)),
+            Op::JumpIfTrue(t) => {
+                let v = pop!();
+                if self.to_boolean(&v) {
+                    return Ok(Ctl::Jump(*t as usize));
+                }
+            }
+            Op::JumpIfFalse(t) => {
+                let v = pop!();
+                if !self.to_boolean(&v) {
+                    return Ok(Ctl::Jump(*t as usize));
+                }
+            }
+            // Fused `cmp ; JumpIfFalse` (see `fuse.rs`). Each arm reuses the
+            // SAME helper as the standalone comparison op, so coercion and any
+            // thrown error are identical; the boolean the pair would materialize
+            // is consumed directly by the branch instead of round-tripping the
+            // operand stack. `to_boolean(Bool(r)) == r`, so the branch condition
+            // matches `JumpIfFalse` exactly.
+            Op::CmpBranchFalse { cmp, target } => {
+                let b = pop!();
+                let a = pop!();
+                if !self.cmp_values(*cmp, &a, &b)? {
+                    return Ok(Ctl::Jump(*target as usize));
+                }
+            }
+            // Fused `cmp ; JumpIfTrue` — mirror of `CmpBranchFalse`; branches when
+            // the comparison is true. Same helpers, so behavior is identical.
+            Op::CmpBranchTrue { cmp, target } => {
+                let b = pop!();
+                let a = pop!();
+                let r = self.cmp_values(*cmp, &a, &b)?;
+                if r {
+                    return Ok(Ctl::Jump(*target as usize));
+                }
+            }
+            // Fused `LoadCellConst ; CmpBranchFalse` — a whole `i < N` loop test.
+            // Same TDZ check, comparison helpers, and branch as the sequence.
+            Op::CmpCellConstBranchFalse {
+                cell,
+                konst,
+                cmp,
+                target,
+            } => {
+                let a = frame.cells[*cell as usize].borrow().clone();
+                if matches!(a, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                let b = self.const_val(frame, *konst);
+                if !self.cmp_values(*cmp, &a, &b)? {
+                    return Ok(Ctl::Jump(*target as usize));
+                }
+            }
+            Op::CmpCellConstBranchTrue {
+                cell,
+                konst,
+                cmp,
+                target,
+            } => {
+                let a = frame.cells[*cell as usize].borrow().clone();
+                if matches!(a, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                let b = self.const_val(frame, *konst);
+                if self.cmp_values(*cmp, &a, &b)? {
+                    return Ok(Ctl::Jump(*target as usize));
+                }
+            }
+            // Fused `LoadCellConst ; Add` / `LoadCellConst ; <binop>` — the same
+            // op_add / arith helpers compute the result; only the intermediate
+            // stack traffic is elided.
+            Op::AddCellConst { cell, konst } => {
+                let a = frame.cells[*cell as usize].borrow().clone();
+                if matches!(a, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                let b = self.const_val(frame, *konst);
+                let r = self.op_add(a, b)?;
+                push!(r);
+            }
+            Op::ArithCellConst { cell, konst, kind } => {
+                let a = frame.cells[*cell as usize].borrow().clone();
+                if matches!(a, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                let b = self.const_val(frame, *konst);
+                let r = self.arith(a, b, *kind)?;
+                push!(r);
+            }
+            // Fused statement-position `i++`/`--i`-style update on a cell. The
+            // exact sequence semantics: TDZ-checked read, ToNumeric (which may
+            // run user code that reassigns the binding — the borrow is released
+            // before it runs), the same unary_arith step, plain in-place store.
+            Op::IncCellStmt { cell, dec } => {
+                let v = frame.cells[*cell as usize].borrow().clone();
+                if matches!(v, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                let n = self.to_numeric(&v)?;
+                let r = self.unary_arith(n, if *dec { UnaryKind::Dec } else { UnaryKind::Inc })?;
+                *frame.cells[*cell as usize].borrow_mut() = r;
+            }
+            // Fused `LoadCell(src) ; InitCell(dest)` — per-iteration `let` copy.
+            Op::LoadCellInit { src, dest } => {
+                let v = frame.cells[*src as usize].borrow().clone();
+                if matches!(v, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                if frame.func.proto.stable_flags[*dest as usize] {
+                    *frame.cells[*dest as usize].borrow_mut() = v;
+                } else {
+                    let fresh = self.take_cell(v);
+                    let old = std::mem::replace(&mut frame.cells[*dest as usize], fresh);
+                    self.recycle_cell(old);
+                }
+            }
+            Op::JumpIfFalsyPeek(t) => {
+                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
+                if !self.to_boolean(&v) {
+                    return Ok(Ctl::Jump(*t as usize));
+                }
+                frame.stack.pop();
+            }
+            Op::JumpIfTruthyPeek(t) => {
+                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
+                if self.to_boolean(&v) {
+                    return Ok(Ctl::Jump(*t as usize));
+                }
+                frame.stack.pop();
+            }
+            Op::JumpIfNullishPeek(t) => {
+                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
+                if !v.is_nullish() {
+                    return Ok(Ctl::Jump(*t as usize));
+                }
+                frame.stack.pop();
+            }
+
+            // ---- exceptions ----
+            Op::Throw => {
+                let v = pop!();
+                return Err(v);
+            }
+            Op::PushTryHandler { catch, finally } => {
+                frame.handlers.push(TryHandler {
+                    catch_ip: if *catch == u32::MAX {
+                        None
+                    } else {
+                        Some(*catch)
+                    },
+                    finally_ip: if *finally == u32::MAX {
+                        None
+                    } else {
+                        Some(*finally)
+                    },
+                    stack_depth: frame.stack.len(),
+                    with_depth: frame.with_scope.len(),
+                    priv_env: frame.priv_env.clone(),
+                    delegation: false,
+                    delegation_return_ip: None,
+                });
+            }
+            Op::PopTryHandler => {
+                frame.handlers.pop();
+            }
+            Op::GetIterator => {
+                let v = pop!();
+                let it = self.get_iterator(&v)?;
+                push!(it);
+            }
+            Op::IteratorNext => {
+                let it = frame.stack.last().cloned().unwrap_or(Value::Undefined);
+                let next = self.get_prop(&it, &PropertyKey::str("next"))?;
+                let res = self.call(next, it, &[])?;
+                push!(res);
+            }
+            Op::ForInPop => {
+                frame.enumerators.pop();
+            }
+            Op::ForInNext => {
+                let idx = frame.enumerators.len() - 1;
+                let (keys, cursor) = &mut frame.enumerators[idx];
+                if *cursor < keys.len() {
+                    let k = keys[*cursor].clone();
+                    *cursor += 1;
+                    push!(Value::String(k));
+                    push!(Value::Bool(true));
+                } else {
+                    push!(Value::Undefined);
+                    push!(Value::Bool(false));
+                }
+            }
+
+            // ---- generators / async ----
+            Op::Await => {
+                let v = pop!();
+                return Ok(Ctl::Await(v));
+            }
+            Op::Yield => {
+                let v = pop!();
+                return Ok(Ctl::Yield(v));
+            }
+            Op::GeneratorStart => return Ok(Ctl::GeneratorStart),
+            Op::YieldStar => {
+                let v = pop!();
+                return Ok(Ctl::YieldStar(v));
+            }
+            Op::ToPropertyKey => {
+                let v = pop!();
+                let k = self.to_property_key(&v)?;
+                push!(match k {
+                    PropertyKey::Str(s) => Value::String(s),
+                    PropertyKey::Sym(s) => Value::Symbol(s),
+                });
+            }
+            Op::ToStringOp => {
+                let v = pop!();
+                let s = self.to_js_string(&v)?;
+                push!(Value::String(s));
+            }
+            Op::ConcatStrings(n) => {
+                let n = *n as usize;
+                let at = frame.stack.len() - n;
+                let parts = frame.stack.split_off(at);
+                let mut strs = Vec::with_capacity(parts.len());
+                let mut total = 0usize;
+                for p in &parts {
+                    let s = self.to_js_string(p)?;
+                    // Same bound as `op_add`: a template-literal join in a doubling
+                    // loop (`` s = `${s}${s}` ``) must not grow without limit.
+                    total += s.byte_len();
+                    if total > crate::value::MAX_STRING_LEN {
+                        return Err(self.throw_range("invalid string length"));
+                    }
+                    strs.push(s);
+                }
+                // Fast path when every part is well-formed (the common case):
+                // a plain UTF-8 join. Otherwise go through code units so a
+                // surrogate straddling a boundary re-pairs (and lone surrogates
+                // survive instead of becoming U+FFFD).
+                let out = if strs.iter().all(|s| s.is_well_formed()) {
+                    let mut out = String::with_capacity(total);
+                    for s in &strs {
+                        out.push_str(s.as_str());
+                    }
+                    JsString::new(out)
+                } else {
+                    let mut units = Vec::new();
+                    for s in &strs {
+                        units.extend(s.code_units());
+                    }
+                    JsString::from_code_units(&units)
+                };
+                push!(Value::String(out));
+            }
+            _ => return self.step_cold(frame, op),
+        }
+        Ok(Ctl::Next)
+    }
+
+    /// The non-hot ops (declarations, names/with/eval, object/class
+    /// definition, super/private, iterators' slow paths, dispose, spread,
+    /// regexp, dynamic import, ...). `#[inline(never)]` keeps their (large,
+    /// unioned) locals out of `step`'s frame; see `step` for why. An op
+    /// handled in `step` never reaches this match.
+    #[inline(never)]
+    fn step_cold(&mut self, frame: &mut Frame, op: &Op) -> Result<Ctl, Value> {
+        macro_rules! pop {
+            () => {
+                frame.stack.pop().unwrap_or(Value::Undefined)
+            };
+        }
+        macro_rules! push {
+            ($v:expr) => {
+                frame.stack.push($v)
+            };
+        }
+        match op {
+            Op::RequireObjectCoercible => {
+                if frame.stack.last().map(|v| v.is_nullish()).unwrap_or(true) {
+                    return Err(self.throw_type("Cannot destructure a null or undefined value"));
+                }
+            }
+            Op::BindThisSloppy => {
+                let t = pop!();
+                let bound = match t {
+                    Value::Undefined | Value::Null => Value::Object(self.realm.global.clone()),
+                    Value::Object(_) => t,
+                    // A primitive `this` is boxed (ToObject) in sloppy mode.
+                    other => Value::Object(self.to_object(&other)?),
+                };
+                push!(bound);
+            }
+            Op::LoadRestArgs(n) => {
+                let rest: Vec<Value> = if (*n as usize) < frame.args.len() {
+                    frame.args[*n as usize..].to_vec()
+                } else {
+                    Vec::new()
+                };
+                push!(Value::Object(self.new_array(rest)));
+            }
+            Op::LoadArguments => {
+                let o = self.make_arguments_object(frame);
+                push!(o);
+            }
+
+            Op::LoadGlobalTypeof(i) => {
+                let name = self.const_name(frame, *i);
+                let key = PropertyKey::Str(name);
+                let g = self.realm.global.clone();
+                let v = self.get_prop(&Value::Object(g), &key)?;
+                push!(v);
             }
             Op::DeclareGlobal { name: i, deletable } => {
                 let name = self.const_name(frame, *i);
@@ -1840,34 +2630,6 @@ impl Vm {
                 }
             }
 
-            Op::Pop => {
-                frame.stack.pop();
-            }
-            Op::Dup => {
-                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                push!(v);
-            }
-            Op::Swap => {
-                let n = frame.stack.len();
-                if n >= 2 {
-                    frame.stack.swap(n - 1, n - 2);
-                }
-            }
-            Op::Rot3 => {
-                let n = frame.stack.len();
-                if n >= 3 {
-                    // a b c -> b c a
-                    frame.stack[n - 3..].rotate_left(1);
-                }
-            }
-
-            Op::NewObject => push!(Value::Object(self.new_object())),
-            Op::NewArray(n) => {
-                let n = *n as usize;
-                let at = frame.stack.len() - n;
-                let elems = frame.stack.split_off(at);
-                push!(Value::Object(self.new_array(elems)));
-            }
             Op::GetTemplateObject(idx) => {
                 let key = (Rc::as_ptr(&frame.func.proto) as *const () as usize, *idx);
                 if let Some(o) = self.template_cache.get(&key) {
@@ -2118,116 +2880,6 @@ impl Vm {
                     }
                 }
                 push!(target);
-            }
-            Op::GetProp(i) => {
-                let name = self.const_name(frame, *i);
-                let obj = pop!();
-                // Inline cache (key-verified hints; see `FuncProto::ic`).
-                // Two levels:
-                //  - `holder == None`: the receiver's OWN data property at
-                //    `slot` (ordinary objects).
-                //  - `holder == Some(p)`: a data property at `slot` on `p`,
-                //    verified to still be the receiver's DIRECT prototype and
-                //    not shadowed by an own property — the method-lookup
-                //    pattern (`arr.push`, class instances calling prototype
-                //    methods). Array receivers exclude keys with exotic own
-                //    behavior (`length`, indices). Deeper chains, accessors,
-                //    proxies, and every other exotic fall to the unchanged
-                //    slow path.
-                if let Value::Object(o) = &obj {
-                    if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
-                        let b = o.borrow();
-                        let (is_ord, is_arr) = (
-                            matches!(b.internal, Internal::Ordinary),
-                            matches!(b.internal, Internal::Array(_)),
-                        );
-                        // Array exotics: `length` and index keys never take
-                        // the IC (they don't live in the props map).
-                        let plain_key = !is_arr
-                            || (name.as_str() != "length"
-                                && crate::value::canonical_index(name.as_str()).is_none());
-                        if (is_ord || is_arr) && plain_key {
-                            // Own-property hit: never touches the holder cell.
-                            if is_ord {
-                                if let Some((PropertyKey::Str(k), prop)) =
-                                    b.props.get_index(ic.own_slot.get() as usize)
-                                {
-                                    if let PropertyKind::Data { value, .. } = &prop.kind {
-                                        if k == &name {
-                                            let v = value.clone();
-                                            drop(b);
-                                            push!(v);
-                                            return Ok(Ctl::Next);
-                                        }
-                                    }
-                                }
-                            }
-                            // Proto hit: valid only when the receiver has no
-                            // own props (nothing can shadow) and its CURRENT
-                            // direct proto is the cached holder.
-                            if b.props.is_empty() {
-                                let holder = ic.holder.borrow();
-                                if let Some(h) = &*holder {
-                                    if b.proto.as_ref().is_some_and(|p| p.ptr_eq(h)) {
-                                        let hb = h.borrow();
-                                        if let Some((PropertyKey::Str(k), prop)) =
-                                            hb.props.get_index(ic.proto_slot.get() as usize)
-                                        {
-                                            if let PropertyKind::Data { value, .. } = &prop.kind {
-                                                if k == &name {
-                                                    let v = value.clone();
-                                                    drop(hb);
-                                                    drop(holder);
-                                                    drop(b);
-                                                    push!(v);
-                                                    return Ok(Ctl::Next);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            // Refill: own data property first (ordinary only),
-                            // then a one-level proto data property when no own
-                            // props can shadow.
-                            let key = PropertyKey::Str(name.clone());
-                            if is_ord {
-                                if let Some((idx, _, prop)) = b.props.get_full(&key) {
-                                    if let PropertyKind::Data { value, .. } = &prop.kind {
-                                        ic.own_slot.set(idx as u32);
-                                        let v = value.clone();
-                                        drop(b);
-                                        push!(v);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                            if b.props.is_empty() {
-                                if let Some(p) = &b.proto {
-                                    let pb = p.borrow();
-                                    if matches!(pb.internal, Internal::Ordinary)
-                                        || matches!(pb.internal, Internal::Array(_))
-                                    {
-                                        if let Some((idx, _, prop)) = pb.props.get_full(&key) {
-                                            if let PropertyKind::Data { value, .. } = &prop.kind {
-                                                ic.proto_slot.set(idx as u32);
-                                                let v = value.clone();
-                                                let holder_obj = p.clone();
-                                                drop(pb);
-                                                *ic.holder.borrow_mut() = Some(holder_obj);
-                                                drop(b);
-                                                push!(v);
-                                                return Ok(Ctl::Next);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                let v = self.get_prop(&obj, &PropertyKey::Str(name))?;
-                push!(v);
             }
             Op::PrivateGet(i) => {
                 let name = self.resolve_private_name(frame, *i)?;
@@ -2665,129 +3317,6 @@ impl Vm {
                 let has = o.borrow().private_get(name.id).is_some();
                 push!(Value::Bool(has));
             }
-            Op::SetProp(i) => {
-                let name = self.const_name(frame, *i);
-                let value = pop!();
-                let obj = pop!();
-                // Inline cache (key-verified slot hint; see `FuncProto::ic`).
-                // Fast path only when the receiver is an ordinary object whose
-                // OWN property at the hinted slot is a WRITABLE data property —
-                // per OrdinarySetWithOwnDescriptor that assignment updates the
-                // value in place (attributes and slot order preserved, no
-                // prototype setter can intervene). Everything else (missing own
-                // key → proto-chain setters/read-only checks, accessors,
-                // non-writable → strict TypeError, exotics) takes the
-                // unchanged put_value path, which also refills the hint.
-                if let Value::Object(o) = &obj {
-                    if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
-                        let mut b = o.borrow_mut();
-                        if matches!(b.internal, Internal::Ordinary) {
-                            if let Some((PropertyKey::Str(k), prop)) =
-                                b.props.get_index_mut(ic.own_slot.get() as usize)
-                            {
-                                if k == &name {
-                                    if let PropertyKind::Data {
-                                        value: slot,
-                                        writable: true,
-                                    } = &mut prop.kind
-                                    {
-                                        *slot = value.clone();
-                                        drop(b);
-                                        push!(value);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                            let key = PropertyKey::Str(name.clone());
-                            if let Some((idx, _, prop)) = b.props.get_full_mut(&key) {
-                                if let PropertyKind::Data {
-                                    value: slot,
-                                    writable: true,
-                                } = &mut prop.kind
-                                {
-                                    ic.own_slot.set(idx as u32);
-                                    *slot = value.clone();
-                                    drop(b);
-                                    push!(value);
-                                    return Ok(Ctl::Next);
-                                }
-                            }
-                        }
-                    }
-                }
-                let strict = frame.func.proto.is_strict;
-                self.put_value(&obj, &PropertyKey::Str(name), value.clone(), strict)?;
-                push!(value);
-            }
-            Op::GetPropDynamic => {
-                let key_v = pop!();
-                let obj = pop!();
-                // Integer fast path: `a[i]` on a dense array with an integral
-                // Number key reads the element directly — skipping
-                // ToPropertyKey's Number→String conversion (a float-format +
-                // heap allocation per access!), the reparse back to an index,
-                // and the property-map machinery. Only when no reified props
-                // entry can shadow the dense element (`props.is_empty()`) and
-                // the slot is a real element (in bounds, not a hole);
-                // everything else takes the unchanged spec path.
-                if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
-                    if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                        let b = o.borrow();
-                        if let Internal::Array(arr) = &b.internal {
-                            if b.props.is_empty() {
-                                if let Some(v) = arr.get(*n as usize) {
-                                    if !matches!(v, Value::Hole) {
-                                        let v = v.clone();
-                                        drop(b);
-                                        push!(v);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // GetValue: RequireObjectCoercible(base) (via ToObject) throws
-                // BEFORE ToPropertyKey coerces the key expression's value.
-                self.require_object_coercible(&obj, "read properties of")?;
-                let key = self.to_property_key(&key_v)?;
-                let v = self.get_prop(&obj, &key)?;
-                push!(v);
-            }
-            Op::SetPropDynamic => {
-                let value = pop!();
-                let key_v = pop!();
-                let obj = pop!();
-                // Integer fast path mirroring `GetPropDynamic`: overwrite an
-                // EXISTING dense element in place. An in-bounds non-hole dense
-                // slot is a plain writable data property (per the array exotic
-                // [[Set]]), so no setter, no length change, and no
-                // extensibility interaction is observable. Appends, holes,
-                // out-of-bounds, and shadowed elements take the spec path.
-                if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
-                    if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                        let mut b = o.borrow_mut();
-                        if b.props.is_empty() {
-                            if let Internal::Array(arr) = &mut b.internal {
-                                let i = *n as usize;
-                                if let Some(slot) = arr.get_mut(i) {
-                                    if !matches!(slot, Value::Hole) {
-                                        *slot = value.clone();
-                                        drop(b);
-                                        push!(value);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                self.require_object_coercible(&obj, "set properties of")?;
-                let key = self.to_property_key(&key_v)?;
-                let strict = frame.func.proto.is_strict;
-                self.put_value(&obj, &key, value.clone(), strict)?;
-                push!(value);
-            }
             Op::DeleteProp(i) => {
                 let name = self.const_name(frame, *i);
                 let obj = pop!();
@@ -2814,166 +3343,6 @@ impl Vm {
                     return Err(self.throw_type("Cannot delete property in strict mode"));
                 }
                 push!(Value::Bool(r));
-            }
-            Op::HasProp => {
-                let obj = pop!();
-                let key_v = pop!();
-                let key = self.to_property_key(&key_v)?;
-                let r = self.has_prop(&obj, &key)?;
-                push!(Value::Bool(r));
-            }
-            Op::JumpIfNullish(t) => {
-                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                if v.is_nullish() {
-                    // An optional chain short-circuits to `undefined` even when
-                    // the base was `null` (the other emit sites pop the value).
-                    if let Some(top) = frame.stack.last_mut() {
-                        *top = Value::Undefined;
-                    }
-                    return Ok(Ctl::Jump(*t as usize));
-                }
-            }
-
-            Op::Call(argc) => {
-                let n = *argc as usize;
-                let at = frame.stack.len() - n;
-                // Stack layout: [func, this, a0..]. A plain sync bytecode
-                // callee takes the direct path: its args MOVE straight from
-                // this operand stack into the pooled callee frame.
-                if let Some(bf) = peek_plain_bytecode(&frame.stack[at - 2]) {
-                    let r = self.call_direct(frame, at, bf, true)?;
-                    push!(r);
-                } else {
-                    // Move the argument values into a pooled buffer rather than
-                    // `split_off` (which allocates a fresh Vec on every call).
-                    let mut args = self.take_value_vec();
-                    args.extend(frame.stack.drain(at..));
-                    let this = pop!();
-                    let func = pop!();
-                    // Owned-args path: the pooled buffer moves into the callee
-                    // frame (recycled by its recycle_frame), skipping the second
-                    // copy make_frame's slice path would do.
-                    let r = self.call_valuevec(func, this, args);
-                    push!(r?);
-                }
-            }
-            Op::CallMethodless(argc) => {
-                let n = *argc as usize;
-                let at = frame.stack.len() - n;
-                // Stack layout: [func, a0..] — no explicit `this`.
-                if let Some(bf) = peek_plain_bytecode(&frame.stack[at - 1]) {
-                    let r = self.call_direct(frame, at, bf, false)?;
-                    push!(r);
-                } else {
-                    let mut args = self.take_value_vec();
-                    args.extend(frame.stack.drain(at..));
-                    let func = pop!();
-                    let r = self.call_valuevec(func, Value::Undefined, args);
-                    push!(r?);
-                }
-            }
-            Op::CallSpread => {
-                let args_arr = pop!();
-                let this = pop!();
-                let func = pop!();
-                let args = self.iterate_to_vec(&args_arr)?;
-                let r = self.call(func, this, &args)?;
-                push!(r);
-            }
-            Op::New(argc) => {
-                let n = *argc as usize;
-                let at = frame.stack.len() - n;
-                let args = frame.stack.split_off(at);
-                let ctor = pop!();
-                let r = self.construct(&ctor, &args, &ctor)?;
-                push!(r);
-            }
-            Op::NewSpread => {
-                let args_arr = pop!();
-                let ctor = pop!();
-                let args = self.iterate_to_vec(&args_arr)?;
-                let r = self.construct(&ctor, &args, &ctor)?;
-                push!(r);
-            }
-            Op::Return => {
-                let v = pop!();
-                // Route through any enclosing `finally` blocks before returning.
-                return self.do_completion(frame, Completion::Return(v));
-            }
-            Op::ReturnUndefined => {
-                let v = frame.completion.clone();
-                return self.do_completion(frame, Completion::Return(v));
-            }
-
-            Op::Closure(i) => {
-                let proto = match &frame.func.proto.consts[*i as usize] {
-                    Const::Func(p) => p.clone(),
-                    _ => return Err(self.throw_type("internal: bad closure const")),
-                };
-                let upvalues = proto
-                    .upvalues
-                    .iter()
-                    .map(|src| match src {
-                        UpvalueSource::ParentCell(idx) => frame.cells[*idx as usize].clone(),
-                        UpvalueSource::ParentUpvalue(idx) => {
-                            frame.func.upvalues[*idx as usize].clone()
-                        }
-                    })
-                    .collect();
-                let inherit_home = proto.kind.is_arrow() || proto.inherit_home;
-                let f = self.make_closure(proto, upvalues);
-                // Capture the active with-scope chain (closures defined inside
-                // `with` resolve free identifiers against it after the block)
-                // and the active private-environment chain (methods and
-                // initializers defined inside class bodies resolve `#x`
-                // against it). Arrows (and synthetic in-class closures) also
-                // inherit the creating frame's [[HomeObject]], so `super.x`
-                // inside them resolves like the enclosing method.
-                if !frame.with_scope.is_empty()
-                    || frame.priv_env.is_some()
-                    || (inherit_home && frame.func.home_object.is_some())
-                {
-                    if let Internal::Function(FunctionInner::Bytecode(bf)) =
-                        &mut f.borrow_mut().internal
-                    {
-                        let bf = Rc::make_mut(bf);
-                        bf.captured_with = frame.with_scope.clone();
-                        bf.captured_priv_env = frame.priv_env.clone();
-                        if inherit_home {
-                            bf.home_object = frame.func.home_object.clone();
-                        }
-                    }
-                }
-                push!(Value::Object(f));
-            }
-
-            // ---- arithmetic ----
-            Op::Add => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.op_add(a, b)?;
-                push!(r);
-            }
-            Op::Sub => bin_arith(self, frame, ArithKind::Sub)?,
-            Op::Mul => bin_arith(self, frame, ArithKind::Mul)?,
-            Op::Div => bin_arith(self, frame, ArithKind::Div)?,
-            Op::Mod => bin_arith(self, frame, ArithKind::Mod)?,
-            Op::Pow => bin_arith(self, frame, ArithKind::Pow)?,
-            Op::Neg => {
-                let a = pop!();
-                push!(self.unary_arith(a, UnaryKind::Neg)?);
-            }
-            Op::Pos => {
-                // ToNumber throws TypeError for BigInt (unary + is invalid on it).
-                let a = pop!();
-                let n = self.to_number(&a)?;
-                push!(Value::Number(n));
-            }
-            Op::ToNumeric => {
-                // ToNumeric: like ToNumber but keeps BigInt (used by ++/-- to
-                // produce the coerced old value).
-                let a = pop!();
-                push!(self.to_numeric(&a)?);
             }
             Op::ThrowConstAssign => {
                 return Err(self.throw_type("Assignment to constant variable."));
@@ -3014,250 +3383,6 @@ impl Vm {
                 }
                 push!(Value::Object(p));
             }
-            Op::Inc => {
-                let a = pop!();
-                push!(self.unary_arith(a, UnaryKind::Inc)?);
-            }
-            Op::Dec => {
-                let a = pop!();
-                push!(self.unary_arith(a, UnaryKind::Dec)?);
-            }
-            Op::BitNot => {
-                let a = pop!();
-                push!(self.unary_arith(a, UnaryKind::BitNot)?);
-            }
-            Op::Not => {
-                let a = pop!();
-                push!(Value::Bool(!self.to_boolean(&a)));
-            }
-            Op::BitAnd => bin_arith(self, frame, ArithKind::BitAnd)?,
-            Op::BitOr => bin_arith(self, frame, ArithKind::BitOr)?,
-            Op::BitXor => bin_arith(self, frame, ArithKind::BitXor)?,
-            Op::Shl => bin_arith(self, frame, ArithKind::Shl)?,
-            Op::Shr => bin_arith(self, frame, ArithKind::Shr)?,
-            Op::UShr => bin_arith(self, frame, ArithKind::UShr)?,
-            Op::TypeofExpr => {
-                let a = pop!();
-                push!(Value::str(a.type_of()));
-            }
-
-            // ---- comparison ----
-            Op::Eq => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.loose_equals(&a, &b)?;
-                push!(Value::Bool(r));
-            }
-            Op::Ne => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.loose_equals(&a, &b)?;
-                push!(Value::Bool(!r));
-            }
-            Op::StrictEq => {
-                let b = pop!();
-                let a = pop!();
-                push!(Value::Bool(self.strict_equals(&a, &b)));
-            }
-            Op::StrictNe => {
-                let b = pop!();
-                let a = pop!();
-                push!(Value::Bool(!self.strict_equals(&a, &b)));
-            }
-            Op::Lt => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.less_than(&a, &b)?;
-                push!(Value::Bool(r == Some(true)));
-            }
-            Op::Gt => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.less_than(&b, &a)?;
-                push!(Value::Bool(r == Some(true)));
-            }
-            Op::Le => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.less_than(&b, &a)?;
-                push!(Value::Bool(r == Some(false)));
-            }
-            Op::Ge => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.less_than(&a, &b)?;
-                push!(Value::Bool(r == Some(false)));
-            }
-            Op::InstanceOf => {
-                let ctor = pop!();
-                let obj = pop!();
-                let r = self.instance_of(&obj, &ctor)?;
-                push!(Value::Bool(r));
-            }
-
-            // ---- control flow ----
-            Op::Jump(t) => return Ok(Ctl::Jump(*t as usize)),
-            Op::JumpIfTrue(t) => {
-                let v = pop!();
-                if self.to_boolean(&v) {
-                    return Ok(Ctl::Jump(*t as usize));
-                }
-            }
-            Op::JumpIfFalse(t) => {
-                let v = pop!();
-                if !self.to_boolean(&v) {
-                    return Ok(Ctl::Jump(*t as usize));
-                }
-            }
-            // Fused `cmp ; JumpIfFalse` (see `fuse.rs`). Each arm reuses the
-            // SAME helper as the standalone comparison op, so coercion and any
-            // thrown error are identical; the boolean the pair would materialize
-            // is consumed directly by the branch instead of round-tripping the
-            // operand stack. `to_boolean(Bool(r)) == r`, so the branch condition
-            // matches `JumpIfFalse` exactly.
-            Op::CmpBranchFalse { cmp, target } => {
-                let b = pop!();
-                let a = pop!();
-                if !self.cmp_values(*cmp, &a, &b)? {
-                    return Ok(Ctl::Jump(*target as usize));
-                }
-            }
-            // Fused `cmp ; JumpIfTrue` — mirror of `CmpBranchFalse`; branches when
-            // the comparison is true. Same helpers, so behavior is identical.
-            Op::CmpBranchTrue { cmp, target } => {
-                let b = pop!();
-                let a = pop!();
-                let r = self.cmp_values(*cmp, &a, &b)?;
-                if r {
-                    return Ok(Ctl::Jump(*target as usize));
-                }
-            }
-            // Fused `LoadCellConst ; CmpBranchFalse` — a whole `i < N` loop test.
-            // Same TDZ check, comparison helpers, and branch as the sequence.
-            Op::CmpCellConstBranchFalse {
-                cell,
-                konst,
-                cmp,
-                target,
-            } => {
-                let a = frame.cells[*cell as usize].borrow().clone();
-                if matches!(a, Value::Uninitialized) {
-                    return Err(self.throw_reference("Cannot access binding before initialization"));
-                }
-                let b = self.const_val(frame, *konst);
-                if !self.cmp_values(*cmp, &a, &b)? {
-                    return Ok(Ctl::Jump(*target as usize));
-                }
-            }
-            Op::CmpCellConstBranchTrue {
-                cell,
-                konst,
-                cmp,
-                target,
-            } => {
-                let a = frame.cells[*cell as usize].borrow().clone();
-                if matches!(a, Value::Uninitialized) {
-                    return Err(self.throw_reference("Cannot access binding before initialization"));
-                }
-                let b = self.const_val(frame, *konst);
-                if self.cmp_values(*cmp, &a, &b)? {
-                    return Ok(Ctl::Jump(*target as usize));
-                }
-            }
-            // Fused `LoadCellConst ; Add` / `LoadCellConst ; <binop>` — the same
-            // op_add / arith helpers compute the result; only the intermediate
-            // stack traffic is elided.
-            Op::AddCellConst { cell, konst } => {
-                let a = frame.cells[*cell as usize].borrow().clone();
-                if matches!(a, Value::Uninitialized) {
-                    return Err(self.throw_reference("Cannot access binding before initialization"));
-                }
-                let b = self.const_val(frame, *konst);
-                let r = self.op_add(a, b)?;
-                push!(r);
-            }
-            Op::ArithCellConst { cell, konst, kind } => {
-                let a = frame.cells[*cell as usize].borrow().clone();
-                if matches!(a, Value::Uninitialized) {
-                    return Err(self.throw_reference("Cannot access binding before initialization"));
-                }
-                let b = self.const_val(frame, *konst);
-                let r = self.arith(a, b, *kind)?;
-                push!(r);
-            }
-            // Fused statement-position `i++`/`--i`-style update on a cell. The
-            // exact sequence semantics: TDZ-checked read, ToNumeric (which may
-            // run user code that reassigns the binding — the borrow is released
-            // before it runs), the same unary_arith step, plain in-place store.
-            Op::IncCellStmt { cell, dec } => {
-                let v = frame.cells[*cell as usize].borrow().clone();
-                if matches!(v, Value::Uninitialized) {
-                    return Err(self.throw_reference("Cannot access binding before initialization"));
-                }
-                let n = self.to_numeric(&v)?;
-                let r = self.unary_arith(n, if *dec { UnaryKind::Dec } else { UnaryKind::Inc })?;
-                *frame.cells[*cell as usize].borrow_mut() = r;
-            }
-            // Fused `LoadCell(src) ; InitCell(dest)` — per-iteration `let` copy.
-            Op::LoadCellInit { src, dest } => {
-                let v = frame.cells[*src as usize].borrow().clone();
-                if matches!(v, Value::Uninitialized) {
-                    return Err(self.throw_reference("Cannot access binding before initialization"));
-                }
-                if frame.func.proto.stable_flags[*dest as usize] {
-                    *frame.cells[*dest as usize].borrow_mut() = v;
-                } else {
-                    let fresh = self.take_cell(v);
-                    let old = std::mem::replace(&mut frame.cells[*dest as usize], fresh);
-                    self.recycle_cell(old);
-                }
-            }
-            Op::JumpIfFalsyPeek(t) => {
-                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                if !self.to_boolean(&v) {
-                    return Ok(Ctl::Jump(*t as usize));
-                }
-                frame.stack.pop();
-            }
-            Op::JumpIfTruthyPeek(t) => {
-                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                if self.to_boolean(&v) {
-                    return Ok(Ctl::Jump(*t as usize));
-                }
-                frame.stack.pop();
-            }
-            Op::JumpIfNullishPeek(t) => {
-                let v = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                if !v.is_nullish() {
-                    return Ok(Ctl::Jump(*t as usize));
-                }
-                frame.stack.pop();
-            }
-
-            // ---- exceptions ----
-            Op::Throw => {
-                let v = pop!();
-                return Err(v);
-            }
-            Op::PushTryHandler { catch, finally } => {
-                frame.handlers.push(TryHandler {
-                    catch_ip: if *catch == u32::MAX {
-                        None
-                    } else {
-                        Some(*catch)
-                    },
-                    finally_ip: if *finally == u32::MAX {
-                        None
-                    } else {
-                        Some(*finally)
-                    },
-                    stack_depth: frame.stack.len(),
-                    with_depth: frame.with_scope.len(),
-                    priv_env: frame.priv_env.clone(),
-                    delegation: false,
-                    delegation_return_ip: None,
-                });
-            }
             Op::MarkDelegationHandler(return_ip) => {
                 if let Some(h) = frame.handlers.last_mut() {
                     h.delegation = true;
@@ -3297,9 +3422,6 @@ impl Vm {
                     push!(v);
                 }
             }
-            Op::PopTryHandler => {
-                frame.handlers.pop();
-            }
             Op::CompletionJump { target, boundary } => {
                 return self.do_completion(
                     frame,
@@ -3319,17 +3441,6 @@ impl Vm {
             }
 
             // ---- iteration ----
-            Op::GetIterator => {
-                let v = pop!();
-                let it = self.get_iterator(&v)?;
-                push!(it);
-            }
-            Op::IteratorNext => {
-                let it = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                let next = self.get_prop(&it, &PropertyKey::str("next"))?;
-                let res = self.call(next, it, &[])?;
-                push!(res);
-            }
             Op::IteratorClose => {
                 // Reached only on an abrupt completion of a `for-of` loop, with
                 // that completion parked in `pending_completion`. Per spec
@@ -3377,91 +3488,12 @@ impl Vm {
                 frame.enumerators.push((keys, 0));
                 push!(Value::Number((frame.enumerators.len() - 1) as f64));
             }
-            Op::ForInPop => {
-                frame.enumerators.pop();
-            }
-            Op::ForInNext => {
-                let idx = frame.enumerators.len() - 1;
-                let (keys, cursor) = &mut frame.enumerators[idx];
-                if *cursor < keys.len() {
-                    let k = keys[*cursor].clone();
-                    *cursor += 1;
-                    push!(Value::String(k));
-                    push!(Value::Bool(true));
-                } else {
-                    push!(Value::Undefined);
-                    push!(Value::Bool(false));
-                }
-            }
-
-            // ---- generators / async ----
-            Op::Await => {
-                let v = pop!();
-                return Ok(Ctl::Await(v));
-            }
-            Op::Yield => {
-                let v = pop!();
-                return Ok(Ctl::Yield(v));
-            }
-            Op::GeneratorStart => return Ok(Ctl::GeneratorStart),
-            Op::YieldStar => {
-                let v = pop!();
-                return Ok(Ctl::YieldStar(v));
-            }
             Op::AsyncReturn => {
                 let v = pop!();
                 return Ok(Ctl::Return(v));
             }
 
             // ---- misc ----
-            Op::ToPropertyKey => {
-                let v = pop!();
-                let k = self.to_property_key(&v)?;
-                push!(match k {
-                    PropertyKey::Str(s) => Value::String(s),
-                    PropertyKey::Sym(s) => Value::Symbol(s),
-                });
-            }
-            Op::ToStringOp => {
-                let v = pop!();
-                let s = self.to_js_string(&v)?;
-                push!(Value::String(s));
-            }
-            Op::ConcatStrings(n) => {
-                let n = *n as usize;
-                let at = frame.stack.len() - n;
-                let parts = frame.stack.split_off(at);
-                let mut strs = Vec::with_capacity(parts.len());
-                let mut total = 0usize;
-                for p in &parts {
-                    let s = self.to_js_string(p)?;
-                    // Same bound as `op_add`: a template-literal join in a doubling
-                    // loop (`` s = `${s}${s}` ``) must not grow without limit.
-                    total += s.byte_len();
-                    if total > crate::value::MAX_STRING_LEN {
-                        return Err(self.throw_range("invalid string length"));
-                    }
-                    strs.push(s);
-                }
-                // Fast path when every part is well-formed (the common case):
-                // a plain UTF-8 join. Otherwise go through code units so a
-                // surrogate straddling a boundary re-pairs (and lone surrogates
-                // survive instead of becoming U+FFFD).
-                let out = if strs.iter().all(|s| s.is_well_formed()) {
-                    let mut out = String::with_capacity(total);
-                    for s in &strs {
-                        out.push_str(s.as_str());
-                    }
-                    JsString::new(out)
-                } else {
-                    let mut units = Vec::new();
-                    for s in &strs {
-                        units.extend(s.code_units());
-                    }
-                    JsString::from_code_units(&units)
-                };
-                push!(Value::String(out));
-            }
             Op::NewRegExp { pattern, flags } => {
                 let p = self.const_name(frame, *pattern);
                 let f = self.const_name(frame, *flags);
@@ -3473,6 +3505,7 @@ impl Vm {
                 let it = self.get_async_iterator(&v)?;
                 push!(it);
             }
+            _ => unreachable!("op handled inline in step: {op:?}"),
         }
         Ok(Ctl::Next)
     }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -310,10 +310,14 @@ impl Vm {
 
     /// Execute the typed loop kernel at `Op::LoopKernel(idx)` (see
     /// `kernel.rs` for the model). Runs only when per-op accounting is off
-    /// (no op budget) and every mapped local holds a `Number`; otherwise the
-    /// original header op (`Kernel::fallback`) executes and the generic
-    /// interpreter takes this iteration — the kernel simply retries the next
-    /// time the back-edge reaches the header.
+    /// (no op budget), every mapped numeric local holds a `Number`, and every
+    /// array-base local holds an object; otherwise the original header op
+    /// (`Kernel::fallback`) executes and the generic interpreter takes this
+    /// iteration — the kernel simply retries the next time the back-edge
+    /// reaches the header. Array-element accesses re-check their fast-path
+    /// conditions on every use and BAIL to the generic interpreter at the
+    /// access op (operand stack reconstructed from the kernel's shape table)
+    /// on any surprise — a bail is a slow iteration, never a wrong answer.
     fn run_kernel_op(&mut self, frame: &mut Frame, idx: u32) -> Result<Ctl, Value> {
         let proto = frame.func.proto.clone();
         let k = &proto.kernels[idx as usize];
@@ -327,7 +331,15 @@ impl Vm {
                 return self.step(frame, &k.fallback);
             }
         }
-        // Unboxed register file (pooled on the Vm; kernels never nest).
+        for &l in k.oslots.iter() {
+            if !matches!(frame.locals[l as usize], Value::Object(_)) {
+                return self.step(frame, &k.fallback);
+            }
+        }
+        // Unboxed register file + array-base cache (both pooled on the Vm;
+        // kernels never nest at runtime). The base objects are pinned for the
+        // whole activation — sound because stores to base LOCALS inside the
+        // region are rejected at translation.
         let mut regs = std::mem::take(&mut self.kernel_regs);
         regs.clear();
         regs.resize(k.n_regs as usize, 0.0);
@@ -336,11 +348,18 @@ impl Vm {
                 regs[r] = n;
             }
         }
+        let mut objs = std::mem::take(&mut self.kernel_objs);
+        objs.clear();
+        for &l in k.oslots.iter() {
+            if let Value::Object(o) = &frame.locals[l as usize] {
+                objs.push(o.clone());
+            }
+        }
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
         let code = &k.code;
         let mut pc = 0usize;
-        let (resume_ip, stack) = loop {
+        let (resume_ip, shape) = loop {
             // Taken branches funnel through here so back-edges can poll the
             // cooperative interrupt flag at the interpreter's cadence.
             macro_rules! branch {
@@ -358,6 +377,8 @@ impl Vm {
                                         frame.locals[l as usize] = Value::Number(regs[r]);
                                     }
                                     self.kernel_regs = regs;
+                                    objs.clear();
+                                    self.kernel_objs = objs;
                                     self.op_budget = Some(0);
                                     return Err(self.throw_range("execution interrupted"));
                                 }
@@ -416,21 +437,98 @@ impl Vm {
                         branch!(target)
                     }
                 }
-                KOp::Exit { resume_ip, stack } => break (resume_ip, stack),
+                // Dense element read: full fast-path re-check, else bail to
+                // the generic op (the `bail` target is an Exit stub).
+                KOp::LoadElem {
+                    dst,
+                    obj,
+                    idx,
+                    bail,
+                } => {
+                    let i = regs[idx as usize];
+                    let mut ok = false;
+                    if i.fract() == 0.0 && (0.0..4294967295.0).contains(&i) {
+                        let b = objs[obj as usize].borrow();
+                        if b.props.is_empty() {
+                            if let Internal::Array(arr) = &b.internal {
+                                if let Some(Value::Number(n)) = arr.get(i as usize) {
+                                    regs[dst as usize] = *n;
+                                    ok = true;
+                                }
+                            }
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                }
+                // Dense element in-place overwrite: exactly the
+                // `Op::SetPropDynamic` fast-path conditions, else bail.
+                KOp::StoreElem {
+                    obj,
+                    idx,
+                    val,
+                    bail,
+                } => {
+                    let i = regs[idx as usize];
+                    let mut ok = false;
+                    if i.fract() == 0.0 && (0.0..4294967295.0).contains(&i) {
+                        let mut b = objs[obj as usize].borrow_mut();
+                        if b.props.is_empty() {
+                            if let Internal::Array(arr) = &mut b.internal {
+                                if let Some(slot) = arr.get_mut(i as usize) {
+                                    if !matches!(slot, Value::Hole) {
+                                        *slot = Value::Number(regs[val as usize]);
+                                        ok = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                }
+                // Dense array `length` (unshadowed only), else bail.
+                KOp::LoadLen { dst, obj, bail } => {
+                    let mut ok = false;
+                    {
+                        let b = objs[obj as usize].borrow();
+                        if b.props.is_empty() {
+                            if let Internal::Array(arr) = &b.internal {
+                                regs[dst as usize] = arr.len() as f64;
+                                ok = true;
+                            }
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                }
+                KOp::Exit { resume_ip, shape } => break (resume_ip, shape),
             }
             pc += 1;
         };
-        // Materialize: every mapped local back to the frame (as Numbers), any
-        // live canonical stack slots onto the operand stack, then resume the
+        // Materialize: every mapped numeric local back to the frame (as
+        // Numbers), then the operand stack from the exit's shape (bottom-up:
+        // registers as Numbers, object slots as objects), then resume the
         // bytecode interpreter at the exit's target.
         for (r, &l) in k.locals.iter().enumerate() {
             frame.locals[l as usize] = Value::Number(regs[r]);
         }
-        let stack_base = k.locals.len();
-        for d in 0..stack as usize {
-            frame.stack.push(Value::Number(regs[stack_base + d]));
+        for slot in k.shapes[shape as usize].iter() {
+            match slot {
+                crate::bytecode::KShapeSlot::Num(r) => {
+                    frame.stack.push(Value::Number(regs[*r as usize]))
+                }
+                crate::bytecode::KShapeSlot::Obj(o) => {
+                    frame.stack.push(Value::Object(objs[*o as usize].clone()))
+                }
+            }
         }
         self.kernel_regs = regs;
+        objs.clear();
+        self.kernel_objs = objs;
         Ok(Ctl::Jump(resume_ip as usize))
     }
 

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -308,6 +308,40 @@ impl Vm {
         r
     }
 
+    /// Verify the global `Math` binding and each used method are still the
+    /// realm's canonical objects, as plain data properties. Any deviation —
+    /// deleted/replaced/shadowed `Math`, an accessor, a monkeypatched method
+    /// — declines the kernel (the generic path then does whatever the
+    /// program set up, observably).
+    fn kernel_math_ok(&self, used: &[crate::bytecode::KMath]) -> bool {
+        let Some(canon) = &self.realm.math_object else {
+            return false;
+        };
+        {
+            let g = self.realm.global.borrow();
+            let math_ok = matches!(
+                g.props.get(&PropertyKey::str("Math")),
+                Some(Property {
+                    kind: PropertyKind::Data { value: Value::Object(o), .. },
+                    ..
+                }) if o.ptr_eq(canon)
+            );
+            if !math_ok {
+                return false;
+            }
+        }
+        let mb = canon.borrow();
+        used.iter().all(|k| {
+            matches!(
+                mb.props.get(&PropertyKey::str(k.name())),
+                Some(Property {
+                    kind: PropertyKind::Data { value: Value::Object(o), .. },
+                    ..
+                }) if o.ptr_eq(&self.realm.math_kernel[*k as usize])
+            )
+        })
+    }
+
     /// Execute the typed loop kernel at `Op::LoopKernel(idx)` (see
     /// `kernel.rs` for the model). Runs only when per-op accounting is off
     /// (no op budget), every mapped numeric local holds a `Number`, and every
@@ -335,6 +369,14 @@ impl Vm {
             if !matches!(frame.locals[l as usize], Value::Object(_)) {
                 return self.step(frame, &k.fallback);
             }
+        }
+        // Math intrinsics: the global `Math` binding must still be the
+        // canonical object as a plain DATA property (an accessor or a
+        // replacement would be observable), and each used method must still
+        // be the canonical builtin (methods are writable). Nothing inside a
+        // kernel region can mutate globals, so entry-time checks suffice.
+        if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
+            return self.step(frame, &k.fallback);
         }
         // Unboxed register file + array-base cache (both pooled on the Vm;
         // kernels never nest at runtime). The base objects are pinned for the
@@ -489,6 +531,12 @@ impl Vm {
                         branch!(bail)
                     }
                 }
+                KOp::Math1 { kind, dst, src } => {
+                    regs[dst as usize] = kmath1(kind, regs[src as usize])
+                }
+                KOp::Math2 { kind, dst, a, b } => {
+                    regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
+                }
                 // Dense array `length` (unshadowed only), else bail.
                 KOp::LoadLen { dst, obj, bail } => {
                     let mut ok = false;
@@ -524,6 +572,13 @@ impl Vm {
                 crate::bytecode::KShapeSlot::Obj(o) => {
                     frame.stack.push(Value::Object(objs[*o as usize].clone()))
                 }
+                // The guard proved the live values ARE the canonicals.
+                crate::bytecode::KShapeSlot::MathObj => frame.stack.push(Value::Object(
+                    self.realm.math_object.clone().expect("guarded"),
+                )),
+                crate::bytecode::KShapeSlot::MathFn(kind) => frame.stack.push(Value::Object(
+                    self.realm.math_kernel[*kind as usize].clone(),
+                )),
             }
         }
         self.kernel_regs = regs;
@@ -4433,6 +4488,36 @@ fn knum_cmp(cmp: CmpOp, a: f64, b: f64) -> bool {
 #[inline]
 fn knum_truthy(x: f64) -> bool {
     x != 0.0 && !x.is_nan()
+}
+
+/// Kernel Math dispatch — every arm is the SAME core its builtin uses, so a
+/// kernelized `Math.round` (etc.) is bit-identical to the generic call.
+fn kmath1(kind: crate::bytecode::KMath, x: f64) -> f64 {
+    use crate::builtins::numbers as m;
+    use crate::bytecode::KMath;
+    match kind {
+        KMath::Abs => x.abs(),
+        KMath::Floor => x.floor(),
+        KMath::Ceil => x.ceil(),
+        KMath::Round => m::math_round(x),
+        KMath::Trunc => x.trunc(),
+        KMath::Sign => m::math_sign(x),
+        KMath::Sqrt => x.sqrt(),
+        KMath::Fround => m::math_fround(x),
+        _ => unreachable!("binary Math kind in Math1"),
+    }
+}
+
+fn kmath2(kind: crate::bytecode::KMath, a: f64, b: f64) -> f64 {
+    use crate::builtins::numbers as m;
+    use crate::bytecode::KMath;
+    match kind {
+        KMath::Min2 => m::math_min2(a, b),
+        KMath::Max2 => m::math_max2(a, b),
+        KMath::Pow2 => m::math_pow(a, b),
+        KMath::Imul2 => m::math_imul2(a, b),
+        _ => unreachable!("unary Math kind in Math2"),
+    }
 }
 
 fn number_arith(x: f64, y: f64, kind: ArithKind) -> Value {

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -360,8 +360,21 @@ impl Vm {
         if self.op_budget.is_some() {
             return self.step(frame, &k.fallback);
         }
-        for &l in k.locals.iter() {
-            if !matches!(frame.locals[l as usize], Value::Number(_)) {
+        for slot in k.locals.iter() {
+            let ok = match slot {
+                crate::bytecode::KSlot::Local(l) => {
+                    matches!(frame.locals[*l as usize], Value::Number(_))
+                }
+                crate::bytecode::KSlot::Upvalue(u) => {
+                    matches!(*frame.func.upvalues[*u as usize].borrow(), Value::Number(_))
+                }
+            };
+            if !ok {
+                return self.step(frame, &k.fallback);
+            }
+        }
+        for &l in k.bool_locals.iter() {
+            if !matches!(frame.locals[l as usize], Value::Bool(_)) {
                 return self.step(frame, &k.fallback);
             }
         }
@@ -385,9 +398,21 @@ impl Vm {
         let mut regs = std::mem::take(&mut self.kernel_regs);
         regs.clear();
         regs.resize(k.n_regs as usize, 0.0);
-        for (r, &l) in k.locals.iter().enumerate() {
-            if let Value::Number(n) = frame.locals[l as usize] {
+        for (r, slot) in k.locals.iter().enumerate() {
+            let v = match slot {
+                crate::bytecode::KSlot::Local(l) => frame.locals[*l as usize].clone(),
+                crate::bytecode::KSlot::Upvalue(u) => {
+                    frame.func.upvalues[*u as usize].borrow().clone()
+                }
+            };
+            if let Value::Number(n) = v {
                 regs[r] = n;
+            }
+        }
+        let bool_base = k.locals.len();
+        for (j, &l) in k.bool_locals.iter().enumerate() {
+            if let Value::Bool(b) = frame.locals[l as usize] {
+                regs[bool_base + j] = if b { 1.0 } else { 0.0 };
             }
         }
         let mut objs = std::mem::take(&mut self.kernel_objs);
@@ -415,8 +440,14 @@ impl Vm {
                                     // Same latch-and-unwind as the interpreter
                                     // loop: zero the budget so a JS catch
                                     // cannot resume execution.
-                                    for (r, &l) in k.locals.iter().enumerate() {
-                                        frame.locals[l as usize] = Value::Number(regs[r]);
+                                    for (r, slot) in k.locals.iter().enumerate() {
+                                        if let crate::bytecode::KSlot::Local(l) = slot {
+                                            frame.locals[*l as usize] = Value::Number(regs[r]);
+                                        }
+                                    }
+                                    for (j, &l) in k.bool_locals.iter().enumerate() {
+                                        frame.locals[l as usize] =
+                                            Value::Bool(regs[bool_base + j] != 0.0);
                                     }
                                     self.kernel_regs = regs;
                                     objs.clear();
@@ -504,8 +535,15 @@ impl Vm {
                         branch!(bail)
                     }
                 }
-                // Dense element in-place overwrite: exactly the
-                // `Op::SetPropDynamic` fast-path conditions, else bail.
+                // Dense element write: in-place overwrite (exactly the
+                // `Op::SetPropDynamic` fast-path conditions), an in-bounds
+                // HOLE fill, or an exact one-past-the-end APPEND. Filling and
+                // appending CREATE a property, so they additionally require
+                // the array to be extensible (a sealed/prevented receiver
+                // must reject through the generic path: silent in sloppy,
+                // TypeError in strict) and to stay under the dense-storage
+                // bound (the generic path owns that RangeError). Everything
+                // else bails.
                 KOp::StoreElem {
                     obj,
                     idx,
@@ -517,11 +555,30 @@ impl Vm {
                     if i.fract() == 0.0 && (0.0..4294967295.0).contains(&i) {
                         let mut b = objs[obj as usize].borrow_mut();
                         if b.props.is_empty() {
+                            let extensible = b.extensible;
                             if let Internal::Array(arr) = &mut b.internal {
-                                if let Some(slot) = arr.get_mut(i as usize) {
-                                    if !matches!(slot, Value::Hole) {
+                                let iu = i as usize;
+                                match arr.get_mut(iu) {
+                                    Some(slot) if !matches!(slot, Value::Hole) => {
                                         *slot = Value::Number(regs[val as usize]);
                                         ok = true;
+                                    }
+                                    Some(slot) => {
+                                        // In-bounds hole: creation.
+                                        if extensible {
+                                            *slot = Value::Number(regs[val as usize]);
+                                            ok = true;
+                                        }
+                                    }
+                                    None => {
+                                        // Exact append (no hole gap).
+                                        if extensible
+                                            && iu == arr.len()
+                                            && iu < crate::value::MAX_DENSE_ARRAY
+                                        {
+                                            arr.push(Value::Number(regs[val as usize]));
+                                            ok = true;
+                                        }
                                     }
                                 }
                             }
@@ -529,6 +586,20 @@ impl Vm {
                     }
                     if !ok {
                         branch!(bail)
+                    }
+                }
+                KOp::CmpSet { cmp, dst, a, b } => {
+                    regs[dst as usize] = if knum_cmp(cmp, regs[a as usize], regs[b as usize]) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                }
+                KOp::BoolNot { dst, src } => {
+                    regs[dst as usize] = if knum_truthy(regs[src as usize]) {
+                        0.0
+                    } else {
+                        1.0
                     }
                 }
                 KOp::Math1 { kind, dst, src } => {
@@ -561,13 +632,21 @@ impl Vm {
         // Numbers), then the operand stack from the exit's shape (bottom-up:
         // registers as Numbers, object slots as objects), then resume the
         // bytecode interpreter at the exit's target.
-        for (r, &l) in k.locals.iter().enumerate() {
-            frame.locals[l as usize] = Value::Number(regs[r]);
+        for (r, slot) in k.locals.iter().enumerate() {
+            if let crate::bytecode::KSlot::Local(l) = slot {
+                frame.locals[*l as usize] = Value::Number(regs[r]);
+            }
+        }
+        for (j, &l) in k.bool_locals.iter().enumerate() {
+            frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
         }
         for slot in k.shapes[shape as usize].iter() {
             match slot {
                 crate::bytecode::KShapeSlot::Num(r) => {
                     frame.stack.push(Value::Number(regs[*r as usize]))
+                }
+                crate::bytecode::KShapeSlot::Bool(r) => {
+                    frame.stack.push(Value::Bool(regs[*r as usize] != 0.0))
                 }
                 crate::bytecode::KShapeSlot::Obj(o) => {
                     frame.stack.push(Value::Object(objs[*o as usize].clone()))

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -374,6 +374,12 @@ impl Vm {
     /// conditions on every use and BAIL to the generic interpreter at the
     /// access op (operand stack reconstructed from the kernel's shape table)
     /// on any surprise — a bail is a slow iteration, never a wrong answer.
+    ///
+    /// `inline(never)`: called once per loop ACTIVATION (not per iteration),
+    /// and keeping its large register loop out of `step` pins the codegen of
+    /// both — growing this function must not perturb the interpreter's hot
+    /// dispatch.
+    #[inline(never)]
     fn run_kernel_op(&mut self, frame: &mut Frame, idx: u32) -> Result<Ctl, Value> {
         let proto = frame.func.proto.clone();
         let k = &proto.kernels[idx as usize];
@@ -414,6 +420,41 @@ impl Vm {
         // kernel region can mutate globals, so entry-time checks suffice.
         if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
             return self.step(frame, &k.fallback);
+        }
+        // Named-property access classes resolve ONCE per activation to raw
+        // slot indices (see `KProp`): each base must be an ORDINARY object
+        // whose own data property exists — a Number where loaded, writable
+        // where stored. Slots stay valid for the whole activation because
+        // nothing inside a kernel region can create/delete properties or run
+        // user code; in-kernel `StoreProp` only overwrites values in place.
+        let mut prop_slots = std::mem::take(&mut self.kernel_prop_slots);
+        prop_slots.clear();
+        for p in k.props_used.iter() {
+            let mut ok = false;
+            if let Value::Object(o) = &frame.locals[k.oslots[p.oslot as usize] as usize] {
+                let b = o.borrow();
+                if matches!(b.internal, Internal::Ordinary) {
+                    if let Some((
+                        idx,
+                        _,
+                        Property {
+                            kind: PropertyKind::Data { value, writable },
+                            ..
+                        },
+                    )) = b.props.get_full(&PropertyKey::str(&p.key))
+                    {
+                        if (!p.load || matches!(value, Value::Number(_))) && (!p.store || *writable)
+                        {
+                            prop_slots.push(idx as u32);
+                            ok = true;
+                        }
+                    }
+                }
+            }
+            if !ok {
+                self.kernel_prop_slots = prop_slots;
+                return self.step(frame, &k.fallback);
+            }
         }
         // Unboxed register file + array-base cache (both pooled on the Vm;
         // kernels never nest at runtime). The base objects are pinned for the
@@ -477,6 +518,7 @@ impl Vm {
                                     self.kernel_regs = regs;
                                     objs.clear();
                                     self.kernel_objs = objs;
+                                    self.kernel_prop_slots = prop_slots;
                                     self.op_budget = Some(0);
                                     return Err(self.throw_range("execution interrupted"));
                                 }
@@ -649,6 +691,41 @@ impl Vm {
                         branch!(bail)
                     }
                 }
+                // Entry-resolved named property access: raw slot, no check —
+                // the activation invariant (no map restructuring inside a
+                // kernel) keeps the slot AND its Number-ness valid.
+                KOp::LoadProp { dst, prop } => {
+                    let p = &k.props_used[prop as usize];
+                    let b = objs[p.oslot as usize].borrow();
+                    match b.props.get_index(prop_slots[prop as usize] as usize) {
+                        Some((
+                            _,
+                            Property {
+                                kind:
+                                    PropertyKind::Data {
+                                        value: Value::Number(n),
+                                        ..
+                                    },
+                                ..
+                            },
+                        )) => regs[dst as usize] = *n,
+                        _ => unreachable!("kernel prop slot invariant"),
+                    }
+                }
+                KOp::StoreProp { prop, src } => {
+                    let p = &k.props_used[prop as usize];
+                    let mut b = objs[p.oslot as usize].borrow_mut();
+                    match b.props.get_index_mut(prop_slots[prop as usize] as usize) {
+                        Some((
+                            _,
+                            Property {
+                                kind: PropertyKind::Data { value, .. },
+                                ..
+                            },
+                        )) => *value = Value::Number(regs[src as usize]),
+                        _ => unreachable!("kernel prop slot invariant"),
+                    }
+                }
                 KOp::Exit { resume_ip, shape } => break (resume_ip, shape),
                 // Function-kernel-only ops; loop translation never emits them.
                 KOp::Ret { .. } | KOp::SelfCall { .. } => unreachable!("fn op in a loop kernel"),
@@ -690,6 +767,7 @@ impl Vm {
         self.kernel_regs = regs;
         objs.clear();
         self.kernel_objs = objs;
+        self.kernel_prop_slots = prop_slots;
         Ok(Ctl::Jump(resume_ip as usize))
     }
 
@@ -853,6 +931,8 @@ impl Vm {
                 KOp::LoadElem { .. }
                 | KOp::StoreElem { .. }
                 | KOp::LoadLen { .. }
+                | KOp::LoadProp { .. }
+                | KOp::StoreProp { .. }
                 | KOp::Exit { .. }
                 | KOp::SelfCall { .. } => unreachable!("bail op in a function kernel"),
             }
@@ -1090,6 +1170,8 @@ impl Vm {
                 KOp::LoadElem { .. }
                 | KOp::StoreElem { .. }
                 | KOp::LoadLen { .. }
+                | KOp::LoadProp { .. }
+                | KOp::StoreProp { .. }
                 | KOp::Exit { .. } => unreachable!("bail op in a function kernel"),
             }
             pc += 1;

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -650,8 +650,8 @@ impl Vm {
                     }
                 }
                 KOp::Exit { resume_ip, shape } => break (resume_ip, shape),
-                // Function-kernel-only op; loop translation never emits it.
-                KOp::Ret { .. } => unreachable!("Ret in a loop kernel"),
+                // Function-kernel-only ops; loop translation never emits them.
+                KOp::Ret { .. } | KOp::SelfCall { .. } => unreachable!("fn op in a loop kernel"),
             }
             pc += 1;
         };
@@ -711,6 +711,10 @@ impl Vm {
         let k = bf.proto.fn_kernel.as_ref()?;
         if self.op_budget.is_some() || self.trace_sink.is_some() {
             return None;
+        }
+        // Self-recursive kernels run the windowed executor.
+        if k.self_global.is_some() {
+            return self.run_fn_kernel_rec(bf, args);
         }
         let mut regs = std::mem::take(&mut self.kernel_regs);
         regs.clear();
@@ -844,7 +848,245 @@ impl Vm {
                     }
                 }
                 // A frameless kernel has no bytecode frame to bail into;
-                // fn-mode translation rejects anything needing one.
+                // fn-mode translation rejects anything needing one. A
+                // SelfCall implies `self_global`, dispatched above.
+                KOp::LoadElem { .. }
+                | KOp::StoreElem { .. }
+                | KOp::LoadLen { .. }
+                | KOp::Exit { .. }
+                | KOp::SelfCall { .. } => unreachable!("bail op in a function kernel"),
+            }
+            pc += 1;
+        };
+        self.kernel_regs = regs;
+        Some(Ok(ret))
+    }
+
+    /// The WINDOWED executor for self-recursive function kernels
+    /// (`Kernel::self_global`): each [`KOp::SelfCall`] pushes a fresh
+    /// `n_regs`-wide register window and an explicit (return-pc, dst,
+    /// caller-window) record — the whole recursion runs without a single
+    /// frame or `Value`. Extra guard over `run_fn_kernel`: the global the
+    /// recursive callee resolves through must be a plain data property
+    /// holding the VERY closure being invoked (pointer identity), so a
+    /// shadowed/rebound/accessor'd name declines and the call runs
+    /// generically. Depth mirrors the interpreter's limit; on overflow the
+    /// activation is ABANDONED and `None` returned — sound because kernels
+    /// are pure (registers only), and the caller's generic rerun then
+    /// raises the spec RangeError from the exact frame it belongs to.
+    fn run_fn_kernel_rec(
+        &mut self,
+        bf: &BytecodeFunction,
+        args: &[Value],
+    ) -> Option<Result<Value, Value>> {
+        let k = bf.proto.fn_kernel.as_ref()?;
+        let name = k.self_global.as_deref()?;
+        {
+            let g = self.realm.global.borrow();
+            let ok = matches!(
+                g.props.get(&PropertyKey::str(name)),
+                Some(Property {
+                    kind: PropertyKind::Data { value: Value::Object(o), .. },
+                    ..
+                }) if matches!(
+                    &o.borrow().internal,
+                    Internal::Function(FunctionInner::Bytecode(bf2))
+                        if std::ptr::eq(Rc::as_ptr(bf2), bf)
+                )
+            );
+            if !ok {
+                return None;
+            }
+        }
+        let n_regs = k.n_regs as usize;
+        let mut regs = std::mem::take(&mut self.kernel_regs);
+        regs.clear();
+        regs.resize(n_regs, 0.0);
+        for (r, slot) in k.locals.iter().enumerate() {
+            match slot {
+                crate::bytecode::KSlot::Arg(a) => match args.get(*a as usize) {
+                    Some(Value::Number(n)) => regs[r] = *n,
+                    _ => {
+                        self.kernel_regs = regs;
+                        return None;
+                    }
+                },
+                crate::bytecode::KSlot::Local(_) => {}
+                crate::bytecode::KSlot::Upvalue(u) => match &*bf.upvalues[*u as usize].borrow() {
+                    Value::Number(n) => regs[r] = *n,
+                    _ => {
+                        self.kernel_regs = regs;
+                        return None;
+                    }
+                },
+            }
+        }
+        if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
+            self.kernel_regs = regs;
+            return None;
+        }
+        let interrupt = self.interrupt.clone();
+        let mut poll: u32 = 0;
+        let code = &k.code;
+        // (return pc, dst register, caller window base) per live self-call.
+        let mut calls: Vec<(u16, u16, usize)> = Vec::new();
+        let mut base = 0usize;
+        let mut pc = 0usize;
+        let ret = loop {
+            // Back-edges AND self-calls poll the cooperative interrupt flag.
+            macro_rules! poll_interrupt {
+                () => {{
+                    poll = poll.wrapping_add(1);
+                    if poll & 0xFF == 0 {
+                        if let Some(flag) = &interrupt {
+                            if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                self.kernel_regs = regs;
+                                self.op_budget = Some(0);
+                                return Some(Err(self.throw_range("execution interrupted")));
+                            }
+                        }
+                    }
+                }};
+            }
+            macro_rules! branch {
+                ($t:expr) => {{
+                    let t = $t as usize;
+                    if t <= pc {
+                        poll_interrupt!();
+                    }
+                    pc = t;
+                    continue;
+                }};
+            }
+            match code[pc] {
+                KOp::Mov { dst, src } => regs[base + dst as usize] = regs[base + src as usize],
+                KOp::Const { dst, k } => regs[base + dst as usize] = k,
+                KOp::Add { dst, a, b } => {
+                    regs[base + dst as usize] = regs[base + a as usize] + regs[base + b as usize]
+                }
+                KOp::AddK { dst, a, k } => regs[base + dst as usize] = regs[base + a as usize] + k,
+                KOp::Arith { kind, dst, a, b } => {
+                    regs[base + dst as usize] =
+                        number_arith_raw(regs[base + a as usize], regs[base + b as usize], kind)
+                }
+                KOp::ArithK { kind, dst, a, k } => {
+                    regs[base + dst as usize] = number_arith_raw(regs[base + a as usize], k, kind)
+                }
+                KOp::Neg { dst, src } => regs[base + dst as usize] = -regs[base + src as usize],
+                KOp::BitNot { dst, src } => {
+                    regs[base + dst as usize] =
+                        !crate::vm::to_int32(regs[base + src as usize]) as f64
+                }
+                KOp::Br { target } => branch!(target),
+                KOp::BrCmp {
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target,
+                } => {
+                    if knum_cmp(cmp, regs[base + a as usize], regs[base + b as usize]) == if_true {
+                        branch!(target)
+                    }
+                }
+                KOp::BrCmpK {
+                    cmp,
+                    a,
+                    k,
+                    if_true,
+                    target,
+                } => {
+                    if knum_cmp(cmp, regs[base + a as usize], k) == if_true {
+                        branch!(target)
+                    }
+                }
+                KOp::BrFalsy { src, target } => {
+                    if !knum_truthy(regs[base + src as usize]) {
+                        branch!(target)
+                    }
+                }
+                KOp::BrTruthy { src, target } => {
+                    if knum_truthy(regs[base + src as usize]) {
+                        branch!(target)
+                    }
+                }
+                KOp::CmpSet { cmp, dst, a, b } => {
+                    regs[base + dst as usize] =
+                        if knum_cmp(cmp, regs[base + a as usize], regs[base + b as usize]) {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                }
+                KOp::BoolNot { dst, src } => {
+                    regs[base + dst as usize] = if knum_truthy(regs[base + src as usize]) {
+                        0.0
+                    } else {
+                        1.0
+                    }
+                }
+                KOp::Math1 { kind, dst, src } => {
+                    regs[base + dst as usize] = kmath1(kind, regs[base + src as usize])
+                }
+                KOp::Math2 { kind, dst, a, b } => {
+                    regs[base + dst as usize] =
+                        kmath2(kind, regs[base + a as usize], regs[base + b as usize])
+                }
+                KOp::SelfCall {
+                    dst,
+                    base: abase,
+                    argc: _,
+                } => {
+                    // Mirror the generic per-call depth guard: an overflow
+                    // abandons the pure activation; the generic rerun then
+                    // recurses to the same depth and raises the RangeError.
+                    if self.call_depth + calls.len() + 1 > self.max_call_depth {
+                        self.kernel_regs = regs;
+                        return None;
+                    }
+                    poll_interrupt!();
+                    let new_base = base + n_regs;
+                    if regs.len() < new_base + n_regs {
+                        regs.resize(new_base + n_regs, 0.0);
+                    }
+                    // Populate the callee window: arguments from the call
+                    // site's contiguous registers, upvalues copied through
+                    // (same closure — the guard proved it), locals are
+                    // scratch (store-before-read proven at translation).
+                    for (r, slot) in k.locals.iter().enumerate() {
+                        match slot {
+                            crate::bytecode::KSlot::Arg(a) => {
+                                // Translation guarantees argc covers every
+                                // consumed argument index.
+                                regs[new_base + r] = regs[base + abase as usize + *a as usize];
+                            }
+                            crate::bytecode::KSlot::Upvalue(_) => {
+                                regs[new_base + r] = regs[base + r];
+                            }
+                            crate::bytecode::KSlot::Local(_) => {}
+                        }
+                    }
+                    calls.push((pc as u16 + 1, dst, base));
+                    base = new_base;
+                    pc = 0;
+                    continue;
+                }
+                KOp::Ret { src, boolean } => {
+                    // Recursive kernels are Number-only (enforced at
+                    // translation) — a boolean would land in a caller
+                    // register statically typed Num.
+                    debug_assert!(!boolean);
+                    let v = regs[base + src as usize];
+                    match calls.pop() {
+                        Some((ret_pc, dst, prev)) => {
+                            base = prev;
+                            regs[base + dst as usize] = v;
+                            pc = ret_pc as usize;
+                            continue;
+                        }
+                        None => break Value::Number(v),
+                    }
+                }
                 KOp::LoadElem { .. }
                 | KOp::StoreElem { .. }
                 | KOp::LoadLen { .. }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -379,8 +379,30 @@ impl Vm {
     /// and keeping its large register loop out of `step` pins the codegen of
     /// both — growing this function must not perturb the interpreter's hot
     /// dispatch.
+    ///
+    /// The register loop is MONOMORPHIZED on whether the kernel calls pinned
+    /// closures: the plain instantiation compiles the `CallKernel` arm (and
+    /// the callee state's liveness) out entirely, so growing the closure
+    /// tier cannot tax pure numeric/array/property loops with register
+    /// spills in their dispatch.
     #[inline(never)]
     fn run_kernel_op(&mut self, frame: &mut Frame, idx: u32) -> Result<Ctl, Value> {
+        if frame.func.proto.kernels[idx as usize]
+            .callee_slots
+            .is_empty()
+        {
+            self.run_kernel_op_impl::<false>(frame, idx)
+        } else {
+            self.run_kernel_op_impl::<true>(frame, idx)
+        }
+    }
+
+    #[inline(never)]
+    fn run_kernel_op_impl<const CALLEES: bool>(
+        &mut self,
+        frame: &mut Frame,
+        idx: u32,
+    ) -> Result<Ctl, Value> {
         let proto = frame.func.proto.clone();
         let k = &proto.kernels[idx as usize];
         // An installed op budget makes per-op counts observable (the
@@ -488,6 +510,90 @@ impl Vm {
                 objs.push(o.clone());
             }
         }
+        // Pinned closure callees (`KOp::CallKernel`): ONE guard per
+        // activation covers everything the per-call `run_fn_kernel` guard
+        // would check — the callee object is an oslot (in-region stores to
+        // it reject), so its identity, kernel, upvalue types and the Math
+        // canonicals cannot change while the loop runs. Loop calls happen at
+        // one constant depth, so a single depth check suffices; a trace sink
+        // declines (it must see an enter/exit per call).
+        let mut callee_bfs = std::mem::take(&mut self.kernel_callees);
+        callee_bfs.clear();
+        if CALLEES {
+            let mut ok = self.trace_sink.is_none() && self.call_depth < self.max_call_depth;
+            let mut win = k.n_regs as usize;
+            if ok {
+                for c in k.callee_slots.iter() {
+                    let bf = {
+                        let b = objs[c.oslot as usize].borrow();
+                        match &b.internal {
+                            Internal::Function(FunctionInner::Bytecode(bf))
+                                if !bf.is_class_ctor =>
+                            {
+                                Some(bf.clone())
+                            }
+                            _ => None,
+                        }
+                    };
+                    let Some(bf) = bf else {
+                        ok = false;
+                        break;
+                    };
+                    let Some(ck) = bf.proto.fn_kernel.as_ref() else {
+                        ok = false;
+                        break;
+                    };
+                    // Number-returning, non-recursive, fully-supplied args,
+                    // canonical Math, Number upvalues — else stay generic.
+                    let ck_ok = ck.self_global.is_none()
+                        && ck
+                            .code
+                            .iter()
+                            .all(|op| !matches!(op, KOp::Ret { boolean: true, .. }))
+                        && ck.locals.iter().all(|sl| match sl {
+                            crate::bytecode::KSlot::Arg(a) => *a < u32::from(c.min_argc),
+                            _ => true,
+                        })
+                        && (ck.math_used.is_empty() || self.kernel_math_ok(&ck.math_used))
+                        && ck.locals.iter().all(|sl| match sl {
+                            crate::bytecode::KSlot::Upvalue(u) => {
+                                matches!(*bf.upvalues[*u as usize].borrow(), Value::Number(_))
+                            }
+                            _ => true,
+                        });
+                    if !ck_ok {
+                        ok = false;
+                        break;
+                    }
+                    let n = ck.n_regs as usize;
+                    callee_bfs.push((bf, win as u32));
+                    win += n;
+                }
+            }
+            if !ok {
+                self.kernel_regs = regs;
+                objs.clear();
+                self.kernel_objs = objs;
+                self.kernel_prop_slots = prop_slots;
+                callee_bfs.clear();
+                self.kernel_callees = callee_bfs;
+                return self.step(frame, &k.fallback);
+            }
+            // Extend the register file with the callee windows and load each
+            // window's upvalue snapshot ONCE (identities are pinned; callee
+            // code never writes an upvalue register).
+            regs.resize(win, 0.0);
+            for (bf, wb) in callee_bfs.iter() {
+                let ck = bf.proto.fn_kernel.as_ref().expect("guarded");
+                for (r, slot) in ck.locals.iter().enumerate() {
+                    if let crate::bytecode::KSlot::Upvalue(u) = slot {
+                        if let Value::Number(n) = *bf.upvalues[*u as usize].borrow() {
+                            regs[*wb as usize + r] = n;
+                        }
+                    }
+                }
+            }
+        }
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
         let code = &k.code;
@@ -519,6 +625,8 @@ impl Vm {
                                     objs.clear();
                                     self.kernel_objs = objs;
                                     self.kernel_prop_slots = prop_slots;
+                                    callee_bfs.clear();
+                                    self.kernel_callees = callee_bfs;
                                     self.op_budget = Some(0);
                                     return Err(self.throw_range("execution interrupted"));
                                 }
@@ -726,7 +834,47 @@ impl Vm {
                         _ => unreachable!("kernel prop slot invariant"),
                     }
                 }
+                // A pinned-closure call: copy the arguments into the
+                // callee's window and run its (guarded) kernel inline.
+                KOp::CallKernel {
+                    dst,
+                    fslot,
+                    base,
+                    argc: _,
+                } if CALLEES => {
+                    let (bf, wb) = &callee_bfs[fslot as usize];
+                    let ck = bf.proto.fn_kernel.as_ref().expect("guarded");
+                    let win = *wb as usize;
+                    for (r, slot) in ck.locals.iter().enumerate() {
+                        if let crate::bytecode::KSlot::Arg(a) = slot {
+                            regs[win + r] = regs[base as usize + *a as usize];
+                        }
+                    }
+                    if !run_callee_window(&mut regs, ck, win, dst as usize, &interrupt, &mut poll) {
+                        // Interrupted on a callee back-edge: the same
+                        // latch-and-unwind as an interrupted caller edge.
+                        for (r, slot) in k.locals.iter().enumerate() {
+                            if let crate::bytecode::KSlot::Local(l) = slot {
+                                frame.locals[*l as usize] = Value::Number(regs[r]);
+                            }
+                        }
+                        for (j, &l) in k.bool_locals.iter().enumerate() {
+                            frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
+                        }
+                        self.kernel_regs = regs;
+                        objs.clear();
+                        self.kernel_objs = objs;
+                        self.kernel_prop_slots = prop_slots;
+                        callee_bfs.clear();
+                        self.kernel_callees = callee_bfs;
+                        self.op_budget = Some(0);
+                        return Err(self.throw_range("execution interrupted"));
+                    }
+                }
                 KOp::Exit { resume_ip, shape } => break (resume_ip, shape),
+                // Plain instantiation: a kernel without callee_slots never
+                // contains CallKernel (translator invariant).
+                KOp::CallKernel { .. } => unreachable!("CallKernel in a plain kernel loop"),
                 // Function-kernel-only ops; loop translation never emits them.
                 KOp::Ret { .. } | KOp::SelfCall { .. } => unreachable!("fn op in a loop kernel"),
             }
@@ -768,6 +916,8 @@ impl Vm {
         objs.clear();
         self.kernel_objs = objs;
         self.kernel_prop_slots = prop_slots;
+        callee_bfs.clear();
+        self.kernel_callees = callee_bfs;
         Ok(Ctl::Jump(resume_ip as usize))
     }
 
@@ -934,6 +1084,7 @@ impl Vm {
                 | KOp::LoadProp { .. }
                 | KOp::StoreProp { .. }
                 | KOp::Exit { .. }
+                | KOp::CallKernel { .. }
                 | KOp::SelfCall { .. } => unreachable!("bail op in a function kernel"),
             }
             pc += 1;
@@ -1172,6 +1323,7 @@ impl Vm {
                 | KOp::LoadLen { .. }
                 | KOp::LoadProp { .. }
                 | KOp::StoreProp { .. }
+                | KOp::CallKernel { .. }
                 | KOp::Exit { .. } => unreachable!("bail op in a function kernel"),
             }
             pc += 1;
@@ -5065,6 +5217,133 @@ fn bin_arith(vm: &mut Vm, frame: &mut Frame, kind: ArithKind) -> Result<(), Valu
     let r = vm.arith(a, b, kind)?;
     frame.stack.push(r);
     Ok(())
+}
+
+/// Execute the pinned-callee kernel `ck` (guarded by the caller loop
+/// kernel's entry: non-recursive, Number-returning, args/upvalues in the
+/// window at `win`) and write its return value to `regs[dst]`. Returns
+/// `false` when the cooperative interrupt fired on a callee back-edge — the
+/// caller then unwinds exactly like one of its own interrupted edges.
+#[inline(never)]
+fn run_callee_window(
+    regs: &mut [f64],
+    ck: &crate::bytecode::Kernel,
+    win: usize,
+    dst: usize,
+    interrupt: &Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    poll: &mut u32,
+) -> bool {
+    let code = &ck.code;
+    let mut pc = 0usize;
+    loop {
+        macro_rules! branch {
+            ($t:expr) => {{
+                let t = $t as usize;
+                if t <= pc {
+                    *poll = poll.wrapping_add(1);
+                    if *poll & 0xFF == 0 {
+                        if let Some(flag) = interrupt {
+                            if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                pc = t;
+                continue;
+            }};
+        }
+        match code[pc] {
+            KOp::Mov { dst, src } => regs[win + dst as usize] = regs[win + src as usize],
+            KOp::Const { dst, k } => regs[win + dst as usize] = k,
+            KOp::Add { dst, a, b } => {
+                regs[win + dst as usize] = regs[win + a as usize] + regs[win + b as usize]
+            }
+            KOp::AddK { dst, a, k } => regs[win + dst as usize] = regs[win + a as usize] + k,
+            KOp::Arith { kind, dst, a, b } => {
+                regs[win + dst as usize] =
+                    number_arith_raw(regs[win + a as usize], regs[win + b as usize], kind)
+            }
+            KOp::ArithK { kind, dst, a, k } => {
+                regs[win + dst as usize] = number_arith_raw(regs[win + a as usize], k, kind)
+            }
+            KOp::Neg { dst, src } => regs[win + dst as usize] = -regs[win + src as usize],
+            KOp::BitNot { dst, src } => {
+                regs[win + dst as usize] = !crate::vm::to_int32(regs[win + src as usize]) as f64
+            }
+            KOp::Br { target } => branch!(target),
+            KOp::BrCmp {
+                cmp,
+                a,
+                b,
+                if_true,
+                target,
+            } => {
+                if knum_cmp(cmp, regs[win + a as usize], regs[win + b as usize]) == if_true {
+                    branch!(target)
+                }
+            }
+            KOp::BrCmpK {
+                cmp,
+                a,
+                k,
+                if_true,
+                target,
+            } => {
+                if knum_cmp(cmp, regs[win + a as usize], k) == if_true {
+                    branch!(target)
+                }
+            }
+            KOp::BrFalsy { src, target } => {
+                if !knum_truthy(regs[win + src as usize]) {
+                    branch!(target)
+                }
+            }
+            KOp::BrTruthy { src, target } => {
+                if knum_truthy(regs[win + src as usize]) {
+                    branch!(target)
+                }
+            }
+            KOp::CmpSet { cmp, dst, a, b } => {
+                regs[win + dst as usize] =
+                    if knum_cmp(cmp, regs[win + a as usize], regs[win + b as usize]) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+            }
+            KOp::BoolNot { dst, src } => {
+                regs[win + dst as usize] = if knum_truthy(regs[win + src as usize]) {
+                    0.0
+                } else {
+                    1.0
+                }
+            }
+            KOp::Math1 { kind, dst, src } => {
+                regs[win + dst as usize] = kmath1(kind, regs[win + src as usize])
+            }
+            KOp::Math2 { kind, dst, a, b } => {
+                regs[win + dst as usize] =
+                    kmath2(kind, regs[win + a as usize], regs[win + b as usize])
+            }
+            KOp::Ret { src, boolean: _ } => {
+                // Number-only (the caller guard rejected boolean returns).
+                regs[dst] = regs[win + src as usize];
+                return true;
+            }
+            // Impossible in a guarded callee: no bails, no exits, no
+            // recursion, no nested closure calls.
+            KOp::LoadElem { .. }
+            | KOp::StoreElem { .. }
+            | KOp::LoadLen { .. }
+            | KOp::LoadProp { .. }
+            | KOp::StoreProp { .. }
+            | KOp::Exit { .. }
+            | KOp::SelfCall { .. }
+            | KOp::CallKernel { .. } => unreachable!("unsupported op in a callee kernel"),
+        }
+        pc += 1;
+    }
 }
 
 /// Number (f64) arithmetic preserving the original JS semantics.

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -4,7 +4,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::bytecode::{CmpOp, Const, FuncKind, Op, UpvalueSource};
+use crate::bytecode::{CmpOp, Const, FuncKind, KOp, Op, UpvalueSource};
 use crate::value::*;
 use crate::vm::*;
 
@@ -306,6 +306,132 @@ impl Vm {
         };
         self.call_depth -= 1;
         r
+    }
+
+    /// Execute the typed loop kernel at `Op::LoopKernel(idx)` (see
+    /// `kernel.rs` for the model). Runs only when per-op accounting is off
+    /// (no op budget) and every mapped local holds a `Number`; otherwise the
+    /// original header op (`Kernel::fallback`) executes and the generic
+    /// interpreter takes this iteration — the kernel simply retries the next
+    /// time the back-edge reaches the header.
+    fn run_kernel_op(&mut self, frame: &mut Frame, idx: u32) -> Result<Ctl, Value> {
+        let proto = frame.func.proto.clone();
+        let k = &proto.kernels[idx as usize];
+        // An installed op budget makes per-op counts observable (the
+        // exhaustion throw lands on an exact op); kernels would skew it.
+        if self.op_budget.is_some() {
+            return self.step(frame, &k.fallback);
+        }
+        for &l in k.locals.iter() {
+            if !matches!(frame.locals[l as usize], Value::Number(_)) {
+                return self.step(frame, &k.fallback);
+            }
+        }
+        // Unboxed register file (pooled on the Vm; kernels never nest).
+        let mut regs = std::mem::take(&mut self.kernel_regs);
+        regs.clear();
+        regs.resize(k.n_regs as usize, 0.0);
+        for (r, &l) in k.locals.iter().enumerate() {
+            if let Value::Number(n) = frame.locals[l as usize] {
+                regs[r] = n;
+            }
+        }
+        let interrupt = self.interrupt.clone();
+        let mut poll: u32 = 0;
+        let code = &k.code;
+        let mut pc = 0usize;
+        let (resume_ip, stack) = loop {
+            // Taken branches funnel through here so back-edges can poll the
+            // cooperative interrupt flag at the interpreter's cadence.
+            macro_rules! branch {
+                ($t:expr) => {{
+                    let t = $t as usize;
+                    if t <= pc {
+                        poll = poll.wrapping_add(1);
+                        if poll & 0xFF == 0 {
+                            if let Some(flag) = &interrupt {
+                                if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                    // Same latch-and-unwind as the interpreter
+                                    // loop: zero the budget so a JS catch
+                                    // cannot resume execution.
+                                    for (r, &l) in k.locals.iter().enumerate() {
+                                        frame.locals[l as usize] = Value::Number(regs[r]);
+                                    }
+                                    self.kernel_regs = regs;
+                                    self.op_budget = Some(0);
+                                    return Err(self.throw_range("execution interrupted"));
+                                }
+                            }
+                        }
+                    }
+                    pc = t;
+                    continue;
+                }};
+            }
+            match code[pc] {
+                KOp::Mov { dst, src } => regs[dst as usize] = regs[src as usize],
+                KOp::Const { dst, k } => regs[dst as usize] = k,
+                KOp::Add { dst, a, b } => regs[dst as usize] = regs[a as usize] + regs[b as usize],
+                KOp::AddK { dst, a, k } => regs[dst as usize] = regs[a as usize] + k,
+                KOp::Arith { kind, dst, a, b } => {
+                    regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind)
+                }
+                KOp::ArithK { kind, dst, a, k } => {
+                    regs[dst as usize] = number_arith_raw(regs[a as usize], k, kind)
+                }
+                KOp::Neg { dst, src } => regs[dst as usize] = -regs[src as usize],
+                KOp::BitNot { dst, src } => {
+                    regs[dst as usize] = !crate::vm::to_int32(regs[src as usize]) as f64
+                }
+                KOp::Br { target } => branch!(target),
+                KOp::BrCmp {
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target,
+                } => {
+                    if knum_cmp(cmp, regs[a as usize], regs[b as usize]) == if_true {
+                        branch!(target)
+                    }
+                }
+                KOp::BrCmpK {
+                    cmp,
+                    a,
+                    k,
+                    if_true,
+                    target,
+                } => {
+                    if knum_cmp(cmp, regs[a as usize], k) == if_true {
+                        branch!(target)
+                    }
+                }
+                KOp::BrFalsy { src, target } => {
+                    if !knum_truthy(regs[src as usize]) {
+                        branch!(target)
+                    }
+                }
+                KOp::BrTruthy { src, target } => {
+                    if knum_truthy(regs[src as usize]) {
+                        branch!(target)
+                    }
+                }
+                KOp::Exit { resume_ip, stack } => break (resume_ip, stack),
+            }
+            pc += 1;
+        };
+        // Materialize: every mapped local back to the frame (as Numbers), any
+        // live canonical stack slots onto the operand stack, then resume the
+        // bytecode interpreter at the exit's target.
+        for (r, &l) in k.locals.iter().enumerate() {
+            frame.locals[l as usize] = Value::Number(regs[r]);
+        }
+        let stack_base = k.locals.len();
+        for d in 0..stack as usize {
+            frame.stack.push(Value::Number(regs[stack_base + d]));
+        }
+        self.kernel_regs = regs;
+        Ok(Ctl::Jump(resume_ip as usize))
     }
 
     fn describe(&self, v: &Value) -> String {
@@ -2361,6 +2487,8 @@ impl Vm {
                 };
                 push!(Value::String(out));
             }
+            Op::LoopKernel(i) => return self.run_kernel_op(frame, *i),
+
             _ => return self.step_cold(frame, op),
         }
         Ok(Ctl::Next)
@@ -4188,9 +4316,37 @@ fn bin_arith(vm: &mut Vm, frame: &mut Frame, kind: ArithKind) -> Result<(), Valu
 }
 
 /// Number (f64) arithmetic preserving the original JS semantics.
+/// Numeric comparison for kernel registers — exactly the interpreter's
+/// `cmp_values`/`less_than` restricted to `Number` operands: `f64` ordered
+/// comparisons are false on NaN, and `==` gives NaN != NaN, +0 == -0.
+#[inline]
+fn knum_cmp(cmp: CmpOp, a: f64, b: f64) -> bool {
+    match cmp {
+        CmpOp::Eq | CmpOp::StrictEq => a == b,
+        CmpOp::Ne | CmpOp::StrictNe => a != b,
+        CmpOp::Lt => a < b,
+        CmpOp::Gt => a > b,
+        CmpOp::Le => a <= b,
+        CmpOp::Ge => a >= b,
+    }
+}
+
+/// ToBoolean restricted to `Number`: false for `0`, `-0`, and NaN.
+#[inline]
+fn knum_truthy(x: f64) -> bool {
+    x != 0.0 && !x.is_nan()
+}
+
 fn number_arith(x: f64, y: f64, kind: ArithKind) -> Value {
+    Value::Number(number_arith_raw(x, y, kind))
+}
+
+/// The raw `f64` form of [`number_arith`] — shared with the typed loop
+/// kernels (`kernel.rs` / [`Vm::run_kernel_op`]) so kernel arithmetic is
+/// bit-identical to the interpreter's Number×Number paths by construction.
+pub(crate) fn number_arith_raw(x: f64, y: f64, kind: ArithKind) -> f64 {
     use crate::vm::{to_int32, to_uint32};
-    Value::Number(match kind {
+    match kind {
         ArithKind::Sub => x - y,
         ArithKind::Mul => x * y,
         ArithKind::Div => x / y,
@@ -4202,7 +4358,7 @@ fn number_arith(x: f64, y: f64, kind: ArithKind) -> Value {
         ArithKind::Shl => to_int32(x).wrapping_shl(to_uint32(y) & 31) as f64,
         ArithKind::Shr => to_int32(x).wrapping_shr(to_uint32(y) & 31) as f64,
         ArithKind::UShr => (to_uint32(x) >> (to_uint32(y) & 31)) as f64,
-    })
+    }
 }
 
 // ---- BigInt comparison helpers (relational + loose-equality) ----

--- a/crates/chidori-js/src/generator.rs
+++ b/crates/chidori-js/src/generator.rs
@@ -48,8 +48,12 @@ impl Vm {
                 }
             }
         };
+        let uses_arguments = bf.proto.uses_arguments;
         let mut frame = self.make_frame(bf, this, args, new_target);
-        frame.func_obj = Some(func_obj.clone());
+        // `func_obj` only feeds `arguments.callee` (see `call_bytecode_vec`).
+        if uses_arguments {
+            frame.func_obj = Some(func_obj.clone());
+        }
         let token = self.trace_enter(&frame.func.proto);
         frame.trace_token = token;
         // Run the parameter prologue now (call-time parameter evaluation): the
@@ -249,7 +253,7 @@ impl Vm {
                     self.trace_resume(token);
                     let flow = match (is_start, kind) {
                         (true, ResumeKind::Throw) => self.resume_frame_throw(frame, value),
-                        (true, _) => self.run_frame(*frame),
+                        (true, _) => self.run_frame(frame),
                         (false, ResumeKind::Throw) => self.resume_frame_throw(frame, value),
                         (false, _) => self.resume_frame(frame, value),
                     };
@@ -439,7 +443,7 @@ impl Vm {
             // First resume: ignore the sent value (spec).
             match kind {
                 ResumeKind::Throw => self.resume_frame_throw(frame, value),
-                _ => self.run_frame(*frame),
+                _ => self.run_frame(frame),
             }
         } else {
             match kind {

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -64,7 +64,7 @@
 //! corpus + fuzz (`tests/kernels.rs`) runs every supported construct with
 //! kernels on and off and asserts byte-identical behavior.
 
-use crate::bytecode::{CmpOp, Const, KMath, KOp, KShapeSlot, KSlot, Kernel, Op};
+use crate::bytecode::{CmpOp, Const, KMath, KOp, KProp, KShapeSlot, KSlot, Kernel, Op};
 use crate::exec::ArithKind;
 
 /// Bounds keeping `u16` fields comfortable and per-kernel work finite. Loops
@@ -383,6 +383,9 @@ struct Xlate<'a> {
     exits: Vec<(usize, u32, Vec<VE>)>,
     /// Math intrinsics used (entry guard checks each against the realm).
     math_used: Vec<KMath>,
+    /// Named-property access classes over oslot bases (entry-resolved; see
+    /// [`KProp`]). Deduplicated by (oslot, key); flags OR together.
+    props_used: Vec<KProp>,
     /// a compare op fused with its following conditional jump: skip that ip.
     absorbed: Option<usize>,
     max_stack: u16,
@@ -440,6 +443,7 @@ fn translate(
         fixups: Vec::new(),
         exits: Vec::new(),
         math_used: Vec::new(),
+        props_used: Vec::new(),
         absorbed: None,
         max_stack: 0,
     };
@@ -633,6 +637,8 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *val = remap(*val);
             }
             KOp::LoadLen { dst, .. } => *dst = remap(*dst),
+            KOp::LoadProp { dst, .. } => *dst = remap(*dst),
+            KOp::StoreProp { src, .. } => *src = remap(*src),
             KOp::Ret { src, .. } => *src = remap(*src),
             KOp::SelfCall { dst, base, .. } => {
                 *dst = remap(*dst);
@@ -684,6 +690,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         oslots: x.oslot_locals.to_vec().into_boxed_slice(),
         shapes: shapes.into_boxed_slice(),
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
+        props_used: std::mem::take(&mut x.props_used).into_boxed_slice(),
         n_regs: n_locals + n_bools + x.max_stack + 1,
         self_global: None, // `kernelize_function` fills it for recursive kernels
         fallback: Box::new(Op::Nop), // caller stores the real header op
@@ -966,6 +973,31 @@ impl Xlate<'_> {
                 Some(u16::try_from(s).ok()?)
             }
         }
+    }
+
+    /// Named-property access class for (`oslot`, `key`), deduplicated with
+    /// flags OR'd (a site that both loads and stores demands both entry
+    /// conditions). Bounded so per-activation entry resolution stays cheap.
+    fn kprop(&mut self, oslot: u16, key: &str, load: bool, store: bool) -> Option<u16> {
+        if let Some(i) = self
+            .props_used
+            .iter()
+            .position(|p| p.oslot == oslot && &*p.key == key)
+        {
+            self.props_used[i].load |= load;
+            self.props_used[i].store |= store;
+            return u16::try_from(i).ok();
+        }
+        if self.props_used.len() >= 64 {
+            return None;
+        }
+        self.props_used.push(KProp {
+            oslot,
+            key: key.into(),
+            load,
+            store,
+        });
+        u16::try_from(self.props_used.len() - 1).ok()
     }
 
     /// Within the same basic block starting at region-relative ip `from`, is
@@ -1553,21 +1585,51 @@ impl Xlate<'_> {
                     self.kops.push(K::Const { dst, k });
                     return Some(());
                 }
-                match self.consts.get(*c as usize)? {
-                    Const::String(s) if s.as_str() == "length" => {}
+                let key = match self.consts.get(*c as usize)? {
+                    Const::String(s) => s.as_str().to_string(),
                     _ => return None,
+                };
+                if key == "length" {
+                    // Arrays: derived length, per-access checked, bailable.
+                    let shape = self.vstack.clone();
+                    let obj = self.base_slot(0)?;
+                    self.pop()?; // base
+                    let dst = self.push_num()?;
+                    let kidx = self.kops.len();
+                    self.kops.push(K::LoadLen {
+                        dst,
+                        obj,
+                        bail: u16::MAX,
+                    });
+                    self.exits.push((kidx, self.base_ip + i as u32, shape));
+                } else {
+                    // Ordinary-object own data property: entry-resolved slot,
+                    // no per-access check, no bail (see `KOp::LoadProp`).
+                    let obj = self.base_slot(0)?;
+                    let prop = self.kprop(obj, &key, true, false)?;
+                    self.pop()?; // base
+                    let dst = self.push_num()?;
+                    self.kops.push(K::LoadProp { dst, prop });
                 }
-                let shape = self.vstack.clone();
-                let obj = self.base_slot(0)?;
+            }
+
+            // `o.k = v` named write: the entry-resolved in-place overwrite
+            // (`KOp::StoreProp`); the op's result is the assigned value.
+            Op::SetProp(c) => {
+                let key = match self.consts.get(*c as usize)? {
+                    Const::String(s) => s.as_str().to_string(),
+                    _ => return None,
+                };
+                let val = self.top_num_reg(0)?;
+                let obj = self.base_slot(1)?;
+                let prop = self.kprop(obj, &key, false, true)?;
+                self.pop()?; // val
                 self.pop()?; // base
                 let dst = self.push_num()?;
-                let kidx = self.kops.len();
-                self.kops.push(K::LoadLen {
-                    dst,
-                    obj,
-                    bail: u16::MAX,
-                });
-                self.exits.push((kidx, self.base_ip + i as u32, shape));
+                self.kops.push(K::StoreProp { prop, src: val });
+                if dst != val {
+                    self.kops.push(K::Mov { dst, src: val });
+                }
             }
 
             // A call is supported ONLY as the compiler's Math method-call

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -17,50 +17,59 @@
 //! it may only run where it provably computes exactly what the generic
 //! interpreter would.
 //!
-//! - **Eligibility is static.** A loop region qualifies only if every op in it
-//!   is on the numeric allowlist: loads/stores of `frame.locals` slots,
-//!   `Number` constants, arithmetic/comparison/branch ops and their fused
-//!   forms. Anything else — calls, property access, cells/upvalues, TDZ
-//!   *initialization*, try handlers, iterators, suspension — and the loop is
-//!   simply not kernelized. No op is ever half-supported.
-//! - **Entry is guarded.** At runtime the kernel runs only after checking that
-//!   every mapped local currently holds a `Number`. JS numeric ops are closed
-//!   over numbers, so once the guard passes no non-number can appear
-//!   mid-kernel — there is no mid-loop type surprise and therefore no deopt
-//!   map. A failed guard executes the original header op ([`Kernel::fallback`])
-//!   and the generic interpreter takes that iteration; the kernel retries when
-//!   the back-edge next reaches the header (late entry: a binding that warms
-//!   to a number on iteration 1 enters the kernel from iteration 2).
+//! - **Eligibility is static.** A loop region qualifies only if every op is on
+//!   the allowlist: loads/stores of localized `frame.locals` slots, `Number`
+//!   constants, arithmetic/comparison/branch ops and their fused forms, plus
+//!   dense-array element access (`a[i]`, `a[i] = v`, `a.length`) on
+//!   local-held bases. Anything else — calls, other property access,
+//!   cells/upvalues, TDZ *initialization*, try handlers, iterators,
+//!   suspension — and the loop is simply not kernelized. An inner loop's own
+//!   `Op::LoopKernel` translates as its preserved fallback op, so NESTED
+//!   numeric loops kernelize as one outer kernel.
+//! - **Entry is guarded, accesses are checked, exits are precise.** The kernel
+//!   runs only after checking every mapped numeric local holds a `Number` and
+//!   every array-base local holds an object. Numeric JS ops are closed over
+//!   numbers, so no non-number can appear mid-kernel from arithmetic; the ONLY
+//!   speculative reads are array elements, and each `LoadElem`/`StoreElem`/
+//!   `LoadLen` re-checks its full fast-path condition (unshadowed dense array,
+//!   integral in-bounds index, non-hole `Number` element) and otherwise BAILS:
+//!   registers are written back and the generic interpreter resumes AT the
+//!   access op with the operand stack reconstructed from a shape table — the
+//!   slow path then performs the exact spec semantics. A failed entry guard
+//!   executes the original header op ([`Kernel::fallback`]); the kernel
+//!   retries when the back-edge next reaches the header (late entry).
 //! - **Semantics are shared, not re-implemented.** Kernel arithmetic calls the
 //!   same `number_arith_raw`/`js_mod`/`to_int32` helpers as the interpreter's
-//!   `Number`×`Number` fast paths, so results are bit-identical (NaN, -0,
-//!   overflow, shift masking — all of it).
+//!   `Number`×`Number` fast paths, and element access mirrors the
+//!   `Op::GetPropDynamic`/`Op::SetPropDynamic` fast-path conditions verbatim,
+//!   so results are bit-identical (NaN, -0, shift masking, holes — all of it).
 //! - **Observability.** Within an eligible region the generic interpreter
-//!   touches nothing but local slots, the operand stack, and control flow: no
-//!   journal, no allocation, no user code. The op budget IS observable (an
-//!   exact-count uncatchable throw), so kernels are disabled whenever a budget
-//!   is installed (see `Vm::run_kernel`); the cooperative interrupt flag is
-//!   polled on kernel back-edges, preserving prompt cancellation.
+//!   touches nothing but local slots, dense elements, the operand stack, and
+//!   control flow: no journal, no allocation, no user code. The op budget IS
+//!   observable (an exact-count uncatchable throw), so kernels are disabled
+//!   whenever a budget is installed (see `Vm::run_kernel_op`); the cooperative
+//!   interrupt flag is polled on kernel back-edges, preserving prompt
+//!   cancellation.
 //!
 //! Determinism: translation is a pure function of the bytecode (itself a pure
-//! function of the source) and the guard depends only on program values, so
+//! function of the source) and every guard depends only on program values, so
 //! record and replay execute identically with kernels on. The differential
-//! corpus (`tests/kernels.rs`) runs every supported construct with kernels on
-//! and off and asserts byte-identical behavior.
+//! corpus + fuzz (`tests/kernels.rs`) runs every supported construct with
+//! kernels on and off and asserts byte-identical behavior.
 
-use crate::bytecode::{CmpOp, Const, KOp, Kernel, Op};
+use crate::bytecode::{CmpOp, Const, KOp, KShapeSlot, Kernel, Op};
 use crate::exec::ArithKind;
 
 /// Bounds keeping `u16` fields comfortable and per-kernel work finite. Loops
 /// beyond them stay generic.
 const MAX_REGION_OPS: usize = 512;
 const MAX_KOPS: usize = 2048;
-/// Provisional numbering during translation: stack slot `d` is register
-/// `STACK_BASE + d`, scratch is `SCRATCH0/1`. A final remap compacts the file
-/// to `locals + stack + scratch` so the executor zeroes only what is used.
+/// Provisional numbering during translation: the virtual-stack entry at
+/// position `p` owns register `STACK_BASE + p` (object entries reserve theirs
+/// unused — uniform numbering keeps shuffles and merges trivial); `SCRATCH0`
+/// is the shuffle scratch. A final remap compacts the register file.
 const STACK_BASE: u16 = 64;
 const SCRATCH0: u16 = 252;
-const SCRATCH1: u16 = 253;
 
 /// Find every eligible loop in `code` and install kernels for them. Returns
 /// the (possibly rewritten) code and the kernel table. Loop-header ops are
@@ -84,9 +93,13 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
             }
         }
     }
-    // Innermost-first: smaller regions translate before enclosing ones; an
-    // enclosing region then sees the inner loop's fresh `LoopKernel` op and is
-    // rejected by the allowlist (nested kernels are out of scope for v1).
+    // Innermost-first: an inner loop kernelizes on its own; when the ENCLOSING
+    // region is then translated, the inner `Op::LoopKernel` header translates
+    // as its preserved fallback op and the rest of the inner loop's bytecode
+    // (still present in the region) translates normally — so a fully-numeric
+    // loop NEST becomes one outer kernel, and the inner kernel simply never
+    // dispatches at runtime. If the outer region is ineligible, the inner
+    // kernel still runs on its own.
     regions.sort_by_key(|&(s, e)| (e - s, s));
 
     for (start, end) in regions {
@@ -105,7 +118,16 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
         if jumps_into_interior {
             continue;
         }
-        if let Some(mut k) = translate(&code[start..=end], start as u32, consts) {
+        // Phase 1 discovers which locals are used as array BASES (`a[i]`);
+        // phase 2 re-translates with those locals as object slots. Both
+        // phases reject identically on anything off the allowlist.
+        let oslots = match translate(&code[start..=end], start as u32, consts, &kernels, &[]) {
+            Some((_, discovered)) => discovered,
+            None => continue,
+        };
+        if let Some((mut k, _)) =
+            translate(&code[start..=end], start as u32, consts, &kernels, &oslots)
+        {
             k.fallback = Box::new(code[start].clone());
             code[start] = Op::LoopKernel(kernels.len() as u32);
             kernels.push(k);
@@ -149,32 +171,66 @@ fn op_targets(op: &Op) -> Vec<u32> {
     out
 }
 
+/// A virtual operand-stack entry during translation. The entry at stack
+/// position `p` owns provisional register `STACK_BASE + p`; `Obj` entries
+/// reserve theirs unused (values live in object slots, resolved at runtime).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum VE {
+    Num,
+    /// An array base: object slot index.
+    Obj(u16),
+    /// The value `undefined`, from `LoadUndefined`. Exists only transiently
+    /// within a basic block: its ONLY legal consumer is a store to a local
+    /// that is provably re-stored before any read (the compiler's
+    /// per-iteration `let` reset emits `LoadUndefined; StoreLocal(j)` right
+    /// before the loop re-initializes `j`). Everything else rejects.
+    Undef,
+}
+
 struct Xlate<'a> {
     region: &'a [Op],
     base_ip: u32,
     consts: &'a [Const],
+    /// Already-built kernels (inner loops) — `Op::LoopKernel` translates as
+    /// its fallback op.
+    inner: &'a [Kernel],
+    /// Locals designated as array bases (phase 2) — empty in phase 1.
+    oslot_locals: &'a [u32],
     kops: Vec<KOp>,
     /// kernel pc for each region-relative ip (`u16::MAX` = not emitted).
     kpc: Vec<u16>,
-    /// expected canonical stack depth at each region-relative ip, when known.
-    depth_at: Vec<Option<u16>>,
+    /// expected virtual-stack shape at each region-relative ip, when known.
+    shape_at: Vec<Option<Vec<VE>>>,
     /// in-region branch targets (any op branching to that ip).
     is_target: Vec<bool>,
-    /// (frame-local index, register) pairs, registers dense from 0.
+    /// numeric locals: (frame-local index, register), registers dense from 0.
     local_reg: Vec<(u32, u16)>,
+    /// phase 1: locals observed as array bases (with clean origins).
+    discovered: Vec<u32>,
+    /// phase 1 origin tracking: (local, version) of a pushed LoadLocal.
+    origins: Vec<Option<(u32, u32)>>,
+    versions: std::collections::HashMap<u32, u32>,
+    /// the current virtual stack.
+    vstack: Vec<VE>,
     /// pending in-region branch fixups: (kop index, region-relative target).
     fixups: Vec<(usize, usize)>,
-    /// pending exits: (kop index, absolute resume ip, stack depth).
-    exits: Vec<(usize, u32, u16)>,
+    /// pending exits: (kop index or LoadElem-style bail, resume ip, shape).
+    exits: Vec<(usize, u32, Vec<VE>)>,
     /// a compare op fused with its following conditional jump: skip that ip.
     absorbed: Option<usize>,
     max_stack: u16,
 }
 
-/// Attempt to translate a region into a kernel. Returns `None` — the loop
-/// stays generic — on ANY construct outside the allowlist. `fallback` is a
-/// placeholder for the caller to fill.
-fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
+/// Attempt to translate a region. Returns the kernel (fallback is a
+/// placeholder) and the discovered array-base locals, or `None` — the loop
+/// stays generic — on ANY construct outside the allowlist.
+fn translate(
+    region: &[Op],
+    base_ip: u32,
+    consts: &[Const],
+    inner: &[Kernel],
+    oslot_locals: &[u32],
+) -> Option<(Kernel, Vec<u32>)> {
     let mut is_target = vec![false; region.len()];
     for op in region {
         for t in op_targets(op) {
@@ -189,35 +245,42 @@ fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
         region,
         base_ip,
         consts,
+        inner,
+        oslot_locals,
         kops: Vec::new(),
         kpc: vec![u16::MAX; region.len()],
-        depth_at: vec![None; region.len()],
+        shape_at: vec![None; region.len()],
         is_target,
         local_reg: Vec::new(),
+        discovered: Vec::new(),
+        origins: Vec::new(),
+        versions: std::collections::HashMap::new(),
+        vstack: Vec::new(),
         fixups: Vec::new(),
         exits: Vec::new(),
         absorbed: None,
         max_stack: 0,
     };
-    x.depth_at[0] = Some(0);
+    x.shape_at[0] = Some(Vec::new());
 
-    let mut depth: u16 = 0;
     let mut reachable = true;
-    // The index is load-bearing (kpc/depth_at bookkeeping keyed by ip).
+    // The index is load-bearing (kpc/shape_at bookkeeping keyed by ip).
     #[allow(clippy::needless_range_loop)]
     for i in 0..region.len() {
         if x.absorbed.take() == Some(i) {
             // This conditional jump was fused into the preceding compare.
             continue;
         }
-        match x.depth_at[i] {
-            Some(d) => {
-                // A recorded depth: either a forward-branch target (must agree
-                // with the fallthrough depth when both reach it) or ip 0.
-                if reachable && d != depth {
-                    return None; // inconsistent stack depth at a merge point
+        match x.shape_at[i].take() {
+            Some(shape) => {
+                if reachable && shape != x.vstack {
+                    return None; // inconsistent stack shape at a merge point
                 }
-                depth = d;
+                if !reachable {
+                    x.vstack = shape.clone();
+                    x.origins = vec![None; shape.len()];
+                }
+                x.shape_at[i] = Some(shape);
                 reachable = true;
             }
             None => {
@@ -227,15 +290,16 @@ fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
                     // it fails the fixup pass below (kpc stays unmapped).
                     continue;
                 }
-                // Record the depth every executed op is translated at, so a
+                // Record the shape every executed op is translated at, so a
                 // later BACKWARD branch to it verifies register alignment.
-                x.depth_at[i] = Some(depth);
+                x.shape_at[i] = Some(x.vstack.clone());
             }
         }
         x.kpc[i] = u16::try_from(x.kops.len()).ok()?;
-        depth = x.emit(i, depth)?;
-        x.max_stack = x.max_stack.max(depth);
-        if x.kops.len() > MAX_KOPS {
+        let op = &region[i];
+        x.emit(op, i)?;
+        x.max_stack = x.max_stack.max(u16::try_from(x.vstack.len()).ok()?);
+        if x.kops.len() > MAX_KOPS || x.vstack.len() + (STACK_BASE as usize) >= SCRATCH0 as usize {
             return None;
         }
         // Ops with no fallthrough edge end the current basic block.
@@ -248,10 +312,10 @@ fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
     // the region: synthesize that exit.
     if reachable {
         let resume = base_ip + u32::try_from(region.len()).ok()?;
-        x.kops.push(KOp::Exit {
-            resume_ip: resume,
-            stack: depth,
-        });
+        let shape = x.vstack.clone();
+        let kidx = x.kops.len();
+        x.kops.push(KOp::Br { target: u16::MAX });
+        x.exits.push((kidx, resume, shape));
     }
 
     // Patch in-region branches.
@@ -263,27 +327,48 @@ fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
         }
         patch(&mut x.kops, kidx, pc);
     }
-    // Synthesize exit stubs.
+    // Synthesize exit stubs (deduplicated by resume ip + shape) and collect
+    // the shape table.
     let exits = std::mem::take(&mut x.exits);
-    for (kidx, resume_ip, stack) in exits {
-        let pc = u16::try_from(x.kops.len()).ok()?;
-        x.kops.push(KOp::Exit { resume_ip, stack });
+    let mut shapes: Vec<Vec<VE>> = Vec::new();
+    let mut stubs: Vec<(u32, u16, u16)> = Vec::new(); // (resume, shape idx, pc)
+    for (kidx, resume_ip, shape) in exits {
+        if shape.contains(&VE::Undef) {
+            return None; // `undefined` never survives to an exit
+        }
+        let sidx = match shapes.iter().position(|s| *s == shape) {
+            Some(p) => p as u16,
+            None => {
+                shapes.push(shape);
+                (shapes.len() - 1) as u16
+            }
+        };
+        let pc = match stubs.iter().find(|(r, s, _)| *r == resume_ip && *s == sidx) {
+            Some(&(_, _, pc)) => pc,
+            None => {
+                let pc = u16::try_from(x.kops.len()).ok()?;
+                x.kops.push(KOp::Exit {
+                    resume_ip,
+                    shape: sidx,
+                });
+                stubs.push((resume_ip, sidx, pc));
+                pc
+            }
+        };
         patch(&mut x.kops, kidx, pc);
     }
     if x.kops.len() > MAX_KOPS {
         return None;
     }
 
-    // Compact the register file: locals stay 0..n, provisional stack slots
-    // move to n.., scratch to the top. The executor zeroes exactly `n_regs`.
+    // Compact the register file: numeric locals stay 0..n, provisional stack
+    // position regs move to n.., scratch to the top.
     let n_locals = u16::try_from(x.local_reg.len()).ok()?;
     let remap = |r: u16| -> u16 {
         if r < STACK_BASE {
             r
         } else if r == SCRATCH0 {
             n_locals + x.max_stack
-        } else if r == SCRATCH1 {
-            n_locals + x.max_stack + 1
         } else {
             n_locals + (r - STACK_BASE)
         }
@@ -310,20 +395,47 @@ fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
             }
             KOp::BrCmpK { a, .. } => *a = remap(*a),
             KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } => *src = remap(*src),
+            KOp::LoadElem { dst, idx, .. } => {
+                *dst = remap(*dst);
+                *idx = remap(*idx);
+            }
+            KOp::StoreElem { idx, val, .. } => {
+                *idx = remap(*idx);
+                *val = remap(*val);
+            }
+            KOp::LoadLen { dst, .. } => *dst = remap(*dst),
             KOp::Br { .. } | KOp::Exit { .. } => {}
         }
     }
+    let shapes: Vec<Box<[KShapeSlot]>> = shapes
+        .into_iter()
+        .map(|s| {
+            s.iter()
+                .enumerate()
+                .map(|(p, e)| match e {
+                    VE::Num => KShapeSlot::Num(remap(STACK_BASE + p as u16)),
+                    VE::Obj(o) => KShapeSlot::Obj(*o),
+                    VE::Undef => unreachable!("undef never crosses block boundaries"),
+                })
+                .collect()
+        })
+        .collect();
 
     let mut locals: Vec<u32> = vec![0; n_locals as usize];
     for &(l, r) in &x.local_reg {
         locals[r as usize] = l;
     }
-    Some(Kernel {
-        code: x.kops.into_boxed_slice(),
-        locals: locals.into_boxed_slice(),
-        n_regs: n_locals + x.max_stack + 2,
-        fallback: Box::new(Op::Nop), // caller stores the real header op
-    })
+    Some((
+        Kernel {
+            code: x.kops.into_boxed_slice(),
+            locals: locals.into_boxed_slice(),
+            oslots: x.oslot_locals.to_vec().into_boxed_slice(),
+            shapes: shapes.into_boxed_slice(),
+            n_regs: n_locals + x.max_stack + 1,
+            fallback: Box::new(Op::Nop), // caller stores the real header op
+        },
+        x.discovered,
+    ))
 }
 
 fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
@@ -333,30 +445,49 @@ fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
         | KOp::BrCmpK { target, .. }
         | KOp::BrFalsy { target, .. }
         | KOp::BrTruthy { target, .. } => *target = pc,
+        KOp::LoadElem { bail, .. } | KOp::StoreElem { bail, .. } | KOp::LoadLen { bail, .. } => {
+            *bail = pc
+        }
         _ => unreachable!("patching a non-branch kop"),
     }
 }
 
 impl Xlate<'_> {
-    /// Register mirroring `frame.locals[l]`.
+    /// Register mirroring numeric `frame.locals[l]`. An array-base local can
+    /// never be a numeric local (that would need it to hold a Number and an
+    /// object at once — some iteration would bail every time; reject).
     fn lreg(&mut self, l: u32) -> Option<u16> {
+        if self.oslot_locals.contains(&l) {
+            return None;
+        }
         if let Some(&(_, r)) = self.local_reg.iter().find(|(ll, _)| *ll == l) {
             return Some(r);
         }
         let r = u16::try_from(self.local_reg.len()).ok()?;
         if r >= STACK_BASE {
-            return None; // more distinct locals than the numbering supports
+            return None;
         }
         self.local_reg.push((l, r));
         Some(r)
     }
 
-    /// Provisional register for canonical stack slot `d`.
-    fn sreg(&self, d: u16) -> Option<u16> {
-        if STACK_BASE + d >= SCRATCH0 {
+    /// Provisional register owned by virtual-stack position `p`.
+    fn preg(&self, p: usize) -> Option<u16> {
+        let r = STACK_BASE as usize + p;
+        if r >= SCRATCH0 as usize {
             return None;
         }
-        Some(STACK_BASE + d)
+        Some(r as u16)
+    }
+
+    /// Register of the CURRENT top-of-stack numeric entry `depth_from_top`
+    /// below the top (0 = top).
+    fn top_reg(&self, depth_from_top: usize) -> Option<u16> {
+        let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
+        match self.vstack[p] {
+            VE::Num => self.preg(p),
+            VE::Obj(_) | VE::Undef => None,
+        }
     }
 
     fn num_const(&self, idx: u32) -> Option<f64> {
@@ -366,187 +497,360 @@ impl Xlate<'_> {
         }
     }
 
-    /// Record a branch to absolute bytecode ip `t` from the kop at `kidx`:
-    /// in-region targets become fixups (recording/checking the canonical
-    /// stack depth `depth` at the target); out-of-region targets synthesize an
-    /// [`KOp::Exit`] stub that materializes `depth` stack slots.
-    fn branch_to(&mut self, kidx: usize, t: u32, depth: u16) -> Option<()> {
+    /// Push a Num entry, returning its register.
+    fn push_num(&mut self) -> Option<u16> {
+        let r = self.preg(self.vstack.len())?;
+        self.vstack.push(VE::Num);
+        self.origins.push(None);
+        Some(r)
+    }
+
+    fn pop(&mut self) -> Option<VE> {
+        self.origins.pop();
+        self.vstack.pop()
+    }
+
+    /// Pop, requiring a Num entry; returns its (position) register.
+    fn pop_num(&mut self) -> Option<u16> {
+        let r = self.top_reg(0)?;
+        self.pop();
+        Some(r)
+    }
+
+    /// Bump a local's version (any store invalidates pushed origins).
+    fn store_of(&mut self, l: u32) {
+        *self.versions.entry(l).or_insert(0) += 1;
+    }
+
+    /// Resolve the entry at `depth_from_top` as an ARRAY BASE. Phase 1: if it
+    /// has a clean local origin, record the local as discovered and treat the
+    /// entry as an object. Phase 2: it must already be `VE::Obj`.
+    fn base_slot(&mut self, depth_from_top: usize) -> Option<u16> {
+        let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
+        match self.vstack[p] {
+            VE::Obj(s) => Some(s),
+            VE::Undef => None,
+            VE::Num => {
+                // Phase 1 discovery only. (A local used BOTH as a base and
+                // numerically is caught in phase 2: its loads become `Obj`
+                // entries there, and any numeric consumer rejects the region.)
+                let (l, ver) = self.origins[p]?;
+                if *self.versions.get(&l).unwrap_or(&0) != ver {
+                    return None;
+                }
+                let s = match self.discovered.iter().position(|&d| d == l) {
+                    Some(s) => s,
+                    None => {
+                        self.discovered.push(l);
+                        self.discovered.len() - 1
+                    }
+                };
+                Some(u16::try_from(s).ok()?)
+            }
+        }
+    }
+
+    /// Within the same basic block starting at region-relative ip `from`, is
+    /// local `l` stored again before anything can observe it? Observation =
+    /// any op reading `l`, any branch/return-class op, or any branch target
+    /// (another block might read it). Conservative and linear.
+    fn dead_store_ahead(&self, from: usize, l: u32) -> bool {
+        for j in from..self.region.len() {
+            if self.is_target[j] {
+                return false;
+            }
+            let op = &self.region[j];
+            match op {
+                Op::StoreLocal(x) | Op::StoreLocalChecked(x) if *x == l => return true,
+                // Ops that read `l` (or copy into it — CopyLocal reads src).
+                Op::LoadLocal(x)
+                | Op::IncLocalStmt { local: x, .. }
+                | Op::AddLocalConst { local: x, .. }
+                | Op::ArithLocalConst { local: x, .. }
+                | Op::LoadLocalConst { local: x, .. }
+                | Op::CmpLocalConstBranchFalse { local: x, .. }
+                | Op::CmpLocalConstBranchTrue { local: x, .. }
+                    if *x == l =>
+                {
+                    return false;
+                }
+                Op::CopyLocal { src, dest } => {
+                    if *src == l {
+                        return false;
+                    }
+                    if *dest == l {
+                        return true;
+                    }
+                }
+                // Block enders / control transfers end the scan.
+                _ if !op_targets(op).is_empty() => return false,
+                Op::Return | Op::ReturnUndefined | Op::Throw | Op::LoopKernel(_) => return false,
+                _ => {}
+            }
+        }
+        false
+    }
+
+    /// Record a branch to absolute bytecode ip `t` from the kop at `kidx`.
+    fn branch_to(&mut self, kidx: usize, t: u32, shape: Vec<VE>) -> Option<()> {
+        if shape.contains(&VE::Undef) {
+            return None; // `undefined` never crosses block boundaries
+        }
         let rel = (t as usize).wrapping_sub(self.base_ip as usize);
         if rel < self.region.len() {
-            match self.depth_at[rel] {
-                Some(d) if d != depth => return None,
-                _ => self.depth_at[rel] = Some(depth),
+            match &self.shape_at[rel] {
+                Some(s) if *s != shape => return None,
+                Some(_) => {}
+                None => self.shape_at[rel] = Some(shape),
             }
             self.fixups.push((kidx, rel));
         } else {
-            self.exits.push((kidx, t, depth));
+            self.exits.push((kidx, t, shape));
         }
         Some(())
     }
 
-    fn bin(&mut self, kind: ArithKind, d: u16) -> Option<u16> {
-        let a = self.sreg(d.checked_sub(2)?)?;
-        let b = self.sreg(d - 1)?;
+    fn bin(&mut self, kind: ArithKind) -> Option<()> {
+        let b = self.pop_num()?;
+        let a = self.top_reg(0)?;
         self.kops.push(KOp::Arith { kind, dst: a, a, b });
-        Some(d - 1)
+        self.origins[self.vstack.len() - 1] = None;
+        Some(())
     }
 
-    /// Translate the op at region-relative ip `i` at canonical stack depth
-    /// `d`; returns the post-op depth, or `None` to reject the whole region.
-    fn emit(&mut self, i: usize, d: u16) -> Option<u16> {
+    /// Translate one op (region-relative ip `i`); `Op::LoopKernel` recurses
+    /// into its fallback. Mutates the virtual stack; returns `None` to reject
+    /// the whole region.
+    fn emit(&mut self, op: &Op, i: usize) -> Option<()> {
         use KOp as K;
-        let op = self.region[i].clone();
-        Some(match &op {
-            Op::Nop => d,
+        match op {
+            Op::Nop => {}
+
+            // `undefined` may be pushed only as a dead store's operand (see
+            // `VE::Undef`); the store arm below validates and elides it.
+            Op::LoadUndefined => {
+                self.vstack.push(VE::Undef);
+                self.origins.push(None);
+            }
+
+            // An inner loop's kernel header: translate the op it replaced.
+            Op::LoopKernel(idx) => {
+                let fb = (*self.inner.get(*idx as usize)?.fallback).clone();
+                return self.emit(&fb, i);
+            }
 
             // ---- locals (TDZ subsumed by the entry guard: a mapped local is
             // a Number, never Uninitialized) ----
             Op::LoadLocal(l) => {
-                let src = self.lreg(*l)?;
-                let dst = self.sreg(d)?;
-                self.kops.push(K::Mov { dst, src });
-                d + 1
+                if let Some(pos) = self.oslot_locals.iter().position(|&o| o == *l) {
+                    // Phase 2: this local is an array base — push the object.
+                    self.vstack.push(VE::Obj(pos as u16));
+                    self.origins.push(None);
+                } else {
+                    let src = self.lreg(*l)?;
+                    let dst = self.push_num()?;
+                    self.kops.push(K::Mov { dst, src });
+                    let ver = *self.versions.get(l).unwrap_or(&0);
+                    *self.origins.last_mut()? = Some((*l, ver));
+                }
             }
             // The checked store's TDZ test reads the CURRENT slot value; the
             // guard proves it is a Number, so the store is a plain move.
             Op::StoreLocal(l) | Op::StoreLocalChecked(l) => {
-                let dst = self.lreg(*l)?;
-                let src = self.sreg(d.checked_sub(1)?)?;
-                self.kops.push(K::Mov { dst, src });
-                d - 1
+                if matches!(self.vstack.last(), Some(VE::Undef)) {
+                    // Storing `undefined` to a numeric local can only be
+                    // elided if the local is provably RE-STORED before any
+                    // read, branch, or branch target — i.e. the store is dead
+                    // within this basic block (the per-iteration `let` reset
+                    // pattern). Otherwise the region is rejected.
+                    self.lreg(*l)?;
+                    if !self.dead_store_ahead(i + 1, *l) {
+                        return None;
+                    }
+                    self.pop()?;
+                    self.store_of(*l);
+                } else {
+                    let dst = self.lreg(*l)?;
+                    let src = self.pop_num()?;
+                    self.kops.push(K::Mov { dst, src });
+                    self.store_of(*l);
+                }
             }
             Op::CopyLocal { src, dest } => {
                 let s = self.lreg(*src)?;
-                let dst = self.lreg(*dest)?;
-                if s != dst {
-                    self.kops.push(K::Mov { dst, src: s });
+                let d = self.lreg(*dest)?;
+                if s != d {
+                    self.kops.push(K::Mov { dst: d, src: s });
                 }
-                d
+                self.store_of(*dest);
             }
             Op::LoadConst(c) => {
                 let k = self.num_const(*c)?;
-                let dst = self.sreg(d)?;
+                let dst = self.push_num()?;
                 self.kops.push(K::Const { dst, k });
-                d + 1
             }
             Op::LoadLocalConst { local, konst } => {
                 let src = self.lreg(*local)?;
                 let k = self.num_const(*konst)?;
-                let dst0 = self.sreg(d)?;
-                let dst1 = self.sreg(d + 1)?;
+                let dst0 = self.push_num()?;
                 self.kops.push(K::Mov { dst: dst0, src });
+                let ver = *self.versions.get(local).unwrap_or(&0);
+                *self.origins.last_mut()? = Some((*local, ver));
+                let dst1 = self.push_num()?;
                 self.kops.push(K::Const { dst: dst1, k });
-                d + 2
             }
 
-            // ---- stack shuffles ----
-            Op::Pop => d.checked_sub(1)?,
+            // ---- stack shuffles (object entries move virtually; numeric
+            // VALUES move between position-owned registers) ----
+            Op::Pop => {
+                self.pop()?;
+            }
             Op::Dup => {
-                let src = self.sreg(d.checked_sub(1)?)?;
-                let dst = self.sreg(d)?;
-                self.kops.push(K::Mov { dst, src });
-                d + 1
+                let top = *self.vstack.last()?;
+                match top {
+                    VE::Num => {
+                        let src = self.top_reg(0)?;
+                        let dst = self.push_num()?;
+                        self.kops.push(K::Mov { dst, src });
+                    }
+                    VE::Obj(s) => {
+                        self.vstack.push(VE::Obj(s));
+                        self.origins.push(None);
+                    }
+                    VE::Undef => return None,
+                }
             }
             Op::Swap => {
-                let a = self.sreg(d.checked_sub(2)?)?;
-                let b = self.sreg(d - 1)?;
-                self.kops.push(K::Mov {
-                    dst: SCRATCH0,
-                    src: a,
-                });
-                self.kops.push(K::Mov { dst: a, src: b });
-                self.kops.push(K::Mov {
-                    dst: b,
-                    src: SCRATCH0,
-                });
-                d
+                let n = self.vstack.len();
+                let (pa, pb) = (n.checked_sub(2)?, n - 1);
+                let (ea, eb) = (self.vstack[pa], self.vstack[pb]);
+                match (ea, eb) {
+                    (VE::Undef, _) | (_, VE::Undef) => return None,
+                    (VE::Num, VE::Num) => {
+                        let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
+                        self.kops.push(K::Mov {
+                            dst: SCRATCH0,
+                            src: ra,
+                        });
+                        self.kops.push(K::Mov { dst: ra, src: rb });
+                        self.kops.push(K::Mov {
+                            dst: rb,
+                            src: SCRATCH0,
+                        });
+                    }
+                    (VE::Num, VE::Obj(_)) => {
+                        // The number moves from position pa's reg to pb's.
+                        let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
+                        self.kops.push(K::Mov { dst: rb, src: ra });
+                    }
+                    (VE::Obj(_), VE::Num) => {
+                        let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
+                        self.kops.push(K::Mov { dst: ra, src: rb });
+                    }
+                    (VE::Obj(_), VE::Obj(_)) => {}
+                }
+                self.vstack.swap(pa, pb);
+                self.origins.swap(pa, pb);
             }
             Op::Rot3 => {
-                // [a b c] -> [c a b] (match the interpreter's Rot3).
-                let a = self.sreg(d.checked_sub(3)?)?;
-                let b = self.sreg(d - 2)?;
-                let c = self.sreg(d - 1)?;
-                self.kops.push(K::Mov {
-                    dst: SCRATCH0,
-                    src: c,
-                });
-                self.kops.push(K::Mov { dst: c, src: b });
-                self.kops.push(K::Mov { dst: b, src: a });
-                self.kops.push(K::Mov {
-                    dst: a,
-                    src: SCRATCH0,
-                });
-                d
+                // [a b c] -> [c a b] (match the interpreter's Rot3): values
+                // rotate downward one position; each Num value moves to its
+                // entry's new position register.
+                let n = self.vstack.len();
+                let (pa, pb, pc_) = (n.checked_sub(3)?, n - 2, n - 1);
+                let (ra, rb, rc) = (self.preg(pa)?, self.preg(pb)?, self.preg(pc_)?);
+                let (ea, eb, ec) = (self.vstack[pa], self.vstack[pb], self.vstack[pc_]);
+                if ea == VE::Undef || eb == VE::Undef || ec == VE::Undef {
+                    return None;
+                }
+                // c -> position a, a -> position b, b -> position c.
+                if ec == VE::Num {
+                    self.kops.push(K::Mov {
+                        dst: SCRATCH0,
+                        src: rc,
+                    });
+                }
+                if eb == VE::Num {
+                    self.kops.push(K::Mov { dst: rc, src: rb });
+                }
+                if ea == VE::Num {
+                    self.kops.push(K::Mov { dst: rb, src: ra });
+                }
+                if ec == VE::Num {
+                    self.kops.push(K::Mov {
+                        dst: ra,
+                        src: SCRATCH0,
+                    });
+                }
+                // Rotate the last three entries: [a b c] -> [c a b].
+                self.vstack[pa..].rotate_right(1);
+                self.origins[pa..].rotate_right(1);
             }
 
             // ---- arithmetic (numbers in, numbers out) ----
             Op::Add => {
-                let a = self.sreg(d.checked_sub(2)?)?;
-                let b = self.sreg(d - 1)?;
+                let b = self.pop_num()?;
+                let a = self.top_reg(0)?;
                 self.kops.push(K::Add { dst: a, a, b });
-                d - 1
+                let p = self.vstack.len() - 1;
+                self.origins[p] = None;
             }
-            Op::Sub => self.bin(ArithKind::Sub, d)?,
-            Op::Mul => self.bin(ArithKind::Mul, d)?,
-            Op::Div => self.bin(ArithKind::Div, d)?,
-            Op::Mod => self.bin(ArithKind::Mod, d)?,
-            Op::Pow => self.bin(ArithKind::Pow, d)?,
-            Op::BitAnd => self.bin(ArithKind::BitAnd, d)?,
-            Op::BitOr => self.bin(ArithKind::BitOr, d)?,
-            Op::BitXor => self.bin(ArithKind::BitXor, d)?,
-            Op::Shl => self.bin(ArithKind::Shl, d)?,
-            Op::Shr => self.bin(ArithKind::Shr, d)?,
-            Op::UShr => self.bin(ArithKind::UShr, d)?,
+            Op::Sub => self.bin(ArithKind::Sub)?,
+            Op::Mul => self.bin(ArithKind::Mul)?,
+            Op::Div => self.bin(ArithKind::Div)?,
+            Op::Mod => self.bin(ArithKind::Mod)?,
+            Op::Pow => self.bin(ArithKind::Pow)?,
+            Op::BitAnd => self.bin(ArithKind::BitAnd)?,
+            Op::BitOr => self.bin(ArithKind::BitOr)?,
+            Op::BitXor => self.bin(ArithKind::BitXor)?,
+            Op::Shl => self.bin(ArithKind::Shl)?,
+            Op::Shr => self.bin(ArithKind::Shr)?,
+            Op::UShr => self.bin(ArithKind::UShr)?,
             Op::Neg => {
-                let s = self.sreg(d.checked_sub(1)?)?;
+                let s = self.top_reg(0)?;
                 self.kops.push(K::Neg { dst: s, src: s });
-                d
+                let p = self.vstack.len() - 1;
+                self.origins[p] = None;
             }
             Op::BitNot => {
-                let s = self.sreg(d.checked_sub(1)?)?;
+                let s = self.top_reg(0)?;
                 self.kops.push(K::BitNot { dst: s, src: s });
-                d
+                let p = self.vstack.len() - 1;
+                self.origins[p] = None;
             }
-            // ToNumber/ToNumeric on a Number is the identity.
-            Op::Pos | Op::ToNumeric => d,
-            Op::Inc => {
-                let s = self.sreg(d.checked_sub(1)?)?;
+            // ToNumber/ToNumeric on a Number is the identity — but only on a
+            // NUMBER entry (an object would coerce: reject).
+            Op::Pos | Op::ToNumeric => {
+                self.top_reg(0)?;
+            }
+            Op::Inc | Op::Dec => {
+                let s = self.top_reg(0)?;
                 self.kops.push(K::AddK {
                     dst: s,
                     a: s,
-                    k: 1.0,
+                    k: if matches!(op, Op::Inc) { 1.0 } else { -1.0 },
                 });
-                d
-            }
-            Op::Dec => {
-                let s = self.sreg(d.checked_sub(1)?)?;
-                self.kops.push(K::AddK {
-                    dst: s,
-                    a: s,
-                    k: -1.0,
-                });
-                d
+                let p = self.vstack.len() - 1;
+                self.origins[p] = None;
             }
 
             // ---- fused local-const forms ----
             Op::AddLocalConst { local, konst } => {
                 let a = self.lreg(*local)?;
                 let k = self.num_const(*konst)?;
-                let dst = self.sreg(d)?;
+                let dst = self.push_num()?;
                 self.kops.push(K::AddK { dst, a, k });
-                d + 1
             }
             Op::ArithLocalConst { local, konst, kind } => {
                 let a = self.lreg(*local)?;
                 let k = self.num_const(*konst)?;
-                let dst = self.sreg(d)?;
+                let dst = self.push_num()?;
                 self.kops.push(K::ArithK {
                     kind: *kind,
                     dst,
                     a,
                     k,
                 });
-                d + 1
             }
             Op::IncLocalStmt { local, dec } => {
                 let r = self.lreg(*local)?;
@@ -555,14 +859,76 @@ impl Xlate<'_> {
                     a: r,
                     k: if *dec { -1.0 } else { 1.0 },
                 });
-                d
+                self.store_of(*local);
+            }
+
+            // ---- dense-array access ----
+            // `a[i]` read: base must be an array-base entry, index numeric.
+            Op::GetPropDynamic => {
+                // Shape AT the op (before popping) is what the generic op
+                // expects on a bail.
+                let shape = self.vstack.clone();
+                let obj = self.base_slot(1)?;
+                let idx = self.top_reg(0)?;
+                self.pop()?; // idx
+                self.pop()?; // base
+                let dst = self.push_num()?;
+                let kidx = self.kops.len();
+                self.kops.push(K::LoadElem {
+                    dst,
+                    obj,
+                    idx,
+                    bail: u16::MAX,
+                });
+                self.exits.push((kidx, self.base_ip + i as u32, shape));
+            }
+            // `a[i] = v` write: pushes the value back (expression result).
+            Op::SetPropDynamic => {
+                let shape = self.vstack.clone();
+                let obj = self.base_slot(2)?;
+                let val = self.top_reg(0)?;
+                let idx = self.top_reg(1)?;
+                self.pop()?; // val
+                self.pop()?; // idx
+                self.pop()?; // base
+                let dst = self.push_num()?;
+                let kidx = self.kops.len();
+                self.kops.push(K::StoreElem {
+                    obj,
+                    idx,
+                    val,
+                    bail: u16::MAX,
+                });
+                self.exits.push((kidx, self.base_ip + i as u32, shape));
+                // The op's result is the assigned value.
+                if dst != val {
+                    self.kops.push(K::Mov { dst, src: val });
+                }
+            }
+            // `a.length` (the only named property access supported).
+            Op::GetProp(c) => {
+                match self.consts.get(*c as usize)? {
+                    Const::String(s) if s.as_str() == "length" => {}
+                    _ => return None,
+                }
+                let shape = self.vstack.clone();
+                let obj = self.base_slot(0)?;
+                self.pop()?; // base
+                let dst = self.push_num()?;
+                let kidx = self.kops.len();
+                self.kops.push(K::LoadLen {
+                    dst,
+                    obj,
+                    bail: u16::MAX,
+                });
+                self.exits.push((kidx, self.base_ip + i as u32, shape));
             }
 
             // ---- comparisons: supported only in compare-and-branch form. A
             // materialized boolean (stored, returned, fed to arithmetic)
             // would put a non-number on the stack — reject the region.
             Op::Eq | Op::Ne | Op::StrictEq | Op::StrictNe | Op::Lt | Op::Gt | Op::Le | Op::Ge => {
-                let cmp = match &op {
+                let cmp = match op {
                     Op::Eq => CmpOp::Eq,
                     Op::Ne => CmpOp::Ne,
                     Op::StrictEq => CmpOp::StrictEq,
@@ -580,8 +946,8 @@ impl Xlate<'_> {
                     Some(Op::JumpIfTrue(t)) if !self.is_target[i + 1] => (true, *t),
                     _ => return None,
                 };
-                let a = self.sreg(d.checked_sub(2)?)?;
-                let b = self.sreg(d - 1)?;
+                let b = self.pop_num()?;
+                let a = self.pop_num()?;
                 let kidx = self.kops.len();
                 self.kops.push(K::BrCmp {
                     cmp,
@@ -590,20 +956,18 @@ impl Xlate<'_> {
                     if_true,
                     target: u16::MAX,
                 });
-                self.branch_to(kidx, target, d - 2)?;
+                self.branch_to(kidx, target, self.vstack.clone())?;
                 self.absorbed = Some(i + 1);
-                d - 2
             }
 
             // ---- branches ----
             Op::Jump(t) => {
                 let kidx = self.kops.len();
                 self.kops.push(K::Br { target: u16::MAX });
-                self.branch_to(kidx, *t, d)?;
-                d
+                self.branch_to(kidx, *t, self.vstack.clone())?;
             }
             Op::JumpIfFalse(t) | Op::JumpIfTrue(t) => {
-                let src = self.sreg(d.checked_sub(1)?)?;
+                let src = self.pop_num()?;
                 let kidx = self.kops.len();
                 if matches!(op, Op::JumpIfFalse(_)) {
                     self.kops.push(K::BrFalsy {
@@ -616,14 +980,12 @@ impl Xlate<'_> {
                         target: u16::MAX,
                     });
                 }
-                self.branch_to(kidx, *t, d - 1)?;
-                d - 1
+                self.branch_to(kidx, *t, self.vstack.clone())?;
             }
             // Peek variants (`&&`/`||` short-circuits): the TAKEN edge keeps
-            // the tested value on the stack (depth d); the fallthrough edge
-            // pops it (depth d-1).
+            // the tested value on the stack; the fallthrough edge pops it.
             Op::JumpIfFalsyPeek(t) | Op::JumpIfTruthyPeek(t) => {
-                let src = self.sreg(d.checked_sub(1)?)?;
+                let src = self.top_reg(0)?;
                 let kidx = self.kops.len();
                 if matches!(op, Op::JumpIfFalsyPeek(_)) {
                     self.kops.push(K::BrFalsy {
@@ -636,31 +998,29 @@ impl Xlate<'_> {
                         target: u16::MAX,
                     });
                 }
-                self.branch_to(kidx, *t, d)?;
-                d - 1
+                self.branch_to(kidx, *t, self.vstack.clone())?;
+                self.pop()?;
             }
             // A Number is never nullish. `JumpIfNullishPeek` jumps on NOT
             // nullish keeping the value — for kernel-typed values that is an
             // unconditional jump (the pop-and-fall-through edge is the nullish
             // case, unreachable here).
             Op::JumpIfNullishPeek(t) => {
-                d.checked_sub(1)?;
+                self.top_reg(0)?;
                 let kidx = self.kops.len();
                 self.kops.push(K::Br { target: u16::MAX });
-                self.branch_to(kidx, *t, d)?;
-                d
+                self.branch_to(kidx, *t, self.vstack.clone())?;
             }
             // `JumpIfNullish` jumps on nullish (replacing the top with
             // `undefined`) — never taken for kernel-typed values: no-op.
             Op::JumpIfNullish(_) => {
-                d.checked_sub(1)?; // require an operand, like the interpreter
-                d
+                self.top_reg(0)?;
             }
 
             Op::CmpBranchFalse { cmp, target } | Op::CmpBranchTrue { cmp, target } => {
                 let if_true = matches!(op, Op::CmpBranchTrue { .. });
-                let a = self.sreg(d.checked_sub(2)?)?;
-                let b = self.sreg(d - 1)?;
+                let b = self.pop_num()?;
+                let a = self.pop_num()?;
                 let kidx = self.kops.len();
                 self.kops.push(K::BrCmp {
                     cmp: *cmp,
@@ -669,8 +1029,7 @@ impl Xlate<'_> {
                     if_true,
                     target: u16::MAX,
                 });
-                self.branch_to(kidx, *target, d - 2)?;
-                d - 2
+                self.branch_to(kidx, *target, self.vstack.clone())?;
             }
             Op::CmpLocalConstBranchFalse {
                 local,
@@ -695,14 +1054,14 @@ impl Xlate<'_> {
                     if_true,
                     target: u16::MAX,
                 });
-                self.branch_to(kidx, *target, d)?;
-                d
+                self.branch_to(kidx, *target, self.vstack.clone())?;
             }
 
-            // Anything else — calls, property access, cells, upvalues, TDZ
-            // init, globals, objects, strings, try/dispose/iterator/suspend
-            // machinery, nested kernels — rejects the region.
+            // Anything else — calls, other property access, cells, upvalues,
+            // TDZ init, globals, objects, strings, try/dispose/iterator/
+            // suspend machinery — rejects the region.
             _ => return None,
-        })
+        }
+        Some(())
     }
 }

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -1,0 +1,708 @@
+//! Typed loop kernels: translate eligible bytecode loops into unboxed-`f64`
+//! register programs (docs/js-performance-roadmap.md §6.5).
+//!
+//! ## Why
+//!
+//! The retired closure-threading experiment (docs/jit.md) proved that removing
+//! *dispatch* alone buys almost nothing (1.01–1.11×): the interpreter's real
+//! per-op tax on numeric loops is the boxed [`Value`](crate::value::Value)
+//! traffic — clone, match, drop, operand-stack push/pop — around every add and
+//! compare. A kernel keeps the loop's state in a flat `f64` register file for
+//! the whole loop, so an iteration of the canonical counting loop is a handful
+//! of unboxed register ops instead of a dozen boxed dispatches.
+//!
+//! ## Safety model
+//!
+//! A kernel is a pure performance side effect, gated like the inline caches:
+//! it may only run where it provably computes exactly what the generic
+//! interpreter would.
+//!
+//! - **Eligibility is static.** A loop region qualifies only if every op in it
+//!   is on the numeric allowlist: loads/stores of `frame.locals` slots,
+//!   `Number` constants, arithmetic/comparison/branch ops and their fused
+//!   forms. Anything else — calls, property access, cells/upvalues, TDZ
+//!   *initialization*, try handlers, iterators, suspension — and the loop is
+//!   simply not kernelized. No op is ever half-supported.
+//! - **Entry is guarded.** At runtime the kernel runs only after checking that
+//!   every mapped local currently holds a `Number`. JS numeric ops are closed
+//!   over numbers, so once the guard passes no non-number can appear
+//!   mid-kernel — there is no mid-loop type surprise and therefore no deopt
+//!   map. A failed guard executes the original header op ([`Kernel::fallback`])
+//!   and the generic interpreter takes that iteration; the kernel retries when
+//!   the back-edge next reaches the header (late entry: a binding that warms
+//!   to a number on iteration 1 enters the kernel from iteration 2).
+//! - **Semantics are shared, not re-implemented.** Kernel arithmetic calls the
+//!   same `number_arith_raw`/`js_mod`/`to_int32` helpers as the interpreter's
+//!   `Number`×`Number` fast paths, so results are bit-identical (NaN, -0,
+//!   overflow, shift masking — all of it).
+//! - **Observability.** Within an eligible region the generic interpreter
+//!   touches nothing but local slots, the operand stack, and control flow: no
+//!   journal, no allocation, no user code. The op budget IS observable (an
+//!   exact-count uncatchable throw), so kernels are disabled whenever a budget
+//!   is installed (see `Vm::run_kernel`); the cooperative interrupt flag is
+//!   polled on kernel back-edges, preserving prompt cancellation.
+//!
+//! Determinism: translation is a pure function of the bytecode (itself a pure
+//! function of the source) and the guard depends only on program values, so
+//! record and replay execute identically with kernels on. The differential
+//! corpus (`tests/kernels.rs`) runs every supported construct with kernels on
+//! and off and asserts byte-identical behavior.
+
+use crate::bytecode::{CmpOp, Const, KOp, Kernel, Op};
+use crate::exec::ArithKind;
+
+/// Bounds keeping `u16` fields comfortable and per-kernel work finite. Loops
+/// beyond them stay generic.
+const MAX_REGION_OPS: usize = 512;
+const MAX_KOPS: usize = 2048;
+/// Provisional numbering during translation: stack slot `d` is register
+/// `STACK_BASE + d`, scratch is `SCRATCH0/1`. A final remap compacts the file
+/// to `locals + stack + scratch` so the executor zeroes only what is used.
+const STACK_BASE: u16 = 64;
+const SCRATCH0: u16 = 252;
+const SCRATCH1: u16 = 253;
+
+/// Find every eligible loop in `code` and install kernels for them. Returns
+/// the (possibly rewritten) code and the kernel table. Loop-header ops are
+/// replaced by [`Op::LoopKernel`] IN PLACE — code length, instruction indices
+/// and all jump targets are unchanged.
+pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) {
+    let mut kernels: Vec<Kernel> = Vec::new();
+
+    // Collect back-edges: any branch whose target is at or before it. Group by
+    // header, keeping the furthest back-edge, so a loop with several continue
+    // paths gets ONE region covering all of them.
+    let mut regions: Vec<(usize, usize)> = Vec::new(); // (start, end) inclusive
+    for (ip, op) in code.iter().enumerate() {
+        for t in op_targets(op) {
+            let t = t as usize;
+            if t <= ip {
+                match regions.iter_mut().find(|(s, _)| *s == t) {
+                    Some((_, e)) => *e = (*e).max(ip),
+                    None => regions.push((t, ip)),
+                }
+            }
+        }
+    }
+    // Innermost-first: smaller regions translate before enclosing ones; an
+    // enclosing region then sees the inner loop's fresh `LoopKernel` op and is
+    // rejected by the allowlist (nested kernels are out of scope for v1).
+    regions.sort_by_key(|&(s, e)| (e - s, s));
+
+    for (start, end) in regions {
+        if end - start + 1 > MAX_REGION_OPS {
+            continue;
+        }
+        // Single-entry check: nothing outside the region may branch into its
+        // interior. (The region start is the loop entry and is fine — jumps
+        // and fallthrough arrive at the header, which is the kernel op.)
+        let jumps_into_interior = code.iter().enumerate().any(|(ip, op)| {
+            (ip < start || ip > end)
+                && op_targets(op)
+                    .iter()
+                    .any(|&t| (t as usize) > start && (t as usize) <= end)
+        });
+        if jumps_into_interior {
+            continue;
+        }
+        if let Some(mut k) = translate(&code[start..=end], start as u32, consts) {
+            k.fallback = Box::new(code[start].clone());
+            code[start] = Op::LoopKernel(kernels.len() as u32);
+            kernels.push(k);
+        }
+    }
+    (code, kernels)
+}
+
+/// Every code index an op can transfer control to (not counting fallthrough).
+/// `u32::MAX` sentinels ("no finally", "no delegation return") are filtered.
+/// This must cover EVERY variant carrying a code index — a missed one would
+/// let the pass treat a jumped-into loop as single-entry.
+fn op_targets(op: &Op) -> Vec<u32> {
+    let mut out = Vec::new();
+    match op {
+        Op::Jump(t)
+        | Op::JumpIfTrue(t)
+        | Op::JumpIfFalse(t)
+        | Op::JumpIfNullish(t)
+        | Op::JumpIfFalsyPeek(t)
+        | Op::JumpIfTruthyPeek(t)
+        | Op::JumpIfNullishPeek(t) => out.push(*t),
+        Op::CmpBranchFalse { target, .. }
+        | Op::CmpBranchTrue { target, .. }
+        | Op::CmpLocalConstBranchFalse { target, .. }
+        | Op::CmpLocalConstBranchTrue { target, .. }
+        | Op::CmpCellConstBranchFalse { target, .. }
+        | Op::CmpCellConstBranchTrue { target, .. }
+        | Op::CompletionJump { target, .. } => out.push(*target),
+        Op::PushTryHandler { catch, finally } => {
+            if *catch != u32::MAX {
+                out.push(*catch);
+            }
+            if *finally != u32::MAX {
+                out.push(*finally);
+            }
+        }
+        Op::MarkDelegationHandler(t) if *t != u32::MAX => out.push(*t),
+        _ => {}
+    }
+    out
+}
+
+struct Xlate<'a> {
+    region: &'a [Op],
+    base_ip: u32,
+    consts: &'a [Const],
+    kops: Vec<KOp>,
+    /// kernel pc for each region-relative ip (`u16::MAX` = not emitted).
+    kpc: Vec<u16>,
+    /// expected canonical stack depth at each region-relative ip, when known.
+    depth_at: Vec<Option<u16>>,
+    /// in-region branch targets (any op branching to that ip).
+    is_target: Vec<bool>,
+    /// (frame-local index, register) pairs, registers dense from 0.
+    local_reg: Vec<(u32, u16)>,
+    /// pending in-region branch fixups: (kop index, region-relative target).
+    fixups: Vec<(usize, usize)>,
+    /// pending exits: (kop index, absolute resume ip, stack depth).
+    exits: Vec<(usize, u32, u16)>,
+    /// a compare op fused with its following conditional jump: skip that ip.
+    absorbed: Option<usize>,
+    max_stack: u16,
+}
+
+/// Attempt to translate a region into a kernel. Returns `None` — the loop
+/// stays generic — on ANY construct outside the allowlist. `fallback` is a
+/// placeholder for the caller to fill.
+fn translate(region: &[Op], base_ip: u32, consts: &[Const]) -> Option<Kernel> {
+    let mut is_target = vec![false; region.len()];
+    for op in region {
+        for t in op_targets(op) {
+            let rel = (t as usize).wrapping_sub(base_ip as usize);
+            if rel < region.len() {
+                is_target[rel] = true;
+            }
+        }
+    }
+
+    let mut x = Xlate {
+        region,
+        base_ip,
+        consts,
+        kops: Vec::new(),
+        kpc: vec![u16::MAX; region.len()],
+        depth_at: vec![None; region.len()],
+        is_target,
+        local_reg: Vec::new(),
+        fixups: Vec::new(),
+        exits: Vec::new(),
+        absorbed: None,
+        max_stack: 0,
+    };
+    x.depth_at[0] = Some(0);
+
+    let mut depth: u16 = 0;
+    let mut reachable = true;
+    // The index is load-bearing (kpc/depth_at bookkeeping keyed by ip).
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..region.len() {
+        if x.absorbed.take() == Some(i) {
+            // This conditional jump was fused into the preceding compare.
+            continue;
+        }
+        match x.depth_at[i] {
+            Some(d) => {
+                // A recorded depth: either a forward-branch target (must agree
+                // with the fallthrough depth when both reach it) or ip 0.
+                if reachable && d != depth {
+                    return None; // inconsistent stack depth at a merge point
+                }
+                depth = d;
+                reachable = true;
+            }
+            None => {
+                if !reachable {
+                    // Dead code (after an unconditional jump, not a known
+                    // target). It can never execute; skip. A later branch INTO
+                    // it fails the fixup pass below (kpc stays unmapped).
+                    continue;
+                }
+                // Record the depth every executed op is translated at, so a
+                // later BACKWARD branch to it verifies register alignment.
+                x.depth_at[i] = Some(depth);
+            }
+        }
+        x.kpc[i] = u16::try_from(x.kops.len()).ok()?;
+        depth = x.emit(i, depth)?;
+        x.max_stack = x.max_stack.max(depth);
+        if x.kops.len() > MAX_KOPS {
+            return None;
+        }
+        // Ops with no fallthrough edge end the current basic block.
+        if matches!(region[i], Op::Jump(_) | Op::JumpIfNullishPeek(_)) {
+            reachable = false;
+        }
+    }
+    // A region ending on an op WITH a fallthrough edge (a conditional
+    // back-edge — the do/while shape) continues into the bytecode right after
+    // the region: synthesize that exit.
+    if reachable {
+        let resume = base_ip + u32::try_from(region.len()).ok()?;
+        x.kops.push(KOp::Exit {
+            resume_ip: resume,
+            stack: depth,
+        });
+    }
+
+    // Patch in-region branches.
+    let fixups = std::mem::take(&mut x.fixups);
+    for (kidx, rel) in fixups {
+        let pc = x.kpc[rel];
+        if pc == u16::MAX {
+            return None; // branch into an absorbed/dead instruction
+        }
+        patch(&mut x.kops, kidx, pc);
+    }
+    // Synthesize exit stubs.
+    let exits = std::mem::take(&mut x.exits);
+    for (kidx, resume_ip, stack) in exits {
+        let pc = u16::try_from(x.kops.len()).ok()?;
+        x.kops.push(KOp::Exit { resume_ip, stack });
+        patch(&mut x.kops, kidx, pc);
+    }
+    if x.kops.len() > MAX_KOPS {
+        return None;
+    }
+
+    // Compact the register file: locals stay 0..n, provisional stack slots
+    // move to n.., scratch to the top. The executor zeroes exactly `n_regs`.
+    let n_locals = u16::try_from(x.local_reg.len()).ok()?;
+    let remap = |r: u16| -> u16 {
+        if r < STACK_BASE {
+            r
+        } else if r == SCRATCH0 {
+            n_locals + x.max_stack
+        } else if r == SCRATCH1 {
+            n_locals + x.max_stack + 1
+        } else {
+            n_locals + (r - STACK_BASE)
+        }
+    };
+    for kop in &mut x.kops {
+        match kop {
+            KOp::Mov { dst, src } | KOp::Neg { dst, src } | KOp::BitNot { dst, src } => {
+                *dst = remap(*dst);
+                *src = remap(*src);
+            }
+            KOp::Const { dst, .. } => *dst = remap(*dst),
+            KOp::Add { dst, a, b } | KOp::Arith { dst, a, b, .. } => {
+                *dst = remap(*dst);
+                *a = remap(*a);
+                *b = remap(*b);
+            }
+            KOp::AddK { dst, a, .. } | KOp::ArithK { dst, a, .. } => {
+                *dst = remap(*dst);
+                *a = remap(*a);
+            }
+            KOp::BrCmp { a, b, .. } => {
+                *a = remap(*a);
+                *b = remap(*b);
+            }
+            KOp::BrCmpK { a, .. } => *a = remap(*a),
+            KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } => *src = remap(*src),
+            KOp::Br { .. } | KOp::Exit { .. } => {}
+        }
+    }
+
+    let mut locals: Vec<u32> = vec![0; n_locals as usize];
+    for &(l, r) in &x.local_reg {
+        locals[r as usize] = l;
+    }
+    Some(Kernel {
+        code: x.kops.into_boxed_slice(),
+        locals: locals.into_boxed_slice(),
+        n_regs: n_locals + x.max_stack + 2,
+        fallback: Box::new(Op::Nop), // caller stores the real header op
+    })
+}
+
+fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
+    match &mut kops[kidx] {
+        KOp::Br { target }
+        | KOp::BrCmp { target, .. }
+        | KOp::BrCmpK { target, .. }
+        | KOp::BrFalsy { target, .. }
+        | KOp::BrTruthy { target, .. } => *target = pc,
+        _ => unreachable!("patching a non-branch kop"),
+    }
+}
+
+impl Xlate<'_> {
+    /// Register mirroring `frame.locals[l]`.
+    fn lreg(&mut self, l: u32) -> Option<u16> {
+        if let Some(&(_, r)) = self.local_reg.iter().find(|(ll, _)| *ll == l) {
+            return Some(r);
+        }
+        let r = u16::try_from(self.local_reg.len()).ok()?;
+        if r >= STACK_BASE {
+            return None; // more distinct locals than the numbering supports
+        }
+        self.local_reg.push((l, r));
+        Some(r)
+    }
+
+    /// Provisional register for canonical stack slot `d`.
+    fn sreg(&self, d: u16) -> Option<u16> {
+        if STACK_BASE + d >= SCRATCH0 {
+            return None;
+        }
+        Some(STACK_BASE + d)
+    }
+
+    fn num_const(&self, idx: u32) -> Option<f64> {
+        match self.consts.get(idx as usize)? {
+            Const::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Record a branch to absolute bytecode ip `t` from the kop at `kidx`:
+    /// in-region targets become fixups (recording/checking the canonical
+    /// stack depth `depth` at the target); out-of-region targets synthesize an
+    /// [`KOp::Exit`] stub that materializes `depth` stack slots.
+    fn branch_to(&mut self, kidx: usize, t: u32, depth: u16) -> Option<()> {
+        let rel = (t as usize).wrapping_sub(self.base_ip as usize);
+        if rel < self.region.len() {
+            match self.depth_at[rel] {
+                Some(d) if d != depth => return None,
+                _ => self.depth_at[rel] = Some(depth),
+            }
+            self.fixups.push((kidx, rel));
+        } else {
+            self.exits.push((kidx, t, depth));
+        }
+        Some(())
+    }
+
+    fn bin(&mut self, kind: ArithKind, d: u16) -> Option<u16> {
+        let a = self.sreg(d.checked_sub(2)?)?;
+        let b = self.sreg(d - 1)?;
+        self.kops.push(KOp::Arith { kind, dst: a, a, b });
+        Some(d - 1)
+    }
+
+    /// Translate the op at region-relative ip `i` at canonical stack depth
+    /// `d`; returns the post-op depth, or `None` to reject the whole region.
+    fn emit(&mut self, i: usize, d: u16) -> Option<u16> {
+        use KOp as K;
+        let op = self.region[i].clone();
+        Some(match &op {
+            Op::Nop => d,
+
+            // ---- locals (TDZ subsumed by the entry guard: a mapped local is
+            // a Number, never Uninitialized) ----
+            Op::LoadLocal(l) => {
+                let src = self.lreg(*l)?;
+                let dst = self.sreg(d)?;
+                self.kops.push(K::Mov { dst, src });
+                d + 1
+            }
+            // The checked store's TDZ test reads the CURRENT slot value; the
+            // guard proves it is a Number, so the store is a plain move.
+            Op::StoreLocal(l) | Op::StoreLocalChecked(l) => {
+                let dst = self.lreg(*l)?;
+                let src = self.sreg(d.checked_sub(1)?)?;
+                self.kops.push(K::Mov { dst, src });
+                d - 1
+            }
+            Op::CopyLocal { src, dest } => {
+                let s = self.lreg(*src)?;
+                let dst = self.lreg(*dest)?;
+                if s != dst {
+                    self.kops.push(K::Mov { dst, src: s });
+                }
+                d
+            }
+            Op::LoadConst(c) => {
+                let k = self.num_const(*c)?;
+                let dst = self.sreg(d)?;
+                self.kops.push(K::Const { dst, k });
+                d + 1
+            }
+            Op::LoadLocalConst { local, konst } => {
+                let src = self.lreg(*local)?;
+                let k = self.num_const(*konst)?;
+                let dst0 = self.sreg(d)?;
+                let dst1 = self.sreg(d + 1)?;
+                self.kops.push(K::Mov { dst: dst0, src });
+                self.kops.push(K::Const { dst: dst1, k });
+                d + 2
+            }
+
+            // ---- stack shuffles ----
+            Op::Pop => d.checked_sub(1)?,
+            Op::Dup => {
+                let src = self.sreg(d.checked_sub(1)?)?;
+                let dst = self.sreg(d)?;
+                self.kops.push(K::Mov { dst, src });
+                d + 1
+            }
+            Op::Swap => {
+                let a = self.sreg(d.checked_sub(2)?)?;
+                let b = self.sreg(d - 1)?;
+                self.kops.push(K::Mov {
+                    dst: SCRATCH0,
+                    src: a,
+                });
+                self.kops.push(K::Mov { dst: a, src: b });
+                self.kops.push(K::Mov {
+                    dst: b,
+                    src: SCRATCH0,
+                });
+                d
+            }
+            Op::Rot3 => {
+                // [a b c] -> [c a b] (match the interpreter's Rot3).
+                let a = self.sreg(d.checked_sub(3)?)?;
+                let b = self.sreg(d - 2)?;
+                let c = self.sreg(d - 1)?;
+                self.kops.push(K::Mov {
+                    dst: SCRATCH0,
+                    src: c,
+                });
+                self.kops.push(K::Mov { dst: c, src: b });
+                self.kops.push(K::Mov { dst: b, src: a });
+                self.kops.push(K::Mov {
+                    dst: a,
+                    src: SCRATCH0,
+                });
+                d
+            }
+
+            // ---- arithmetic (numbers in, numbers out) ----
+            Op::Add => {
+                let a = self.sreg(d.checked_sub(2)?)?;
+                let b = self.sreg(d - 1)?;
+                self.kops.push(K::Add { dst: a, a, b });
+                d - 1
+            }
+            Op::Sub => self.bin(ArithKind::Sub, d)?,
+            Op::Mul => self.bin(ArithKind::Mul, d)?,
+            Op::Div => self.bin(ArithKind::Div, d)?,
+            Op::Mod => self.bin(ArithKind::Mod, d)?,
+            Op::Pow => self.bin(ArithKind::Pow, d)?,
+            Op::BitAnd => self.bin(ArithKind::BitAnd, d)?,
+            Op::BitOr => self.bin(ArithKind::BitOr, d)?,
+            Op::BitXor => self.bin(ArithKind::BitXor, d)?,
+            Op::Shl => self.bin(ArithKind::Shl, d)?,
+            Op::Shr => self.bin(ArithKind::Shr, d)?,
+            Op::UShr => self.bin(ArithKind::UShr, d)?,
+            Op::Neg => {
+                let s = self.sreg(d.checked_sub(1)?)?;
+                self.kops.push(K::Neg { dst: s, src: s });
+                d
+            }
+            Op::BitNot => {
+                let s = self.sreg(d.checked_sub(1)?)?;
+                self.kops.push(K::BitNot { dst: s, src: s });
+                d
+            }
+            // ToNumber/ToNumeric on a Number is the identity.
+            Op::Pos | Op::ToNumeric => d,
+            Op::Inc => {
+                let s = self.sreg(d.checked_sub(1)?)?;
+                self.kops.push(K::AddK {
+                    dst: s,
+                    a: s,
+                    k: 1.0,
+                });
+                d
+            }
+            Op::Dec => {
+                let s = self.sreg(d.checked_sub(1)?)?;
+                self.kops.push(K::AddK {
+                    dst: s,
+                    a: s,
+                    k: -1.0,
+                });
+                d
+            }
+
+            // ---- fused local-const forms ----
+            Op::AddLocalConst { local, konst } => {
+                let a = self.lreg(*local)?;
+                let k = self.num_const(*konst)?;
+                let dst = self.sreg(d)?;
+                self.kops.push(K::AddK { dst, a, k });
+                d + 1
+            }
+            Op::ArithLocalConst { local, konst, kind } => {
+                let a = self.lreg(*local)?;
+                let k = self.num_const(*konst)?;
+                let dst = self.sreg(d)?;
+                self.kops.push(K::ArithK {
+                    kind: *kind,
+                    dst,
+                    a,
+                    k,
+                });
+                d + 1
+            }
+            Op::IncLocalStmt { local, dec } => {
+                let r = self.lreg(*local)?;
+                self.kops.push(K::AddK {
+                    dst: r,
+                    a: r,
+                    k: if *dec { -1.0 } else { 1.0 },
+                });
+                d
+            }
+
+            // ---- comparisons: supported only in compare-and-branch form. A
+            // materialized boolean (stored, returned, fed to arithmetic)
+            // would put a non-number on the stack — reject the region.
+            Op::Eq | Op::Ne | Op::StrictEq | Op::StrictNe | Op::Lt | Op::Gt | Op::Le | Op::Ge => {
+                let cmp = match &op {
+                    Op::Eq => CmpOp::Eq,
+                    Op::Ne => CmpOp::Ne,
+                    Op::StrictEq => CmpOp::StrictEq,
+                    Op::StrictNe => CmpOp::StrictNe,
+                    Op::Lt => CmpOp::Lt,
+                    Op::Gt => CmpOp::Gt,
+                    Op::Le => CmpOp::Le,
+                    Op::Ge => CmpOp::Ge,
+                    _ => unreachable!(),
+                };
+                // Must be immediately consumed by a conditional jump that is
+                // itself not a branch target (it is fused away entirely).
+                let (if_true, target) = match self.region.get(i + 1) {
+                    Some(Op::JumpIfFalse(t)) if !self.is_target[i + 1] => (false, *t),
+                    Some(Op::JumpIfTrue(t)) if !self.is_target[i + 1] => (true, *t),
+                    _ => return None,
+                };
+                let a = self.sreg(d.checked_sub(2)?)?;
+                let b = self.sreg(d - 1)?;
+                let kidx = self.kops.len();
+                self.kops.push(K::BrCmp {
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target: u16::MAX,
+                });
+                self.branch_to(kidx, target, d - 2)?;
+                self.absorbed = Some(i + 1);
+                d - 2
+            }
+
+            // ---- branches ----
+            Op::Jump(t) => {
+                let kidx = self.kops.len();
+                self.kops.push(K::Br { target: u16::MAX });
+                self.branch_to(kidx, *t, d)?;
+                d
+            }
+            Op::JumpIfFalse(t) | Op::JumpIfTrue(t) => {
+                let src = self.sreg(d.checked_sub(1)?)?;
+                let kidx = self.kops.len();
+                if matches!(op, Op::JumpIfFalse(_)) {
+                    self.kops.push(K::BrFalsy {
+                        src,
+                        target: u16::MAX,
+                    });
+                } else {
+                    self.kops.push(K::BrTruthy {
+                        src,
+                        target: u16::MAX,
+                    });
+                }
+                self.branch_to(kidx, *t, d - 1)?;
+                d - 1
+            }
+            // Peek variants (`&&`/`||` short-circuits): the TAKEN edge keeps
+            // the tested value on the stack (depth d); the fallthrough edge
+            // pops it (depth d-1).
+            Op::JumpIfFalsyPeek(t) | Op::JumpIfTruthyPeek(t) => {
+                let src = self.sreg(d.checked_sub(1)?)?;
+                let kidx = self.kops.len();
+                if matches!(op, Op::JumpIfFalsyPeek(_)) {
+                    self.kops.push(K::BrFalsy {
+                        src,
+                        target: u16::MAX,
+                    });
+                } else {
+                    self.kops.push(K::BrTruthy {
+                        src,
+                        target: u16::MAX,
+                    });
+                }
+                self.branch_to(kidx, *t, d)?;
+                d - 1
+            }
+            // A Number is never nullish. `JumpIfNullishPeek` jumps on NOT
+            // nullish keeping the value — for kernel-typed values that is an
+            // unconditional jump (the pop-and-fall-through edge is the nullish
+            // case, unreachable here).
+            Op::JumpIfNullishPeek(t) => {
+                d.checked_sub(1)?;
+                let kidx = self.kops.len();
+                self.kops.push(K::Br { target: u16::MAX });
+                self.branch_to(kidx, *t, d)?;
+                d
+            }
+            // `JumpIfNullish` jumps on nullish (replacing the top with
+            // `undefined`) — never taken for kernel-typed values: no-op.
+            Op::JumpIfNullish(_) => {
+                d.checked_sub(1)?; // require an operand, like the interpreter
+                d
+            }
+
+            Op::CmpBranchFalse { cmp, target } | Op::CmpBranchTrue { cmp, target } => {
+                let if_true = matches!(op, Op::CmpBranchTrue { .. });
+                let a = self.sreg(d.checked_sub(2)?)?;
+                let b = self.sreg(d - 1)?;
+                let kidx = self.kops.len();
+                self.kops.push(K::BrCmp {
+                    cmp: *cmp,
+                    a,
+                    b,
+                    if_true,
+                    target: u16::MAX,
+                });
+                self.branch_to(kidx, *target, d - 2)?;
+                d - 2
+            }
+            Op::CmpLocalConstBranchFalse {
+                local,
+                konst,
+                cmp,
+                target,
+            }
+            | Op::CmpLocalConstBranchTrue {
+                local,
+                konst,
+                cmp,
+                target,
+            } => {
+                let if_true = matches!(op, Op::CmpLocalConstBranchTrue { .. });
+                let a = self.lreg(*local)?;
+                let k = self.num_const(*konst)?;
+                let kidx = self.kops.len();
+                self.kops.push(K::BrCmpK {
+                    cmp: *cmp,
+                    a,
+                    k,
+                    if_true,
+                    target: u16::MAX,
+                });
+                self.branch_to(kidx, *target, d)?;
+                d
+            }
+
+            // Anything else — calls, property access, cells, upvalues, TDZ
+            // init, globals, objects, strings, try/dispose/iterator/suspend
+            // machinery, nested kernels — rejects the region.
+            _ => return None,
+        })
+    }
+}

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -147,6 +147,7 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
                 &oslots,
                 &bools,
                 false,
+                None,
             );
             let mut grew = false;
             for o in d_obj {
@@ -189,7 +190,12 @@ const MAX_FN_OPS: usize = 128;
 /// needs a frame to resume into), every local read dominated by a real store
 /// on every path (there is no guard to type frameless locals), and every
 /// completing path ending at `Return` with a scalar. `None` = stay generic.
-pub fn kernelize_function(code: &[Op], consts: &[Const], inner: &[Kernel]) -> Option<Kernel> {
+pub fn kernelize_function(
+    code: &[Op],
+    consts: &[Const],
+    inner: &[Kernel],
+    self_name: Option<&str>,
+) -> Option<Kernel> {
     if code.len() > MAX_FN_OPS {
         return None;
     }
@@ -201,7 +207,7 @@ pub fn kernelize_function(code: &[Op], consts: &[Const], inner: &[Kernel]) -> Op
     // reject outright (element access can't run frameless).
     let mut bools: Vec<u32> = Vec::new();
     for _ in 0..6 {
-        let (k, d_obj, d_bool) = translate(code, 0, consts, inner, &[], &bools, true);
+        let (k, d_obj, d_bool) = translate(code, 0, consts, inner, &[], &bools, true, self_name);
         if !d_obj.is_empty() {
             return None;
         }
@@ -213,9 +219,34 @@ pub fn kernelize_function(code: &[Op], consts: &[Const], inner: &[Kernel]) -> Op
             }
         }
         if !grew {
-            let k = k?;
+            let mut k = k?;
             // Frameless kernels are self-contained by construction.
             debug_assert!(k.oslots.is_empty() && k.shapes.is_empty());
+            if k.code.iter().any(|op| matches!(op, KOp::SelfCall { .. })) {
+                // RECURSIVE kernel. Every self-call must supply every
+                // argument the body consumes (a short call would need the
+                // generic `undefined` parameter), and every return must be
+                // a NUMBER (a boolean result would land in a caller
+                // register statically typed Num — typeof/strict-eq would
+                // diverge). Either miss keeps the whole function generic.
+                let args_used = k
+                    .locals
+                    .iter()
+                    .filter_map(|sl| match sl {
+                        KSlot::Arg(a) => Some(*a + 1),
+                        _ => None,
+                    })
+                    .max()
+                    .unwrap_or(0);
+                for op in k.code.iter() {
+                    match *op {
+                        KOp::SelfCall { argc, .. } if u32::from(argc) < args_used => return None,
+                        KOp::Ret { boolean: true, .. } => return None,
+                        _ => {}
+                    }
+                }
+                k.self_global = Some(self_name?.into());
+            }
             return Some(k);
         }
     }
@@ -291,6 +322,11 @@ enum VE {
     /// consumer is a store to a local (the `init` tracking then rejects any
     /// read of that local); everything else rejects.
     Opaque,
+    /// fn mode only: the function ITSELF, from `LoadGlobal` of its own name
+    /// — speculative: the entry guard verifies the global binding still
+    /// holds the very closure being invoked. Its ONLY legal consumer is a
+    /// `Call` (which fuses to [`KOp::SelfCall`]); everything else rejects.
+    SelfFn,
 }
 
 struct Xlate<'a> {
@@ -306,6 +342,9 @@ struct Xlate<'a> {
     /// every local read must be dominated by a real store (`init` tracking) —
     /// there is no entry guard over locals to type them.
     fn_mode: bool,
+    /// fn mode: the function's own name — `LoadGlobal` of it becomes
+    /// [`VE::SelfFn`] and a direct recursive call fuses to `KOp::SelfCall`.
+    self_name: Option<&'a str>,
     /// Locals designated as array bases (phase 2) — empty in phase 1.
     oslot_locals: &'a [u32],
     /// Locals statically typed BOOLEAN (fixpoint-discovered from stores).
@@ -353,6 +392,9 @@ struct Xlate<'a> {
 /// placeholder; `None` on ANY construct outside the allowlist) plus whatever
 /// array-base and boolean-local discoveries were made up to the point of
 /// success or failure — the caller iterates those to a fixpoint.
+// The parameters ARE the pass's inputs (region + the two fixpoint sets +
+// the two mode toggles); a bundling struct would just rename the call sites.
+#[allow(clippy::too_many_arguments)]
 fn translate(
     region: &[Op],
     base_ip: u32,
@@ -361,6 +403,7 @@ fn translate(
     oslot_locals: &[u32],
     bool_locals: &[u32],
     fn_mode: bool,
+    self_name: Option<&str>,
 ) -> (Option<Kernel>, Vec<u32>, Vec<u32>) {
     let mut is_target = vec![false; region.len()];
     for op in region {
@@ -378,6 +421,7 @@ fn translate(
         consts,
         inner,
         fn_mode,
+        self_name,
         oslot_locals,
         bool_locals,
         kops: Vec::new(),
@@ -502,8 +546,11 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     let mut shapes: Vec<Vec<VE>> = Vec::new();
     let mut stubs: Vec<(u32, u16, u16)> = Vec::new(); // (resume, shape idx, pc)
     for (kidx, resume_ip, shape) in exits {
-        if shape.contains(&VE::Undef) || shape.contains(&VE::Opaque) {
-            return None; // undefined/opaque never survives to an exit
+        if shape
+            .iter()
+            .any(|e| matches!(e, VE::Undef | VE::Opaque | VE::SelfFn))
+        {
+            return None; // undefined/opaque/self never survives to an exit
         }
         let sidx = match shapes.iter().position(|s| *s == shape) {
             Some(p) => p as u16,
@@ -587,6 +634,10 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
             }
             KOp::LoadLen { dst, .. } => *dst = remap(*dst),
             KOp::Ret { src, .. } => *src = remap(*src),
+            KOp::SelfCall { dst, base, .. } => {
+                *dst = remap(*dst);
+                *base = remap(*base);
+            }
             KOp::Math1 { dst, src, .. } => {
                 *dst = remap(*dst);
                 *src = remap(*src);
@@ -610,8 +661,8 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::Obj(o) => KShapeSlot::Obj(*o),
                     VE::MathObj => KShapeSlot::MathObj,
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
-                    VE::Undef | VE::Opaque => {
-                        unreachable!("undef/opaque never crosses block boundaries")
+                    VE::Undef | VE::Opaque | VE::SelfFn => {
+                        unreachable!("undef/opaque/self never crosses block boundaries")
                     }
                 })
                 .collect()
@@ -634,6 +685,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         shapes: shapes.into_boxed_slice(),
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
         n_regs: n_locals + n_bools + x.max_stack + 1,
+        self_global: None, // `kernelize_function` fills it for recursive kernels
         fallback: Box::new(Op::Nop), // caller stores the real header op
     })
 }
@@ -895,7 +947,7 @@ impl Xlate<'_> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Obj(s) => Some(s),
-            VE::Bool | VE::Undef | VE::Opaque | VE::MathObj | VE::MathFn(_) => None,
+            VE::Bool | VE::Undef | VE::Opaque | VE::SelfFn | VE::MathObj | VE::MathFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -959,8 +1011,11 @@ impl Xlate<'_> {
 
     /// Record a branch to absolute bytecode ip `t` from the kop at `kidx`.
     fn branch_to(&mut self, kidx: usize, t: u32, shape: Vec<VE>) -> Option<()> {
-        if shape.contains(&VE::Undef) || shape.contains(&VE::Opaque) {
-            return None; // undefined/opaque never crosses block boundaries
+        if shape
+            .iter()
+            .any(|e| matches!(e, VE::Undef | VE::Opaque | VE::SelfFn))
+        {
+            return None; // undefined/opaque/self never crosses block boundaries
         }
         let rel = (t as usize).wrapping_sub(self.base_ip as usize);
         if rel < self.region.len() {
@@ -1025,15 +1080,22 @@ impl Xlate<'_> {
                 }
             }
 
-            // The ONLY supported global: `Math` (speculatively — the entry
-            // guard verifies the global binding is still the canonical data
-            // property before the kernel runs).
+            // The only supported globals, both speculative (entry-guarded):
+            // `Math` (canonical object as a data property) and — fn mode —
+            // the function's OWN name (the binding must hold the closure
+            // being invoked; see `Kernel::self_global`).
             Op::LoadGlobal(c) => {
-                match self.consts.get(*c as usize)? {
-                    Const::String(n) if n.as_str() == "Math" => {}
+                let name = match self.consts.get(*c as usize)? {
+                    Const::String(n) => n.as_str(),
                     _ => return None,
+                };
+                if name == "Math" {
+                    self.vstack.push(VE::MathObj);
+                } else if self.fn_mode && Some(name) == self.self_name {
+                    self.vstack.push(VE::SelfFn);
+                } else {
+                    return None;
                 }
-                self.vstack.push(VE::MathObj);
                 self.origins.push(None);
             }
 
@@ -1246,14 +1308,16 @@ impl Xlate<'_> {
                         self.vstack.push(VE::MathObj);
                         self.origins.push(None);
                     }
-                    VE::MathFn(_) | VE::Undef | VE::Opaque => return None,
+                    VE::MathFn(_) | VE::Undef | VE::Opaque | VE::SelfFn => return None,
                 }
             }
             Op::Swap => {
                 let n = self.vstack.len();
                 let (pa, pb) = (n.checked_sub(2)?, n - 1);
                 let (ea, eb) = (self.vstack[pa], self.vstack[pb]);
-                if matches!(ea, VE::Undef | VE::Opaque) || matches!(eb, VE::Undef | VE::Opaque) {
+                if matches!(ea, VE::Undef | VE::Opaque | VE::SelfFn)
+                    || matches!(eb, VE::Undef | VE::Opaque | VE::SelfFn)
+                {
                     return None;
                 }
                 let is_reg = |e: VE| matches!(e, VE::Num | VE::Bool);
@@ -1294,7 +1358,7 @@ impl Xlate<'_> {
                 let (ea, eb, ec) = (self.vstack[pa], self.vstack[pb], self.vstack[pc_]);
                 if [ea, eb, ec]
                     .iter()
-                    .any(|e| matches!(e, VE::Undef | VE::Opaque))
+                    .any(|e| matches!(e, VE::Undef | VE::Opaque | VE::SelfFn))
                 {
                     return None;
                 }
@@ -1507,11 +1571,37 @@ impl Xlate<'_> {
             }
 
             // A call is supported ONLY as the compiler's Math method-call
-            // pattern: [.., MathFn(kind), MathObj(this), args...] with the
-            // kind's exact arity. Everything else rejects the region.
+            // pattern — [.., MathFn(kind), MathObj(this), args...] with the
+            // kind's exact arity — or, fn mode, a DIRECT SELF-CALL:
+            // [.., SelfFn, undefined(this), args...]. Everything else
+            // rejects the region.
             Op::Call(argc) => {
                 let n = *argc as usize;
                 let fn_pos = self.vstack.len().checked_sub(n + 2)?;
+                if matches!(self.vstack.get(fn_pos)?, VE::SelfFn) {
+                    // Plain sloppy call: `this` is the pushed `undefined`.
+                    if !matches!(self.vstack.get(fn_pos + 1)?, VE::Undef) {
+                        return None;
+                    }
+                    // Every argument must be a statically-NUMBER register
+                    // (the callee's Arg slots assume Numbers — a raw-0/1
+                    // boolean would diverge under typeof/strict-eq); they
+                    // sit contiguously in the positions' own registers.
+                    for d in 0..n {
+                        self.top_num_reg(d)?;
+                    }
+                    let base = if n > 0 { self.preg(fn_pos + 2)? } else { 0 };
+                    for _ in 0..n + 2 {
+                        self.pop()?;
+                    }
+                    let dst = self.push_num()?;
+                    self.kops.push(K::SelfCall {
+                        dst,
+                        base,
+                        argc: u16::try_from(n).ok()?,
+                    });
+                    return Some(());
+                }
                 let kind = match self.vstack.get(fn_pos)? {
                     VE::MathFn(k) => *k,
                     _ => return None,

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -57,7 +57,7 @@
 //! corpus + fuzz (`tests/kernels.rs`) runs every supported construct with
 //! kernels on and off and asserts byte-identical behavior.
 
-use crate::bytecode::{CmpOp, Const, KOp, KShapeSlot, Kernel, Op};
+use crate::bytecode::{CmpOp, Const, KMath, KOp, KShapeSlot, Kernel, Op};
 use crate::exec::ArithKind;
 
 /// Bounds keeping `u16` fields comfortable and per-kernel work finite. Loops
@@ -179,6 +179,13 @@ enum VE {
     Num,
     /// An array base: object slot index.
     Obj(u16),
+    /// The canonical `Math` object, from `LoadGlobal("Math")` — speculative:
+    /// the entry guard verifies the global binding still IS the canonical
+    /// object (a data property, not shadowed/replaced/accessor'd) before the
+    /// kernel runs; otherwise the whole kernel declines.
+    MathObj,
+    /// A kernel-supported `Math` method, from `GetProp` on [`VE::MathObj`].
+    MathFn(KMath),
     /// The value `undefined`, from `LoadUndefined`. Exists only transiently
     /// within a basic block: its ONLY legal consumer is a store to a local
     /// that is provably re-stored before any read (the compiler's
@@ -216,6 +223,8 @@ struct Xlate<'a> {
     fixups: Vec<(usize, usize)>,
     /// pending exits: (kop index or LoadElem-style bail, resume ip, shape).
     exits: Vec<(usize, u32, Vec<VE>)>,
+    /// Math intrinsics used (entry guard checks each against the realm).
+    math_used: Vec<KMath>,
     /// a compare op fused with its following conditional jump: skip that ip.
     absorbed: Option<usize>,
     max_stack: u16,
@@ -258,6 +267,7 @@ fn translate(
         vstack: Vec::new(),
         fixups: Vec::new(),
         exits: Vec::new(),
+        math_used: Vec::new(),
         absorbed: None,
         max_stack: 0,
     };
@@ -404,6 +414,15 @@ fn translate(
                 *val = remap(*val);
             }
             KOp::LoadLen { dst, .. } => *dst = remap(*dst),
+            KOp::Math1 { dst, src, .. } => {
+                *dst = remap(*dst);
+                *src = remap(*src);
+            }
+            KOp::Math2 { dst, a, b, .. } => {
+                *dst = remap(*dst);
+                *a = remap(*a);
+                *b = remap(*b);
+            }
             KOp::Br { .. } | KOp::Exit { .. } => {}
         }
     }
@@ -415,6 +434,8 @@ fn translate(
                 .map(|(p, e)| match e {
                     VE::Num => KShapeSlot::Num(remap(STACK_BASE + p as u16)),
                     VE::Obj(o) => KShapeSlot::Obj(*o),
+                    VE::MathObj => KShapeSlot::MathObj,
+                    VE::MathFn(k) => KShapeSlot::MathFn(*k),
                     VE::Undef => unreachable!("undef never crosses block boundaries"),
                 })
                 .collect()
@@ -431,6 +452,7 @@ fn translate(
             locals: locals.into_boxed_slice(),
             oslots: x.oslot_locals.to_vec().into_boxed_slice(),
             shapes: shapes.into_boxed_slice(),
+            math_used: x.math_used.into_boxed_slice(),
             n_regs: n_locals + x.max_stack + 1,
             fallback: Box::new(Op::Nop), // caller stores the real header op
         },
@@ -486,7 +508,7 @@ impl Xlate<'_> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Num => self.preg(p),
-            VE::Obj(_) | VE::Undef => None,
+            _ => None,
         }
     }
 
@@ -529,7 +551,7 @@ impl Xlate<'_> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Obj(s) => Some(s),
-            VE::Undef => None,
+            VE::Undef | VE::MathObj | VE::MathFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -633,6 +655,18 @@ impl Xlate<'_> {
                 self.origins.push(None);
             }
 
+            // The ONLY supported global: `Math` (speculatively — the entry
+            // guard verifies the global binding is still the canonical data
+            // property before the kernel runs).
+            Op::LoadGlobal(c) => {
+                match self.consts.get(*c as usize)? {
+                    Const::String(n) if n.as_str() == "Math" => {}
+                    _ => return None,
+                }
+                self.vstack.push(VE::MathObj);
+                self.origins.push(None);
+            }
+
             // An inner loop's kernel header: translate the op it replaced.
             Op::LoopKernel(idx) => {
                 let fb = (*self.inner.get(*idx as usize)?.fallback).clone();
@@ -676,6 +710,18 @@ impl Xlate<'_> {
                     self.store_of(*l);
                 }
             }
+            // A block-scoped declaration's TDZ marker: writes `Uninitialized`
+            // to the slot. Elidable exactly like the dead `undefined` store —
+            // the local must be provably re-stored before anything can read
+            // it (a genuine TDZ read would need the generic path's
+            // ReferenceError, so such regions stay generic).
+            Op::InitLocalTdz(l) => {
+                self.lreg(*l)?;
+                if !self.dead_store_ahead(i + 1, *l) {
+                    return None;
+                }
+                self.store_of(*l);
+            }
             Op::CopyLocal { src, dest } => {
                 let s = self.lreg(*src)?;
                 let d = self.lreg(*dest)?;
@@ -717,16 +763,22 @@ impl Xlate<'_> {
                         self.vstack.push(VE::Obj(s));
                         self.origins.push(None);
                     }
-                    VE::Undef => return None,
+                    VE::MathObj => {
+                        self.vstack.push(VE::MathObj);
+                        self.origins.push(None);
+                    }
+                    VE::MathFn(_) | VE::Undef => return None,
                 }
             }
             Op::Swap => {
                 let n = self.vstack.len();
                 let (pa, pb) = (n.checked_sub(2)?, n - 1);
                 let (ea, eb) = (self.vstack[pa], self.vstack[pb]);
-                match (ea, eb) {
-                    (VE::Undef, _) | (_, VE::Undef) => return None,
-                    (VE::Num, VE::Num) => {
+                if ea == VE::Undef || eb == VE::Undef {
+                    return None;
+                }
+                match (ea == VE::Num, eb == VE::Num) {
+                    (true, true) => {
                         let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
                         self.kops.push(K::Mov {
                             dst: SCRATCH0,
@@ -738,16 +790,16 @@ impl Xlate<'_> {
                             src: SCRATCH0,
                         });
                     }
-                    (VE::Num, VE::Obj(_)) => {
+                    (true, false) => {
                         // The number moves from position pa's reg to pb's.
                         let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
                         self.kops.push(K::Mov { dst: rb, src: ra });
                     }
-                    (VE::Obj(_), VE::Num) => {
+                    (false, true) => {
                         let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
                         self.kops.push(K::Mov { dst: ra, src: rb });
                     }
-                    (VE::Obj(_), VE::Obj(_)) => {}
+                    (false, false) => {}
                 }
                 self.vstack.swap(pa, pb);
                 self.origins.swap(pa, pb);
@@ -905,8 +957,43 @@ impl Xlate<'_> {
                     self.kops.push(K::Mov { dst, src: val });
                 }
             }
-            // `a.length` (the only named property access supported).
+            // Named property access: `a.length` on an array base, or a
+            // method/constant on the (guarded canonical) `Math` object.
             Op::GetProp(c) => {
+                if matches!(self.vstack.last(), Some(VE::MathObj)) {
+                    let name = match self.consts.get(*c as usize)? {
+                        Const::String(n) => n.as_str().to_string(),
+                        _ => return None,
+                    };
+                    if let Some(kind) = KMath::from_name(&name) {
+                        self.pop()?;
+                        self.vstack.push(VE::MathFn(kind));
+                        self.origins.push(None);
+                        if !self.math_used.contains(&kind) {
+                            self.math_used.push(kind);
+                        }
+                        return Some(());
+                    }
+                    // The canonical Math object's value constants are
+                    // non-writable AND non-configurable — immutable forever —
+                    // so with the object identity guarded they fold to
+                    // constants outright.
+                    let k = match name.as_str() {
+                        "PI" => std::f64::consts::PI,
+                        "E" => std::f64::consts::E,
+                        "LN2" => std::f64::consts::LN_2,
+                        "LN10" => std::f64::consts::LN_10,
+                        "LOG2E" => std::f64::consts::LOG2_E,
+                        "LOG10E" => std::f64::consts::LOG10_E,
+                        "SQRT2" => std::f64::consts::SQRT_2,
+                        "SQRT1_2" => std::f64::consts::FRAC_1_SQRT_2,
+                        _ => return None,
+                    };
+                    self.pop()?;
+                    let dst = self.push_num()?;
+                    self.kops.push(K::Const { dst, k });
+                    return Some(());
+                }
                 match self.consts.get(*c as usize)? {
                     Const::String(s) if s.as_str() == "length" => {}
                     _ => return None,
@@ -922,6 +1009,42 @@ impl Xlate<'_> {
                     bail: u16::MAX,
                 });
                 self.exits.push((kidx, self.base_ip + i as u32, shape));
+            }
+
+            // A call is supported ONLY as the compiler's Math method-call
+            // pattern: [.., MathFn(kind), MathObj(this), args...] with the
+            // kind's exact arity. Everything else rejects the region.
+            Op::Call(argc) => {
+                let n = *argc as usize;
+                let fn_pos = self.vstack.len().checked_sub(n + 2)?;
+                let kind = match self.vstack.get(fn_pos)? {
+                    VE::MathFn(k) => *k,
+                    _ => return None,
+                };
+                if !matches!(self.vstack.get(fn_pos + 1)?, VE::MathObj) || kind.arity() != n {
+                    return None;
+                }
+                match n {
+                    1 => {
+                        let src = self.top_reg(0)?;
+                        self.pop()?; // arg
+                        self.pop()?; // this (MathObj)
+                        self.pop()?; // fn
+                        let dst = self.push_num()?;
+                        self.kops.push(K::Math1 { kind, dst, src });
+                    }
+                    2 => {
+                        let b = self.top_reg(0)?;
+                        let a = self.top_reg(1)?;
+                        self.pop()?;
+                        self.pop()?;
+                        self.pop()?; // this
+                        self.pop()?; // fn
+                        let dst = self.push_num()?;
+                        self.kops.push(K::Math2 { kind, dst, a, b });
+                    }
+                    _ => return None,
+                }
             }
 
             // ---- comparisons: supported only in compare-and-branch form. A

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -57,7 +57,7 @@
 //! corpus + fuzz (`tests/kernels.rs`) runs every supported construct with
 //! kernels on and off and asserts byte-identical behavior.
 
-use crate::bytecode::{CmpOp, Const, KMath, KOp, KShapeSlot, Kernel, Op};
+use crate::bytecode::{CmpOp, Const, KMath, KOp, KShapeSlot, KSlot, Kernel, Op};
 use crate::exec::ArithKind;
 
 /// Bounds keeping `u16` fields comfortable and per-kernel work finite. Loops
@@ -69,6 +69,10 @@ const MAX_KOPS: usize = 2048;
 /// unused — uniform numbering keeps shuffles and merges trivial); `SCRATCH0`
 /// is the shuffle scratch. A final remap compacts the register file.
 const STACK_BASE: u16 = 64;
+/// Provisional register space for BOOLEAN-typed locals (numeric locals are
+/// `0..BOOL_BASE`, boolean locals `BOOL_BASE..STACK_BASE`); compacted by the
+/// final remap to sit right after the numeric locals.
+const BOOL_BASE: u16 = 32;
 const SCRATCH0: u16 = 252;
 
 /// Find every eligible loop in `code` and install kernels for them. Returns
@@ -118,16 +122,43 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
         if jumps_into_interior {
             continue;
         }
-        // Phase 1 discovers which locals are used as array BASES (`a[i]`);
-        // phase 2 re-translates with those locals as object slots. Both
-        // phases reject identically on anything off the allowlist.
-        let oslots = match translate(&code[start..=end], start as u32, consts, &kernels, &[]) {
-            Some((_, discovered)) => discovered,
-            None => continue,
-        };
-        if let Some((mut k, _)) =
-            translate(&code[start..=end], start as u32, consts, &kernels, &oslots)
-        {
+        // Iterate translation to a FIXPOINT over the discovered local types:
+        // array bases (`a` in `a[i]`) become object slots, and locals that
+        // receive boolean stores become Bool-typed registers. Each run feeds
+        // its discoveries into the next; a stable run whose translation
+        // succeeded installs the kernel. (Discovery is monotone over a
+        // bounded set, so the cap is belt-and-braces.)
+        let mut oslots: Vec<u32> = Vec::new();
+        let mut bools: Vec<u32> = Vec::new();
+        let mut installed: Option<Kernel> = None;
+        for _ in 0..6 {
+            let (k, d_obj, d_bool) = translate(
+                &code[start..=end],
+                start as u32,
+                consts,
+                &kernels,
+                &oslots,
+                &bools,
+            );
+            let mut grew = false;
+            for o in d_obj {
+                if !oslots.contains(&o) {
+                    oslots.push(o);
+                    grew = true;
+                }
+            }
+            for b in d_bool {
+                if !bools.contains(&b) {
+                    bools.push(b);
+                    grew = true;
+                }
+            }
+            if !grew {
+                installed = k;
+                break;
+            }
+        }
+        if let Some(mut k) = installed {
             k.fallback = Box::new(code[start].clone());
             code[start] = Op::LoopKernel(kernels.len() as u32);
             kernels.push(k);
@@ -179,6 +210,13 @@ enum VE {
     Num,
     /// An array base: object slot index.
     Obj(u16),
+    /// A value statically known BOOLEAN, in the entry's position register as
+    /// exactly 0.0/1.0. Coercing consumers (arithmetic, branches, Math args)
+    /// read the register raw — identical to ToNumber/ToBoolean on a boolean —
+    /// but exits materialize `Value::Bool`, array indices/elements refuse it
+    /// (`a[true]` is the property "true"!), and strict equality against a
+    /// statically-Number operand folds to a constant.
+    Bool,
     /// The canonical `Math` object, from `LoadGlobal("Math")` — speculative:
     /// the entry guard verifies the global binding still IS the canonical
     /// object (a data property, not shadowed/replaced/accessor'd) before the
@@ -203,6 +241,8 @@ struct Xlate<'a> {
     inner: &'a [Kernel],
     /// Locals designated as array bases (phase 2) — empty in phase 1.
     oslot_locals: &'a [u32],
+    /// Locals statically typed BOOLEAN (fixpoint-discovered from stores).
+    bool_locals: &'a [u32],
     kops: Vec<KOp>,
     /// kernel pc for each region-relative ip (`u16::MAX` = not emitted).
     kpc: Vec<u16>,
@@ -210,10 +250,15 @@ struct Xlate<'a> {
     shape_at: Vec<Option<Vec<VE>>>,
     /// in-region branch targets (any op branching to that ip).
     is_target: Vec<bool>,
-    /// numeric locals: (frame-local index, register), registers dense from 0.
-    local_reg: Vec<(u32, u16)>,
+    /// numeric slots (locals and read-only upvalues): (source, register),
+    /// registers dense from 0.
+    local_reg: Vec<(KSlot, u16)>,
+    /// boolean locals: (frame-local index, register from BOOL_BASE).
+    bool_reg: Vec<(u32, u16)>,
     /// phase 1: locals observed as array bases (with clean origins).
     discovered: Vec<u32>,
+    /// locals observed receiving BOOLEAN stores (fixpoint feedback).
+    discovered_bools: Vec<u32>,
     /// phase 1 origin tracking: (local, version) of a pushed LoadLocal.
     origins: Vec<Option<(u32, u32)>>,
     versions: std::collections::HashMap<u32, u32>,
@@ -231,15 +276,17 @@ struct Xlate<'a> {
 }
 
 /// Attempt to translate a region. Returns the kernel (fallback is a
-/// placeholder) and the discovered array-base locals, or `None` — the loop
-/// stays generic — on ANY construct outside the allowlist.
+/// placeholder; `None` on ANY construct outside the allowlist) plus whatever
+/// array-base and boolean-local discoveries were made up to the point of
+/// success or failure — the caller iterates those to a fixpoint.
 fn translate(
     region: &[Op],
     base_ip: u32,
     consts: &[Const],
     inner: &[Kernel],
     oslot_locals: &[u32],
-) -> Option<(Kernel, Vec<u32>)> {
+    bool_locals: &[u32],
+) -> (Option<Kernel>, Vec<u32>, Vec<u32>) {
     let mut is_target = vec![false; region.len()];
     for op in region {
         for t in op_targets(op) {
@@ -256,12 +303,15 @@ fn translate(
         consts,
         inner,
         oslot_locals,
+        bool_locals,
         kops: Vec::new(),
         kpc: vec![u16::MAX; region.len()],
         shape_at: vec![None; region.len()],
         is_target,
         local_reg: Vec::new(),
+        bool_reg: Vec::new(),
         discovered: Vec::new(),
+        discovered_bools: Vec::new(),
         origins: Vec::new(),
         versions: std::collections::HashMap::new(),
         vstack: Vec::new(),
@@ -272,6 +322,15 @@ fn translate(
         max_stack: 0,
     };
     x.shape_at[0] = Some(Vec::new());
+    let kernel = translate_inner(&mut x);
+    let d_obj = std::mem::take(&mut x.discovered);
+    let d_bool = std::mem::take(&mut x.discovered_bools);
+    (kernel, d_obj, d_bool)
+}
+
+fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
+    let region = x.region;
+    let base_ip = x.base_ip;
 
     let mut reachable = true;
     // The index is load-bearing (kpc/shape_at bookkeeping keyed by ip).
@@ -371,16 +430,20 @@ fn translate(
         return None;
     }
 
-    // Compact the register file: numeric locals stay 0..n, provisional stack
-    // position regs move to n.., scratch to the top.
+    // Compact the register file: numeric locals stay 0..n, boolean locals
+    // follow at n.., provisional stack position regs after those, scratch at
+    // the top.
     let n_locals = u16::try_from(x.local_reg.len()).ok()?;
+    let n_bools = u16::try_from(x.bool_reg.len()).ok()?;
     let remap = |r: u16| -> u16 {
-        if r < STACK_BASE {
+        if r < BOOL_BASE {
             r
+        } else if r < STACK_BASE {
+            n_locals + (r - BOOL_BASE)
         } else if r == SCRATCH0 {
-            n_locals + x.max_stack
+            n_locals + n_bools + x.max_stack
         } else {
-            n_locals + (r - STACK_BASE)
+            n_locals + n_bools + (r - STACK_BASE)
         }
     };
     for kop in &mut x.kops {
@@ -405,6 +468,15 @@ fn translate(
             }
             KOp::BrCmpK { a, .. } => *a = remap(*a),
             KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } => *src = remap(*src),
+            KOp::CmpSet { dst, a, b, .. } => {
+                *dst = remap(*dst);
+                *a = remap(*a);
+                *b = remap(*b);
+            }
+            KOp::BoolNot { dst, src } => {
+                *dst = remap(*dst);
+                *src = remap(*src);
+            }
             KOp::LoadElem { dst, idx, .. } => {
                 *dst = remap(*dst);
                 *idx = remap(*idx);
@@ -433,6 +505,7 @@ fn translate(
                 .enumerate()
                 .map(|(p, e)| match e {
                     VE::Num => KShapeSlot::Num(remap(STACK_BASE + p as u16)),
+                    VE::Bool => KShapeSlot::Bool(remap(STACK_BASE + p as u16)),
                     VE::Obj(o) => KShapeSlot::Obj(*o),
                     VE::MathObj => KShapeSlot::MathObj,
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
@@ -442,22 +515,40 @@ fn translate(
         })
         .collect();
 
-    let mut locals: Vec<u32> = vec![0; n_locals as usize];
-    for &(l, r) in &x.local_reg {
-        locals[r as usize] = l;
+    let mut locals: Vec<KSlot> = vec![KSlot::Local(0); n_locals as usize];
+    for &(sl, r) in &x.local_reg {
+        locals[r as usize] = sl;
     }
-    Some((
-        Kernel {
-            code: x.kops.into_boxed_slice(),
-            locals: locals.into_boxed_slice(),
-            oslots: x.oslot_locals.to_vec().into_boxed_slice(),
-            shapes: shapes.into_boxed_slice(),
-            math_used: x.math_used.into_boxed_slice(),
-            n_regs: n_locals + x.max_stack + 1,
-            fallback: Box::new(Op::Nop), // caller stores the real header op
-        },
-        x.discovered,
-    ))
+    let mut bool_locals: Vec<u32> = vec![0; n_bools as usize];
+    for &(l, r) in &x.bool_reg {
+        bool_locals[(r - BOOL_BASE) as usize] = l;
+    }
+    Some(Kernel {
+        code: std::mem::take(&mut x.kops).into_boxed_slice(),
+        locals: locals.into_boxed_slice(),
+        bool_locals: bool_locals.into_boxed_slice(),
+        oslots: x.oslot_locals.to_vec().into_boxed_slice(),
+        shapes: shapes.into_boxed_slice(),
+        math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
+        n_regs: n_locals + n_bools + x.max_stack + 1,
+        fallback: Box::new(Op::Nop), // caller stores the real header op
+    })
+}
+
+/// Statically-decidable comparison outcome: strict (in)equality between a
+/// boolean-typed and a number-typed operand is `false`/`true` regardless of
+/// values (the generic `strict_equals` checks the type tag first). All other
+/// combinations are dynamic — raw register comparison matches the generic
+/// numeric coercions exactly.
+fn static_cmp(cmp: CmpOp, a_bool: bool, b_bool: bool) -> Option<bool> {
+    if a_bool == b_bool {
+        return None;
+    }
+    match cmp {
+        CmpOp::StrictEq => Some(false),
+        CmpOp::StrictNe => Some(true),
+        _ => None,
+    }
 }
 
 fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
@@ -475,22 +566,85 @@ fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
 }
 
 impl Xlate<'_> {
-    /// Register mirroring numeric `frame.locals[l]`. An array-base local can
-    /// never be a numeric local (that would need it to hold a Number and an
-    /// object at once — some iteration would bail every time; reject).
+    /// Register mirroring numeric `frame.locals[l]`. A local can have exactly
+    /// ONE static type: an array base, a boolean, or a number — mixed use
+    /// rejects the region (some iteration would bail every time anyway).
     fn lreg(&mut self, l: u32) -> Option<u16> {
-        if self.oslot_locals.contains(&l) {
+        if self.oslot_locals.contains(&l)
+            || self.bool_locals.contains(&l)
+            || self.bool_reg.iter().any(|&(ll, _)| ll == l)
+        {
             return None;
         }
-        if let Some(&(_, r)) = self.local_reg.iter().find(|(ll, _)| *ll == l) {
+        let slot = KSlot::Local(l);
+        if let Some(&(_, r)) = self.local_reg.iter().find(|(sl, _)| *sl == slot) {
             return Some(r);
         }
         let r = u16::try_from(self.local_reg.len()).ok()?;
+        if r >= BOOL_BASE {
+            return None;
+        }
+        self.local_reg.push((slot, r));
+        Some(r)
+    }
+
+    /// Register snapshotting captured upvalue cell `u` (read-only: nothing
+    /// can write the cell during a kernel — regions contain no calls — and
+    /// in-region upvalue writes are not on the allowlist).
+    fn uvreg(&mut self, u: u32) -> Option<u16> {
+        let slot = KSlot::Upvalue(u);
+        if let Some(&(_, r)) = self.local_reg.iter().find(|(sl, _)| *sl == slot) {
+            return Some(r);
+        }
+        let r = u16::try_from(self.local_reg.len()).ok()?;
+        if r >= BOOL_BASE {
+            return None;
+        }
+        self.local_reg.push((slot, r));
+        Some(r)
+    }
+
+    /// Register mirroring BOOLEAN-typed `frame.locals[l]` (holds 0.0/1.0; the
+    /// guard requires `Value::Bool`, write-back restores it). Records the
+    /// local for the caller's fixpoint when it is not yet in this run's set.
+    fn blreg(&mut self, l: u32) -> Option<u16> {
+        // Record the discovery FIRST: "this local receives boolean stores" is
+        // true even when this run cannot use it yet (e.g. an earlier load in
+        // this run already typed it numeric — the next fixpoint run reloads
+        // it as a boolean).
+        if !self.bool_locals.contains(&l) && !self.discovered_bools.contains(&l) {
+            self.discovered_bools.push(l);
+        }
+        if self.oslot_locals.contains(&l)
+            || self.local_reg.iter().any(|&(sl, _)| sl == KSlot::Local(l))
+        {
+            return None;
+        }
+        if let Some(&(_, r)) = self.bool_reg.iter().find(|(ll, _)| *ll == l) {
+            return Some(r);
+        }
+        let r = BOOL_BASE + u16::try_from(self.bool_reg.len()).ok()?;
         if r >= STACK_BASE {
             return None;
         }
-        self.local_reg.push((l, r));
+        self.bool_reg.push((l, r));
         Some(r)
+    }
+
+    /// Read-only scalar register for local `l` — numeric or boolean space
+    /// (coercing consumers treat a boolean's 0.0/1.0 exactly as ToNumber
+    /// would). Never valid for array bases.
+    fn scalar_lreg(&mut self, l: u32) -> Option<u16> {
+        if self.bool_locals.contains(&l) {
+            self.blreg(l)
+        } else {
+            self.lreg(l)
+        }
+    }
+
+    /// Whether local `l` is boolean-typed IN THIS RUN.
+    fn is_bool_local(&self, l: u32) -> bool {
+        self.bool_locals.contains(&l)
     }
 
     /// Provisional register owned by virtual-stack position `p`.
@@ -502,9 +656,21 @@ impl Xlate<'_> {
         Some(r as u16)
     }
 
-    /// Register of the CURRENT top-of-stack numeric entry `depth_from_top`
-    /// below the top (0 = top).
+    /// Register of the entry `depth_from_top` below the top (0 = top) when it
+    /// is a SCALAR (number or statically-typed boolean — coercing consumers
+    /// read the raw 0.0/1.0). `None` for objects/Math/undefined.
     fn top_reg(&self, depth_from_top: usize) -> Option<u16> {
+        let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
+        match self.vstack[p] {
+            VE::Num | VE::Bool => self.preg(p),
+            _ => None,
+        }
+    }
+
+    /// As [`Xlate::top_reg`], but NUMBER-only — array indices and stored
+    /// elements must refuse booleans (`a[true]` is the property "true", and
+    /// a stored element must not change type).
+    fn top_num_reg(&self, depth_from_top: usize) -> Option<u16> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Num => self.preg(p),
@@ -512,11 +678,23 @@ impl Xlate<'_> {
         }
     }
 
-    fn num_const(&self, idx: u32) -> Option<f64> {
-        match self.consts.get(idx as usize)? {
-            Const::Number(n) => Some(*n),
+    /// Static type of the scalar entry `depth_from_top` below the top:
+    /// `Some(true)` boolean, `Some(false)` number, `None` non-scalar.
+    fn top_is_bool(&self, depth_from_top: usize) -> Option<bool> {
+        let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
+        match self.vstack[p] {
+            VE::Bool => Some(true),
+            VE::Num => Some(false),
             _ => None,
         }
+    }
+
+    /// Push a Bool entry, returning its register.
+    fn push_bool(&mut self) -> Option<u16> {
+        let r = self.preg(self.vstack.len())?;
+        self.vstack.push(VE::Bool);
+        self.origins.push(None);
+        Some(r)
     }
 
     /// Push a Num entry, returning its register.
@@ -532,11 +710,27 @@ impl Xlate<'_> {
         self.vstack.pop()
     }
 
-    /// Pop, requiring a Num entry; returns its (position) register.
-    fn pop_num(&mut self) -> Option<u16> {
+    /// Pop, requiring a SCALAR entry (number/boolean); returns its register.
+    fn pop_scalar(&mut self) -> Option<u16> {
         let r = self.top_reg(0)?;
         self.pop();
         Some(r)
+    }
+
+    /// Pop, requiring a NUMBER entry; returns its register.
+    fn pop_num(&mut self) -> Option<u16> {
+        let r = self.top_num_reg(0)?;
+        self.pop();
+        Some(r)
+    }
+
+    /// A constant usable as a scalar operand: `(value, is_bool)`.
+    fn scalar_const(&self, idx: u32) -> Option<(f64, bool)> {
+        match self.consts.get(idx as usize)? {
+            Const::Number(n) => Some((*n, false)),
+            Const::Bool(b) => Some((if *b { 1.0 } else { 0.0 }, true)),
+            _ => None,
+        }
     }
 
     /// Bump a local's version (any store invalidates pushed origins).
@@ -551,7 +745,7 @@ impl Xlate<'_> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Obj(s) => Some(s),
-            VE::Undef | VE::MathObj | VE::MathFn(_) => None,
+            VE::Bool | VE::Undef | VE::MathObj | VE::MathFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -633,10 +827,12 @@ impl Xlate<'_> {
     }
 
     fn bin(&mut self, kind: ArithKind) -> Option<()> {
-        let b = self.pop_num()?;
+        let b = self.pop_scalar()?;
         let a = self.top_reg(0)?;
         self.kops.push(KOp::Arith { kind, dst: a, a, b });
-        self.origins[self.vstack.len() - 1] = None;
+        let p = self.vstack.len() - 1;
+        self.vstack[p] = VE::Num; // ToNumeric(boolean) -> number
+        self.origins[p] = None;
         Some(())
     }
 
@@ -677,9 +873,13 @@ impl Xlate<'_> {
             // a Number, never Uninitialized) ----
             Op::LoadLocal(l) => {
                 if let Some(pos) = self.oslot_locals.iter().position(|&o| o == *l) {
-                    // Phase 2: this local is an array base — push the object.
+                    // This local is an array base — push the object.
                     self.vstack.push(VE::Obj(pos as u16));
                     self.origins.push(None);
+                } else if self.is_bool_local(*l) {
+                    let src = self.blreg(*l)?;
+                    let dst = self.push_bool()?;
+                    self.kops.push(K::Mov { dst, src });
                 } else {
                     let src = self.lreg(*l)?;
                     let dst = self.push_num()?;
@@ -688,26 +888,47 @@ impl Xlate<'_> {
                     *self.origins.last_mut()? = Some((*l, ver));
                 }
             }
+            // A captured (read-only in-region) numeric upvalue: snapshot.
+            Op::LoadUpvalue(u) => {
+                let src = self.uvreg(*u)?;
+                let dst = self.push_num()?;
+                self.kops.push(K::Mov { dst, src });
+            }
+
             // The checked store's TDZ test reads the CURRENT slot value; the
             // guard proves it is a Number, so the store is a plain move.
             Op::StoreLocal(l) | Op::StoreLocalChecked(l) => {
-                if matches!(self.vstack.last(), Some(VE::Undef)) {
-                    // Storing `undefined` to a numeric local can only be
-                    // elided if the local is provably RE-STORED before any
-                    // read, branch, or branch target — i.e. the store is dead
-                    // within this basic block (the per-iteration `let` reset
-                    // pattern). Otherwise the region is rejected.
-                    self.lreg(*l)?;
-                    if !self.dead_store_ahead(i + 1, *l) {
-                        return None;
+                match self.vstack.last() {
+                    Some(VE::Undef) => {
+                        // Storing `undefined` can only be elided if the local
+                        // is provably RE-STORED before any read, branch, or
+                        // branch target — i.e. the store is dead within this
+                        // basic block (the per-iteration `let` reset pattern).
+                        // Otherwise the region is rejected.
+                        if !self.dead_store_ahead(i + 1, *l) {
+                            return None;
+                        }
+                        self.pop()?;
+                        self.store_of(*l);
                     }
-                    self.pop()?;
-                    self.store_of(*l);
-                } else {
-                    let dst = self.lreg(*l)?;
-                    let src = self.pop_num()?;
-                    self.kops.push(K::Mov { dst, src });
-                    self.store_of(*l);
+                    Some(VE::Bool) => {
+                        // A boolean store TYPES the local (fixpoint feedback);
+                        // in the stable run the local is in the bool set and
+                        // its loads/guard/write-back use `Value::Bool`.
+                        let dst = self.blreg(*l)?;
+                        if !self.is_bool_local(*l) {
+                            return None; // rerun with the discovery applied
+                        }
+                        let src = self.pop_scalar()?;
+                        self.kops.push(K::Mov { dst, src });
+                        self.store_of(*l);
+                    }
+                    _ => {
+                        let dst = self.lreg(*l)?;
+                        let src = self.pop_num()?;
+                        self.kops.push(K::Mov { dst, src });
+                        self.store_of(*l);
+                    }
                 }
             }
             // A block-scoped declaration's TDZ marker: writes `Uninitialized`
@@ -716,33 +937,69 @@ impl Xlate<'_> {
             // it (a genuine TDZ read would need the generic path's
             // ReferenceError, so such regions stay generic).
             Op::InitLocalTdz(l) => {
-                self.lreg(*l)?;
+                // No type demand here — the local's static type comes from
+                // the actual store that must follow (numeric or boolean).
                 if !self.dead_store_ahead(i + 1, *l) {
                     return None;
                 }
                 self.store_of(*l);
             }
             Op::CopyLocal { src, dest } => {
-                let s = self.lreg(*src)?;
-                let d = self.lreg(*dest)?;
+                let (s, d) = if self.is_bool_local(*src) {
+                    let s = self.blreg(*src)?;
+                    let d = self.blreg(*dest)?;
+                    if !self.is_bool_local(*dest) {
+                        return None; // rerun with the discovery applied
+                    }
+                    (s, d)
+                } else {
+                    (self.lreg(*src)?, self.lreg(*dest)?)
+                };
                 if s != d {
                     self.kops.push(K::Mov { dst: d, src: s });
                 }
                 self.store_of(*dest);
             }
             Op::LoadConst(c) => {
-                let k = self.num_const(*c)?;
-                let dst = self.push_num()?;
+                let (k, is_bool) = self.scalar_const(*c)?;
+                let dst = if is_bool {
+                    self.push_bool()?
+                } else {
+                    self.push_num()?
+                };
                 self.kops.push(K::Const { dst, k });
             }
+            Op::LoadTrue | Op::LoadFalse => {
+                let dst = self.push_bool()?;
+                self.kops.push(K::Const {
+                    dst,
+                    k: if matches!(op, Op::LoadTrue) { 1.0 } else { 0.0 },
+                });
+            }
+            // `!x` on a scalar: ToBoolean then negate — a boolean result.
+            Op::Not => {
+                let src = self.pop_scalar()?;
+                let dst = self.push_bool()?;
+                self.kops.push(K::BoolNot { dst, src });
+            }
             Op::LoadLocalConst { local, konst } => {
-                let src = self.lreg(*local)?;
-                let k = self.num_const(*konst)?;
-                let dst0 = self.push_num()?;
-                self.kops.push(K::Mov { dst: dst0, src });
-                let ver = *self.versions.get(local).unwrap_or(&0);
-                *self.origins.last_mut()? = Some((*local, ver));
-                let dst1 = self.push_num()?;
+                let (k, k_bool) = self.scalar_const(*konst)?;
+                if self.is_bool_local(*local) {
+                    let src = self.blreg(*local)?;
+                    let dst0 = self.push_bool()?;
+                    self.kops.push(K::Mov { dst: dst0, src });
+                } else {
+                    let src = self.lreg(*local)?;
+                    let dst0 = self.push_num()?;
+                    self.kops.push(K::Mov { dst: dst0, src });
+                    let ver = *self.versions.get(local).unwrap_or(&0);
+                    *self.origins.last_mut()? = Some((*local, ver));
+                }
+                let dst1 = if k_bool {
+                    self.push_bool()?
+                } else {
+                    self.push_num()?
+                };
                 self.kops.push(K::Const { dst: dst1, k });
             }
 
@@ -754,9 +1011,13 @@ impl Xlate<'_> {
             Op::Dup => {
                 let top = *self.vstack.last()?;
                 match top {
-                    VE::Num => {
+                    VE::Num | VE::Bool => {
                         let src = self.top_reg(0)?;
-                        let dst = self.push_num()?;
+                        let dst = if top == VE::Bool {
+                            self.push_bool()?
+                        } else {
+                            self.push_num()?
+                        };
                         self.kops.push(K::Mov { dst, src });
                     }
                     VE::Obj(s) => {
@@ -777,7 +1038,8 @@ impl Xlate<'_> {
                 if ea == VE::Undef || eb == VE::Undef {
                     return None;
                 }
-                match (ea == VE::Num, eb == VE::Num) {
+                let is_reg = |e: VE| matches!(e, VE::Num | VE::Bool);
+                match (is_reg(ea), is_reg(eb)) {
                     (true, true) => {
                         let (ra, rb) = (self.preg(pa)?, self.preg(pb)?);
                         self.kops.push(K::Mov {
@@ -815,20 +1077,21 @@ impl Xlate<'_> {
                 if ea == VE::Undef || eb == VE::Undef || ec == VE::Undef {
                     return None;
                 }
+                let is_reg = |e: VE| matches!(e, VE::Num | VE::Bool);
                 // c -> position a, a -> position b, b -> position c.
-                if ec == VE::Num {
+                if is_reg(ec) {
                     self.kops.push(K::Mov {
                         dst: SCRATCH0,
                         src: rc,
                     });
                 }
-                if eb == VE::Num {
+                if is_reg(eb) {
                     self.kops.push(K::Mov { dst: rc, src: rb });
                 }
-                if ea == VE::Num {
+                if is_reg(ea) {
                     self.kops.push(K::Mov { dst: rb, src: ra });
                 }
-                if ec == VE::Num {
+                if is_reg(ec) {
                     self.kops.push(K::Mov {
                         dst: ra,
                         src: SCRATCH0,
@@ -841,10 +1104,11 @@ impl Xlate<'_> {
 
             // ---- arithmetic (numbers in, numbers out) ----
             Op::Add => {
-                let b = self.pop_num()?;
+                let b = self.pop_scalar()?;
                 let a = self.top_reg(0)?;
                 self.kops.push(K::Add { dst: a, a, b });
                 let p = self.vstack.len() - 1;
+                self.vstack[p] = VE::Num;
                 self.origins[p] = None;
             }
             Op::Sub => self.bin(ArithKind::Sub)?,
@@ -862,18 +1126,23 @@ impl Xlate<'_> {
                 let s = self.top_reg(0)?;
                 self.kops.push(K::Neg { dst: s, src: s });
                 let p = self.vstack.len() - 1;
+                self.vstack[p] = VE::Num;
                 self.origins[p] = None;
             }
             Op::BitNot => {
                 let s = self.top_reg(0)?;
                 self.kops.push(K::BitNot { dst: s, src: s });
                 let p = self.vstack.len() - 1;
+                self.vstack[p] = VE::Num;
                 self.origins[p] = None;
             }
-            // ToNumber/ToNumeric on a Number is the identity — but only on a
-            // NUMBER entry (an object would coerce: reject).
+            // ToNumber/ToNumeric on a scalar: identity on the 0/1 register,
+            // but the RESULT is a number (retype a boolean entry).
             Op::Pos | Op::ToNumeric => {
                 self.top_reg(0)?;
+                let p = self.vstack.len() - 1;
+                self.vstack[p] = VE::Num;
+                self.origins[p] = None;
             }
             Op::Inc | Op::Dec => {
                 let s = self.top_reg(0)?;
@@ -883,19 +1152,20 @@ impl Xlate<'_> {
                     k: if matches!(op, Op::Inc) { 1.0 } else { -1.0 },
                 });
                 let p = self.vstack.len() - 1;
+                self.vstack[p] = VE::Num;
                 self.origins[p] = None;
             }
 
             // ---- fused local-const forms ----
             Op::AddLocalConst { local, konst } => {
-                let a = self.lreg(*local)?;
-                let k = self.num_const(*konst)?;
+                let a = self.scalar_lreg(*local)?;
+                let (k, _) = self.scalar_const(*konst)?;
                 let dst = self.push_num()?;
                 self.kops.push(K::AddK { dst, a, k });
             }
             Op::ArithLocalConst { local, konst, kind } => {
-                let a = self.lreg(*local)?;
-                let k = self.num_const(*konst)?;
+                let a = self.scalar_lreg(*local)?;
+                let (k, _) = self.scalar_const(*konst)?;
                 let dst = self.push_num()?;
                 self.kops.push(K::ArithK {
                     kind: *kind,
@@ -921,7 +1191,7 @@ impl Xlate<'_> {
                 // expects on a bail.
                 let shape = self.vstack.clone();
                 let obj = self.base_slot(1)?;
-                let idx = self.top_reg(0)?;
+                let idx = self.top_num_reg(0)?;
                 self.pop()?; // idx
                 self.pop()?; // base
                 let dst = self.push_num()?;
@@ -938,8 +1208,8 @@ impl Xlate<'_> {
             Op::SetPropDynamic => {
                 let shape = self.vstack.clone();
                 let obj = self.base_slot(2)?;
-                let val = self.top_reg(0)?;
-                let idx = self.top_reg(1)?;
+                let val = self.top_num_reg(0)?;
+                let idx = self.top_num_reg(1)?;
                 self.pop()?; // val
                 self.pop()?; // idx
                 self.pop()?; // base
@@ -1047,9 +1317,11 @@ impl Xlate<'_> {
                 }
             }
 
-            // ---- comparisons: supported only in compare-and-branch form. A
-            // materialized boolean (stored, returned, fed to arithmetic)
-            // would put a non-number on the stack — reject the region.
+            // ---- comparisons: fused into the following conditional jump
+            // when one immediately consumes them, otherwise MATERIALIZED as a
+            // boolean register (CmpSet). Strict (in)equality between
+            // statically mixed boolean/number operands folds to a constant —
+            // the generic `strict_equals` never compares values across types.
             Op::Eq | Op::Ne | Op::StrictEq | Op::StrictNe | Op::Lt | Op::Gt | Op::Le | Op::Ge => {
                 let cmp = match op {
                     Op::Eq => CmpOp::Eq,
@@ -1062,25 +1334,53 @@ impl Xlate<'_> {
                     Op::Ge => CmpOp::Ge,
                     _ => unreachable!(),
                 };
-                // Must be immediately consumed by a conditional jump that is
-                // itself not a branch target (it is fused away entirely).
-                let (if_true, target) = match self.region.get(i + 1) {
-                    Some(Op::JumpIfFalse(t)) if !self.is_target[i + 1] => (false, *t),
-                    Some(Op::JumpIfTrue(t)) if !self.is_target[i + 1] => (true, *t),
-                    _ => return None,
+                let b_bool = self.top_is_bool(0)?;
+                let a_bool = self.top_is_bool(1)?;
+                let fixed = static_cmp(cmp, a_bool, b_bool);
+                // Fused form: immediately consumed by a conditional jump that
+                // is itself not a branch target.
+                let fuse = match self.region.get(i + 1) {
+                    Some(Op::JumpIfFalse(t)) if !self.is_target[i + 1] => Some((false, *t)),
+                    Some(Op::JumpIfTrue(t)) if !self.is_target[i + 1] => Some((true, *t)),
+                    _ => None,
                 };
-                let b = self.pop_num()?;
-                let a = self.pop_num()?;
-                let kidx = self.kops.len();
-                self.kops.push(K::BrCmp {
-                    cmp,
-                    a,
-                    b,
-                    if_true,
-                    target: u16::MAX,
-                });
-                self.branch_to(kidx, target, self.vstack.clone())?;
-                self.absorbed = Some(i + 1);
+                let b = self.pop_scalar()?;
+                let a = self.pop_scalar()?;
+                match (fuse, fixed) {
+                    (Some((if_true, target)), None) => {
+                        let kidx = self.kops.len();
+                        self.kops.push(K::BrCmp {
+                            cmp,
+                            a,
+                            b,
+                            if_true,
+                            target: u16::MAX,
+                        });
+                        self.branch_to(kidx, target, self.vstack.clone())?;
+                        self.absorbed = Some(i + 1);
+                    }
+                    (Some((if_true, target)), Some(outcome)) => {
+                        // Statically decided branch: taken -> unconditional
+                        // jump; not taken -> fall through (operands consumed).
+                        if outcome == if_true {
+                            let kidx = self.kops.len();
+                            self.kops.push(K::Br { target: u16::MAX });
+                            self.branch_to(kidx, target, self.vstack.clone())?;
+                        }
+                        self.absorbed = Some(i + 1);
+                    }
+                    (None, None) => {
+                        let dst = self.push_bool()?;
+                        self.kops.push(K::CmpSet { cmp, dst, a, b });
+                    }
+                    (None, Some(outcome)) => {
+                        let dst = self.push_bool()?;
+                        self.kops.push(K::Const {
+                            dst,
+                            k: if outcome { 1.0 } else { 0.0 },
+                        });
+                    }
+                }
             }
 
             // ---- branches ----
@@ -1090,7 +1390,7 @@ impl Xlate<'_> {
                 self.branch_to(kidx, *t, self.vstack.clone())?;
             }
             Op::JumpIfFalse(t) | Op::JumpIfTrue(t) => {
-                let src = self.pop_num()?;
+                let src = self.pop_scalar()?;
                 let kidx = self.kops.len();
                 if matches!(op, Op::JumpIfFalse(_)) {
                     self.kops.push(K::BrFalsy {
@@ -1142,17 +1442,27 @@ impl Xlate<'_> {
 
             Op::CmpBranchFalse { cmp, target } | Op::CmpBranchTrue { cmp, target } => {
                 let if_true = matches!(op, Op::CmpBranchTrue { .. });
-                let b = self.pop_num()?;
-                let a = self.pop_num()?;
-                let kidx = self.kops.len();
-                self.kops.push(K::BrCmp {
-                    cmp: *cmp,
-                    a,
-                    b,
-                    if_true,
-                    target: u16::MAX,
-                });
-                self.branch_to(kidx, *target, self.vstack.clone())?;
+                let b_bool = self.top_is_bool(0)?;
+                let a_bool = self.top_is_bool(1)?;
+                let b = self.pop_scalar()?;
+                let a = self.pop_scalar()?;
+                if let Some(outcome) = static_cmp(*cmp, a_bool, b_bool) {
+                    if outcome == if_true {
+                        let kidx = self.kops.len();
+                        self.kops.push(K::Br { target: u16::MAX });
+                        self.branch_to(kidx, *target, self.vstack.clone())?;
+                    }
+                } else {
+                    let kidx = self.kops.len();
+                    self.kops.push(K::BrCmp {
+                        cmp: *cmp,
+                        a,
+                        b,
+                        if_true,
+                        target: u16::MAX,
+                    });
+                    self.branch_to(kidx, *target, self.vstack.clone())?;
+                }
             }
             Op::CmpLocalConstBranchFalse {
                 local,
@@ -1167,17 +1477,26 @@ impl Xlate<'_> {
                 target,
             } => {
                 let if_true = matches!(op, Op::CmpLocalConstBranchTrue { .. });
-                let a = self.lreg(*local)?;
-                let k = self.num_const(*konst)?;
-                let kidx = self.kops.len();
-                self.kops.push(K::BrCmpK {
-                    cmp: *cmp,
-                    a,
-                    k,
-                    if_true,
-                    target: u16::MAX,
-                });
-                self.branch_to(kidx, *target, self.vstack.clone())?;
+                let a_bool = self.is_bool_local(*local);
+                let a = self.scalar_lreg(*local)?;
+                let (k, k_bool) = self.scalar_const(*konst)?;
+                if let Some(outcome) = static_cmp(*cmp, a_bool, k_bool) {
+                    if outcome == if_true {
+                        let kidx = self.kops.len();
+                        self.kops.push(K::Br { target: u16::MAX });
+                        self.branch_to(kidx, *target, self.vstack.clone())?;
+                    }
+                } else {
+                    let kidx = self.kops.len();
+                    self.kops.push(K::BrCmpK {
+                        cmp: *cmp,
+                        a,
+                        k,
+                        if_true,
+                        target: u16::MAX,
+                    });
+                    self.branch_to(kidx, *target, self.vstack.clone())?;
+                }
             }
 
             // Anything else — calls, other property access, cells, upvalues,

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -1,6 +1,13 @@
 //! Typed loop kernels: translate eligible bytecode loops into unboxed-`f64`
 //! register programs (docs/js-performance-roadmap.md §6.5).
 //!
+//! The same translator also compiles FUNCTION kernels
+//! ([`kernelize_function`]): a tiny pure-scalar body — a sort comparator, a
+//! `map`/`filter`/`reduce` callback — becomes a register program the call
+//! paths execute FRAMELESS when its per-call entry guard passes (arguments
+//! present and `Number`s, upvalues `Number`s, no op budget, no trace sink);
+//! any guard failure takes the ordinary frame path. See `Vm::run_fn_kernel`.
+//!
 //! ## Why
 //!
 //! The retired closure-threading experiment (docs/jit.md) proved that removing
@@ -139,6 +146,7 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
                 &kernels,
                 &oslots,
                 &bools,
+                false,
             );
             let mut grew = false;
             for o in d_obj {
@@ -165,6 +173,53 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
         }
     }
     (code, kernels)
+}
+
+/// Bound keeping FUNCTION-kernel translation cheap: bodies beyond this stay
+/// generic (the win is tiny leaf callbacks — comparators, HOF callbacks;
+/// larger bodies amortize their frame anyway).
+const MAX_FN_OPS: usize = 128;
+
+/// Translate an ENTIRE function body into a kernel executed FRAMELESS at call
+/// time (`FuncProto::fn_kernel`): no frame, no operand stack, no local slots —
+/// arguments load straight into registers under the entry guard (every
+/// consumed argument present and a `Number`, captured upvalues `Number`s) and
+/// `Return` yields the call's result directly. Eligibility is the loop-kernel
+/// allowlist plus fn-mode rules: no element access or `a.length` (a bail
+/// needs a frame to resume into), every local read dominated by a real store
+/// on every path (there is no guard to type frameless locals), and every
+/// completing path ending at `Return` with a scalar. `None` = stay generic.
+pub fn kernelize_function(code: &[Op], consts: &[Const], inner: &[Kernel]) -> Option<Kernel> {
+    if code.len() > MAX_FN_OPS {
+        return None;
+    }
+    // Cheap pre-screen: a kernelizable body always ends paths at `Op::Return`.
+    if !code.iter().any(|op| matches!(op, Op::Return)) {
+        return None;
+    }
+    // Same boolean-local fixpoint as `kernelize`; array-base discoveries
+    // reject outright (element access can't run frameless).
+    let mut bools: Vec<u32> = Vec::new();
+    for _ in 0..6 {
+        let (k, d_obj, d_bool) = translate(code, 0, consts, inner, &[], &bools, true);
+        if !d_obj.is_empty() {
+            return None;
+        }
+        let mut grew = false;
+        for b in d_bool {
+            if !bools.contains(&b) {
+                bools.push(b);
+                grew = true;
+            }
+        }
+        if !grew {
+            let k = k?;
+            // Frameless kernels are self-contained by construction.
+            debug_assert!(k.oslots.is_empty() && k.shapes.is_empty());
+            return Some(k);
+        }
+    }
+    None
 }
 
 /// Every code index an op can transfer control to (not counting fallthrough).
@@ -230,6 +285,12 @@ enum VE {
     /// per-iteration `let` reset emits `LoadUndefined; StoreLocal(j)` right
     /// before the loop re-initializes `j`). Everything else rejects.
     Undef,
+    /// fn mode only: a value the kernel cannot represent — `this` /
+    /// `new.target`, which a declared function's calling-convention prologue
+    /// materializes into locals the body may never touch. Its ONLY legal
+    /// consumer is a store to a local (the `init` tracking then rejects any
+    /// read of that local); everything else rejects.
+    Opaque,
 }
 
 struct Xlate<'a> {
@@ -239,6 +300,12 @@ struct Xlate<'a> {
     /// Already-built kernels (inner loops) — `Op::LoopKernel` translates as
     /// its fallback op.
     inner: &'a [Kernel],
+    /// FUNCTION-kernel translation (`kernelize_function`): the region is an
+    /// entire function body executed FRAMELESS. `Op::LoadArg`/`Op::Return`
+    /// join the allowlist; exits are impossible (no frame to resume), and
+    /// every local read must be dominated by a real store (`init` tracking) —
+    /// there is no entry guard over locals to type them.
+    fn_mode: bool,
     /// Locals designated as array bases (phase 2) — empty in phase 1.
     oslot_locals: &'a [u32],
     /// Locals statically typed BOOLEAN (fixpoint-discovered from stores).
@@ -248,6 +315,13 @@ struct Xlate<'a> {
     kpc: Vec<u16>,
     /// expected virtual-stack shape at each region-relative ip, when known.
     shape_at: Vec<Option<Vec<VE>>>,
+    /// fn mode: the set of locals provably stored on the current path,
+    /// SORTED. Merge points require identical sets — the same rule as the
+    /// stack shape — so a read is dominated by a store on EVERY path.
+    init: Vec<u32>,
+    /// fn mode: expected `init` set at each region-relative ip, when known
+    /// (kept in lockstep with `shape_at`).
+    init_at: Vec<Option<Vec<u32>>>,
     /// in-region branch targets (any op branching to that ip).
     is_target: Vec<bool>,
     /// numeric slots (locals and read-only upvalues): (source, register),
@@ -286,6 +360,7 @@ fn translate(
     inner: &[Kernel],
     oslot_locals: &[u32],
     bool_locals: &[u32],
+    fn_mode: bool,
 ) -> (Option<Kernel>, Vec<u32>, Vec<u32>) {
     let mut is_target = vec![false; region.len()];
     for op in region {
@@ -302,11 +377,14 @@ fn translate(
         base_ip,
         consts,
         inner,
+        fn_mode,
         oslot_locals,
         bool_locals,
         kops: Vec::new(),
         kpc: vec![u16::MAX; region.len()],
         shape_at: vec![None; region.len()],
+        init: Vec::new(),
+        init_at: vec![None; region.len()],
         is_target,
         local_reg: Vec::new(),
         bool_reg: Vec::new(),
@@ -322,6 +400,7 @@ fn translate(
         max_stack: 0,
     };
     x.shape_at[0] = Some(Vec::new());
+    x.init_at[0] = Some(Vec::new());
     let kernel = translate_inner(&mut x);
     let d_obj = std::mem::take(&mut x.discovered);
     let d_bool = std::mem::take(&mut x.discovered_bools);
@@ -345,6 +424,16 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 if reachable && shape != x.vstack {
                     return None; // inconsistent stack shape at a merge point
                 }
+                if x.fn_mode {
+                    // The initialized-locals set merges under the same rule.
+                    let init = x.init_at[i].clone().unwrap_or_default();
+                    if reachable && init != x.init {
+                        return None;
+                    }
+                    if !reachable {
+                        x.init = init;
+                    }
+                }
                 if !reachable {
                     x.vstack = shape.clone();
                     x.origins = vec![None; shape.len()];
@@ -362,6 +451,9 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 // Record the shape every executed op is translated at, so a
                 // later BACKWARD branch to it verifies register alignment.
                 x.shape_at[i] = Some(x.vstack.clone());
+                if x.fn_mode {
+                    x.init_at[i] = Some(x.init.clone());
+                }
             }
         }
         x.kpc[i] = u16::try_from(x.kops.len()).ok()?;
@@ -372,7 +464,9 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
             return None;
         }
         // Ops with no fallthrough edge end the current basic block.
-        if matches!(region[i], Op::Jump(_) | Op::JumpIfNullishPeek(_)) {
+        if matches!(region[i], Op::Jump(_) | Op::JumpIfNullishPeek(_))
+            || (x.fn_mode && matches!(region[i], Op::Return))
+        {
             reachable = false;
         }
     }
@@ -396,14 +490,20 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         }
         patch(&mut x.kops, kidx, pc);
     }
+    // A FUNCTION kernel runs frameless — there is no bytecode frame to
+    // resume, so any path needing a generic-interpreter exit rejects the
+    // whole function (element access, or a body not ending in `Return`).
+    if x.fn_mode && !x.exits.is_empty() {
+        return None;
+    }
     // Synthesize exit stubs (deduplicated by resume ip + shape) and collect
     // the shape table.
     let exits = std::mem::take(&mut x.exits);
     let mut shapes: Vec<Vec<VE>> = Vec::new();
     let mut stubs: Vec<(u32, u16, u16)> = Vec::new(); // (resume, shape idx, pc)
     for (kidx, resume_ip, shape) in exits {
-        if shape.contains(&VE::Undef) {
-            return None; // `undefined` never survives to an exit
+        if shape.contains(&VE::Undef) || shape.contains(&VE::Opaque) {
+            return None; // undefined/opaque never survives to an exit
         }
         let sidx = match shapes.iter().position(|s| *s == shape) {
             Some(p) => p as u16,
@@ -486,6 +586,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *val = remap(*val);
             }
             KOp::LoadLen { dst, .. } => *dst = remap(*dst),
+            KOp::Ret { src, .. } => *src = remap(*src),
             KOp::Math1 { dst, src, .. } => {
                 *dst = remap(*dst);
                 *src = remap(*src);
@@ -509,7 +610,9 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::Obj(o) => KShapeSlot::Obj(*o),
                     VE::MathObj => KShapeSlot::MathObj,
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
-                    VE::Undef => unreachable!("undef never crosses block boundaries"),
+                    VE::Undef | VE::Opaque => {
+                        unreachable!("undef/opaque never crosses block boundaries")
+                    }
                 })
                 .collect()
         })
@@ -604,6 +707,49 @@ impl Xlate<'_> {
         Some(r)
     }
 
+    /// FUNCTION kernels: register holding call argument `a` (read-only; the
+    /// entry guard requires it present and a `Number`). Shares the numeric
+    /// slot space with locals/upvalues.
+    fn argreg(&mut self, a: u32) -> Option<u16> {
+        let slot = KSlot::Arg(a);
+        if let Some(&(_, r)) = self.local_reg.iter().find(|(sl, _)| *sl == slot) {
+            return Some(r);
+        }
+        let r = u16::try_from(self.local_reg.len()).ok()?;
+        if r >= BOOL_BASE {
+            return None;
+        }
+        self.local_reg.push((slot, r));
+        Some(r)
+    }
+
+    /// fn mode: a local may be read only when a real store to it dominates
+    /// (tracked per-path in `init`; merge points require identical sets — no
+    /// entry guard exists to type frameless locals). Loop mode: always true.
+    fn local_readable(&self, l: u32) -> bool {
+        !self.fn_mode || self.init.binary_search(&l).is_ok()
+    }
+
+    /// Record a real (value-carrying) store to local `l` on this path.
+    fn mark_init(&mut self, l: u32) {
+        if self.fn_mode {
+            if let Err(p) = self.init.binary_search(&l) {
+                self.init.insert(p, l);
+            }
+        }
+    }
+
+    /// fn mode: local `l` no longer holds a readable value on this path (an
+    /// elided `undefined`/TDZ store — the generic slot would be
+    /// `undefined`/`Uninitialized`, which no kernel register can represent).
+    fn clear_init(&mut self, l: u32) {
+        if self.fn_mode {
+            if let Ok(p) = self.init.binary_search(&l) {
+                self.init.remove(p);
+            }
+        }
+    }
+
     /// Register mirroring BOOLEAN-typed `frame.locals[l]` (holds 0.0/1.0; the
     /// guard requires `Value::Bool`, write-back restores it). Records the
     /// local for the caller's fixpoint when it is not yet in this run's set.
@@ -633,8 +779,12 @@ impl Xlate<'_> {
 
     /// Read-only scalar register for local `l` — numeric or boolean space
     /// (coercing consumers treat a boolean's 0.0/1.0 exactly as ToNumber
-    /// would). Never valid for array bases.
+    /// would). Never valid for array bases. Every caller is a READ, so fn
+    /// mode demands a dominating store.
     fn scalar_lreg(&mut self, l: u32) -> Option<u16> {
+        if !self.local_readable(l) {
+            return None;
+        }
         if self.bool_locals.contains(&l) {
             self.blreg(l)
         } else {
@@ -745,7 +895,7 @@ impl Xlate<'_> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Obj(s) => Some(s),
-            VE::Bool | VE::Undef | VE::MathObj | VE::MathFn(_) => None,
+            VE::Bool | VE::Undef | VE::Opaque | VE::MathObj | VE::MathFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -809,8 +959,8 @@ impl Xlate<'_> {
 
     /// Record a branch to absolute bytecode ip `t` from the kop at `kidx`.
     fn branch_to(&mut self, kidx: usize, t: u32, shape: Vec<VE>) -> Option<()> {
-        if shape.contains(&VE::Undef) {
-            return None; // `undefined` never crosses block boundaries
+        if shape.contains(&VE::Undef) || shape.contains(&VE::Opaque) {
+            return None; // undefined/opaque never crosses block boundaries
         }
         let rel = (t as usize).wrapping_sub(self.base_ip as usize);
         if rel < self.region.len() {
@@ -818,6 +968,14 @@ impl Xlate<'_> {
                 Some(s) if *s != shape => return None,
                 Some(_) => {}
                 None => self.shape_at[rel] = Some(shape),
+            }
+            if self.fn_mode {
+                // The initialized-locals set must agree at the target too.
+                match &self.init_at[rel] {
+                    Some(s) if *s != self.init => return None,
+                    Some(_) => {}
+                    None => self.init_at[rel] = Some(self.init.clone()),
+                }
             }
             self.fixups.push((kidx, rel));
         } else {
@@ -851,6 +1009,22 @@ impl Xlate<'_> {
                 self.origins.push(None);
             }
 
+            // fn mode: the declared-function prologue materializes `this`
+            // and `new.target` into locals. The values are unrepresentable
+            // (`VE::Opaque`) — legal only when stored into locals the body
+            // never reads (`init` tracking rejects any read).
+            Op::LoadThis | Op::LoadNewTarget if self.fn_mode => {
+                self.vstack.push(VE::Opaque);
+                self.origins.push(None);
+            }
+            // OrdinaryCallBindThis (sloppy): coerces the top-of-stack `this`
+            // — opaque in, opaque out.
+            Op::BindThisSloppy if self.fn_mode => {
+                if !matches!(self.vstack.last(), Some(VE::Opaque)) {
+                    return None;
+                }
+            }
+
             // The ONLY supported global: `Math` (speculatively — the entry
             // guard verifies the global binding is still the canonical data
             // property before the kernel runs).
@@ -872,6 +1046,9 @@ impl Xlate<'_> {
             // ---- locals (TDZ subsumed by the entry guard: a mapped local is
             // a Number, never Uninitialized) ----
             Op::LoadLocal(l) => {
+                if !self.local_readable(*l) {
+                    return None;
+                }
                 if let Some(pos) = self.oslot_locals.iter().position(|&o| o == *l) {
                     // This local is an array base — push the object.
                     self.vstack.push(VE::Obj(pos as u16));
@@ -894,22 +1071,50 @@ impl Xlate<'_> {
                 let dst = self.push_num()?;
                 self.kops.push(K::Mov { dst, src });
             }
+            // FUNCTION kernels: a call argument (read-only; the entry guard
+            // requires it present and a `Number`). Loop regions never see
+            // `LoadArg` — parameters are copied to locals in the prologue.
+            Op::LoadArg(a) if self.fn_mode => {
+                let src = self.argreg(*a)?;
+                let dst = self.push_num()?;
+                self.kops.push(K::Mov { dst, src });
+            }
+            // FUNCTION kernels: yield the (scalar) result and finish the
+            // frameless call. Loop regions reject `Return` (the catch-all).
+            Op::Return if self.fn_mode => {
+                let boolean = self.top_is_bool(0)?;
+                let src = self.pop_scalar()?;
+                self.kops.push(K::Ret { src, boolean });
+            }
 
             // The checked store's TDZ test reads the CURRENT slot value; the
-            // guard proves it is a Number, so the store is a plain move.
+            // loop-kernel guard proves it is a Number, so the store is a
+            // plain move. fn mode has no such guard: the checked store is
+            // only provably non-throwing when a real store already dominates
+            // (the slot then holds a value, never `Uninitialized`).
             Op::StoreLocal(l) | Op::StoreLocalChecked(l) => {
+                if self.fn_mode
+                    && matches!(op, Op::StoreLocalChecked(_))
+                    && !self.local_readable(*l)
+                {
+                    return None;
+                }
                 match self.vstack.last() {
-                    Some(VE::Undef) => {
-                        // Storing `undefined` can only be elided if the local
-                        // is provably RE-STORED before any read, branch, or
+                    Some(VE::Undef) | Some(VE::Opaque) => {
+                        // Storing an unrepresentable value is elided. fn
+                        // mode: sound outright — the `init` tracking rejects
+                        // any read of the local not dominated by a real
+                        // store. Loop mode (`undefined` only): the local must
+                        // provably be RE-STORED before any read, branch, or
                         // branch target — i.e. the store is dead within this
-                        // basic block (the per-iteration `let` reset pattern).
-                        // Otherwise the region is rejected.
-                        if !self.dead_store_ahead(i + 1, *l) {
+                        // basic block (the per-iteration `let` reset
+                        // pattern). Otherwise the region is rejected.
+                        if !self.fn_mode && !self.dead_store_ahead(i + 1, *l) {
                             return None;
                         }
                         self.pop()?;
                         self.store_of(*l);
+                        self.clear_init(*l);
                     }
                     Some(VE::Bool) => {
                         // A boolean store TYPES the local (fixpoint feedback);
@@ -922,12 +1127,14 @@ impl Xlate<'_> {
                         let src = self.pop_scalar()?;
                         self.kops.push(K::Mov { dst, src });
                         self.store_of(*l);
+                        self.mark_init(*l);
                     }
                     _ => {
                         let dst = self.lreg(*l)?;
                         let src = self.pop_num()?;
                         self.kops.push(K::Mov { dst, src });
                         self.store_of(*l);
+                        self.mark_init(*l);
                     }
                 }
             }
@@ -939,12 +1146,19 @@ impl Xlate<'_> {
             Op::InitLocalTdz(l) => {
                 // No type demand here — the local's static type comes from
                 // the actual store that must follow (numeric or boolean).
-                if !self.dead_store_ahead(i + 1, *l) {
+                // fn mode: `init` tracking subsumes the dead-store proof (a
+                // genuine TDZ read rejects the region, and the generic path
+                // then raises the ReferenceError).
+                if !self.fn_mode && !self.dead_store_ahead(i + 1, *l) {
                     return None;
                 }
                 self.store_of(*l);
+                self.clear_init(*l);
             }
             Op::CopyLocal { src, dest } => {
+                if !self.local_readable(*src) {
+                    return None;
+                }
                 let (s, d) = if self.is_bool_local(*src) {
                     let s = self.blreg(*src)?;
                     let d = self.blreg(*dest)?;
@@ -959,6 +1173,7 @@ impl Xlate<'_> {
                     self.kops.push(K::Mov { dst: d, src: s });
                 }
                 self.store_of(*dest);
+                self.mark_init(*dest);
             }
             Op::LoadConst(c) => {
                 let (k, is_bool) = self.scalar_const(*c)?;
@@ -983,6 +1198,9 @@ impl Xlate<'_> {
                 self.kops.push(K::BoolNot { dst, src });
             }
             Op::LoadLocalConst { local, konst } => {
+                if !self.local_readable(*local) {
+                    return None;
+                }
                 let (k, k_bool) = self.scalar_const(*konst)?;
                 if self.is_bool_local(*local) {
                     let src = self.blreg(*local)?;
@@ -1028,14 +1246,14 @@ impl Xlate<'_> {
                         self.vstack.push(VE::MathObj);
                         self.origins.push(None);
                     }
-                    VE::MathFn(_) | VE::Undef => return None,
+                    VE::MathFn(_) | VE::Undef | VE::Opaque => return None,
                 }
             }
             Op::Swap => {
                 let n = self.vstack.len();
                 let (pa, pb) = (n.checked_sub(2)?, n - 1);
                 let (ea, eb) = (self.vstack[pa], self.vstack[pb]);
-                if ea == VE::Undef || eb == VE::Undef {
+                if matches!(ea, VE::Undef | VE::Opaque) || matches!(eb, VE::Undef | VE::Opaque) {
                     return None;
                 }
                 let is_reg = |e: VE| matches!(e, VE::Num | VE::Bool);
@@ -1074,7 +1292,10 @@ impl Xlate<'_> {
                 let (pa, pb, pc_) = (n.checked_sub(3)?, n - 2, n - 1);
                 let (ra, rb, rc) = (self.preg(pa)?, self.preg(pb)?, self.preg(pc_)?);
                 let (ea, eb, ec) = (self.vstack[pa], self.vstack[pb], self.vstack[pc_]);
-                if ea == VE::Undef || eb == VE::Undef || ec == VE::Undef {
+                if [ea, eb, ec]
+                    .iter()
+                    .any(|e| matches!(e, VE::Undef | VE::Opaque))
+                {
                     return None;
                 }
                 let is_reg = |e: VE| matches!(e, VE::Num | VE::Bool);
@@ -1175,6 +1396,10 @@ impl Xlate<'_> {
                 });
             }
             Op::IncLocalStmt { local, dec } => {
+                // Reads the local before writing it.
+                if !self.local_readable(*local) {
+                    return None;
+                }
                 let r = self.lreg(*local)?;
                 self.kops.push(K::AddK {
                     dst: r,

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -64,7 +64,7 @@
 //! corpus + fuzz (`tests/kernels.rs`) runs every supported construct with
 //! kernels on and off and asserts byte-identical behavior.
 
-use crate::bytecode::{CmpOp, Const, KMath, KOp, KProp, KShapeSlot, KSlot, Kernel, Op};
+use crate::bytecode::{CmpOp, Const, KCallee, KMath, KOp, KProp, KShapeSlot, KSlot, Kernel, Op};
 use crate::exec::ArithKind;
 
 /// Bounds keeping `u16` fields comfortable and per-kernel work finite. Loops
@@ -386,6 +386,9 @@ struct Xlate<'a> {
     /// Named-property access classes over oslot bases (entry-resolved; see
     /// [`KProp`]). Deduplicated by (oslot, key); flags OR together.
     props_used: Vec<KProp>,
+    /// Pinned closure callees (loop mode; see [`KCallee`]): per oslot, the
+    /// smallest argc any call site supplies.
+    callees: Vec<KCallee>,
     /// a compare op fused with its following conditional jump: skip that ip.
     absorbed: Option<usize>,
     max_stack: u16,
@@ -444,6 +447,7 @@ fn translate(
         exits: Vec::new(),
         math_used: Vec::new(),
         props_used: Vec::new(),
+        callees: Vec::new(),
         absorbed: None,
         max_stack: 0,
     };
@@ -639,6 +643,10 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
             KOp::LoadLen { dst, .. } => *dst = remap(*dst),
             KOp::LoadProp { dst, .. } => *dst = remap(*dst),
             KOp::StoreProp { src, .. } => *src = remap(*src),
+            KOp::CallKernel { dst, base, .. } => {
+                *dst = remap(*dst);
+                *base = remap(*base);
+            }
             KOp::Ret { src, .. } => *src = remap(*src),
             KOp::SelfCall { dst, base, .. } => {
                 *dst = remap(*dst);
@@ -691,6 +699,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         shapes: shapes.into_boxed_slice(),
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
         props_used: std::mem::take(&mut x.props_used).into_boxed_slice(),
+        callee_slots: std::mem::take(&mut x.callees).into_boxed_slice(),
         n_regs: n_locals + n_bools + x.max_stack + 1,
         self_global: None, // `kernelize_function` fills it for recursive kernels
         fallback: Box::new(Op::Nop), // caller stores the real header op
@@ -1661,6 +1670,48 @@ impl Xlate<'_> {
                         dst,
                         base,
                         argc: u16::try_from(n).ok()?,
+                    });
+                    return Some(());
+                }
+                // LOOP mode: a call of a PINNED closure — the callee is an
+                // object-typed local (oslot machinery, discovered exactly
+                // like an array base) under a plain `undefined` this.
+                // Arguments must be statically NUMBER registers: they copy
+                // raw into the callee kernel's guarded-Number arg registers.
+                if !self.fn_mode
+                    && matches!(self.vstack.get(fn_pos + 1)?, VE::Undef)
+                    && !matches!(self.vstack.get(fn_pos)?, VE::MathFn(_) | VE::MathObj)
+                {
+                    for d in 0..n {
+                        self.top_num_reg(d)?;
+                    }
+                    let oslot = self.base_slot(n + 1)?;
+                    let argc = u16::try_from(n).ok()?;
+                    // `fslot` indexes the CALLEE table (parallel to the
+                    // executor's per-activation window list), NOT the oslots.
+                    let fslot = match self.callees.iter().position(|c| c.oslot == oslot) {
+                        Some(i) => {
+                            self.callees[i].min_argc = self.callees[i].min_argc.min(argc);
+                            i
+                        }
+                        None => {
+                            self.callees.push(KCallee {
+                                oslot,
+                                min_argc: argc,
+                            });
+                            self.callees.len() - 1
+                        }
+                    };
+                    let base = if n > 0 { self.preg(fn_pos + 2)? } else { 0 };
+                    for _ in 0..n + 2 {
+                        self.pop()?;
+                    }
+                    let dst = self.push_num()?;
+                    self.kops.push(K::CallKernel {
+                        dst,
+                        fslot: u16::try_from(fslot).ok()?,
+                        base,
+                        argc,
                     });
                     return Some(());
                 }

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -20,6 +20,7 @@ pub mod host;
 pub mod iter;
 pub mod journal;
 pub mod jsx;
+pub mod kernel;
 pub mod localize;
 pub mod module;
 /// Phase-0 opcode-frequency instrumentation; present only under the

--- a/crates/chidori-js/src/promise.rs
+++ b/crates/chidori-js/src/promise.rs
@@ -253,7 +253,7 @@ impl Vm {
     // Async function driving
     // =====================================================================
 
-    pub fn start_async(&mut self, frame: Frame) -> Value {
+    pub fn start_async(&mut self, frame: Box<Frame>) -> Value {
         let promise = self.new_promise();
         // The trace token (set by the caller before start_async) rides the frame
         // through every suspend/resume; capture it here for the synchronous
@@ -302,13 +302,13 @@ impl Vm {
     /// Resume a suspended frame with an injected value (await fulfilled).
     pub fn resume_frame(&mut self, mut frame: Box<Frame>, value: Value) -> Flow {
         frame.stack.push(value);
-        self.run_frame(*frame)
+        self.run_frame(frame)
     }
 
     /// Resume a suspended frame by raising an injected exception (await rejected).
     pub fn resume_frame_throw(&mut self, mut frame: Box<Frame>, err: Value) -> Flow {
         frame.pending_throw = Some(err);
-        self.run_frame(*frame)
+        self.run_frame(frame)
     }
 
     /// Resume a suspended generator frame with an injected `return` completion
@@ -316,7 +316,7 @@ impl Vm {
     /// `yield` run before the frame completes.
     pub fn resume_frame_return(&mut self, mut frame: Box<Frame>, value: Value) -> Flow {
         frame.pending_return = Some(value);
-        self.run_frame(*frame)
+        self.run_frame(frame)
     }
 
     // =====================================================================

--- a/crates/chidori-js/src/realm.rs
+++ b/crates/chidori-js/src/realm.rs
@@ -13,6 +13,13 @@ pub struct Realm {
     /// The %eval% intrinsic function object — `Op::DirectEval` compares the
     /// callee against it to decide direct-vs-ordinary call semantics.
     pub eval_fn: Option<JsObject>,
+    /// The canonical `Math` object and its kernel-supported methods (indexed
+    /// by [`crate::bytecode::KMath`]), captured at install. The typed loop
+    /// kernels identity-check these at entry: a kernel using `Math.max` runs
+    /// only while the global `Math` binding and the method are still these
+    /// exact objects; anything else declines to the generic path.
+    pub math_object: Option<JsObject>,
+    pub math_kernel: Vec<JsObject>,
 
     pub object_proto: JsObject,
     pub function_proto: JsObject,
@@ -164,6 +171,8 @@ impl Realm {
         Realm {
             global: bare(),
             eval_fn: None,
+            math_object: None,
+            math_kernel: Vec::new(),
             object_proto: bare(),
             function_proto: bare(),
             array_proto: bare(),

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -349,6 +349,9 @@ pub struct Vm {
     /// `kernel_regs`); cleared after every activation so the pool never
     /// extends an object's lifetime.
     pub(crate) kernel_objs: Vec<crate::value::JsObject>,
+    /// Pooled entry-resolved property-slot indices for kernel
+    /// `LoadProp`/`StoreProp` (see `KProp`).
+    pub(crate) kernel_prop_slots: Vec<u32>,
 }
 
 impl Vm {
@@ -383,6 +386,7 @@ impl Vm {
             frame_pool: Vec::new(),
             kernel_regs: Vec::new(),
             kernel_objs: Vec::new(),
+            kernel_prop_slots: Vec::new(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(
                     "",

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -352,6 +352,9 @@ pub struct Vm {
     /// Pooled entry-resolved property-slot indices for kernel
     /// `LoadProp`/`StoreProp` (see `KProp`).
     pub(crate) kernel_prop_slots: Vec<u32>,
+    /// Pooled entry-verified closure callees for kernel `CallKernel`:
+    /// (callee function, register-window base).
+    pub(crate) kernel_callees: Vec<(std::rc::Rc<crate::value::BytecodeFunction>, u32)>,
 }
 
 impl Vm {
@@ -387,6 +390,7 @@ impl Vm {
             kernel_regs: Vec::new(),
             kernel_objs: Vec::new(),
             kernel_prop_slots: Vec::new(),
+            kernel_callees: Vec::new(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(
                     "",

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -339,6 +339,12 @@ pub struct Vm {
     /// pool holds no live `BytecodeFunction` (whose upvalues/home object would
     /// otherwise outlive their frame). Shared, empty, never executed.
     pub(crate) dummy_bf: Rc<BytecodeFunction>,
+    /// Scratch register file for the typed loop kernels (`kernel.rs`): reused
+    /// across activations so entering a kernel allocates nothing. Kernels
+    /// never nest (a region containing a `LoopKernel` op is not kernelized),
+    /// and the generic interpreter running under a kernel's fallback path
+    /// never touches this, so one buffer per Vm suffices.
+    pub(crate) kernel_regs: Vec<f64>,
 }
 
 impl Vm {
@@ -371,6 +377,7 @@ impl Vm {
             cell_pool: Vec::new(),
             dummy_cell: Rc::new(RefCell::new(Value::Undefined)),
             frame_pool: Vec::new(),
+            kernel_regs: Vec::new(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(
                     "",

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -1360,6 +1360,7 @@ impl Vm {
         // the dense store, so route the write through the ordinary props path
         // below (which honours its writable flag) when such an entry exists.
         let has_props_entry = b.props.contains_key(key);
+        let extensible = b.extensible;
         // A non-writable `length` marker blocks index writes past the end.
         let len_not_writable = matches!(
             b.props.get(&PropertyKey::str("length")),
@@ -1392,6 +1393,22 @@ impl Vm {
                 }
                 if let Some(idx) = key.array_index() {
                     let idx = idx as usize;
+                    // An append OR an in-bounds hole fill CREATES a property
+                    // (a hole is absent), so a non-extensible receiver rejects
+                    // it (OrdinarySet → CreateDataProperty → [[DefineOwnProperty]]
+                    // step 2.b): silently in sloppy mode, TypeError in strict.
+                    // Object.seal/preventExtensions on a dense array land here.
+                    let creates = idx >= arr.len() || matches!(arr[idx], Value::Hole);
+                    if creates && !extensible {
+                        if strict {
+                            drop(b);
+                            return Err(self.throw_type(&format!(
+                                "Cannot add property {}, object is not extensible",
+                                key_display(key)
+                            )));
+                        }
+                        return Ok(());
+                    }
                     if idx >= arr.len() {
                         if len_not_writable {
                             // Growing past a non-writable `length` is rejected

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -314,13 +314,31 @@ pub struct Vm {
     /// is extended by the pool. Kills the dominant malloc/free traffic of the
     /// call path (one heap allocation per binding per call).
     pub(crate) cell_pool: Vec<Rc<RefCell<Value>>>,
-    pub(crate) cells_vec_pool: Vec<Vec<Rc<RefCell<Value>>>>,
     /// Shared placeholder filling the cell-vec slots of LOCALIZED bindings
     /// (see `localize.rs`): those indices are never dereferenced (their ops
     /// were rewritten to `frame.locals`), so one `Rc` bump replaces a pooled
     /// cell per slot. Its strong count is always > 1, so `recycle_cell` can
     /// never pull it into the pool.
     pub(crate) dummy_cell: Rc<RefCell<Value>>,
+    /// Free-list of whole call frames. A synchronously-finished frame is
+    /// scrubbed (every value-bearing field cleared, so the pool never extends
+    /// a value's lifetime) and parked here BOXED; the next call pops it and
+    /// re-initializes the fields in place. This keeps the operand-stack /
+    /// locals / cells / args buffer *capacities* attached to the frame across
+    /// calls (no per-call pool round-trips for four buffers) and makes every
+    /// frame move — into `run_frame`, into a `Suspension` — a pointer move
+    /// instead of a ~400-byte memcpy. Suspended frames simply keep their box
+    /// (a pool miss, never a leak).
+    ///
+    /// The boxing is the point (frames circulate as `Box<Frame>` through
+    /// `run_frame` and `Suspension`); a `Vec<Frame>` pool would re-move the
+    /// ~400-byte struct on every round-trip.
+    #[allow(clippy::vec_box)]
+    pub(crate) frame_pool: Vec<Box<Frame>>,
+    /// Placeholder function installed in a pooled frame's `func` slot so the
+    /// pool holds no live `BytecodeFunction` (whose upvalues/home object would
+    /// otherwise outlive their frame). Shared, empty, never executed.
+    pub(crate) dummy_bf: Rc<BytecodeFunction>,
 }
 
 impl Vm {
@@ -351,8 +369,19 @@ impl Vm {
             template_cache: std::collections::HashMap::new(),
             value_vec_pool: Vec::new(),
             cell_pool: Vec::new(),
-            cells_vec_pool: Vec::new(),
             dummy_cell: Rc::new(RefCell::new(Value::Undefined)),
+            frame_pool: Vec::new(),
+            dummy_bf: Rc::new(BytecodeFunction {
+                proto: Rc::new(crate::bytecode::FuncProto::empty(
+                    "",
+                    crate::bytecode::FuncKind::Normal,
+                )),
+                upvalues: Vec::new(),
+                home_object: None,
+                is_class_ctor: false,
+                captured_with: Vec::new(),
+                captured_priv_env: None,
+            }),
         };
         crate::realm::init_realm(&mut vm);
         // The placeholder realm's intrinsic objects were created before the VM

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -345,6 +345,10 @@ pub struct Vm {
     /// and the generic interpreter running under a kernel's fallback path
     /// never touches this, so one buffer per Vm suffices.
     pub(crate) kernel_regs: Vec<f64>,
+    /// Scratch cache of the array-base objects for the active kernel (see
+    /// `kernel_regs`); cleared after every activation so the pool never
+    /// extends an object's lifetime.
+    pub(crate) kernel_objs: Vec<crate::value::JsObject>,
 }
 
 impl Vm {
@@ -378,6 +382,7 @@ impl Vm {
             dummy_cell: Rc::new(RefCell::new(Value::Undefined)),
             frame_pool: Vec::new(),
             kernel_regs: Vec::new(),
+            kernel_objs: Vec::new(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(
                     "",

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -2108,6 +2108,35 @@ pub fn string_to_number(s: &str) -> f64 {
     t.parse::<f64>().unwrap_or(f64::NAN)
 }
 
+/// Append Number::toString(n) to `out`. Integral |n| <= 2^53 — every such
+/// f64 is exact and its plain decimal digits ARE the spec's shortest
+/// round-trip form — formats directly into the buffer, skipping the grisu +
+/// `format!` machinery (`String(2**60)`-class values, where the shortest
+/// form is NOT the exact integer, stay on the slow path). Hot in
+/// JSON.stringify.
+pub fn push_number_string(n: f64, out: &mut String) {
+    if n.fract() == 0.0 && n.abs() <= 9_007_199_254_740_992.0 {
+        let mut i = n as i64; // -0.0 casts to 0: prints "0" like the spec
+        if i < 0 {
+            out.push('-');
+            i = -i;
+        }
+        let mut buf = [0u8; 16]; // 2^53 has 16 digits
+        let mut p = buf.len();
+        loop {
+            p -= 1;
+            buf[p] = b'0' + (i % 10) as u8;
+            i /= 10;
+            if i == 0 {
+                break;
+            }
+        }
+        out.push_str(std::str::from_utf8(&buf[p..]).expect("ascii digits"));
+    } else {
+        out.push_str(&number_to_string(n));
+    }
+}
+
 /// ECMAScript Number::toString (radix 10).
 pub fn number_to_string(n: f64) -> String {
     if n.is_nan() {

--- a/crates/chidori-js/tests/fusion.rs
+++ b/crates/chidori-js/tests/fusion.rs
@@ -109,8 +109,21 @@ fn fusion_preserves_observable_behavior() {
 }
 
 /// Count ops matching `pred` across a proto and its nested function templates.
+/// The loop-kernel pass may replace a fused loop-header op with
+/// `Op::LoopKernel`, preserving the original as the kernel's fallback — count
+/// that op too, since it is what the interpreter's generic path executes.
 fn count_ops(proto: &FuncProto, pred: fn(&Op) -> bool) -> usize {
-    let here = proto.code.iter().filter(|op| pred(op)).count();
+    let here = proto
+        .code
+        .iter()
+        .map(|op| match op {
+            Op::LoopKernel(i) => {
+                let fb = &proto.kernels[*i as usize].fallback;
+                usize::from(pred(op)) + usize::from(pred(fb))
+            }
+            _ => usize::from(pred(op)),
+        })
+        .sum::<usize>();
     let nested: usize = proto
         .consts
         .iter()

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -159,6 +159,40 @@ const CORPUS: &[&str] = &[
     "const a = [0,1,NaN,3]; let c = 0; for (let i = 0; i < a.length; i++) { if (a[i]) c += 1; c += a[i] || 10; } console.log(c);",
     // Writing NaN/-0/Infinity through the kernel store.
     "const a = [0,0,0]; for (let i = 0; i < 3; i++) { a[i] = i === 0 ? -0 : i === 1 ? NaN : 1/0; } console.log(Object.is(a[0], -0), a[1] !== a[1], a[2]);",
+    // ---- Math intrinsics (kernel v3) ----
+    // The supported set, exercised across sign/NaN/-0/half-way edges.
+    "let s = 0; for (let i = -5; i < 6; i++) { s += Math.abs(i) + Math.max(i, 2) + Math.min(i, -2); } console.log(s);",
+    "let s = ''; for (let i = 0; i < 5; i++) { const x = i - 2.5; s += Math.round(x) + '/' + Math.floor(x) + '/' + Math.ceil(x) + '/' + Math.trunc(x) + ';'; } console.log(s);",
+    "console.log((() => { let r = 0; for (let i = 0; i < 4; i++) { r += Math.round(-0.5 - i) * 2 + Math.sign(i - 2); } return r; })());",
+    "let z = 0; for (let i = 0; i < 3; i++) { z = Math.min(0, -0) + Math.max(0, -0) + z; } console.log(Object.is(Math.min(0,-0), -0), Object.is(Math.max(-0,0), 0), z);",
+    "let s = 0; for (let i = 1; i <= 10; i++) { s += Math.sqrt(i) + Math.pow(i, 1.5); } console.log(s);",
+    "let h = 0; for (let i = 0; i < 200; i++) { h = (Math.imul(h, 31) + i) | 0; } console.log(h);",
+    "let f = 0; for (let i = 0; i < 8; i++) { f += Math.fround(0.1 * i); } console.log(f);",
+    "let n = 0; for (let i = 0; i < 4; i++) { n += Math.max(i === 2 ? NaN : i, 1); } console.log(n, n === n);",
+    // Math constants fold (non-writable, non-configurable on the canonical).
+    "let c = 0; for (let i = 0; i < 5; i++) { c += Math.PI * i + Math.E - Math.LN2 + Math.SQRT2 * Math.LOG2E; } console.log(c);",
+    // Math mixed with array access (bail shapes carrying Math entries).
+    "const a = [3,-1,4,-1,5]; let s = 0; for (let i = 0; i < a.length; i++) { s += Math.abs(a[i]); } console.log(s);",
+    "const a = [1,'x',3]; let s = 0; for (let i = 0; i < a.length; i++) { s += Math.max(+a[i] || 0, 1); } console.log(s);",
+    // MONKEYPATCHED Math.max: the guard must decline and run the patch.
+    "let calls = 0; const orig = Math.max; Math.max = function(a, b) { calls++; return orig(a, b) + 100; }; let s = 0; for (let i = 0; i < 3; i++) { s += Math.max(i, 1); } Math.max = orig; console.log(s, calls);",
+    // Math REPLACED wholesale / deleted mid-program.
+    "const RealMath = Math; let s = 0; globalThis.Math = { max: () => 7 }; for (let i = 0; i < 3; i++) { s += Math.max(i, 1); } globalThis.Math = RealMath; console.log(s);",
+    // Patch BETWEEN two activations of the same kernelized function.
+    "function f() { let s = 0; for (let i = 0; i < 3; i++) { s += Math.abs(i - 1); } return s; } const first = f(); const orig = Math.abs; Math.abs = () => 42; const second = f(); Math.abs = orig; console.log(first, second);",
+    // Accessor on globalThis.Math must fire per LoadGlobal (guard declines).
+    "const RealMath = Math; let gets = 0; Object.defineProperty(globalThis, 'Math', { get() { gets++; return RealMath; }, configurable: true }); let s = 0; for (let i = 0; i < 3; i++) { s += Math.abs(-i); } Object.defineProperty(globalThis, 'Math', { value: RealMath, writable: true, configurable: true }); console.log(s, gets >= 3);",
+    // Unsupported arities / methods stay generic but correct.
+    "let s = 0; for (let i = 0; i < 4; i++) { s += Math.max(i, 1, 2) + Math.min(i) + Math.hypot(i, 4); } console.log(s);",
+    "let s = 0; for (let i = 1; i < 5; i++) { s += Math.log(i) + Math.atan2(i, 2); } console.log(s);",
+    // ---- in-body block-scoped declarations (TDZ-init elision) ----
+    // Multiple consts per iteration, chained.
+    "function f(n) { let s = 0; for (let i = 0; i < n; i++) { const a = i * 2; const b = a + 1; s += b - a; } return s; } console.log(f(50));",
+    // A REAL TDZ read on one path must still throw identically (region has
+    // a conditional read before the init -> stays generic).
+    "try { for (let i = 1; i >= 0; i--) { if (i === 0) { y; } const y = i; } } catch (e) { console.log('tdz', e.constructor.name); }",
+    // const inside the loop feeding Math and array access.
+    "const arr = [4,1,3,2]; let s = 0; for (let i = 0; i < arr.length; i++) { const v = arr[i]; s += Math.max(v, 2); } console.log(s);",
 ];
 
 #[test]
@@ -234,6 +268,25 @@ fn array_and_nested_loops_get_kernels() {
     );
 }
 
+/// Math-using loops actually kernelize (pins v3 eligibility).
+#[test]
+fn math_loops_get_kernels() {
+    let proto = compile_script(
+        "function f(n) { let s = 0; for (let i = 0; i < n; i++) { s += Math.max(Math.abs(i - 5), 1) * Math.PI; } return s; }",
+    )
+    .expect("compiles");
+    fn count(p: &FuncProto) -> usize {
+        let mut n = p.kernels.len();
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += count(f);
+            }
+        }
+        n
+    }
+    assert!(count(&proto) >= 1, "Math loop must kernelize");
+}
+
 /// Deterministic fuzz: generate random numeric loops (random arithmetic,
 /// comparisons, short-circuits, breaks, and occasional type pollution to
 /// force guard bails) and require kernel-on/off equivalence on every one.
@@ -278,6 +331,20 @@ fn kernel_fuzz_differential() {
         }
         if case % 17 == 0 {
             body.push_str(&format!("if (i === 7) v{} = 'x';\n", rnd(nvars as u64)));
+        }
+        // Some cases route a value through a supported Math intrinsic.
+        if case % 5 == 0 {
+            let v = rnd(nvars as u64);
+            let w = rnd(nvars as u64);
+            let m = [
+                "Math.abs(v{W})",
+                "Math.max(v{W}, i)",
+                "Math.min(v{W}, 10)",
+                "Math.floor(v{W} / 3)",
+                "Math.imul(v{W}, 7)",
+                "Math.round(v{W} * 0.3)",
+            ][rnd(6) as usize];
+            body.push_str(&format!("v{v} = {};\n", m.replace("{W}", &w.to_string())));
         }
         // A third of the cases mix in dense-array reads/writes (in-bounds,
         // hole-adjacent, and occasionally out-of-bounds — all must bail or

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -193,6 +193,44 @@ const CORPUS: &[&str] = &[
     "try { for (let i = 1; i >= 0; i--) { if (i === 0) { y; } const y = i; } } catch (e) { console.log('tdz', e.constructor.name); }",
     // const inside the loop feeding Math and array access.
     "const arr = [4,1,3,2]; let s = 0; for (let i = 0; i < arr.length; i++) { const v = arr[i]; s += Math.max(v, 2); } console.log(s);",
+    // ---- materialized booleans (kernel v4) ----
+    // A stored comparison stays a BOOLEAN across write-back (typeof!).
+    "let ok = false; for (let i = 0; i < 10; i++) { ok = i > 4; } console.log(ok, typeof ok);",
+    "function f(n) { let even = true; for (let i = 0; i < n; i++) { even = !even; } return [even, typeof even]; } console.log(f(7).join(','), f(8).join(','));",
+    // Boolean fed to arithmetic coerces to 0/1; result is a NUMBER.
+    "let c = 0; for (let i = 0; i < 20; i++) { const big = i >= 10; c += big; } console.log(c, typeof c);",
+    // Strict equality between a boolean and a number is ALWAYS false.
+    "let hits = 0; for (let i = 0; i < 5; i++) { const t = i < 3; if (t === 1) hits += 100; if (t == 1) hits += 1; if (t === true) hits += 10; } console.log(hits);",
+    "let s = 0; for (let i = 0; i < 6; i++) { const b = i % 2 === 0; s += b !== 1 ? 1 : 0; s += b === (i < 100) ? 10 : 0; } console.log(s);",
+    // !x / !!x chains on numbers and booleans.
+    "let n = 0; for (let i = -3; i < 4; i++) { n += !i ? 100 : 0; n += !!i ? 1 : 0; } console.log(n);",
+    // Boolean as ARRAY INDEX reads the \"true\"/\"false\" properties, not 0/1.
+    "const a = [10, 20]; a[true] = 77; let s = 0; for (let i = 0; i < 4; i++) { const b = i % 2 === 1; s += a[b] || 0; } console.log(s, a['true']);",
+    // Boolean STORED INTO an element must stay a boolean element.
+    "const a = [0, 0, 0]; for (let i = 0; i < 3; i++) { a[i] = i > 0; } console.log(a.join(','), typeof a[0], typeof a[2]);",
+    // Late entry: undefined -> boolean transition.
+    "let f; let c = 0; for (let i = 0; i < 6; i++) { if (f) c++; f = i % 2 === 0; } console.log(c, typeof f);",
+    // Loop-carried toggle driving control flow.
+    "let flip = false, s = 0; for (let i = 0; i < 9; i++) { if (flip) s += i; flip = !flip; } console.log(s, flip);",
+    // Booleans crossing an exit shape (break with a live comparison).
+    "let last = false; for (let i = 0; i < 10; i++) { last = i > 7; if (last) break; } console.log(last, typeof last);",
+    // Boolean local compared with relational operators (coerces to 0/1).
+    "let s = 0; for (let i = 0; i < 6; i++) { const b = i > 2; if (b < 1) s += 1; if (b >= 1) s += 10; } console.log(s);",
+    // A local that is SOMETIMES number, sometimes boolean: stays generic.
+    "let m = 0; for (let i = 0; i < 6; i++) { m = i % 2 ? (i > 2) : i; } console.log(m, typeof m);",
+    // ---- dense appends (kernel v4) ----
+    // The classic fill-by-append loop.
+    "const a = []; for (let i = 0; i < 100; i++) { a[a.length] = i * 2; } console.log(a.length, a[0], a[99]);",
+    // Fill of a `new Array(n)` (in-bounds hole fills).
+    "const a = new Array(50); for (let i = 0; i < a.length; i++) { a[i] = i * i; } console.log(a.length, a[49], 0 in a);",
+    // Append with the length read live in the condition (bounded growth).
+    "const a = [1]; for (let i = 0; i < a.length && a.length < 20; i++) { a[a.length] = a[i] + 1; } console.log(a.length, a.join(','));",
+    // Append blocked by preventExtensions (generic path: silent in sloppy).
+    "const a = [1]; Object.preventExtensions(a); for (let i = 0; i < 3; i++) { a[a.length] = 9; } console.log(a.length, a.join(','));",
+    // ... and throwing in strict mode.
+    "'use strict'; const a = [1]; Object.preventExtensions(a); try { for (let i = 0; i < 3; i++) { a[a.length] = 9; } } catch (e) { console.log('strict', e.constructor.name); } console.log(a.length);",
+    // Append far past the end leaves holes (generic path).
+    "const a = []; for (let i = 0; i < 4; i++) { a[i * 2] = i; } console.log(a.length, 1 in a, a.join('|'));",
 ];
 
 #[test]
@@ -268,6 +306,38 @@ fn array_and_nested_loops_get_kernels() {
     );
 }
 
+/// Boolean, append, and captured-bound loops actually kernelize (pins v4).
+#[test]
+fn v4_loops_get_kernels() {
+    fn kernels_in(src: &str) -> usize {
+        fn count(p: &FuncProto) -> usize {
+            let mut n = p.kernels.len();
+            for c in &p.consts {
+                if let Const::Func(f) = c {
+                    n += count(f);
+                }
+            }
+            n
+        }
+        count(&compile_script(src).expect("compiles"))
+    }
+    // Materialized boolean local (stored comparison + toggle + branch).
+    assert!(
+        kernels_in("function f(n) { let flip = false, s = 0; for (let i = 0; i < n; i++) { const hi = i > 5; if (hi !== flip) s++; flip = !hi; } return s; }") >= 1,
+        "boolean loop must kernelize"
+    );
+    // Append-fill loop.
+    assert!(
+        kernels_in("function f(n) { const a = []; for (let i = 0; i < n; i++) { a[a.length] = i; } return a.length; }") >= 1,
+        "append loop must kernelize"
+    );
+    // Loop bound captured from the enclosing scope (upvalue snapshot).
+    assert!(
+        kernels_in("const N = 100; function f() { let s = 0; for (let i = 0; i < N; i++) { s += i; } return s; } f();") >= 1,
+        "upvalue-bound loop must kernelize"
+    );
+}
+
 /// Math-using loops actually kernelize (pins v3 eligibility).
 #[test]
 fn math_loops_get_kernels() {
@@ -332,6 +402,18 @@ fn kernel_fuzz_differential() {
         if case % 17 == 0 {
             body.push_str(&format!("if (i === 7) v{} = 'x';\n", rnd(nvars as u64)));
         }
+        // Some cases carry a BOOLEAN variable: stored comparisons, negation,
+        // use in conditions and arithmetic (differential must preserve
+        // boolean-ness through write-back).
+        if case % 4 == 0 {
+            let v = rnd(nvars as u64);
+            let w = rnd(nvars as u64);
+            match rnd(3) {
+                0 => body.push_str(&format!("bfz = v{v} < v{w};\n")),
+                1 => body.push_str(&format!("bfz = !bfz; if (bfz) v{v} += 1;\n")),
+                _ => body.push_str(&format!("v{v} += bfz; bfz = v{w} % 2 === 0;\n")),
+            }
+        }
         // Some cases route a value through a supported Math intrinsic.
         if case % 5 == 0 {
             let v = rnd(nvars as u64);
@@ -375,8 +457,18 @@ fn kernel_fuzz_differential() {
             ""
         };
         let arr_print = if use_array { ", arr.join('|')" } else { "" };
+        let bool_decl = if case % 4 == 0 {
+            "let bfz = false; "
+        } else {
+            ""
+        };
+        let bool_print = if case % 4 == 0 {
+            ", bfz, typeof bfz"
+        } else {
+            ""
+        };
         let src = format!(
-            "{}\n{arr_decl}for (let i = 0; i < 25; i++) {{\n{body}}}\nconsole.log({}{arr_print});",
+            "{}\n{bool_decl}{arr_decl}for (let i = 0; i < 25; i++) {{\n{body}}}\nconsole.log({}{arr_print}{bool_print});",
             decls.join(" "),
             prints.join(", ")
         );

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -114,6 +114,51 @@ const CORPUS: &[&str] = &[
     "let s = 0; for (let i = 0; i < 12; i++) { switch (i % 3) { case 0: s += 1; break; case 1: s += 10; break; default: s += 100; } } console.log(s);",
     // Deeply chained expression stressing canonical stack depth.
     "let s = 0; for (let i = 1; i < 20; i++) { s += ((i + 1) * (i + 2) - (i + 3)) / ((i % 5) + 1) + ((i << 2) ^ (i >> 1)); } console.log(s);",
+    // ---- dense-array element access (kernel v2) ----
+    // Read loop with `a.length` condition.
+    "const a = [1,2,3,4,5]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } console.log(s);",
+    // In-place write loop; values visible after.
+    "const a = [1,2,3]; for (let i = 0; i < a.length; i++) { a[i] = a[i] * 10 + i; } console.log(a.join(','));",
+    // Compound element update, reversed iteration, index arithmetic.
+    "const a = [5,4,3,2,1]; let s = 0; for (let i = a.length - 1; i >= 0; i--) { a[i] += i; s += a[i]; } console.log(s, a.join(','));",
+    // Dot product across two arrays.
+    "const x = [1,2,3,4], y = [10,20,30,40]; let d = 0; for (let i = 0; i < x.length; i++) { d += x[i] * y[i]; } console.log(d);",
+    // ALIASED bases: writes through one visible through the other.
+    "const a = [1,2,3]; const b = a; let s = 0; for (let i = 0; i < a.length; i++) { b[i] = a[i] + 1; s += a[i]; } console.log(s, a.join(','));",
+    // Nested indexing a[b[i]].
+    "const idx = [2,0,1], v = [10,20,30]; let s = 0; for (let i = 0; i < idx.length; i++) { s = s * 100 + v[idx[i]]; } console.log(s);",
+    // HOLES: element read falls back to the prototype chain.
+    "Array.prototype[1] = 99; const a = [1,,3]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } delete Array.prototype[1]; console.log(s);",
+    // Hole WRITE (creates a property — non-extensible interactions aside,
+    // plain arrays fill the hole; kernel must bail and match).
+    "const a = [1,,3]; for (let i = 0; i < a.length; i++) { a[i] = (a[i] || 0) + 1; } console.log(a.join(','), 1 in a);",
+    // Out-of-bounds read (undefined -> NaN via arithmetic; loop bound lies).
+    "const a = [1,2]; let s = 0; for (let i = 0; i < 4; i++) { s += a[i] === undefined ? 100 : a[i]; } console.log(s);",
+    // Non-number elements: strings force per-access bail; result exact.
+    "const a = [1,'x',3]; let s = ''; for (let i = 0; i < a.length; i++) { s += a[i]; } console.log(s);",
+    // Float / negative / huge indices take the generic path mid-kernel.
+    "const a = [1,2,3]; a[1.5] = 7; let s = 0; for (let i = 0; i < 3; i += 0.5) { s += a[i] || 0; } console.log(s, a['1.5']);",
+    "const a = [9]; let s = 0; for (let i = -1; i < 2; i++) { s += a[i] || 0; } console.log(s);",
+    // Frozen / sealed arrays: reified props make every access bail; sloppy
+    // writes are silently ignored, exactly like the generic path.
+    "const a = Object.freeze([1,2,3]); let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; a[i] = 0; } console.log(s, a.join(','));",
+    "const a = Object.seal([1,2,3]); for (let i = 0; i < a.length; i++) { a[i] = a[i] * 2; } console.log(a.join(','));",
+    // Accessor element (defineProperty): getter must fire on every read.
+    "const a = [1,2,3]; let got = 0; Object.defineProperty(a, 1, { get() { got++; return 50; } }); let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } console.log(s, got);",
+    // Array GROWTH inside the loop (appends bail; length re-read each pass).
+    "const a = [1]; for (let i = 0; i < a.length && i < 5; i++) { a[a.length] = a[i] + 1; } console.log(a.join(','));",
+    // Base REASSIGNED inside the loop: translation must reject (store to a
+    // base local) and the generic loop must swap arrays mid-flight.
+    "let a = [1,2,3,4]; const b = [100,200,300,400]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; if (i === 1) a = b; } console.log(s);",
+    // The base local holding a non-array (typed later): guard declines.
+    "let a = 5; let s = 0; for (let i = 0; i < 3; i++) { s += a; } console.log(s);",
+    // Fully-kernelized nested loops inside a function (incl. 2D array walk).
+    "function grid(n) { let m = 0; for (let i = 0; i < n; i++) { for (let j = 0; j < n; j++) { m += i ^ j; } } return m; } console.log(grid(20));",
+    "function sum2d(g) { let s = 0; for (let i = 0; i < g.length; i++) { const row = g[i]; for (let j = 0; j < row.length; j++) { s += row[j]; } } return s; } console.log(sum2d([[1,2],[3,4],[5,6]]));",
+    // Element values feeding branches and short-circuits.
+    "const a = [0,1,NaN,3]; let c = 0; for (let i = 0; i < a.length; i++) { if (a[i]) c += 1; c += a[i] || 10; } console.log(c);",
+    // Writing NaN/-0/Infinity through the kernel store.
+    "const a = [0,0,0]; for (let i = 0; i < 3; i++) { a[i] = i === 0 ? -0 : i === 1 ? NaN : 1/0; } console.log(Object.is(a[0], -0), a[1] !== a[1], a[2]);",
 ];
 
 #[test]
@@ -151,6 +196,41 @@ fn canonical_loop_gets_a_kernel() {
     assert!(
         proto.code.iter().any(|op| matches!(op, Op::LoopKernel(_))),
         "expected a LoopKernel op at the loop header"
+    );
+}
+
+/// Array-access loops and function-level nested loops actually kernelize
+/// (pins v2 eligibility against silent regressions).
+#[test]
+fn array_and_nested_loops_get_kernels() {
+    fn kernels_in(src: &str) -> usize {
+        fn count(p: &FuncProto) -> usize {
+            let mut n = p.kernels.len();
+            for c in &p.consts {
+                if let Const::Func(f) = c {
+                    n += count(f);
+                }
+            }
+            n
+        }
+        count(&compile_script(src).expect("compiles"))
+    }
+    // `s += a[i]` with an `a.length` bound: one kernel.
+    assert!(
+        kernels_in("function f(a) { let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } return s; }") >= 1,
+        "array read loop must kernelize"
+    );
+    // In-place write loop: one kernel.
+    assert!(
+        kernels_in("function f(a) { for (let i = 0; i < a.length; i++) { a[i] = a[i] * 2; } }")
+            >= 1,
+        "array write loop must kernelize"
+    );
+    // Nested numeric loops in a function: TWO kernels (inner on its own, and
+    // the outer subsuming it via the inner header's fallback).
+    assert!(
+        kernels_in("function g(n) { let m = 0; for (let i = 0; i < n; i++) { for (let j = 0; j < n; j++) { m += i ^ j; } } return m; }") >= 2,
+        "nested loops must both kernelize"
     );
 }
 
@@ -199,12 +279,37 @@ fn kernel_fuzz_differential() {
         if case % 17 == 0 {
             body.push_str(&format!("if (i === 7) v{} = 'x';\n", rnd(nvars as u64)));
         }
+        // A third of the cases mix in dense-array reads/writes (in-bounds,
+        // hole-adjacent, and occasionally out-of-bounds — all must bail or
+        // fast-path to identical results).
+        let use_array = case % 3 == 0;
+        if use_array {
+            let v = rnd(nvars as u64);
+            match rnd(4) {
+                0 => body.push_str(&format!("v{v} += arr[i % arr.length];\n")),
+                1 => body.push_str(&format!("arr[i % arr.length] = v{v} + i;\n")),
+                2 => body.push_str(&format!("v{v} = arr[i] === undefined ? 1 : arr[i];\n")),
+                _ => body.push_str(&format!(
+                    "arr[i % arr.length] += v{v}; v{v} = arr[(i + 1) % arr.length];\n"
+                )),
+            }
+        }
         let decls: Vec<String> = (0..nvars)
             .map(|v| format!("let v{v} = {};", [0, 1, -1, 42][v % 4]))
             .collect();
         let prints: Vec<String> = (0..nvars).map(|v| format!("v{v}")).collect();
+        let arr_decl = if use_array {
+            match case % 9 {
+                0 => "const arr = [3,,7,1];\n",         // holey
+                3 => "const arr = [0.5, 2, 'k', 4];\n", // string element
+                _ => "const arr = [2,4,6,8,10];\n",
+            }
+        } else {
+            ""
+        };
+        let arr_print = if use_array { ", arr.join('|')" } else { "" };
         let src = format!(
-            "{}\nfor (let i = 0; i < 25; i++) {{\n{body}}}\nconsole.log({});",
+            "{}\n{arr_decl}for (let i = 0; i < 25; i++) {{\n{body}}}\nconsole.log({}{arr_print});",
             decls.join(" "),
             prints.join(", ")
         );

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -335,6 +335,40 @@ const CORPUS: &[&str] = &[
     // `length` as a plain object property takes the array bail path per
     // access (LoadLen on a non-array) — correct, just generic.
     "const o = { length: 4 }; let s = 0; for (let i = 0; i < o.length; i++) { s += i; } console.log(s);",
+    // ---- pinned-closure calls inside loop kernels (CallKernel) ----
+    // The closures workload shape: capturing adder called per iteration.
+    "function adder(n) { return function (x) { return x + n; }; } const f = adder(5); let s = 0; for (let i = 0; i < 100; i++) s = f(s) - 4; console.log(s);",
+    // Arrow callee, two args, result feeding compound arithmetic.
+    "const mul = (a, b) => a * b + 1; let s = 0; for (let i = 1; i <= 20; i++) { s += mul(i, s % 7); } console.log(s);",
+    // TWO distinct callees in one region.
+    "const inc = x => x + 1; const dbl = x => x * 2; let s = 0; for (let i = 0; i < 10; i++) { s = dbl(inc(s)); } console.log(s);",
+    // Callee with a NON-number captured upvalue: declines, generic concat.
+    "function tag(t) { return x => x + t; } const g = tag('!'); let s = ''; for (let i = 0; i < 3; i++) { s = g(s); } console.log(s);",
+    // Callee REASSIGNED inside the loop: base-local store rejects the
+    // region; the generic loop swaps functions mid-flight.
+    "let f = x => x + 1; const g = x => x * 10; let s = 0; for (let i = 0; i < 6; i++) { s = f(s); if (i === 2) f = g; } console.log(s);",
+    // Callee changed BETWEEN activations of a kernelized loop.
+    "function run(f, n) { let s = 0; for (let i = 0; i < n; i++) { s = f(s) + 1; } return s; } console.log(run(x => x + 2, 5), run(x => x * 2, 5));",
+    // BOOLEAN-returning callee declines (result register is Number-typed).
+    "const isPos = x => x > 0; let c = 0; for (let i = -3; i < 4; i++) { if (isPos(i)) c++; const t = isPos(i); c += typeof t === 'boolean' ? 10 : 0; } console.log(c);",
+    // Callee without a function kernel (touches a property): generic.
+    "const o = { v: 2 }; const get = x => o.v + x; let s = 0; for (let i = 0; i < 5; i++) { s = get(s); } console.log(s);",
+    // NATIVE callee (not a bytecode function): declines.
+    "const f = Math.sqrt; let s = 0; for (let i = 0; i < 5; i++) { s += f(i * i); } console.log(s);",
+    // RECURSIVE callee (has a self-kernel): declines the loop tier; the
+    // recursive kernel still runs per call through the generic loop.
+    "function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); } let s = 0; for (let i = 0; i < 8; i++) { s += fib(i); } console.log(s);",
+    // Fewer args than the callee consumes: guard declines (undefined param).
+    "const add = (a, b) => a + b; let s = 0; for (let i = 0; i < 4; i++) { s = add(i); s = typeof s; } console.log(s);",
+    // Extra args are ignored on both paths.
+    "const one = a => a + 1; let s = 0; for (let i = 0; i < 5; i++) { s = one(s, i, 99); } console.log(s);",
+    // Callee with Math intrinsics; then a monkeypatched Math declines.
+    "const clamp = x => Math.max(Math.min(x, 10), 0); let s = 0; for (let i = -5; i < 15; i++) { s += clamp(i); } console.log(s);",
+    "const orig = Math.abs; const f = x => Math.abs(x); let s = 0; Math.abs = () => 7; for (let i = -2; i < 2; i++) { s += f(i); } Math.abs = orig; console.log(s);",
+    // Declared-function callee (this/new.target prologue) with -0/NaN pins.
+    "function m(x, y) { return x * y; } let z = 1; for (let i = 0; i < 3; i++) { z = m(-0, i); } console.log(Object.is(z, -0), Object.is(m(0, -1), -0));",
+    // Callee result stored through kernel props and elements.
+    "const step = x => (x * 3 + 1) % 97; const o = { v: 5 }; const a = [0, 0, 0]; for (let i = 0; i < a.length; i++) { o.v = step(o.v); a[i] = o.v; } console.log(a.join(','), o.v);",
 ];
 
 #[test]
@@ -589,6 +623,31 @@ fn property_loops_get_kernels() {
     )
     .expect("compiles");
     assert!(count(&proto) >= 1, "property get/set loop must kernelize");
+}
+
+/// Loops calling a pinned tiny closure actually kernelize (pins the
+/// CallKernel tier — the whole region rejects if the call can't fuse).
+#[test]
+fn closure_call_loops_get_kernels() {
+    fn count(p: &FuncProto) -> usize {
+        let mut n = p.kernels.len();
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += count(f);
+            }
+        }
+        n
+    }
+    for src in [
+        "function adder(n) { return function (x) { return x + n; }; } const f = adder(5); let s = 0; for (let i = 0; i < 10; i++) s = f(s) - 4; s;",
+        "const inc = x => x + 1; const dbl = x => x * 2; let s = 0; for (let i = 0; i < 10; i++) { s = dbl(inc(s)); } s;",
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert!(
+            count(&proto) >= 1,
+            "closure-call loop must kernelize in {src:?}"
+        );
+    }
 }
 
 /// Math-using loops actually kernelize (pins v3 eligibility).

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -302,6 +302,39 @@ const CORPUS: &[&str] = &[
     // Non-number argument at the top call (per-call decline; the inner
     // numeric self-calls still kernelize mid-recursion).
     "function s(n) { return n < 2 ? n : s(n - 1) + s(n - 2); } console.log(s(8), s('4'));",
+    // ---- named-property access on pinned objects (LoadProp/StoreProp) ----
+    // The canonical get/set loop (mirrors the property_access workload).
+    "const o = { a: 0, b: 0, c: 0 }; for (let i = 0; i < 100; i++) { o.a = i; o.b = o.a + 1; o.c = o.b + o.a; } console.log(o.a, o.b, o.c);",
+    // ALIASED bases: writes through one binding read through the other.
+    "const o = { v: 0 }; const p = o; let s = 0; for (let i = 0; i < 10; i++) { o.v = i * 2; s += p.v; } console.log(s, p.v);",
+    // GETTER on the receiver: entry declines; the getter fires per read.
+    "let gets = 0; const o = { n: 3, get x() { gets++; return this.n; } }; let s = 0; for (let i = 0; i < 5; i++) { s += o.x; } console.log(s, gets);",
+    // SETTER: entry declines; the setter observes every write.
+    "let sets = 0; const o = { n: 0, set v(x) { sets++; this.n = x * 2; } }; for (let i = 0; i < 4; i++) { o.v = i; } console.log(o.n, sets);",
+    // Frozen receiver: sloppy silent no-op / strict TypeError, generically.
+    "const o = Object.freeze({ k: 1 }); let s = 0; for (let i = 0; i < 3; i++) { o.k = i; s += o.k; } console.log(s, o.k);",
+    "'use strict'; const o = Object.freeze({ k: 1 }); try { for (let i = 0; i < 3; i++) { o.k = i; } } catch (e) { console.log('frozen', e.constructor.name); }",
+    // Single non-writable property via defineProperty.
+    "const o = { a: 0 }; Object.defineProperty(o, 'b', { value: 9, writable: false, enumerable: true }); let s = 0; for (let i = 0; i < 3; i++) { o.a = i; o.b = i; s += o.a + o.b; } console.log(s, o.b);",
+    // PROTOTYPE-inherited read (no own property): stays generic.
+    "const proto = { k: 7 }; const o = Object.create(proto); let s = 0; for (let i = 0; i < 4; i++) { s += o.k; } console.log(s);",
+    // Property CREATED by the loop's first iteration (late entry after).
+    "const o = {}; for (let i = 0; i < 10; i++) { o.d = (o.d || 0) + i; } console.log(o.d);",
+    // Non-number property value: per-iteration decline, exact semantics.
+    "const o = { s: '' }; for (let i = 0; i < 3; i++) { o.s = o.s + i; } console.log(o.s);",
+    // `delete` inside the loop rejects the region; still correct.
+    "const o = { a: 1, b: 2 }; let s = 0; for (let i = 0; i < 4; i++) { o.a = i; s += o.a; if (i === 1) { delete o.b; } } console.log(s, 'b' in o);",
+    // Shape changed BETWEEN activations (slots re-resolve per entry).
+    "function f(o, n) { let s = 0; for (let i = 0; i < n; i++) { o.x = i; s += o.x + o.y; } return s; } const o = { x: 0, y: 10 }; console.log(f(o, 5)); delete o.x; o.z = 1; o.x = 0; console.log(f(o, 5));",
+    // Non-Ordinary receiver (Date): declines, generic path.
+    "const d = new Date(0); d.foo = 0; let s = 0; for (let i = 0; i < 3; i++) { d.foo = i; s += d.foo; } console.log(s);",
+    // Props mixed with dense-element access in one region.
+    "const o = { sum: 0 }; const a = [5, 6, 7]; for (let i = 0; i < a.length; i++) { o.sum = o.sum + a[i]; } console.log(o.sum);",
+    // -0 / NaN through property writes; typeof pins.
+    "const o = { z: 1, n: 1 }; for (let i = 0; i < 3; i++) { o.z = -0 * i; o.n = i === 1 ? NaN : i; } console.log(Object.is(o.z, -0), o.n !== o.n, typeof o.z);",
+    // `length` as a plain object property takes the array bail path per
+    // access (LoadLen on a non-array) — correct, just generic.
+    "const o = { length: 4 }; let s = 0; for (let i = 0; i < o.length; i++) { s += i; } console.log(s);",
 ];
 
 #[test]
@@ -536,6 +569,26 @@ fn self_kernel_depth_overflow_reruns_generic() {
         .expect("spawns")
         .join()
         .expect("no panic");
+}
+
+/// Named-property get/set loops on plain objects actually kernelize
+/// (pins the LoadProp/StoreProp tier against silent regressions).
+#[test]
+fn property_loops_get_kernels() {
+    fn count(p: &FuncProto) -> usize {
+        let mut n = p.kernels.len();
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += count(f);
+            }
+        }
+        n
+    }
+    let proto = compile_script(
+        "const o = { a: 0, b: 0, c: 0 }; for (let i = 0; i < 10; i++) { o.a = i; o.b = o.a + 1; o.c = o.b + o.a; } o.c;",
+    )
+    .expect("compiles");
+    assert!(count(&proto) >= 1, "property get/set loop must kernelize");
 }
 
 /// Math-using loops actually kernelize (pins v3 eligibility).

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -277,6 +277,31 @@ const CORPUS: &[&str] = &[
     "'use strict'; function f(a, b) { return a * b; } console.log(f(6, 7));",
     // Boolean ARGUMENT declines (guard is Number-only) — generic coercion.
     "const f = (a, b) => a - b; console.log(f(true, 1), f(5, false));",
+    // ---- self-recursive function kernels (SelfCall) ----
+    // The canonical fib shape (global function declaration).
+    "function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); } console.log(fib(15), fib(0), fib(1));",
+    // Two arguments, self-call feeding a self-call argument (Ackermann).
+    "function ack(m, n) { return m === 0 ? n + 1 : n === 0 ? ack(m - 1, 1) : ack(m - 1, ack(m, n - 1)); } console.log(ack(2, 3));",
+    // Euclid: argument expressions evaluated at the call site.
+    "function gcd(a, b) { return b === 0 ? a : gcd(b, a % b); } console.log(gcd(1071, 462), gcd(3, 7), gcd(0, 5));",
+    // Anonymous function expression recursing through its global `var`.
+    "var f = function (n) { return n <= 0 ? 0 : n + f(n - 1); }; console.log(f(10));",
+    // REBINDING the global mid-program: the old closure's self-call must see
+    // the NEW binding (guard declines; generic LoadGlobal resolves it).
+    "function g(n) { return n <= 0 ? 0 : 1 + g(n - 1); } const orig = g; console.log(orig(5)); globalThis.g = (n) => 100; console.log(orig(5));",
+    // Math intrinsics inside a recursive kernel.
+    "function h(n) { return n < 2 ? n : Math.max(h(n - 1), h(n - 2)) + 1; } console.log(h(10));",
+    // Mutual recursion is NOT a self-call — stays generic, still correct.
+    "function even(n) { return n === 0 ? 1 : odd(n - 1); } function odd(n) { return n === 0 ? 0 : even(n - 1); } console.log(even(10), odd(7));",
+    // A boolean-returning recursive function must stay generic (a bool
+    // result would land in a Number-typed caller register).
+    "function tob(n) { return n <= 0 ? true : tob(n - 1); } console.log(tob(5), typeof tob(5), tob(0));",
+    // Named function EXPRESSION: the inner name is a lexical binding, not a
+    // global — no self-fusion, still correct.
+    "const k = function inner(n) { return n <= 0 ? 0 : n + inner(n - 1); }; console.log(k(6));",
+    // Non-number argument at the top call (per-call decline; the inner
+    // numeric self-calls still kernelize mid-recursion).
+    "function s(n) { return n < 2 ? n : s(n - 1) + s(n - 2); } console.log(s(8), s('4'));",
 ];
 
 #[test]
@@ -431,6 +456,86 @@ fn tiny_functions_get_fn_kernels() {
             "expected NO function kernel in {src:?}"
         );
     }
+}
+
+/// Self-recursive numeric functions get a RECURSIVE function kernel
+/// (`self_global` set), and the shapes that must not — boolean returns,
+/// mutual recursion, named-expression self-reference — never do.
+#[test]
+fn recursive_functions_get_self_kernels() {
+    fn self_kernels(p: &FuncProto) -> usize {
+        let mut n = usize::from(
+            p.fn_kernel
+                .as_ref()
+                .is_some_and(|k| k.self_global.is_some()),
+        );
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += self_kernels(f);
+            }
+        }
+        n
+    }
+    for src in [
+        "function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); }",
+        "function gcd(a, b) { return b === 0 ? a : gcd(b, a % b); }",
+        "function ack(m, n) { return m === 0 ? n + 1 : n === 0 ? ack(m - 1, 1) : ack(m - 1, ack(m, n - 1)); }",
+        "var f = function (n) { return n <= 0 ? 0 : n + f(n - 1); };",
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert!(
+            self_kernels(&proto) >= 1,
+            "expected a recursive kernel in {src:?}"
+        );
+    }
+    for src in [
+        // Boolean-returning recursion (result register is Number-typed).
+        "function tob(n) { return n <= 0 ? true : tob(n - 1); }",
+        // Mutual recursion is not a SELF call.
+        "function even(n) { return n === 0 ? 1 : odd(n - 1); }",
+        // A named expression's self-reference is lexical, not global.
+        "const k = function inner(n) { return n <= 0 ? 0 : n + inner(n - 1); };",
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert_eq!(
+            self_kernels(&proto),
+            0,
+            "expected NO recursive kernel in {src:?}"
+        );
+    }
+}
+
+/// Depth-limit fidelity for recursive kernels: overflowing the limit must
+/// abandon the (pure) kernel activation and rerun generically, raising the
+/// exact spec RangeError — byte-identical to the kernels-off run. Uses a
+/// tiny `max_call_depth` so the generic recursion fits a test-thread stack.
+#[test]
+fn self_kernel_depth_overflow_reruns_generic() {
+    // A dedicated big-stack thread: 60+ generic interpreter levels don't fit
+    // a default 2 MiB test thread in DEBUG builds (production runs the VM on
+    // 16 MiB stacks; the JS depth limit is sized for release frames).
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            let src = "function rec(n) { return n <= 0 ? 0 : 1 + rec(n - 1); } \
+                       try { console.log(rec(1000)); } catch (e) { console.log('deep', e.constructor.name); } \
+                       console.log(rec(10));";
+            let mut outs = Vec::new();
+            for kernels in [true, false] {
+                let proto = Rc::new(compile_script_kernels(src, kernels).expect("compiles"));
+                let mut engine = Engine::new();
+                engine.vm.max_call_depth = 64;
+                let func = engine.vm.make_closure(proto, Vec::new());
+                let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+                assert!(res.is_ok(), "caught in-script (kernels={kernels})");
+                outs.push(engine.console().to_vec());
+            }
+            assert_eq!(outs[0], outs[1], "depth overflow diverged");
+            assert_eq!(outs[0][0], "deep RangeError");
+        })
+        .expect("spawns")
+        .join()
+        .expect("no panic");
 }
 
 /// Math-using loops actually kernelize (pins v3 eligibility).

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -1,0 +1,240 @@
+//! Differential + structural tests for the typed loop-kernel pass
+//! (`kernel.rs`).
+//!
+//! The guarantee: kernelization is a pure optimization. Every program must
+//! produce byte-identical observable behavior with kernels on and off — same
+//! console output, same completion value, same thrown error. The corpus
+//! concentrates on what the kernels must never break: exact numeric semantics
+//! (NaN, -0, infinities, `%`, `>>>`, shift masking, float precision),
+//! control flow (break/continue/labels, nested loops, short-circuits,
+//! ternaries, do/while), guard bail-outs and LATE ENTRY (a binding that warms
+//! from undefined to a number mid-loop), and the boundary between kernel and
+//! generic execution (calls, strings, property access inside loops disable
+//! the kernel without changing results).
+
+use std::rc::Rc;
+
+use chidori_js::bytecode::{Const, FuncProto, Op};
+use chidori_js::compiler::{compile_script, compile_script_kernels};
+use chidori_js::{Engine, Value};
+
+fn run(src: &str, kernels: bool) -> (bool, Vec<String>, String) {
+    let proto = Rc::new(compile_script_kernels(src, kernels).expect("compiles"));
+    let mut engine = Engine::new();
+    let func = engine.vm.make_closure(proto, Vec::new());
+    let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+    let _ = engine.vm.run_jobs_until_blocked();
+    let console = engine.console().to_vec();
+    match res {
+        Ok(_) => (false, console, String::new()),
+        Err(e) => (true, console, engine.vm.error_to_string(&e)),
+    }
+}
+
+const CORPUS: &[&str] = &[
+    // The canonical counting loop (mirrors the arith_loop workload).
+    "let s = 0; for (let i = 0; i < 1000; i++) { s += i * 2 - (i % 3); } console.log(s);",
+    // while / do-while shapes (conditional back-edge).
+    "let i = 0, s = 0; while (i < 500) { s = (s + i) | 0; i++; } console.log(s);",
+    "let i = 10, n = 0; do { n += i; i--; } while (i > 0); console.log(n);",
+    "let i = 0; do { i++; } while (false); console.log(i);",
+    // break / continue / labeled break out of nested loops.
+    "let s = 0; for (let i = 0; i < 100; i++) { if (i === 7) continue; if (i > 20) break; s += i; } console.log(s);",
+    "let s = 0; outer: for (let i = 0; i < 10; i++) { for (let j = 0; j < 10; j++) { if (i * j > 30) break outer; s += j; } } console.log(s);",
+    // Nested numeric loops: the inner one kernels; the outer stays generic.
+    "let s = 0; for (let i = 0; i < 50; i++) { for (let j = 0; j < 50; j++) { s += i ^ j; } } console.log(s);",
+    // Exact float semantics: NaN, -0, infinities, precision.
+    "let x = 0; for (let i = 0; i < 10; i++) { x += 0.1; } console.log(x);",
+    "let s = 0; for (let i = -5; i < 5; i++) { s += 1 / i; } console.log(s, 1 / s);",
+    "let z = 0; for (let i = 0; i < 3; i++) { z = -0 * i + z; } console.log(Object.is(z, -0), Object.is(z, 0));",
+    "let n = 0; for (let i = 0; i < 4; i++) { n = n + (i === 2 ? NaN : i); } console.log(n, n === n);",
+    // Modulo sign / integer fast path vs fmod, ** precedence, division.
+    "let s = ''; for (let i = -6; i <= 6; i += 3) { s += (i % 4) + ','; } console.log(s);",
+    "let p = 0; for (let i = 1; i < 6; i++) { p += 2 ** i; } console.log(p, (-8) % 3, 7 / 2);",
+    // 32-bit ops: shifts mask their count, >>> produces unsigned, ~ truncates.
+    "let h = 123456789; for (let i = 0; i < 100; i++) { h = (h * 31 + i) | 0; } console.log(h);",
+    "let u = 0; for (let i = 0; i < 40; i++) { u = (u + (1 << i)) >>> 0; } console.log(u);",
+    "let b = 0; for (let i = 0; i < 10; i++) { b ^= ~i & (i >> 1) | (i >>> 2); } console.log(b);",
+    "let seed = 123456789, c = 0; for (let r = 0; r < 6; r++) { seed = (seed * 1103515245 + 12345) >>> 0; c = (c + seed) >>> 0; } console.log(c);",
+    // Comparisons in all branch polarities, equality with NaN.
+    "let c = 0; for (let i = 0; i < 20; i++) { if (i >= 10) c++; if (i <= 3) c--; if (i === 5) c += 100; if (i !== 5) c += 2; } console.log(c);",
+    "let c = 0, x = NaN; for (let i = 0; i < 5; i++) { if (x < i) c += 1; if (x >= i) c += 2; if (x === x) c += 4; } console.log(c);",
+    // Short-circuits and ternaries inside the loop body (peek jumps).
+    "let s = 0; for (let i = 0; i < 30; i++) { s += i % 2 && i; } console.log(s);",
+    "let s = 1; for (let i = 0; i < 10; i++) { s = i || s; } console.log(s);",
+    "let s = 0; for (let i = 0; i < 25; i++) { s += i > 12 ? i * 2 : -i; } console.log(s);",
+    // Compound assignments and update expressions in expression position.
+    "let a = 1, b = 2, s = 0; for (let i = 0; i < 10; i++) { a *= 1.5; b -= 0.25; s = a + b + s; } console.log(s);",
+    "let i = 0, s = 0; while (i < 10) { s += i++; } console.log(s, i);",
+    "let i = 10, s = 0; while (i > 0) { s += --i; } console.log(s, i);",
+    // Multiple locals, swaps via temporaries (fibonacci iteration).
+    "let a = 0, b = 1; for (let i = 0; i < 30; i++) { const t = a + b; a = b; b = t; } console.log(a, b);",
+    // Empty / single-iteration / zero-iteration loops.
+    "let s = 0; for (let i = 0; i < 0; i++) { s += i; } console.log(s);",
+    "for (let i = 0; i < 3; i++) {} console.log('done');",
+    // Infinite loop broken from inside.
+    "let i = 0; for (;;) { i++; if (i > 100) break; } console.log(i);",
+    // GUARD BAIL: a string flows through the loop-carried binding — the loop
+    // must stay generic (or bail) and concatenate exactly.
+    "let s = 0; for (let i = 0; i < 5; i++) { if (i === 3) s = '' + s; s += i; } console.log(s);",
+    "let x = 'a'; for (let i = 0; i < 3; i++) { x += i; } console.log(x);",
+    // LATE ENTRY: binding starts undefined (guard fails on iteration 1),
+    // becomes a number, kernel may take over — result must be identical.
+    "let t; let s = 0; for (let i = 0; i < 10; i++) { t = (t || 0) + i; s = t; } console.log(s, t);",
+    // Calls / property access / arrays in the body disable kernels entirely.
+    "let s = 0; for (let i = 0; i < 10; i++) { s += Math.max(i, 5); } console.log(s);",
+    "const a = [1, 2, 3]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } console.log(s);",
+    // Loop condition via function call each iteration (header not eligible).
+    "let i = 0; function lim() { return 5; } let s = 0; while (i < lim()) { s += i; i++; } console.log(s);",
+    // Captured binding inside the loop -> cells, not locals: stays generic.
+    "const fs = []; let s = 0; for (let i = 0; i < 3; i++) { fs.push(() => i); s += i; } console.log(s, fs.map(f => f()).join(','));",
+    // try/catch enclosing the loop (handlers OUTSIDE the region are fine).
+    "try { let s = 0; for (let i = 0; i < 10; i++) { s += i; } console.log(s); } catch (e) { console.log('no'); }",
+    // try/catch INSIDE the loop body (handlers in-region: stays generic).
+    "let s = 0; for (let i = 0; i < 5; i++) { try { s += i; } catch (e) {} } console.log(s);",
+    // Throw from a loop that LOOKS numeric until it isn't: division by a
+    // string-tainted binding after bail.
+    "let d = 2; let s = 0; for (let i = 0; i < 6; i++) { if (i === 4) d = '0'; s += i / d; } console.log(s);",
+    // Sequence/comma expressions and grouped arithmetic.
+    "let s = 0; for (let i = 0, j = 10; i < j; i++, j--) { s += i * j; } console.log(s);",
+    // Unary minus / plus on loop values.
+    "let s = 0; for (let i = 0; i < 8; i++) { s += -i + +i * 2; } console.log(s);",
+    // A loop whose body reassigns the LOOP BOUND (loop-carried compare operand).
+    "let n = 10, s = 0; for (let i = 0; i < n; i++) { if (i === 5) n = 8; s += 1; } console.log(s);",
+    // Number.MAX_SAFE_INTEGER-scale accumulation (precision at the edge).
+    "let s = 9007199254740980; for (let i = 0; i < 20; i++) { s += 1; } console.log(s);",
+    // Loop inside a FUNCTION (kernels apply per-proto, not just top level).
+    "function hot(n) { let s = 0; for (let i = 0; i < n; i++) { s = (s * 3 + i) % 1000003; } return s; } console.log(hot(1000), hot(0), hot(1));",
+    // Generator containing a numeric loop between yields (frame suspension
+    // around — never inside — the kernel region).
+    "function* g() { let s = 0; for (let i = 0; i < 100; i++) { s += i; } yield s; for (let i = 0; i < 10; i++) { s -= i; } yield s; } const it = g(); console.log(it.next().value, it.next().value);",
+    // Async function with a kernel-able loop after an await.
+    "(async () => { await 0; let s = 0; for (let i = 0; i < 50; i++) { s += i * i; } console.log('async', s); })();",
+    // Switch dispatch inside a loop (CompletionJump/complex flow: generic).
+    "let s = 0; for (let i = 0; i < 12; i++) { switch (i % 3) { case 0: s += 1; break; case 1: s += 10; break; default: s += 100; } } console.log(s);",
+    // Deeply chained expression stressing canonical stack depth.
+    "let s = 0; for (let i = 1; i < 20; i++) { s += ((i + 1) * (i + 2) - (i + 3)) / ((i % 5) + 1) + ((i << 2) ^ (i >> 1)); } console.log(s);",
+];
+
+#[test]
+fn kernel_differential_corpus() {
+    for (n, src) in CORPUS.iter().enumerate() {
+        let with = run(src, true);
+        let without = run(src, false);
+        assert_eq!(
+            with, without,
+            "kernels changed observable behavior for corpus[{n}]:\n{src}"
+        );
+    }
+}
+
+/// The production compile of the canonical counting loop actually installs a
+/// kernel (guards the pass against silently regressing to "never eligible").
+#[test]
+fn canonical_loop_gets_a_kernel() {
+    fn count_kernels(p: &FuncProto) -> usize {
+        let mut n = p.kernels.len();
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += count_kernels(f);
+            }
+        }
+        n
+    }
+    let proto =
+        compile_script("let s = 0; for (let i = 0; i < 10; i++) { s += i * 2 - (i % 3); } s;")
+            .expect("compiles");
+    assert!(
+        count_kernels(&proto) >= 1,
+        "expected at least one kernel in the canonical loop"
+    );
+    assert!(
+        proto.code.iter().any(|op| matches!(op, Op::LoopKernel(_))),
+        "expected a LoopKernel op at the loop header"
+    );
+}
+
+/// Deterministic fuzz: generate random numeric loops (random arithmetic,
+/// comparisons, short-circuits, breaks, and occasional type pollution to
+/// force guard bails) and require kernel-on/off equivalence on every one.
+#[test]
+fn kernel_fuzz_differential() {
+    // Tiny LCG — the test must be deterministic (fixed seed, no host RNG).
+    let mut state: u64 = 0x2545F4914F6CDD1D;
+    let mut rnd = move |n: u64| -> u64 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (state >> 33) % n
+    };
+
+    for case in 0..300 {
+        let nvars = 2 + rnd(3) as usize; // v0..v{n}
+        let mut body = String::new();
+        let stmts = 1 + rnd(5);
+        for _ in 0..stmts {
+            let v = rnd(nvars as u64);
+            let w = rnd(nvars as u64);
+            let konst = [0.0, 1.0, 2.5, -3.0, 7.0, 0.1, 1e9][rnd(7) as usize];
+            let ops = ["+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>"];
+            let op = ops[rnd(ops.len() as u64) as usize];
+            match rnd(6) {
+                0 => body.push_str(&format!("v{v} = v{v} {op} v{w};\n")),
+                1 => body.push_str(&format!("v{v} = v{w} {op} {konst};\n")),
+                2 => body.push_str(&format!("v{v} += i {op} {konst};\n")),
+                3 => {
+                    let cmps = ["<", "<=", ">", ">=", "===", "!=="];
+                    let c = cmps[rnd(6) as usize];
+                    body.push_str(&format!("if (v{v} {c} v{w}) v{v} = v{w} {op} i;\n"));
+                }
+                4 => body.push_str(&format!("v{v} = i % 2 ? v{w} : -v{v};\n")),
+                _ => body.push_str(&format!("v{v} = (v{v} {op} i) || v{w};\n")),
+            }
+        }
+        // A few cases break early or pollute a variable with a string to
+        // exercise exits and guard bails.
+        if case % 11 == 0 {
+            body.push_str("if (i === 13) break;\n");
+        }
+        if case % 17 == 0 {
+            body.push_str(&format!("if (i === 7) v{} = 'x';\n", rnd(nvars as u64)));
+        }
+        let decls: Vec<String> = (0..nvars)
+            .map(|v| format!("let v{v} = {};", [0, 1, -1, 42][v % 4]))
+            .collect();
+        let prints: Vec<String> = (0..nvars).map(|v| format!("v{v}")).collect();
+        let src = format!(
+            "{}\nfor (let i = 0; i < 25; i++) {{\n{body}}}\nconsole.log({});",
+            decls.join(" "),
+            prints.join(", ")
+        );
+        let with = run(&src, true);
+        let without = run(&src, false);
+        assert_eq!(with, without, "fuzz case {case} diverged:\n{src}");
+    }
+}
+
+/// Kernels must not run under an op budget (exact per-op accounting), and the
+/// budget must observe the SAME counts as the generic path.
+#[test]
+fn op_budget_identical_with_kernels() {
+    let src = "let s = 0; for (let i = 0; i < 100; i++) { s += i; }";
+    // Find the exact op count via a generous budget on a kernel-on engine.
+    let mut probe = Engine::new();
+    probe.vm.op_budget = Some(1_000_000);
+    probe.eval(src).expect("runs");
+    let used = 1_000_000 - probe.vm.op_budget.unwrap();
+
+    // Exhaustion one op short must throw on BOTH compilations.
+    for kernels in [true, false] {
+        let proto = Rc::new(compile_script_kernels(src, kernels).expect("compiles"));
+        let mut engine = Engine::new();
+        engine.vm.op_budget = Some(used - 1);
+        let func = engine.vm.make_closure(proto, Vec::new());
+        let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+        assert!(
+            res.is_err(),
+            "budget exhaustion must throw (kernels={kernels})"
+        );
+    }
+}

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -231,6 +231,52 @@ const CORPUS: &[&str] = &[
     "'use strict'; const a = [1]; Object.preventExtensions(a); try { for (let i = 0; i < 3; i++) { a[a.length] = 9; } } catch (e) { console.log('strict', e.constructor.name); } console.log(a.length);",
     // Append far past the end leaves holes (generic path).
     "const a = []; for (let i = 0; i < 4; i++) { a[i * 2] = i; } console.log(a.length, 1 in a, a.join('|'));",
+    // ---- function kernels (frameless tiny callees) ----
+    // The canonical sort comparators, ascending/descending/ternary/bitmask.
+    "const a = [5,3,8,1,9,2,7]; a.sort((x, y) => x - y); console.log(a.join(','));",
+    "const a = [5,3,8,1,9,2,7]; a.sort((x, y) => y - x); console.log(a.join(','));",
+    "const a = [3,1,2,1,3]; a.sort((x, y) => x < y ? -1 : x > y ? 1 : 0); console.log(a.join(','));",
+    "const f = (a, b) => (a & 15) - (b & 15); const xs = [30, 7, 22, 13]; xs.sort(f); console.log(xs.join(','));",
+    // A BOOLEAN-returning comparator (ToNumber(true/false) inside sort).
+    "const f = (a, b) => a > b; console.log([3,1,2].sort(f).join(','), f(1, 2), typeof f(1, 2));",
+    // Declared function with a body-local temporary.
+    "function f(a, b) { const d = a - b; return d; } console.log(f(9, 4), typeof f(9, 4), f(0.5, 0.25));",
+    // HOF callbacks: map / filter / reduce / every / findIndex.
+    "const f = (x) => x % 2 === 0; console.log([1,2,3,4,5,6].filter(f).join(','));",
+    "console.log([1,2,3].map((x) => x * x + 1).join(','));",
+    "console.log([1,2,3,4].reduce((acc, v) => acc + v * 2, 0));",
+    "console.log([2,4,6].every((x) => x % 2 === 0), [1,2].findIndex((x) => x > 1));",
+    // Captured numeric upvalue (guarded snapshot) — and a non-number one
+    // (guard declines; the generic path concatenates).
+    "const k = 3; console.log([1,2,3].map(x => x * k).join(','));",
+    "let k = 'no'; const g = x => x + k; console.log(g(1));",
+    // Missing / extra / non-number arguments decline per CALL, not per fn.
+    "function f(a, b) { return a + b; } console.log(f(1), f(1, 2), f(1, 2, 3), f('x', 'y'));",
+    // Math intrinsics inside a function kernel; then monkeypatched (decline).
+    "const f = x => Math.abs(x) + Math.max(x, 0); console.log(f(-5), f(5));",
+    "const orig = Math.abs; Math.abs = () => 42; const f = x => Math.abs(x); console.log(f(-5)); Math.abs = orig;",
+    // Boolean returns and typeof pins.
+    "const f = x => !x; console.log(f(0), f(1), f(NaN), typeof f(0));",
+    "const f = n => n !== n; console.log(f(NaN), f(1), typeof f(NaN));",
+    // Exact float semantics through the frameless path: -0 and NaN.
+    "const f = (x, y) => x * y; console.log(Object.is(f(-0, 5), -0), Object.is(f(0, -5), -0), f(NaN, 1) !== f(NaN, 1) === false);",
+    "const a = [1e-9, -0, 0, 2]; a.sort((x, y) => 1 / x - 1 / y); console.log(a.map(v => Object.is(v, -0) ? '-0' : String(v)).join(','));",
+    // Short-circuit predicate (&& across blocks) and a loop INSIDE the body.
+    "const f = x => x > 0 && x < 10; console.log(f(5), f(-1), f(20), typeof f(5));",
+    "function f(x) { let s = 0; for (let i = 0; i < x; i++) s += i; return s; } console.log(f(10), f(0), f(1));",
+    // Recursion is a call op — never kernelized, still correct.
+    "function fact(n) { return n <= 1 ? 1 : n * fact(n - 1); } console.log(fact(6));",
+    // Comparator called through .call / .apply (generic entry paths).
+    "const f = (a, b) => a - b; console.log(f.call(null, 5, 2), f.apply(null, [5, 2]));",
+    // `new` on a kernel-carrying function takes [[Construct]] (an object!).
+    "function f(a, b) { return a - b; } const o = new f(1, 2); console.log(typeof o, f(1, 2));",
+    // Default parameter: supplied-numbers kernelize; the default fires only
+    // via the guard-declined generic call.
+    "const f = (a, b = 10) => a - b; console.log(f(3, 1), f(3));",
+    // Strict-mode body (different `this` prologue shape).
+    "'use strict'; function f(a, b) { return a * b; } console.log(f(6, 7));",
+    // Boolean ARGUMENT declines (guard is Number-only) — generic coercion.
+    "const f = (a, b) => a - b; console.log(f(true, 1), f(5, false));",
 ];
 
 #[test]
@@ -336,6 +382,55 @@ fn v4_loops_get_kernels() {
         kernels_in("const N = 100; function f() { let s = 0; for (let i = 0; i < N; i++) { s += i; } return s; } f();") >= 1,
         "upvalue-bound loop must kernelize"
     );
+}
+
+/// Tiny pure-scalar functions get a FUNCTION kernel (frameless call path) —
+/// and frame-dependent bodies never do (pins fn-kernel eligibility).
+#[test]
+fn tiny_functions_get_fn_kernels() {
+    fn fn_kernels(p: &FuncProto) -> usize {
+        let mut n = usize::from(p.fn_kernel.is_some());
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += fn_kernels(f);
+            }
+        }
+        n
+    }
+    for src in [
+        "const f = (a, b) => a - b;",
+        "const f = (a, b) => a < b ? -1 : a > b ? 1 : 0;",
+        "const f = x => x % 2 === 0;",
+        "const f = x => Math.abs(x) + Math.max(x, 0);",
+        "const k = 2; const f = x => x * k;",
+        "function f(a, b) { const d = a - b; return d; }",
+        "const f = x => x > 0 && x < 10;",
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert!(
+            fn_kernels(&proto) >= 1,
+            "expected a function kernel in {src:?}"
+        );
+    }
+    for src in [
+        // `arguments` needs a real frame.
+        "function f() { return arguments.length; }",
+        // Property access needs a frame to bail into.
+        "const f = (a) => a.length;",
+        // Calls (incl. recursion) are off the allowlist.
+        "function f(a, b) { return f(a) - b; }",
+        // Allocation is off the allowlist.
+        "const f = (a) => [a];",
+        // Falling off the end returns `undefined` — not a scalar `Return`.
+        "const f = (a) => { a - 1; };",
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert_eq!(
+            fn_kernels(&proto),
+            0,
+            "expected NO function kernel in {src:?}"
+        );
+    }
 }
 
 /// Math-using loops actually kernelize (pins v3 eligibility).
@@ -482,23 +577,28 @@ fn kernel_fuzz_differential() {
 /// budget must observe the SAME counts as the generic path.
 #[test]
 fn op_budget_identical_with_kernels() {
-    let src = "let s = 0; for (let i = 0; i < 100; i++) { s += i; }";
-    // Find the exact op count via a generous budget on a kernel-on engine.
-    let mut probe = Engine::new();
-    probe.vm.op_budget = Some(1_000_000);
-    probe.eval(src).expect("runs");
-    let used = 1_000_000 - probe.vm.op_budget.unwrap();
+    for src in [
+        "let s = 0; for (let i = 0; i < 100; i++) { s += i; }",
+        // Call-heavy: function kernels must also be disabled under a budget.
+        "const f = (a, b) => a - b; let s = 0; for (let i = 0; i < 40; i++) { s += f(i, 2 * i); }",
+    ] {
+        // Find the exact op count via a generous budget on a kernel-on engine.
+        let mut probe = Engine::new();
+        probe.vm.op_budget = Some(1_000_000);
+        probe.eval(src).expect("runs");
+        let used = 1_000_000 - probe.vm.op_budget.unwrap();
 
-    // Exhaustion one op short must throw on BOTH compilations.
-    for kernels in [true, false] {
-        let proto = Rc::new(compile_script_kernels(src, kernels).expect("compiles"));
-        let mut engine = Engine::new();
-        engine.vm.op_budget = Some(used - 1);
-        let func = engine.vm.make_closure(proto, Vec::new());
-        let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
-        assert!(
-            res.is_err(),
-            "budget exhaustion must throw (kernels={kernels})"
-        );
+        // Exhaustion one op short must throw on BOTH compilations.
+        for kernels in [true, false] {
+            let proto = Rc::new(compile_script_kernels(src, kernels).expect("compiles"));
+            let mut engine = Engine::new();
+            engine.vm.op_budget = Some(used - 1);
+            let func = engine.vm.make_closure(proto, Vec::new());
+            let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+            assert!(
+                res.is_err(),
+                "budget exhaustion must throw (kernels={kernels})"
+            );
+        }
     }
 }

--- a/crates/chidori-js/tests/localize.rs
+++ b/crates/chidori-js/tests/localize.rs
@@ -93,8 +93,22 @@ fn localization_preserves_observable_behavior() {
     }
 }
 
+/// Count ops matching `pred` across a proto and its nested function
+/// templates. The loop-kernel pass may replace a loop-header op with
+/// `Op::LoopKernel`, preserving the original as the kernel's fallback —
+/// count that op too, since it is what the generic path executes.
 fn count_ops(proto: &FuncProto, pred: fn(&Op) -> bool) -> usize {
-    let here = proto.code.iter().filter(|op| pred(op)).count();
+    let here = proto
+        .code
+        .iter()
+        .map(|op| match op {
+            Op::LoopKernel(i) => {
+                let fb = &proto.kernels[*i as usize].fallback;
+                usize::from(pred(op)) + usize::from(pred(fb))
+            }
+            _ => usize::from(pred(op)),
+        })
+        .sum::<usize>();
     let nested: usize = proto
         .consts
         .iter()

--- a/crates/chidori/src/lib.rs
+++ b/crates/chidori/src/lib.rs
@@ -10,6 +10,8 @@ pub mod server;
 pub mod storage;
 pub mod tools;
 
+pub use scheduler::{new_tokio_runtime, JS_THREAD_STACK_BYTES};
+
 pub mod framework {
     pub use crate::mcp::McpManager;
     pub use crate::policy::{Decision, PolicyConfig, PolicyRule};

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -686,7 +686,7 @@ fn cmd_run(
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));
     let tokio_rt =
-        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+        Arc::new(scheduler::new_tokio_runtime().context("Failed to create tokio runtime")?);
 
     // Auto-discover tools from `<project>/tools/` plus any `--tools` dirs.
     let mut tool_dirs: Vec<PathBuf> = vec![base_dir.join("tools")];
@@ -782,7 +782,7 @@ fn cmd_run_stream(
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));
     let tokio_rt =
-        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+        Arc::new(scheduler::new_tokio_runtime().context("Failed to create tokio runtime")?);
 
     let mut tool_dirs: Vec<PathBuf> = vec![base_dir.join("tools")];
     tool_dirs.extend(extra_tool_dirs.iter().cloned());
@@ -920,7 +920,7 @@ fn cmd_chat(
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));
     let tokio_rt =
-        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+        Arc::new(scheduler::new_tokio_runtime().context("Failed to create tokio runtime")?);
 
     let mut tool_dirs: Vec<PathBuf> = vec![base_dir.join("tools")];
     tool_dirs.extend(extra_tool_dirs.iter().cloned());
@@ -1038,7 +1038,7 @@ fn cmd_check(file: &PathBuf) -> Result<()> {
     let providers = Arc::new(ProviderRegistry::new());
     let template_engine = Arc::new(TemplateEngine::new("."));
     let tokio_rt =
-        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+        Arc::new(scheduler::new_tokio_runtime().context("Failed to create tokio runtime")?);
 
     let engine = Engine::new(providers, template_engine, tokio_rt);
     engine.check(file)?;
@@ -1114,7 +1114,7 @@ fn cmd_resume(file: &PathBuf, run_id: &str, dir: Option<&std::path::Path>) -> Re
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));
     let tokio_rt =
-        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+        Arc::new(scheduler::new_tokio_runtime().context("Failed to create tokio runtime")?);
     let tools_dir = base_dir.join("tools");
     let tools = Arc::new(
         ToolRegistry::load_from_dirs(&[tools_dir]).unwrap_or_else(|_| ToolRegistry::new()),
@@ -1154,7 +1154,7 @@ fn branch_engine(dir: Option<&std::path::Path>) -> Result<Engine> {
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));
     let tokio_rt =
-        Arc::new(tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?);
+        Arc::new(scheduler::new_tokio_runtime().context("Failed to create tokio runtime")?);
     let tools_dir = base_dir.join("tools");
     let tools = Arc::new(
         ToolRegistry::load_from_dirs(&[tools_dir]).unwrap_or_else(|_| ToolRegistry::new()),
@@ -1402,7 +1402,7 @@ fn cmd_serve(
     // Validate the agent file before starting the server.
     {
         let rt = Arc::new(
-            tokio::runtime::Runtime::new().context("Failed to create validation runtime")?,
+            scheduler::new_tokio_runtime().context("Failed to create validation runtime")?,
         );
         let engine = Engine::new(providers.clone(), template_engine.clone(), rt);
         engine.check(file).context("Agent file validation failed")?;
@@ -1415,7 +1415,7 @@ fn cmd_serve(
     crate::runtime::isolate::warn_if_untrusted_without_isolation(!trusted);
 
     let (policy, policy_posture) = serve_policy(untrusted, trusted);
-    let tokio_rt = tokio::runtime::Runtime::new().context("Failed to create server runtime")?;
+    let tokio_rt = scheduler::new_tokio_runtime().context("Failed to create server runtime")?;
     tokio_rt.block_on(server::serve(
         providers,
         template_engine,

--- a/crates/chidori/src/scheduler.rs
+++ b/crates/chidori/src/scheduler.rs
@@ -24,6 +24,26 @@ use crate::runtime::template::TemplateEngine;
 use crate::storage::{SessionStatus, SessionStore, StoredSession};
 use crate::tools::ToolRegistry;
 
+/// Stack size for every thread that may run the JS interpreter — tokio
+/// workers/blocking threads (agent runs go through `spawn_blocking`) and the
+/// branch worker threads. The interpreter recurses natively with the agent's
+/// JS call depth (`max_call_depth` = 2000 frames), which needs more headroom
+/// than tokio's 2 MiB default; on 64-bit the extra virtual space is only
+/// committed if actually touched.
+pub const JS_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+
+/// Build the process's tokio runtime. Exactly `tokio::runtime::Runtime::new()`
+/// plus [`JS_THREAD_STACK_BYTES`]-sized threads: agent JS executes on this
+/// runtime's blocking threads, and a 2 MiB-stack thread aborts the whole
+/// process on ~350 frames of JS recursion instead of letting the engine's
+/// depth guard throw a catchable RangeError at 2000.
+pub fn new_tokio_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(JS_THREAD_STACK_BYTES)
+        .build()
+}
+
 #[derive(Clone)]
 pub struct SchedulerDeps {
     pub template_engine: Arc<TemplateEngine>,
@@ -88,7 +108,7 @@ pub async fn run_once(recipe: &Recipe, deps: &SchedulerDeps) -> Result<String> {
     let recipe_name = recipe.name.clone();
 
     let (id, session) = tokio::task::spawn_blocking(move || -> Result<(String, StoredSession)> {
-        let rt = Arc::new(tokio::runtime::Runtime::new()?);
+        let rt = Arc::new(crate::scheduler::new_tokio_runtime()?);
         let providers = Arc::new(ProviderRegistry::from_env());
 
         // Build the tool registry: recipe-local dirs + default `<agent>/tools`

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -712,7 +712,7 @@ async fn health() -> impl IntoResponse {
 /// it here (rather than only at create time) keeps the tightened policy in
 /// force across resume/approve/replay re-runs of the same session.
 fn build_engine(app: &AppState, policy_profile: Option<&str>) -> Engine {
-    let rt = Arc::new(tokio::runtime::Runtime::new().unwrap());
+    let rt = Arc::new(crate::scheduler::new_tokio_runtime().unwrap());
     // Reuse the app's provider registry so a replay-based resume sees the same
     // providers as the live-VM resume path (which drives `state.providers`
     // directly). In production this is the env-derived registry passed to

--- a/crates/test262-runner/test262-expectations.json
+++ b/crates/test262-runner/test262-expectations.json
@@ -10791,7 +10791,7 @@
     "test/built-ins/Object/preventExtensions/15.2.3.10-3-23.js": "pass",
     "test/built-ins/Object/preventExtensions/15.2.3.10-3-24.js": "pass",
     "test/built-ins/Object/preventExtensions/15.2.3.10-3-3.js": "pass",
-    "test/built-ins/Object/preventExtensions/15.2.3.10-3-4.js": "fail",
+    "test/built-ins/Object/preventExtensions/15.2.3.10-3-4.js": "pass",
     "test/built-ins/Object/preventExtensions/15.2.3.10-3-5-1.js": "pass",
     "test/built-ins/Object/preventExtensions/15.2.3.10-3-5.js": "pass",
     "test/built-ins/Object/preventExtensions/15.2.3.10-3-6.js": "pass",
@@ -47293,9 +47293,9 @@
     "test/language/white-space/string-vertical-tab.js": "pass"
   },
   "summary": {
-    "fail": 371,
-    "pass": 39823,
-    "pass_pct": 99.07697666318356,
+    "fail": 370,
+    "pass": 39824,
+    "pass_pct": 99.07946459670598,
     "skip": 7097
   }
 }

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -454,7 +454,7 @@ path (`examples/agent_replay`) went 21.0 → 18.5 ms (−12%) — it is
 host-effect glue rather than tight loops, as §11.5 of the interpreter doc
 predicts.
 
-### 6.3 What's next (new baseline)
+### 6.3 What's next (assessment after round 3 — now addressed by §6.4)
 
 §3.2 (cells→locals) and the property/array cache work are **landed**. Hash
 probing (`get_index_of`) no longer appears in any workload's top profile
@@ -464,14 +464,102 @@ show after round 3:
 - **sort (14.1 G, the biggest remaining)**: ~25% pure call ceremony for the
   tiny comparator — `Frame` is 408 bytes and its construction, pool
   round-trips, and drop dominate each comparison. The lever is a **Frame
-  diet** (box the rarely-used fields: handlers, dispose scopes, enumerators,
-  with/eval state) and/or a leaf-call fast path that skips unused frame
-  machinery.
+  diet** (box the rarely-used fields) and/or a leaf-call fast path that
+  skips unused frame machinery. *(→ landed as the frame POOL + direct-call
+  path, §6.4.)*
 - **register bytecode** (§3.5) remains the dispatch-side end-game for the
   arith/fib class (step + run_frame are >50% there).
 - A discovered pre-existing conformance gap: sealed-array appends are not
   rejected (`Object.seal(a); a[len] = v` writes). Tracked for a separate
   fix validated by Test262.
+
+## 6.4 Round 4 (2026-07-02, follow-up session): the call-ceremony round
+
+Callgrind confirmed §6.3's read: after round 3, ~30–40% of sort/fib-class
+execution was **per-call ceremony** — frame construction (`make_frame_owned`
+6.3%), frame drop (3.9%), buffer-pool round-trips (`recycle_frame` +
+`recycle_value_vec` 7%), ~400-byte `Frame` moves (memcpy 2.8%), and the
+layered call dispatch (~6%). This round attacks exactly that; all safe Rust,
+zero new dependencies, byte-identical benchmark checksums.
+
+1. **Frame pool** — frames are now recycled WHOLE as `Box<Frame>`
+   (`Vm::frame_pool`): a synchronously-finished frame is scrubbed (every
+   value-bearing field cleared, so the pool never extends a value's lifetime
+   — the cell pool's discipline) and parked; the next call re-initializes
+   fields in place. The operand-stack/locals/cells/args buffer *capacities*
+   stay attached to the frame across calls (the per-call
+   `take_value_vec`/`recycle_value_vec` round-trips for three buffers are
+   gone), `run_frame` takes the box (a pointer move, not a ~400-byte
+   memcpy), and a suspension keeps its box (no `Box::new` per await/yield).
+   A pooled frame's `func` slot holds a shared placeholder
+   (`Vm::dummy_bf`) so no `BytecodeFunction` outlives its frame.
+
+2. **Direct call path** (`Op::Call`/`Op::CallMethodless` →
+   `Vm::call_direct`): the callee is peeked on the operand stack; a plain
+   (sync, non-generator, non-class-ctor) bytecode function skips the
+   generic dispatch layers and its arguments MOVE straight from the
+   caller's operand stack into the pooled callee frame — no intermediate
+   pooled `Vec`, no second copy, and the popped function value is reused as
+   `func_obj` without refcount traffic. Everything else (native, bound,
+   proxy, async, generator, not-callable) takes the generic path unchanged.
+   The generic `call_valuevec` itself was collapsed to a single object
+   borrow (callable check + dispatch extraction were two).
+
+3. **Interpreter-loop slimming** — the per-op budget/interrupt checks
+   hoisted behind one `counting` bool sampled at frame entry (both are only
+   ever installed before execution starts); the common case pays one
+   predicted branch instead of two `Option` loads through `self` per op.
+
+4. **`merge_sort` scratch buffer** — the recursion allocated TWO fresh
+   `Vec` clones per node (O(n log n) allocations + refcount churn). Now one
+   scratch buffer for the whole sort; the left run MOVES into it and merges
+   back in place (zero `Value` clones). Identical recursion structure and
+   stable-merge order, so the comparator sees the exact same call sequence.
+
+5. **Sort loop fast paths** — `Array.prototype.sort`'s snapshot loop now
+   uses the existing `has_get_elem` dense fast path (round 3) instead of
+   per-index `HasProperty`/`Get` with a heap-allocated string key, and
+   write-back overwrites existing dense elements in place under the same
+   gate as `Op::SetPropDynamic` (`props.is_empty()` + in-bounds non-hole).
+   The undefined-partition pass moves values instead of cloning.
+
+6. **`func_obj` gating** — the per-call `Rc` round-trip is skipped unless
+   `proto.uses_arguments` (its only consumer is `arguments.callee`).
+
+### 6.4.1 Instruction counts (callgrind, whole workload, deterministic)
+
+| workload | round-3 baseline | after | Δ |
+| --- | ---: | ---: | ---: |
+| sort | 14.09 G | 11.58 G | **−17.8%** |
+| fib_recursive | 8.59 G | 7.45 G | **−13.3%** |
+| closures | 4.47 G | 4.00 G | **−10.4%** |
+| array_hof | 2.52 G | 2.38 G | −5.4% |
+| property_access | 3.95 G | 3.85 G | −2.6% |
+| arith_loop | 2.28 G | 2.23 G | −2.5% |
+| array_push_sum | 3.73 G | 3.67 G | −1.7% |
+| string_build | 0.18 G | 0.18 G | 0% |
+
+Benchmark RESULT checksums are byte-identical before/after every change.
+Wall-clock (5-run median, same shared container, indicative only per §1.1):
+sort 1.09 s → 0.93 s, fib 696 → 572 ms, closures 350 → 311 ms.
+An incidental robustness gain: heap-boxed frames raised the native-stack
+recursion ceiling from ~1160 to ~1460 JS frames (see the known issue below).
+
+### 6.4.2 What's next (new baseline)
+
+- **step dispatch is now the wall**: `step` + `run_frame` are 25–43% of
+  every workload (fib 42%, arith 50%+, sort 25%) with the call ceremony
+  halved. Register bytecode (§3.5) is the remaining structural lever.
+- **Known issue (pre-existing, NOT introduced here)**: `max_call_depth`
+  (2000) exceeds what the default 8 MB native stack supports —
+  `rec(1500)`-style recursion aborts with a native stack overflow instead
+  of throwing a catchable RangeError (main: overflow at ~1160 frames; this
+  branch: ~1460, i.e. strictly better but still short of 2000). Fix
+  options: lower the default depth, raise thread stack at the embedding
+  boundary, or shrink `step`'s stack frame (~5 KB/call, the giant match's
+  unioned locals). Tracked separately; Test262's recursion tests pass
+  because the runner threads carry larger stacks.
+- The sealed-array append gap from §6.3 still stands.
 
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine
 caveats in §1.1 stand.

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -741,16 +741,69 @@ was bailing per-iteration on holes). A run-scanning workload (append-build
 + boolean-flag scan, 500k elements ×4) goes **2065 ms → 204 ms (10.1×)**.
 Other suite counts unchanged (±layout noise), checksums byte-identical.
 
+**Kernel v5 (same branch): FUNCTION kernels — frameless tiny callees.**
+
+The sort/HOF profile is ~55% comparator-call ceremony (frame init/recycle,
+operand-stack moves, `Value` clones/drops) around an 8-op body. A function
+whose ENTIRE body is on the kernel allowlist now also compiles to a register
+program (`FuncProto::fn_kernel`), and the call paths (`call_direct`,
+`call_bytecode_vec`, the slice-based `call_bytecode`) execute it FRAMELESS:
+no frame, no operand stack, no pool traffic — arguments load straight into
+registers and `Return` yields the result value (`KOp::Ret`, typed
+Number/Bool).
+
+- **Entry guard, per call**: every consumed argument present and a `Number`
+  (a missing/extra/string argument declines THAT call, generically);
+  captured upvalues hold `Number`s (read-only snapshots — no calls can run
+  inside a kernelized body, so nothing writes a cell mid-execution); no op
+  budget; no trace sink (it must see an enter/exit per call); `Math`
+  canonicals verified as in v3. Callers apply the depth guard before the
+  hook, so the max-call-depth RangeError fires identically on both paths.
+- **fn-mode translation rules** on top of the loop allowlist: `LoadArg`
+  reads become guarded argument registers; locals are pure register scratch
+  — there is no guard to type them, so every read must be DOMINATED by a
+  real store, tracked as a sorted `init` set merged under the same
+  must-match rule as the virtual-stack shape (a genuine TDZ read or
+  use-before-init rejects; the generic path owns the error). Element access
+  and `a.length` reject outright (a bail needs a frame to resume into). The
+  declared-function prologue (`this`/`new.target` materialized into locals)
+  translates via an OPAQUE stack entry whose only legal consumer is a store
+  to a never-read local — arrows and declared functions both kernelize.
+  Bodies with loops work (the interior `Op::LoopKernel` translates as its
+  fallback, and kernel back-edges poll the interrupt flag as usual).
+
+Measured (callgrind, RESULT checksums byte-identical across the suite):
+**sort 11.56 G → 6.21 G (−46%)**, **closures 4.03 G → 2.31 G (−43%)** (its
+callbacks capture numeric upvalues — the guarded-snapshot rule covers them),
+**array_hof 2.38 G → 1.72 G (−28%)**, arith_loop/array_sum −3.4% each;
+fib_recursive +0.07% (the `fn_kernel.is_some()` probe on a never-eligible
+callee — ~1 instruction per call), property_access unchanged. Wall-clock
+sort ~1.4 s → ~0.6 s on the dev box.
+
+**Gates:** corpus grew ~20 function-kernel programs (comparators incl.
+boolean-returning and ternary, map/filter/reduce/every/findIndex callbacks,
+upvalue capture with number and string cells, missing/extra/non-number
+arguments, monkeypatched Math, −0/NaN pins, `.call`/`.apply` entry,
+recursion staying generic, loops inside kernelized bodies); structural pins
+require the canonical tiny functions to carry `fn_kernel` and
+frame-dependent bodies (`arguments`, property access, calls, allocation,
+implicit-undefined return) to NEVER carry one; the op-budget test now also
+covers a call-heavy program (function kernels are OFF under a budget, like
+loop kernels).
+
 ### 6.5.1 What's next (new baseline)
 
 - Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,
-  loop bounds via own-frame CELLS (captured accumulators), and typed-array
-  element access (a natural fit — elements are statically numeric).
+  loop bounds via own-frame CELLS (captured accumulators), typed-array
+  element access (a natural fit — elements are statically numeric), and
+  argument-typed ARRAY parameters for function kernels (`(a, i) => a[i]`
+  needs arg object slots + a bail-free access story).
 - **step dispatch remains the wall for non-kernel code**: `step` +
   `run_frame` are 25–43% of call-heavy workloads. Register bytecode (§3.5)
   is the remaining structural lever, and kernels shrink its risk: the
   translator's typed-stack machinery is exactly the analysis a register
-  allocator needs.
+  allocator needs. fib_recursive (7.5 G) is now almost pure frame ceremony —
+  its body recurses, so no kernel tier can reach it.
 
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine
 caveats in §1.1 stand.

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -706,11 +706,46 @@ replacement, accessor-on-globalThis, patch-between-activations) plus
 in-body-declaration cases, and the fuzz generator now routes values
 through Math intrinsics.
 
+**Kernel v4 (same branch): dense appends, materialized booleans, and
+captured loop bounds.**
+
+- **Appends & hole fills**: `StoreElem` now performs an exact
+  one-past-the-end append (`a[a.length] = v`, `arr.push`-free building)
+  and in-bounds hole fills — both CREATE a property, so they additionally
+  require the array extensible and under the dense-storage bound;
+  otherwise they bail to the generic path, which owns the sloppy-silent /
+  strict-TypeError / RangeError semantics. This unlocks the fill-by-append
+  and `new Array(n)` fill idioms.
+- **Booleans as first-class kernel values**: the virtual stack and the
+  local map are statically TYPED. A stored comparison (`const hi = x > 5`),
+  `!x`, `true`/`false` literals, and loop-carried flags become Bool
+  registers holding exactly 0.0/1.0; the guard requires `Value::Bool` and
+  write-back restores it — `typeof ok` never sees a number. Coercing
+  consumers (arithmetic, conditions, Math args) read the raw register —
+  identical to `ToNumber`/`ToBoolean` on a boolean — while array
+  indices/elements REFUSE bools (`a[true]` is the property `"true"`), and
+  strict (in)equality between statically mixed bool/number operands folds
+  to its constant (the generic `strict_equals` never compares across
+  types). Local types are discovered to a FIXPOINT (a boolean store types
+  the local; the next translation run reloads it as Bool); genuinely
+  mixed-type locals keep the loop generic.
+- **Captured loop bounds**: a read-only-in-region UPVALUE (`const N`
+  captured from the enclosing scope — the classic module-level bound)
+  snapshots into a register at entry, guarded `Number`. Sound because
+  kernel regions contain no calls: nothing can write the cell
+  mid-activation. In-region upvalue writes still reject.
+
+Measured: array_sum drops further, 3.74 G → 2.03 G instructions (−81%
+total from its 10.67 G pre-kernel baseline — the `new Array(N)` fill loop
+was bailing per-iteration on holes). A run-scanning workload (append-build
++ boolean-flag scan, 500k elements ×4) goes **2065 ms → 204 ms (10.1×)**.
+Other suite counts unchanged (±layout noise), checksums byte-identical.
+
 ### 6.5.1 What's next (new baseline)
 
-- Kernel v4 candidates: materialized booleans (needs typed write-back,
-  since `typeof ok` distinguishes `true` from `1`), and dense appends
-  (`a[a.length] = v` currently bails every iteration).
+- Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,
+  loop bounds via own-frame CELLS (captured accumulators), and typed-array
+  element access (a natural fit — elements are statically numeric).
 - **step dispatch remains the wall for non-kernel code**: `step` +
   `run_frame` are 25–43% of call-heavy workloads. Register bytecode (§3.5)
   is the remaining structural lever, and kernels shrink its risk: the

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -545,21 +545,48 @@ sort 1.09 s → 0.93 s, fib 696 → 572 ms, closures 350 → 311 ms.
 An incidental robustness gain: heap-boxed frames raised the native-stack
 recursion ceiling from ~1160 to ~1460 JS frames (see the known issue below).
 
-### 6.4.2 What's next (new baseline)
+### 6.4.2 Robustness follow-ups (landed with this round)
+
+Both known issues flagged during this round's review are **fixed**:
+
+- **Deep recursion now throws instead of aborting the process.** The
+  pre-existing failure: `max_call_depth` (2000) exceeded what the default
+  8 MB native stack supports, so `rec(1500)`-style recursion killed the
+  process with an uncatchable native stack overflow (main aborted at ~1160
+  frames; the frame pool had already raised that to ~1460). Root cause:
+  `step`'s single ~190-arm match carried a **4 KB stack frame** (LLVM's
+  imperfect stack coloring unions the arms' locals), so every JS call cost
+  ~5.5 KB of native stack. Fix, two-sided:
+  - `step` is split: hot ops stay inline (~2.7 KB frame), everything else
+    delegates to an `#[inline(never)] step_cold`. Each op has exactly ONE
+    implementation. A plain JS→JS call's native footprint is now ~3 KB, so
+    the 2000-frame guard fires (catchable RangeError) comfortably inside
+    8 MB. Probe-verified: `rec(1900)` returns, unbounded recursion throws
+    `RangeError`, spread-call recursion included. Callgrind cost of the
+    split: ≈0.5% geomean (fib +1.1% worst) — the price of the abort→throw
+    conversion.
+  - The chidori server/CLI ran agent JS on `tokio::spawn_blocking` threads
+    with tokio's **2 MiB** default stacks (abort at ~350 frames!). All
+    tokio runtimes are now built via `scheduler::new_tokio_runtime()` with
+    16 MiB threads (`JS_THREAD_STACK_BYTES`, matching the branch worker
+    threads' existing choice).
+  - Remaining sharp edge (accepted): recursion THROUGH `direct eval`
+    (`perform_direct_eval` holds its own 4 KB frame) stacks ~10 KB/frame
+    and can still hit the native limit before the depth guard on small
+    stacks. Pathological; unchanged from before.
+- **Sealed-array appends are rejected.** `Object.seal(a); a[a.len] = v`
+  (and `push`/`unshift`, in-bounds hole writes, `preventExtensions`-only
+  receivers) wrote through the dense-array Set path, which never consulted
+  `extensible` when CREATING an element. `ordinary_define_own` now rejects
+  creation on a non-extensible dense array — silently in sloppy mode,
+  TypeError in strict — matching Node/spec exactly. One Test262 test flips
+  to passing (baseline refreshed).
+
+### 6.4.3 What's next (new baseline)
 
 - **step dispatch is now the wall**: `step` + `run_frame` are 25–43% of
   every workload (fib 42%, arith 50%+, sort 25%) with the call ceremony
   halved. Register bytecode (§3.5) is the remaining structural lever.
-- **Known issue (pre-existing, NOT introduced here)**: `max_call_depth`
-  (2000) exceeds what the default 8 MB native stack supports —
-  `rec(1500)`-style recursion aborts with a native stack overflow instead
-  of throwing a catchable RangeError (main: overflow at ~1160 frames; this
-  branch: ~1460, i.e. strictly better but still short of 2000). Fix
-  options: lower the default depth, raise thread stack at the embedding
-  boundary, or shrink `step`'s stack frame (~5 KB/call, the giant match's
-  unioned locals). Tracked separately; Test262's recursion tests pass
-  because the runner threads carry larger stacks.
-- The sealed-array append gap from §6.3 still stands.
 
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine
 caveats in §1.1 stand.

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -867,6 +867,44 @@ non-writable stores (sloppy + strict), prototype reads, aliasing,
 create-in-loop late entry, `delete`-in-loop rejection, between-activation
 shape changes, non-Ordinary receivers, and −0/NaN pins.
 
+**Kernel v8 (same branch): pinned-closure calls inside loop kernels.**
+
+The closures shape — `for (…) s = f(s) - 4` over a tiny capturing callback
+— spent ~2300 instructions per iteration on generic dispatch and call
+ceremony around ~15 instructions of work (the callee itself already ran
+frameless via its v5 function kernel). A call of an OBJECT-TYPED LOCAL
+under a plain `undefined` this now translates to `KOp::CallKernel`: the
+callee local is pinned exactly like an array base (in-region stores to it
+reject), and the callee's function-kernel register program runs INLINE on
+a dedicated window above the caller's registers.
+
+- **One guard per activation** covers everything `run_fn_kernel` checks
+  per call: plain bytecode function, has a (non-recursive,
+  Number-returning) fn kernel, every consumed argument index below the
+  smallest argc any site supplies, canonical Math, Number upvalues — the
+  upvalue snapshot loads into the window ONCE (callee code never writes
+  upvalue registers, and no calls can run between iterations). Loop calls
+  happen at a constant depth, so one depth check stands in for the
+  per-call guard; an active trace sink declines (it must see an
+  enter/exit per call). Argument registers must be statically NUMBER
+  (they copy raw into the callee's guarded-Number arg registers).
+- **Per call**: copy argc registers, run the callee window (its
+  back-edges poll the interrupt through the caller's counter), copy the
+  `Ret` register out. No frames, no `Value`s, no operand stacks.
+- **Codegen isolation**: the register loop is MONOMORPHIZED on a const
+  `CALLEES` flag — kernels without closure calls compile the arm and its
+  state out entirely. (The naive single loop cost arith_loop/array_sum/
+  property_access 7–10% in register spills; the split restored all three
+  to their prior counts.)
+
+Measured: **closures 2.32 G → 0.57 G instructions (−76%; −86% from the
+4.03 G session start)**, other suite counts within ±1%, checksums
+byte-identical. Corpus grew multi-callee regions, non-number upvalues,
+mid-loop and between-activation callee reassignment, boolean-returning /
+kernel-less / native / recursive callees (all decline observably),
+short/extra argument counts, monkeypatched Math, −0 pins, and callee
+results flowing into property/element stores.
+
 ### 6.5.1 What's next (new baseline)
 
 - Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -830,6 +830,43 @@ boolean-return and mutual-recursion negatives, per-call declines, and a
 dedicated depth-overflow differential (`max_call_depth = 64` on a big-stack
 thread) pinning the abandon-and-rerun RangeError path.
 
+**Kernel v7 (same branch): named-property access on pinned objects.**
+
+The property_access shape — a monomorphic `o.a = i; o.b = o.a + 1; …`
+get/set loop over a plain object — was pure interpreter tax (44% `step`,
+27% `Value` clone/drop/push). `Op::GetProp`/`Op::SetProp` over an
+oslot-pinned base now translate to `KOp::LoadProp`/`KOp::StoreProp`, with
+a resolution model STRONGER than an inline cache: each (base, key) class
+resolves ONCE at kernel entry to a raw property-map slot index, and then
+runs with **zero per-access checks and no bail path**. That is sound
+because nothing inside a kernel region can restructure a property map —
+no calls, no property creation or deletion (`delete` rejects the region;
+a creating store never translates) — and the only in-kernel property
+writes are `StoreProp`'s in-place `Number` overwrites, so both the slot
+index and the loaded-value Number-ness are activation invariants.
+
+- **Entry conditions** per class (mirroring `Op::SetProp`'s interpreter
+  fast path): the base holds an `Internal::Ordinary` object (exotic
+  receivers — Proxy, module namespace, typed arrays, `Date`&c. — decline),
+  the property exists as an OWN data property, holds a `Number` where the
+  region loads it, and is writable where the region stores it. Any miss
+  declines the ACTIVATION into the generic fallback iteration (accessors
+  fire, frozen objects fail silently/throw, prototype reads walk the
+  chain — all observably, on the spec path), and the kernel re-tries at
+  the next back-edge (late entry covers the create-then-loop idiom).
+- Aliased bases stay coherent (every access reads/writes the object's
+  real storage); slots re-resolve on every activation, so shape changes
+  BETWEEN activations are fine. `o.length` keeps the array `LoadLen`
+  path.
+
+Measured: **property_access 3.84 G → 0.69 G instructions (−82%, 5.5×)**,
+checksums byte-identical across the suite. The fatter kernel dispatch
+loop costs arith_loop/array_sum ~+2.5% (register pressure), dwarfed by
+the win. Corpus grew getter/setter observation counts, frozen and
+non-writable stores (sloppy + strict), prototype reads, aliasing,
+create-in-loop late entry, `delete`-in-loop rejection, between-activation
+shape changes, non-Ordinary receivers, and −0/NaN pins.
+
 ### 6.5.1 What's next (new baseline)
 
 - Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -672,13 +672,45 @@ budget, so conformance runs the generic path — the corpus carries
 kernel-specific coverage). The pass is disabled under the `op-histogram`
 feature (it would hide per-op counts).
 
+**Kernel v3 (same branch): `Math.*` intrinsics + in-body `const`/`let`.**
+
+- The compiler's Math method-call pattern (`LoadGlobal("Math"); Dup;
+  GetProp(name); Swap; args…; Call(n)`) translates to direct kernel ops for
+  `abs floor ceil round trunc sign sqrt fround` (unary) and
+  `min max pow imul` (binary, exact-arity only). Every kind calls the SAME
+  core function its builtin uses (`builtins::numbers`), so results are
+  bit-identical — including `Math.round`'s half-up negatives, `min/max`
+  NaN-poisoning and ±0 ordering, and `imul`'s int32 wrap. The **entry
+  guard** identity-checks the global `Math` binding (a plain data property
+  holding the canonical object — accessors/replacements decline) and each
+  used method (methods are writable; a monkeypatched `Math.max` makes the
+  kernel decline and the patch runs generically, observably). `Math.PI`-
+  class value constants are non-writable AND non-configurable on the
+  canonical object, so with the object identity guarded they fold to
+  literal constants at translation. Unsupported methods/arities
+  (`hypot`, `log`, variadic `max`) reject the region as before.
+- In-body `const x = …` / `let y = …` emit a TDZ-init op
+  (`InitLocalTdz`) that previously rejected the region — the single
+  biggest eligibility hole in practice. It is now ELIDED under the same
+  proof as the dead `undefined` store: the local must be re-stored before
+  any read, branch, or branch target; a genuine conditional-TDZ-read
+  region stays generic so the ReferenceError comes from the spec path
+  (pinned in the corpus).
+
+Measured on a Math-heavy loop (clamp + `imul` hash over 2M iterations, the
+DSP/aggregation shape): **2058 ms → 199 ms (10.3×)**, node at 57 ms — the
+gap on this class drops from ~36× to ~3.5×. Benchmark-suite counts are
+otherwise unchanged (checksums identical); the corpus grew Math edge cases
+(NaN/±0 ordering, half-up rounding, monkeypatching, wholesale `Math`
+replacement, accessor-on-globalThis, patch-between-activations) plus
+in-body-declaration cases, and the fuzz generator now routes values
+through Math intrinsics.
+
 ### 6.5.1 What's next (new baseline)
 
-- Kernel v3 candidates, in value order: `Math.*` intrinsics as kernel ops
-  (entry-guarded against the canonical builtins — `Math.abs/min/max/floor`
-  in numeric loops are common), materialized booleans (would need typed
-  write-back, since `typeof ok` distinguishes `true` from `1`), and dense
-  appends (`a[a.length] = v` currently bails every iteration).
+- Kernel v4 candidates: materialized booleans (needs typed write-back,
+  since `typeof ok` distinguishes `true` from `1`), and dense appends
+  (`a[a.length] = v` currently bails every iteration).
 - **step dispatch remains the wall for non-kernel code**: `step` +
   `run_frame` are 25–43% of call-heavy workloads. Register bytecode (§3.5)
   is the remaining structural lever, and kernels shrink its risk: the

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -582,11 +582,78 @@ Both known issues flagged during this round's review are **fixed**:
   TypeError in strict — matching Node/spec exactly. One Test262 test flips
   to passing (baseline refreshed).
 
-### 6.4.3 What's next (new baseline)
+## 6.5 Typed loop kernels (landed): unboxed register execution for numeric loops
 
-- **step dispatch is now the wall**: `step` + `run_frame` are 25–43% of
-  every workload (fib 42%, arith 50%+, sort 25%) with the call ceremony
-  halved. Register bytecode (§3.5) is the remaining structural lever.
+The answer to "can we selectively fast-path compute-heavy loops in a
+limited context" — a deterministic, safe-Rust, zero-dependency middle tier
+between the interpreter and a real JIT. Design informed directly by the
+retired closure-threading experiment (docs/jit.md): removing *dispatch*
+alone bought 1.01–1.11×, so this tier removes the **boxing** instead — the
+`Value` clone/match/drop and operand-stack traffic around every add and
+compare.
+
+**How it works** (`kernel.rs`, `Op::LoopKernel`, `Vm::run_kernel_op`):
+
+- At compile finish (after localize + fuse), back-edges identify loop
+  regions. A region qualifies only if every op is on a numeric allowlist —
+  loads/stores of localized `frame.locals` slots, `Number` constants,
+  arithmetic/comparisons/branches and their fused forms; anything else
+  (calls, property access, cells, TDZ init, try handlers, suspension)
+  disqualifies it entirely. The region's stack bytecode is translated by
+  abstract interpretation into a flat register program over unboxed `f64`s
+  (canonical stack slots become registers; compare ops must feed branches —
+  a materialized boolean disqualifies). The loop-header op is REPLACED by
+  `Op::LoopKernel` (indices/jump targets everywhere are untouched); the
+  original header op is preserved as the kernel's `fallback`.
+- At runtime the kernel enters only when (a) no op budget is installed
+  (per-op accounting stays exact — the conformance runner's budgeted runs
+  execute fully generically) and (b) every mapped local currently holds a
+  `Number`. JS numeric ops are CLOSED over numbers, so after the guard no
+  non-number can appear mid-kernel — there is no deopt map because there is
+  nothing to deopt. A failed guard executes the fallback op and the generic
+  interpreter takes that iteration; the kernel retries at the next
+  back-edge arrival (so a `let x;` warming to a number on iteration 1
+  enters the kernel from iteration 2). Loop exits write the registers back
+  and resume the interpreter at the exit ip. The cooperative interrupt flag
+  is polled on kernel back-edges at the interpreter's cadence.
+- Arithmetic calls the SAME `number_arith_raw`/`js_mod`/`to_int32` helpers
+  as the interpreter's Number×Number fast paths — results are bit-identical
+  by construction (NaN, -0, shift masking, `%` sign, `>>>`).
+
+**Measured (callgrind, whole workload, deterministic):**
+
+| workload | before | after | Δ |
+| --- | ---: | ---: | ---: |
+| arith_loop | 2.23 G | 0.46 G | **−79% (4.8×)** |
+| all others | — | — | unchanged (no eligible loops / call-bound) |
+
+Wall-clock arith_loop: ~245 ms → **~44 ms** (5.6×) on the shared container;
+the gap to V8 on this workload drops from ~100× to ~20×. `fib` (calls),
+`sort` (comparator calls), and property/string workloads are untouched by
+design — kernels only fire where the loop body is pure local numerics.
+
+**Gates:** the differential corpus + 300-case deterministic fuzz
+(`tests/kernels.rs`) require byte-identical behavior kernels-on vs
+kernels-off across break/continue/labels, NaN/-0/precision edges, guard
+bails, late entry, nested loops, and op-budget interaction; structural
+tests assert the canonical loop actually kernelizes; full suites + Test262
+gate green (kernels are additionally OFF under the runner's op budget, so
+conformance runs the generic path — the corpus carries kernel-specific
+coverage). The pass is disabled under the `op-histogram` feature (it would
+hide per-op counts).
+
+### 6.5.1 What's next (new baseline)
+
+- Kernel v2 candidates, in value order: dense-array element access inside
+  kernels (`sum += a[i]` — per-access bounds+density+number guards with
+  precise bail, unlocking array_push_sum/array_hof-class loops), `Math.*`
+  intrinsics as kernel ops, and materialized booleans (0/1-typed registers)
+  for `let ok = a < b` patterns.
+- **step dispatch remains the wall for non-kernel code**: `step` +
+  `run_frame` are 25–43% of call-heavy workloads. Register bytecode (§3.5)
+  is the remaining structural lever, and kernels shrink its risk: the
+  translator's abstract-stack machinery is exactly the analysis a register
+  allocator needs.
 
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine
 caveats in §1.1 stand.

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -887,6 +887,45 @@ shape changes, non-Ordinary receivers, and −0/NaN pins.
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine
 caveats in §1.1 stand.
 
+## 6.6 JSON round-trip (landed): single-buffer stringify + parser fast paths
+
+json_roundtrip's profile was ~30% raw allocator traffic and ~12% Rust
+`format!` machinery: the serializer built a fresh `String` per LEAF, a
+`Vec<String>` + `join` + `format!` wrap per tree LEVEL, and allocated an
+`Rc<str>` property key per member [[Get]]; the parser built every string
+char-by-char and the number formatter ran grisu for every integer.
+
+Changes (`builtins/numbers.rs`, `vm.rs`) — no spec-visible effect moves:
+the [[Get]] order, toJSON/replacer calls, and proxy traps are untouched,
+and a 25-case differential battery (escapes, indent modes, replacer
+allowlists/omission, boxed primitives, toJSON, surrogate escapes,
+control-char rejection, circular detection, −0/1e21/2^53-class numbers)
+is byte-identical to node 22:
+
+- **One output buffer for the whole tree**: `json_stringify` appends and
+  returns emitted/omitted; an omitted object member TRUNCATES its written
+  `"key":` prefix back off (its side effects already ran, exactly as the
+  spec orders). Separators are direct pushes; the pretty-print strings
+  are all empty in compact mode.
+- **Run-based escaping** (`json_quote_into`): only `"`, `\` and control
+  bytes escape — all single ASCII bytes — so maximal clean runs copy as
+  slices, multi-byte UTF-8 included wholesale.
+- **`JsString` keys end-to-end**: member keys stay `Rc` (clone = refcount
+  bump) through the key list, the member [[Get]], toJSON/replacer
+  arguments, and quoting — no per-member allocation.
+- **Small-integer number formatting** (`push_number_string`): integral
+  |n| ≤ 2^53 — exact, and its plain decimal digits ARE the shortest
+  round-trip form — formats straight into the buffer; larger/fractional
+  values keep the spec grisu path (`String(2**60)`-class values differ!).
+- **Parser no-escape fast path**: a string body without escapes/control
+  bytes is ONE slice copy; the escape-aware loop only runs from the first
+  backslash.
+
+Measured: **json_roundtrip 2.07 G → 1.20 G instructions (−42%)**, RESULT
+checksums byte-identical across the suite. Remaining costs are parse-side
+object building (property-map hashing) and the interpreter reads around
+the loop — shape-cache territory, out of scope here.
+
 ## 7. References
 
 - [`docs/interpreter-optimization.md`](./interpreter-optimization.md) —

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -791,6 +791,45 @@ implicit-undefined return) to NEVER carry one; the op-budget test now also
 covers a call-heavy program (function kernels are OFF under a budget, like
 loop kernels).
 
+**Kernel v6 (same branch): SELF-RECURSIVE function kernels.**
+
+fib-class functions are pure scalar bodies whose only off-allowlist ops are
+the recursive call sites. `LoadGlobal` of the function's OWN name now
+translates (fn mode) to a speculative "self" entry, and the plain-call
+pattern over it fuses to `KOp::SelfCall`: the executor
+(`Vm::run_fn_kernel_rec`) runs the whole recursion as stacked REGISTER
+WINDOWS over one grown `Vec<f64>` with an explicit (return-pc, dst,
+window) stack — zero frames, zero `Value`s, zero operand stacks for the
+entire call tree.
+
+- **Guard** (on top of v5's): the global the callee resolves through must
+  be a plain data property holding the VERY closure being invoked (pointer
+  identity) — a rebound/shadowed/accessor'd name declines and the generic
+  `LoadGlobal` observably resolves whatever the program set up. Checked
+  once per top-level entry: nothing inside a kernel can write globals.
+- **Depth fidelity**: self-calls track depth against the interpreter's
+  limit (`call_depth + window count`); an overflow ABANDONS the activation
+  and returns "guard declined" — sound because function kernels are pure
+  (registers only) — so the caller's generic rerun recurses to the same
+  depth and raises the exact spec RangeError from the exact frame.
+  Interrupts poll on self-calls and back-edges as usual.
+- **Static safety rails**: every self-call must supply every argument
+  index the body consumes (a short call would need the generic `undefined`
+  parameter), and a recursive kernel must return NUMBERS only (a boolean
+  would land in a caller register statically typed Num, diverging under
+  `typeof`/strict-eq). Argument expressions must be statically-Number
+  registers. Mutual recursion and named-expression self-reference (a
+  lexical binding, not a global) stay generic.
+
+Measured: **fib_recursive 7.51 G → 0.81 G instructions (−89%, 9.3×)**;
+wall-clock fib(30) ~78 ms vs node 22's ~110 ms total on the same box — the
+first workload where chidori beats node outright. Every other suite count
+is at layout-noise level (±0.15%), checksums byte-identical. Corpus grew
+fib/gcd/Ackermann (nested self-call arguments), rebinding-mid-program,
+boolean-return and mutual-recursion negatives, per-call declines, and a
+dedicated depth-overflow differential (`max_call_depth = 64` on a big-stack
+thread) pinning the abandon-and-rerun RangeError path.
+
 ### 6.5.1 What's next (new baseline)
 
 - Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,
@@ -798,12 +837,15 @@ loop kernels).
   element access (a natural fit — elements are statically numeric), and
   argument-typed ARRAY parameters for function kernels (`(a, i) => a[i]`
   needs arg object slots + a bail-free access story).
+- Kernel-tier extensions with clear shapes: MUTUAL recursion (guard a
+  small set of global bindings instead of one), self-calls through local/
+  captured bindings (`const f = n => … f(…)`), and boolean-returning
+  recursion (type the result register Bool).
 - **step dispatch remains the wall for non-kernel code**: `step` +
   `run_frame` are 25–43% of call-heavy workloads. Register bytecode (§3.5)
   is the remaining structural lever, and kernels shrink its risk: the
   translator's typed-stack machinery is exactly the analysis a register
-  allocator needs. fib_recursive (7.5 G) is now almost pure frame ceremony —
-  its body recurses, so no kernel tier can reach it.
+  allocator needs.
 
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine
 caveats in §1.1 stand.

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -620,39 +620,69 @@ compare.
   as the interpreter's Number×Number fast paths — results are bit-identical
   by construction (NaN, -0, shift masking, `%` sign, `>>>`).
 
+**Kernel v2 (same branch): dense-array access + nested loops.** The
+translator's virtual stack became TYPED — number registers vs. array-base
+entries (a two-phase walk first discovers which locals are used as bases) —
+which generalizes the tier to the `s += a[i]` class:
+
+- `a[i]` reads, `a[i] = v` in-place writes, and `a.length` translate to
+  `LoadElem`/`StoreElem`/`LoadLen` kernel ops. Each access RE-CHECKS its
+  full fast-path condition at runtime (unshadowed dense array, integral
+  in-bounds index, non-hole `Number` element — the same conditions as
+  `Op::SetPropDynamic`'s existing fast path) and otherwise **bails
+  precisely**: registers write back and the generic interpreter resumes AT
+  the access op, its operand stack reconstructed from a per-kernel shape
+  table (numbers from registers, bases from the pinned object slots). A
+  bail is a slow iteration, never a wrong answer — holes that read through
+  the prototype, accessor elements, frozen/sealed arrays, string elements,
+  float/negative/OOB indices, and mid-loop growth all take the exact spec
+  path (differentially pinned in the corpus and cross-checked against
+  Node).
+- Base locals are pinned at entry (stores to them reject at translation),
+  aliased bases work (per-access borrows), and `a[b[i]]` nests.
+- An inner loop's `Op::LoopKernel` header translates as its preserved
+  fallback op, so nested numeric loops collapse into ONE outer kernel
+  (the per-iteration `let j` reset — a dead `undefined` store — is elided
+  when provably re-stored before any read within the block).
+
 **Measured (callgrind, whole workload, deterministic):**
 
 | workload | before | after | Δ |
 | --- | ---: | ---: | ---: |
-| arith_loop | 2.23 G | 0.46 G | **−79% (4.8×)** |
-| all others | — | — | unchanged (no eligible loops / call-bound) |
+| arith_loop | 2.23 G | 0.48 G | **−78% (4.6×)** |
+| array_sum (new workload) | 10.67 G | 3.76 G | **−65% (2.8×)** |
+| array_push_sum | 3.67 G | 2.72 G | **−26%** (its sum loop kernels) |
+| sort / fib / closures / property / string / json | — | — | unchanged |
 
-Wall-clock arith_loop: ~245 ms → **~44 ms** (5.6×) on the shared container;
-the gap to V8 on this workload drops from ~100× to ~20×. `fib` (calls),
-`sort` (comparator calls), and property/string workloads are untouched by
-design — kernels only fire where the loop body is pure local numerics.
+Wall-clock arith_loop ~245 ms → ~44 ms (5.6×); a mixed array/nested
+workload (dot products + 2D walk) 686 ms → 193 ms (3.6×). The gap to V8 on
+pure numeric loops drops from ~100× to ~20×. `fib` (calls), `sort`
+(comparator calls), and property/string workloads are untouched by design —
+kernels only fire where the loop body is local numerics and dense-array
+element access.
 
-**Gates:** the differential corpus + 300-case deterministic fuzz
-(`tests/kernels.rs`) require byte-identical behavior kernels-on vs
+**Gates:** the differential corpus (70+ programs) + 300-case deterministic
+fuzz (`tests/kernels.rs`) require byte-identical behavior kernels-on vs
 kernels-off across break/continue/labels, NaN/-0/precision edges, guard
-bails, late entry, nested loops, and op-budget interaction; structural
-tests assert the canonical loop actually kernelizes; full suites + Test262
-gate green (kernels are additionally OFF under the runner's op budget, so
-conformance runs the generic path — the corpus carries kernel-specific
-coverage). The pass is disabled under the `op-histogram` feature (it would
-hide per-op counts).
+bails, late entry, nested loops, array holes/accessors/freeze/aliasing/
+growth/reassignment, and op-budget interaction; structural tests pin the
+canonical, array, and nested loops to actually kernelize; full suites +
+Test262 gate green (kernels are additionally OFF under the runner's op
+budget, so conformance runs the generic path — the corpus carries
+kernel-specific coverage). The pass is disabled under the `op-histogram`
+feature (it would hide per-op counts).
 
 ### 6.5.1 What's next (new baseline)
 
-- Kernel v2 candidates, in value order: dense-array element access inside
-  kernels (`sum += a[i]` — per-access bounds+density+number guards with
-  precise bail, unlocking array_push_sum/array_hof-class loops), `Math.*`
-  intrinsics as kernel ops, and materialized booleans (0/1-typed registers)
-  for `let ok = a < b` patterns.
+- Kernel v3 candidates, in value order: `Math.*` intrinsics as kernel ops
+  (entry-guarded against the canonical builtins — `Math.abs/min/max/floor`
+  in numeric loops are common), materialized booleans (would need typed
+  write-back, since `typeof ok` distinguishes `true` from `1`), and dense
+  appends (`a[a.length] = v` currently bails every iteration).
 - **step dispatch remains the wall for non-kernel code**: `step` +
   `run_frame` are 25–43% of call-heavy workloads. Register bytecode (§3.5)
   is the remaining structural lever, and kernels shrink its risk: the
-  translator's abstract-stack machinery is exactly the analysis a register
+  translator's typed-stack machinery is exactly the analysis a register
   allocator needs.
 
 Re-run the callgrind sweep before choosing; the noise-floor and idle-machine


### PR DESCRIPTION
Performance work on chidori-js across eleven commits, cutting 40–90% of executed instructions on every call-, loop-, property-, and JSON-bound benchmark while keeping byte-identical output everywhere. fib(30) now beats node 22's wall-clock on the dev box (~78 ms vs ~110 ms).

## Results (callgrind instructions, deterministic; RESULT checksums byte-identical throughout)

| workload | before | after | change |
|---|---|---|---|
| fib_recursive | 7.51G¹ | 0.81G | **−89%** |
| property_access | 3.84G | 0.70G | **−82%** |
| closures | 4.03G | 0.57G | **−86%** |
| arith_loop | 2.28G | 0.50G | **−78%** (wall 245→44 ms) |
| array_sum | 10.67G | 2.02G | **−81%** |
| sort | 14.09G | 6.22G | **−56%** |
| json_roundtrip | 2.07G | 1.20G | **−42%** |
| array_hof | 2.38G | 1.73G | **−28%** |

¹ fib baseline is post-call-ceremony; its pre-branch number was 8.59G.

## What landed

**Call-ceremony round** (`d5a01b1`): whole-`Box<Frame>` recycling pool, a direct JS→JS call path that moves arguments straight off the caller's operand stack into the pooled callee frame, single-borrow call dispatch, and a scratch-buffer merge sort preserving the exact comparator call sequence.

**Robustness** (`c07b653`): deep recursion (`rec(1500)`) used to kill the process with an uncatchable native stack overflow — the interpreter's `step` was split so the 2000-frame guard reliably fires as a catchable RangeError inside 8 MiB, and the embedder's runtime threads got 16 MiB stacks. Also fixed a sealed-array append conformance gap (one test262 test flipped to passing).

**Typed kernel tiers** (`ed67f2b` → `bd54578`, `kernel.rs` + `Vm::run_kernel_op`/`run_fn_kernel`): eligible bytecode translates to unboxed `f64` register programs. Kernels are pure performance side effects gated like the inline caches — entry guards verify, per-access checks bail precisely back to the generic interpreter, and anything off the allowlist simply never kernelizes. Semantics are shared, not re-implemented (same `number_arith_raw`/`js_mod`/Math cores), so results are bit-identical including NaN/−0/shift-masking edges. Kernels are disabled under an op budget or trace sink, and translation is a pure function of the bytecode, preserving the deterministic-replay contract.

- **v1–v4 — loop kernels**: numeric loops, dense-array element access (`a[i]`, `a[i]=v`, `a.length`, exact appends and hole fills), nested loops, 12 `Math.*` intrinsics with identity-guarded canonicals (a monkeypatched `Math.max` declines observably), TDZ-init elision, materialized booleans (`typeof` never sees a number), captured loop bounds.
- **v5 — function kernels**: a tiny pure-scalar body (sort comparator, `map`/`filter`/`reduce` callback) executes FRAMELESS on the call paths — no frame, no operand stack, no pool traffic. Per-call guard: arguments present and Numbers, captured upvalues Numbers, canonical Math. sort −46%, closures −43%, array_hof −28% in that commit alone.
- **v6 — self-recursive kernels**: `fib`-class functions run their entire recursion as stacked register windows with an explicit return stack — zero frames for the whole call tree. Guard: the global binding must hold the invoked closure (pointer identity). Depth overflow abandons the pure activation and reruns generically, raising the exact spec RangeError. fib −89%.
- **v7 — named-property access**: `o.a` / `o.a = v` on pinned plain objects resolve to raw property-map slots ONCE per activation — stronger than an IC, sound because kernel regions can't create/delete properties or run user code. Accessors/frozen/prototype/exotic receivers decline to the spec path. property_access −82%.
- **v8 — pinned-closure calls**: loops calling a tiny closure (`s = f(s) - 4`) run the callee's kernel inline on a register window; one entry guard replaces the per-call guard, upvalues snapshot once. The register loop is monomorphized on a const flag so non-calling kernels compile the tier out (keeps arith/array/property counts unchanged). closures −76% on top of v5.

**JSON round-trip** (`2e3993a`): the stringifier now appends into one buffer for the whole tree (an omitted member truncates its written prefix — spec side-effect order untouched), escapes by copying maximal clean runs, keeps keys as `Rc` strings end-to-end, and formats integers ≤2^53 without grisu; the parser gets a no-escape single-slice fast path. A 25-case battery (indent modes, replacers, toJSON, boxed primitives, surrogate escapes, control-char rejection, circular detection, −0/1e21/2^53 numbers) is byte-identical to node 22. −42%.

## Verification

Every commit was gated on:
- **Differential corpus + fuzz** (`tests/kernels.rs`, now ~190 programs + 300-case deterministic fuzz): every supported construct and every decline path runs kernels-on vs kernels-off and must be byte-identical — including guard bails, late entry, holes/accessors/freeze/aliasing, monkeypatched globals, rebinding mid-program, depth-overflow reruns, and op-budget interaction (budgets observe identical counts).
- Full test suites: chidori-js 112, chidori 603.
- **test262 gate: 99.08%, zero regressions** on every commit (one progression from the sealed-array fix).
- Benchmark RESULT checksums byte-identical before/after every change; callgrind as the load-bearing metric.
- Zero `unsafe`, no new dependencies, clippy warning count unchanged.

`docs/js-performance-roadmap.md` §6.4–6.6 documents each round with measured tables; remaining candidates (string reads in kernels, mutual recursion, register bytecode) are listed in §6.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01822561TdsPuDvxLzvrQvCJ