### PR TITLE
JS perf: dense-array write fast paths in builtins + prepared fn-kernel callbacks for native HOFs

### DIFF
--- a/crates/chidori-js/examples/dump_ops.rs
+++ b/crates/chidori-js/examples/dump_ops.rs
@@ -1,8 +1,9 @@
 //! Dev-only bytecode disassembler: `cargo run --example dump_ops -- file.js`
 //! Prints each compiled function's ops with indices, for inspecting what the
-//! kernel pass will see. Not part of the public surface.
+//! kernel pass will see — and, with `--kernels`, the translated loop/function
+//! kernels' KOps themselves. Not part of the public surface.
 
-fn dump(proto: &chidori_js::bytecode::FuncProto, depth: usize) {
+fn dump(proto: &chidori_js::bytecode::FuncProto, depth: usize, kernels: bool) {
     let pad = "  ".repeat(depth);
     println!(
         "{pad}fn {:?} locals={} cells={} strict={}",
@@ -11,16 +12,43 @@ fn dump(proto: &chidori_js::bytecode::FuncProto, depth: usize) {
     for (i, op) in proto.code.iter().enumerate() {
         println!("{pad}  {i:4}  {op:?}");
     }
+    if kernels {
+        for (ki, k) in proto.kernels.iter().enumerate() {
+            println!(
+                "{pad}  loop kernel {ki}: n_regs={} locals={:?} oslots={:?}",
+                k.n_regs, k.locals, k.oslots
+            );
+            for (i, op) in k.code.iter().enumerate() {
+                println!("{pad}    {i:4}  {op:?}");
+            }
+        }
+        if let Some(k) = &proto.fn_kernel {
+            println!(
+                "{pad}  fn kernel: n_regs={} locals={:?}",
+                k.n_regs, k.locals
+            );
+            for (i, op) in k.code.iter().enumerate() {
+                println!("{pad}    {i:4}  {op:?}");
+            }
+        }
+    }
     for c in &proto.consts {
         if let chidori_js::bytecode::Const::Func(p) = c {
-            dump(p, depth + 1);
+            dump(p, depth + 1, kernels);
         }
     }
 }
 
 fn main() {
-    let path = std::env::args().nth(1).expect("usage: dump_ops <file.js>");
-    let src = std::fs::read_to_string(&path).unwrap();
-    let proto = chidori_js::compiler::compile_script(&src).unwrap();
-    dump(&proto, 0);
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
+    let kernels = args.iter().any(|a| a == "--kernels");
+    args.retain(|a| a != "--kernels");
+    let path = args.first().expect("usage: dump_ops [--kernels] <file.js>");
+    let src = std::fs::read_to_string(path).unwrap();
+    let proto = if kernels {
+        chidori_js::compiler::compile_script_kernels(&src, true).unwrap()
+    } else {
+        chidori_js::compiler::compile_script(&src).unwrap()
+    };
+    dump(&proto, 0, kernels);
 }

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -1541,12 +1541,84 @@ fn merge_sort(
     } else {
         None
     };
+    // All-Number specialization: with a kernel comparator and a snapshot of
+    // nothing but Numbers, the whole sort runs over raw `f64`s — no `Value`
+    // moves in the merge, and (`prime_prepared_cmp`) no per-call guard: no
+    // user code can run between two comparator calls, so the entry checks
+    // hold for the entire sort. The recursion/merge structure is IDENTICAL
+    // to the generic `merge_sort_range`, so an inconsistent comparator
+    // produces the exact same (implementation-defined) order either way.
+    if let Some(p) = prep.as_mut() {
+        if items.iter().all(|v| matches!(v, Value::Number(_))) {
+            if let Some(regs_ab) = vm.prime_prepared_cmp(p) {
+                let mut nums: Vec<f64> = items
+                    .iter()
+                    .map(|v| match v {
+                        Value::Number(n) => *n,
+                        _ => unreachable!("checked all-Number"),
+                    })
+                    .collect();
+                let mut aux: Vec<f64> = Vec::with_capacity(nums.len() / 2 + 1);
+                let n = nums.len();
+                merge_sort_range_f64(vm, &mut nums, &mut aux, 0, n, p, regs_ab)?;
+                for (slot, n) in items.iter_mut().zip(nums) {
+                    *slot = Value::Number(n);
+                }
+                return Ok(());
+            }
+        }
+    }
     // One scratch buffer for the whole sort (max use: the larger half) instead
     // of two fresh Vec clones per recursion node — the naive version's
     // malloc/free + refcount churn was a measurable slice of sort-heavy runs.
     let mut aux: Vec<Value> = Vec::with_capacity(items.len() / 2 + 1);
     let n = items.len();
     merge_sort_range(vm, items, &mut aux, 0, n, cmp, has_cmp, &mut prep)
+}
+
+/// [`merge_sort_range`] over raw `f64`s for the all-Number/kernel-comparator
+/// specialization — same recursion, same stable take-left-on-ties merge, so
+/// the result (even under an inconsistent comparator) is bit-identical to
+/// the generic path; only the value representation changed. Shared with the
+/// TypedArray sort (same split/merge structure there too).
+pub(crate) fn merge_sort_range_f64(
+    vm: &mut Vm,
+    items: &mut [f64],
+    aux: &mut Vec<f64>,
+    lo: usize,
+    hi: usize,
+    p: &mut crate::exec::PreparedKernel,
+    regs_ab: (Option<usize>, Option<usize>),
+) -> Result<(), Value> {
+    let n = hi - lo;
+    if n <= 1 {
+        return Ok(());
+    }
+    let mid = lo + n / 2;
+    merge_sort_range_f64(vm, items, aux, lo, mid, p, regs_ab)?;
+    merge_sort_range_f64(vm, items, aux, mid, hi, p, regs_ab)?;
+    aux.clear();
+    aux.extend_from_slice(&items[lo..mid]);
+    let mut i = 0; // over aux (left run)
+    let mut j = mid; // over items (right run)
+    let mut k = lo; // write cursor; k <= j always
+    while i < aux.len() && j < hi {
+        let order = vm.exec_prepared_cmp_f64(p, regs_ab, aux[i], items[j])?;
+        if order <= 0 {
+            items[k] = aux[i];
+            i += 1;
+        } else {
+            items[k] = items[j];
+            j += 1;
+        }
+        k += 1;
+    }
+    while i < aux.len() {
+        items[k] = aux[i];
+        i += 1;
+        k += 1;
+    }
+    Ok(())
 }
 
 /// Sort `items[lo..hi]` in place. Identical recursion structure and stable

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -146,15 +146,21 @@ pub fn install(vm: &mut Vm) {
 
     install_proto_methods(vm, &proto);
     install_unscopables(vm, &proto);
-    // Pin the canonical `push` for the kernel `ArrayPush` fast path (entry
-    // identity check + bail-shape reconstruction; see `KOp::ArrayPush`).
-    let push_fn = proto
-        .borrow()
-        .props
-        .get(&PropertyKey::str("push"))
-        .and_then(|p| p.value().cloned());
-    if let Some(Value::Object(o)) = push_fn {
-        vm.realm.array_push = Some(o);
+    // Pin the canonical `push`/`pop` for the kernel `ArrayPush`/`ArrayPop`
+    // fast paths (entry identity check + bail-shape reconstruction).
+    for (name, slot) in [("push", 0), ("pop", 1)] {
+        let f = proto
+            .borrow()
+            .props
+            .get(&PropertyKey::str(name))
+            .and_then(|p| p.value().cloned());
+        if let Some(Value::Object(o)) = f {
+            if slot == 0 {
+                vm.realm.array_push = Some(o);
+            } else {
+                vm.realm.array_pop = Some(o);
+            }
+        }
     }
 }
 

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -337,6 +337,23 @@ fn array_create(vm: &mut Vm, len: f64) -> Result<JsObject, Value> {
 
 fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     vm.define_method(proto, "push", 1, |vm, this, args| {
+        // Dense fast path: an UNSHADOWED (`props` empty — no reified length
+        // marker, no index accessors, not frozen/sealed), extensible dense
+        // array appends straight onto the backing vec — one borrow total, no
+        // per-element index→String key, hashing, or prototype walk. These are
+        // exactly the kernel `StoreElem` append conditions; the dense-storage
+        // bound falls back to the generic path, which owns that RangeError.
+        if let Value::Object(o) = &this {
+            let mut b = o.borrow_mut();
+            if b.props.is_empty() && b.extensible {
+                if let Internal::Array(arr) = &mut b.internal {
+                    if arr.len() + args.len() <= crate::value::MAX_DENSE_ARRAY {
+                        arr.extend_from_slice(args);
+                        return Ok(Value::Number(arr.len() as f64));
+                    }
+                }
+            }
+        }
         // Spec-generic: Set(O, len+i, arg, throw); Set(O, "length", …, throw). The
         // throwing Set surfaces a frozen array / non-writable length as a
         // TypeError, and the 2^53-1 guard runs before any element is written.
@@ -355,6 +372,24 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         Ok(Value::Number(len))
     });
     vm.define_method(proto, "pop", 0, |vm, this, _args| {
+        // Dense fast path mirroring push's: on an unshadowed extensible dense
+        // array the Get/Delete/Set-length sequence collapses to `vec.pop`. A
+        // trailing HOLE takes the generic path (its Get consults the
+        // prototype chain), as does an empty array's length write-back.
+        if let Value::Object(o) = &this {
+            let mut b = o.borrow_mut();
+            if b.props.is_empty() && b.extensible {
+                if let Internal::Array(arr) = &mut b.internal {
+                    match arr.last() {
+                        Some(v) if !matches!(v, Value::Hole) => {
+                            return Ok(arr.pop().expect("checked non-empty"));
+                        }
+                        None => return Ok(Value::Undefined),
+                        _ => {}
+                    }
+                }
+            }
+        }
         // Spec-generic: Get the last element, DeletePropertyOrThrow it, then set
         // the (throwing) length — so a frozen/non-writable receiver throws.
         let o = vm.to_object(&this)?;
@@ -764,13 +799,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "forEach", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
             if let Some(v) = has_get_elem(vm, &ov, k)? {
-                vm.call(
-                    cb.clone(),
-                    this_arg.clone(),
+                call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &this_arg,
                     &[v, Value::Number(k), ov.clone()],
                 )?;
             }
@@ -783,13 +821,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         // Result via ArraySpeciesCreate; holes map to holes (the callback is not
         // invoked for an absent index and that output slot stays absent).
         let a = array_species_create(vm, &ov, len)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
             if let Some(v) = has_get_elem(vm, &ov, k)? {
-                let mapped = vm.call(
-                    cb.clone(),
-                    this_arg.clone(),
+                let mapped = call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &this_arg,
                     &[v, Value::Number(k), ov.clone()],
                 )?;
                 create_data_elem(vm, &a, k, mapped)?;
@@ -801,14 +842,17 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     vm.define_method(proto, "filter", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
         let a = array_species_create(vm, &ov, 0.0)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut to = 0.0;
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
             if let Some(v) = has_get_elem(vm, &ov, k)? {
-                let keep = vm.call(
-                    cb.clone(),
-                    this_arg.clone(),
+                let keep = call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &this_arg,
                     &[v.clone(), Value::Number(k), ov.clone()],
                 )?;
                 if vm.to_boolean(&keep) {
@@ -823,13 +867,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     vm.define_method(proto, "find", 1, |vm, this, args| {
         // `find` visits every index via Get (holes read as undefined).
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
             let v = vm.get_prop(&ov, &elem_key(k))?;
-            let r = vm.call(
-                cb.clone(),
-                this_arg.clone(),
+            let r = call_cb(
+                vm,
+                &mut prep,
+                &cb,
+                &this_arg,
                 &[v.clone(), Value::Number(k), ov.clone()],
             )?;
             if vm.to_boolean(&r) {
@@ -841,13 +888,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "findIndex", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
             let v = vm.get_prop(&ov, &elem_key(k))?;
-            let r = vm.call(
-                cb.clone(),
-                this_arg.clone(),
+            let r = call_cb(
+                vm,
+                &mut prep,
+                &cb,
+                &this_arg,
                 &[v, Value::Number(k), ov.clone()],
             )?;
             if vm.to_boolean(&r) {
@@ -859,13 +909,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "findLast", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = len - 1.0;
         while k >= 0.0 {
             vm.native_tick()?;
             let v = vm.get_prop(&ov, &elem_key(k))?;
-            let r = vm.call(
-                cb.clone(),
-                this_arg.clone(),
+            let r = call_cb(
+                vm,
+                &mut prep,
+                &cb,
+                &this_arg,
                 &[v.clone(), Value::Number(k), ov.clone()],
             )?;
             if vm.to_boolean(&r) {
@@ -877,13 +930,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "findLastIndex", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = len - 1.0;
         while k >= 0.0 {
             vm.native_tick()?;
             let v = vm.get_prop(&ov, &elem_key(k))?;
-            let r = vm.call(
-                cb.clone(),
-                this_arg.clone(),
+            let r = call_cb(
+                vm,
+                &mut prep,
+                &cb,
+                &this_arg,
                 &[v, Value::Number(k), ov.clone()],
             )?;
             if vm.to_boolean(&r) {
@@ -895,15 +951,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "some", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
-            let key = elem_key(k);
-            if vm.has_prop(&ov, &key)? {
-                let v = vm.get_prop(&ov, &key)?;
-                let r = vm.call(
-                    cb.clone(),
-                    this_arg.clone(),
+            if let Some(v) = has_get_elem(vm, &ov, k)? {
+                let r = call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &this_arg,
                     &[v, Value::Number(k), ov.clone()],
                 )?;
                 if vm.to_boolean(&r) {
@@ -916,15 +973,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "every", 1, |vm, this, args| {
         let (ov, len, cb, this_arg) = iter_setup(vm, &this, args)?;
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut k = 0.0;
         while k < len {
             vm.native_tick()?;
-            let key = elem_key(k);
-            if vm.has_prop(&ov, &key)? {
-                let v = vm.get_prop(&ov, &key)?;
-                let r = vm.call(
-                    cb.clone(),
-                    this_arg.clone(),
+            if let Some(v) = has_get_elem(vm, &ov, k)? {
+                let r = call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &this_arg,
                     &[v, Value::Number(k), ov.clone()],
                 )?;
                 if !vm.to_boolean(&r) {
@@ -956,13 +1014,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
                 }
             }
         }
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut acc = acc;
         while k < len {
             vm.native_tick()?;
             if let Some(v) = has_get_elem(vm, &ov, k)? {
-                acc = vm.call(
-                    cb.clone(),
-                    Value::Undefined,
+                acc = call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &Value::Undefined,
                     &[acc, v, Value::Number(k), ov.clone()],
                 )?;
             }
@@ -990,15 +1051,16 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
                 }
             }
         }
+        let mut prep = vm.prepare_kernel_callback(&cb);
         let mut acc = acc;
         while k >= 0.0 {
             vm.native_tick()?;
-            let key = elem_key(k);
-            if vm.has_prop(&ov, &key)? {
-                let v = vm.get_prop(&ov, &key)?;
-                acc = vm.call(
-                    cb.clone(),
-                    Value::Undefined,
+            if let Some(v) = has_get_elem(vm, &ov, k)? {
+                acc = call_cb(
+                    vm,
+                    &mut prep,
+                    &cb,
+                    &Value::Undefined,
                     &[acc, v, Value::Number(k), ov.clone()],
                 )?;
             }
@@ -1452,12 +1514,20 @@ fn merge_sort(
     if items.len() <= 1 {
         return Ok(());
     }
+    // The comparator's function kernel, prepared ONCE for the whole sort:
+    // the ~n·log n comparator calls then skip the per-call entry ceremony
+    // (callee resolution, register allocation, frame bookkeeping).
+    let mut prep = if has_cmp {
+        vm.prepare_kernel_callback(cmp)
+    } else {
+        None
+    };
     // One scratch buffer for the whole sort (max use: the larger half) instead
     // of two fresh Vec clones per recursion node — the naive version's
     // malloc/free + refcount churn was a measurable slice of sort-heavy runs.
     let mut aux: Vec<Value> = Vec::with_capacity(items.len() / 2 + 1);
     let n = items.len();
-    merge_sort_range(vm, items, &mut aux, 0, n, cmp, has_cmp)
+    merge_sort_range(vm, items, &mut aux, 0, n, cmp, has_cmp, &mut prep)
 }
 
 /// Sort `items[lo..hi]` in place. Identical recursion structure and stable
@@ -1466,6 +1536,7 @@ fn merge_sort(
 /// buffer management changed. On a comparator throw the scratch's contents
 /// are abandoned mid-merge — harmless, because every caller sorts a detached
 /// scratch list and only writes back to the array on success.
+#[allow(clippy::too_many_arguments)]
 fn merge_sort_range(
     vm: &mut Vm,
     items: &mut [Value],
@@ -1474,14 +1545,15 @@ fn merge_sort_range(
     hi: usize,
     cmp: &Value,
     has_cmp: bool,
+    prep: &mut Option<crate::exec::PreparedKernel>,
 ) -> Result<(), Value> {
     let n = hi - lo;
     if n <= 1 {
         return Ok(());
     }
     let mid = lo + n / 2;
-    merge_sort_range(vm, items, aux, lo, mid, cmp, has_cmp)?;
-    merge_sort_range(vm, items, aux, mid, hi, cmp, has_cmp)?;
+    merge_sort_range(vm, items, aux, lo, mid, cmp, has_cmp, prep)?;
+    merge_sort_range(vm, items, aux, mid, hi, cmp, has_cmp, prep)?;
     // Move the left run into the scratch (no clones; the vacated slots are
     // overwritten before they are ever read), then merge back into
     // `items[lo..]`. Take from the left on ties (order <= 0) so equal
@@ -1495,7 +1567,7 @@ fn merge_sort_range(
     let mut k = lo; // write cursor; k <= j always, so unread right
                     // elements are never overwritten
     while i < aux.len() && j < hi {
-        let order = compare_values(vm, &aux[i], &items[j], cmp, has_cmp)?;
+        let order = compare_values(vm, &aux[i], &items[j], cmp, has_cmp, prep)?;
         if order <= 0 {
             items[k] = std::mem::replace(&mut aux[i], Value::Undefined);
             i += 1;
@@ -1520,8 +1592,36 @@ fn compare_values(
     b: &Value,
     cmp: &Value,
     has_cmp: bool,
+    prep: &mut Option<crate::exec::PreparedKernel>,
 ) -> Result<i32, Value> {
     if has_cmp {
+        // Prepared-kernel comparator: the call runs entirely in unboxed
+        // registers, and its result is a `Number` or `Bool` by construction,
+        // so ToNumber is a direct match (never user code). A per-call guard
+        // miss (non-Number element, patched Math) falls through to the
+        // generic call below for this comparison only.
+        if let Some(p) = prep {
+            if let Some(r) = vm.exec_prepared_kernel(p, &[a.clone(), b.clone()]) {
+                let n = match r? {
+                    Value::Number(n) => n,
+                    Value::Bool(bv) => {
+                        if bv {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    }
+                    _ => unreachable!("fn kernels return Number or Bool"),
+                };
+                return Ok(if n < 0.0 {
+                    -1
+                } else if n > 0.0 {
+                    1
+                } else {
+                    0
+                });
+            }
+        }
         // SortCompare with a user comparator: call it, coerce the result via
         // ToNumber, and treat NaN as 0 (spec). Errors propagate. Owned-args
         // path: the pooled buffer moves straight into the callee frame instead
@@ -1570,6 +1670,28 @@ fn utf16_cmp(a: &str, b: &str) -> i32 {
             (None, None) => return 0,
         }
     }
+}
+
+/// Call an iteration callback through its prepared function kernel when one
+/// exists (see [`Vm::prepare_kernel_callback`]) — the per-element win behind
+/// the native higher-order builtins — falling back to the generic `Vm::call`
+/// when the callback has no kernel or a per-call guard declines (a
+/// non-`Number` element, a patched `Math`, …). A kernelized callback never
+/// consults `this` (translation rejects `this` uses), so skipping `this_arg`
+/// on the fast path is unobservable.
+fn call_cb(
+    vm: &mut Vm,
+    prep: &mut Option<crate::exec::PreparedKernel>,
+    cb: &Value,
+    this_arg: &Value,
+    args: &[Value],
+) -> Result<Value, Value> {
+    if let Some(p) = prep {
+        if let Some(r) = vm.exec_prepared_kernel(p, args) {
+            return r;
+        }
+    }
+    vm.call(cb.clone(), this_arg.clone(), args)
 }
 
 /// Shared prologue for the callback-taking iteration methods (forEach/map/

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -339,15 +339,34 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
     vm.define_method(proto, "push", 1, |vm, this, args| {
         // Dense fast path: an UNSHADOWED (`props` empty — no reified length
         // marker, no index accessors, not frozen/sealed), extensible dense
-        // array appends straight onto the backing vec — one borrow total, no
-        // per-element index→String key, hashing, or prototype walk. These are
-        // exactly the kernel `StoreElem` append conditions; the dense-storage
-        // bound falls back to the generic path, which owns that RangeError.
+        // array appends straight onto the backing vec — no per-element
+        // index→String key or generic Set machinery. Appending CREATES
+        // properties, so the spec consults the prototype chain: the walk is
+        // one cheap reified-index probe per proto (`protos_allow_index_create`
+        // — a polluted chain declines to the generic path, which fires the
+        // proto accessor). The dense-storage bound also falls back to the
+        // generic path, which owns that RangeError.
         if let Value::Object(o) = &this {
-            let mut b = o.borrow_mut();
-            if b.props.is_empty() && b.extensible {
-                if let Internal::Array(arr) = &mut b.internal {
-                    if arr.len() + args.len() <= crate::value::MAX_DENSE_ARRAY {
+            let start = {
+                let b = o.borrow();
+                if b.props.is_empty() && b.extensible {
+                    match &b.internal {
+                        Internal::Array(arr)
+                            if arr.len() + args.len() <= crate::value::MAX_DENSE_ARRAY =>
+                        {
+                            Some((arr.len() as u32, b.proto.clone()))
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            };
+            if let Some((start, proto)) = start {
+                if crate::value::protos_allow_index_create(proto, start, args.len() as u32) {
+                    // No user code ran since the guard borrow; the conditions
+                    // still hold.
+                    if let Internal::Array(arr) = &mut o.borrow_mut().internal {
                         arr.extend_from_slice(args);
                         return Ok(Value::Number(arr.len() as f64));
                     }

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -146,6 +146,16 @@ pub fn install(vm: &mut Vm) {
 
     install_proto_methods(vm, &proto);
     install_unscopables(vm, &proto);
+    // Pin the canonical `push` for the kernel `ArrayPush` fast path (entry
+    // identity check + bail-shape reconstruction; see `KOp::ArrayPush`).
+    let push_fn = proto
+        .borrow()
+        .props
+        .get(&PropertyKey::str("push"))
+        .and_then(|p| p.value().cloned());
+    if let Some(Value::Object(o)) = push_fn {
+        vm.realm.array_push = Some(o);
+    }
 }
 
 fn array_call(vm: &mut Vm, _this: Value, args: &[Value]) -> Result<Value, Value> {

--- a/crates/chidori-js/src/builtins/fundamental.rs
+++ b/crates/chidori-js/src/builtins/fundamental.rs
@@ -528,8 +528,12 @@ fn define_typed_array_index(
 /// `CreateDataPropertyOrThrow(O, ToString(idx), V)` specialized for integer
 /// keys — how every array-producing builtin (map/filter/from/...) fills its
 /// result. For a plain dense array with no reified props, an in-bounds write
-/// or exact append IS the defined default data property; anything else
-/// (holes, gaps, proxies, frozen/sealed, shadowed) takes the spec path.
+/// (including a HOLE fill: [[DefineOwnProperty]] never consults the
+/// prototype, the receiver is extensible, and an in-bounds index leaves
+/// `length` untouched — so defining over an absent slot IS the plain dense
+/// store; `ArrayCreate(len)`-pre-sized results like map's land here) or an
+/// exact append IS the defined default data property; anything else (gaps,
+/// proxies, frozen/sealed, shadowed) takes the spec path.
 pub(crate) fn create_data_index(
     vm: &mut Vm,
     obj: &JsObject,
@@ -543,10 +547,8 @@ pub(crate) fn create_data_index(
                 let i = idx as usize;
                 match i.cmp(&arr.len()) {
                     std::cmp::Ordering::Less => {
-                        if !matches!(arr[i], Value::Hole) {
-                            arr[i] = value;
-                            return Ok(());
-                        }
+                        arr[i] = value;
+                        return Ok(());
                     }
                     std::cmp::Ordering::Equal => {
                         if i < crate::value::MAX_DENSE_ARRAY {

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -894,6 +894,7 @@ fn install_json(vm: &mut Vm) {
             bytes: s.as_str().as_bytes(),
             pos: 0,
             src: s.as_str(),
+            keys: Default::default(),
         };
         p.skip_ws();
         let v = p.parse_value(vm)?;
@@ -1121,6 +1122,17 @@ struct JsonParser<'a> {
     bytes: &'a [u8],
     pos: usize,
     src: &'a str,
+    /// Distinct object keys seen so far, interned by SOURCE SLICE: the
+    /// dominant JSON shape — an array of same-structure records — repeats
+    /// each key once per record, and the naive path paid two allocations
+    /// per occurrence (the parsed `String`, then its `Rc<str>` copy inside
+    /// `PropertyKey::str`). A hit here is one `Rc` bump. Escaped keys (rare)
+    /// take the general string parser uninterned.
+    keys: std::collections::HashMap<
+        &'a str,
+        PropertyKey,
+        std::hash::BuildHasherDefault<crate::fxhash::FxHasher>,
+    >,
 }
 
 impl<'a> JsonParser<'a> {
@@ -1339,6 +1351,31 @@ impl<'a> JsonParser<'a> {
         }
         Ok(Value::Object(vm.new_array(elems)))
     }
+    /// An object key: the unescaped fast path is interned by source slice
+    /// (see the `keys` field); anything needing escape processing falls back
+    /// to the general string parser. `self.pos` is on the opening quote.
+    fn parse_key(&mut self, vm: &mut Vm) -> Result<PropertyKey, Value> {
+        let start = self.pos + 1;
+        let mut i = start;
+        while i < self.bytes.len() {
+            match self.bytes[i] {
+                b'"' => {
+                    let s = &self.src[start..i];
+                    self.pos = i + 1;
+                    if let Some(k) = self.keys.get(s) {
+                        return Ok(k.clone());
+                    }
+                    let k = PropertyKey::str(s);
+                    self.keys.insert(s, k.clone());
+                    return Ok(k);
+                }
+                b'\\' | 0x00..=0x1f => break,
+                _ => i += 1,
+            }
+        }
+        Ok(PropertyKey::str(self.parse_string(vm)?))
+    }
+
     fn parse_object(&mut self, vm: &mut Vm) -> Result<Value, Value> {
         self.pos += 1;
         let obj = vm.new_object();
@@ -1352,16 +1389,14 @@ impl<'a> JsonParser<'a> {
             if self.pos >= self.bytes.len() || self.bytes[self.pos] != b'"' {
                 return Err(vm.throw_syntax("Expected string key in JSON object"));
             }
-            let key = self.parse_string(vm)?;
+            let key = self.parse_key(vm)?;
             self.skip_ws();
             if self.pos >= self.bytes.len() || self.bytes[self.pos] != b':' {
                 return Err(vm.throw_syntax("Expected ':' in JSON object"));
             }
             self.pos += 1;
             let v = self.parse_value(vm)?;
-            obj.borrow_mut()
-                .props
-                .insert(PropertyKey::str(&key), Property::data(v));
+            obj.borrow_mut().props.insert(key, Property::data(v));
             self.skip_ws();
             if self.pos >= self.bytes.len() {
                 return Err(vm.throw_syntax("Unexpected end of JSON input"));

--- a/crates/chidori-js/src/builtins/typedarray.rs
+++ b/crates/chidori-js/src/builtins/typedarray.rs
@@ -1680,6 +1680,23 @@ fn ta_snapshot_array(vm: &mut Vm, o: &JsObject) -> JsObject {
 /// (Number or BigInt). Default compare is ascending numeric (NaN sorts to the
 /// end); an optional comparator is honored. Stable merge sort.
 fn ta_sort(vm: &mut Vm, items: &mut Vec<Value>, cmp: &Value, has_cmp: bool) -> Result<(), Value> {
+    // The comparator's function kernel, prepared ONCE for the whole sort
+    // (see `Vm::prepare_kernel_callback`).
+    let mut prep = if has_cmp {
+        vm.prepare_kernel_callback(cmp)
+    } else {
+        None
+    };
+    ta_sort_range(vm, items, cmp, has_cmp, &mut prep)
+}
+
+fn ta_sort_range(
+    vm: &mut Vm,
+    items: &mut Vec<Value>,
+    cmp: &Value,
+    has_cmp: bool,
+    prep: &mut Option<crate::exec::PreparedKernel>,
+) -> Result<(), Value> {
     let n = items.len();
     if n <= 1 {
         return Ok(());
@@ -1687,13 +1704,13 @@ fn ta_sort(vm: &mut Vm, items: &mut Vec<Value>, cmp: &Value, has_cmp: bool) -> R
     let mid = n / 2;
     let mut left = items[..mid].to_vec();
     let mut right = items[mid..].to_vec();
-    ta_sort(vm, &mut left, cmp, has_cmp)?;
-    ta_sort(vm, &mut right, cmp, has_cmp)?;
+    ta_sort_range(vm, &mut left, cmp, has_cmp, prep)?;
+    ta_sort_range(vm, &mut right, cmp, has_cmp, prep)?;
     let mut i = 0;
     let mut j = 0;
     let mut k = 0;
     while i < left.len() && j < right.len() {
-        let order = ta_compare(vm, &left[i], &right[j], cmp, has_cmp)?;
+        let order = ta_compare(vm, &left[i], &right[j], cmp, has_cmp, prep)?;
         if order <= 0 {
             items[k] = left[i].clone();
             i += 1;
@@ -1716,8 +1733,40 @@ fn ta_sort(vm: &mut Vm, items: &mut Vec<Value>, cmp: &Value, has_cmp: bool) -> R
     Ok(())
 }
 
-fn ta_compare(vm: &mut Vm, a: &Value, b: &Value, cmp: &Value, has_cmp: bool) -> Result<i32, Value> {
+fn ta_compare(
+    vm: &mut Vm,
+    a: &Value,
+    b: &Value,
+    cmp: &Value,
+    has_cmp: bool,
+    prep: &mut Option<crate::exec::PreparedKernel>,
+) -> Result<i32, Value> {
     if has_cmp {
+        // Prepared-kernel comparator (as in Array.prototype.sort's
+        // `compare_values`): unboxed registers, result a Number/Bool by
+        // construction; a per-call guard miss falls through generically.
+        if let Some(p) = prep {
+            if let Some(r) = vm.exec_prepared_kernel(p, &[a.clone(), b.clone()]) {
+                let n = match r? {
+                    Value::Number(n) => n,
+                    Value::Bool(bv) => {
+                        if bv {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    }
+                    _ => unreachable!("fn kernels return Number or Bool"),
+                };
+                return Ok(if n < 0.0 {
+                    -1
+                } else if n > 0.0 {
+                    1
+                } else {
+                    0
+                });
+            }
+        }
         let r = vm.call(cmp.clone(), Value::Undefined, &[a.clone(), b.clone()])?;
         // The comparator result is ToNumber'd even for BigInt arrays; a NaN or
         // ±0 result is treated as 0 (equal).

--- a/crates/chidori-js/src/builtins/typedarray.rs
+++ b/crates/chidori-js/src/builtins/typedarray.rs
@@ -1687,6 +1687,30 @@ fn ta_sort(vm: &mut Vm, items: &mut Vec<Value>, cmp: &Value, has_cmp: bool) -> R
     } else {
         None
     };
+    // All-Number specialization (every non-BigInt element kind): raw-`f64`
+    // merge sort with a primed comparator — the same split/merge structure
+    // as `ta_sort_range`, so results match the generic path exactly. See
+    // `Array.prototype.sort`'s `merge_sort` for the soundness argument.
+    if let Some(p) = prep.as_mut() {
+        if items.iter().all(|v| matches!(v, Value::Number(_))) {
+            if let Some(regs_ab) = vm.prime_prepared_cmp(p) {
+                let mut nums: Vec<f64> = items
+                    .iter()
+                    .map(|v| match v {
+                        Value::Number(n) => *n,
+                        _ => unreachable!("checked all-Number"),
+                    })
+                    .collect();
+                let mut aux: Vec<f64> = Vec::with_capacity(nums.len() / 2 + 1);
+                let n = nums.len();
+                super::array::merge_sort_range_f64(vm, &mut nums, &mut aux, 0, n, p, regs_ab)?;
+                for (slot, n) in items.iter_mut().zip(nums) {
+                    *slot = Value::Number(n);
+                }
+                return Ok(());
+            }
+        }
+    }
     ta_sort_range(vm, items, cmp, has_cmp, &mut prep)
 }
 

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1043,6 +1043,13 @@ pub enum KOp {
         dst: u16,
         bail: u16,
     },
+    /// Pinned-native `Array.prototype.pop` over the dense array in object
+    /// slot `obj`: remove the last element (a non-hole `Number`, else bail —
+    /// an empty array's `undefined` result and a trailing hole's prototype
+    /// consult belong to the generic path) and set `regs[dst]` to it. Entry
+    /// guard as [`KOp::ArrayPush`] (canonical method + receiver resolution,
+    /// `Kernel::uses_array_pop`); the receiver conditions re-check per op.
+    ArrayPop { obj: u16, dst: u16, bail: u16 },
     /// `regs[dst] = <length>` of the dense array in object slot `obj`
     /// (unshadowed only — a reified `length` marker bails).
     LoadLen { dst: u16, obj: u16, bail: u16 },
@@ -1183,6 +1190,8 @@ pub enum KShapeSlot {
     /// proved the live value IS the canonical, so a bail reconstructs it
     /// from the realm — exactly like `MathFn`).
     ArrayPushFn,
+    /// The canonical `Array.prototype.pop`, likewise.
+    ArrayPopFn,
     /// A register statically typed BOOLEAN (holds exactly 0.0/1.0):
     /// materialized as `Value::Bool` — `typeof` must not see a number.
     Bool(u16),
@@ -1331,6 +1340,8 @@ pub struct Kernel {
     /// must verify the canonical `Array.prototype.push` still backs the
     /// `push` property of the canonical Array prototype.
     pub uses_array_push: bool,
+    /// As `uses_array_push`, for [`KOp::ArrayPop`] / `pop`.
+    pub uses_array_pop: bool,
     /// The original loop-header op this kernel replaced; executed verbatim
     /// when the guard declines.
     pub fallback: Box<Op>,

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1029,6 +1029,20 @@ pub enum KOp {
         val: u16,
         bail: u16,
     },
+    /// Pinned-native `Array.prototype.push` over the dense array in object
+    /// slot `obj`: append `Value::Number(regs[val])` and set `regs[dst]` to
+    /// the new length. The activation entry verified the canonical `push`
+    /// still resolves (`Kernel::uses_array_push`) and — via the
+    /// `stores_elems` chain guard — that no prototype can intercept element
+    /// creation; the op re-checks the receiver per push (unshadowed `props`
+    /// empty, extensible, direct proto IS the canonical Array.prototype,
+    /// dense bound) and bails to the generic `Call` otherwise.
+    ArrayPush {
+        obj: u16,
+        val: u16,
+        dst: u16,
+        bail: u16,
+    },
     /// `regs[dst] = <length>` of the dense array in object slot `obj`
     /// (unshadowed only — a reified `length` marker bails).
     LoadLen { dst: u16, obj: u16, bail: u16 },
@@ -1165,6 +1179,10 @@ pub struct KCallee {
 #[derive(Clone, Copy, Debug)]
 pub enum KShapeSlot {
     Num(u16),
+    /// The canonical `Array.prototype.push` function object (the entry guard
+    /// proved the live value IS the canonical, so a bail reconstructs it
+    /// from the realm — exactly like `MathFn`).
+    ArrayPushFn,
     /// A register statically typed BOOLEAN (holds exactly 0.0/1.0):
     /// materialized as `Value::Bool` — `typeof` must not see a number.
     Bool(u16),
@@ -1309,6 +1327,10 @@ pub struct Kernel {
     /// reified index entry (`protos_allow_any_index_create`). Read-only
     /// loops skip that walk entirely.
     pub stores_elems: bool,
+    /// Whether the code contains a [`KOp::ArrayPush`]: the activation entry
+    /// must verify the canonical `Array.prototype.push` still backs the
+    /// `push` property of the canonical Array prototype.
+    pub uses_array_push: bool,
     /// The original loop-header op this kernel replaced; executed verbatim
     /// when the guard declines.
     pub fallback: Box<Op>,

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1126,12 +1126,19 @@ pub enum KSlot {
 
 /// One named-property access class in a kernel (`o.a` / `o.a = v` sites over
 /// the pinned base object in oslot `oslot`): resolved ONCE per kernel
-/// activation to a raw property-map slot index. The entry check requires an
+/// activation to a raw property-map slot index AND LOCALIZED into a
+/// dedicated register at the tail of the register file — the entry loads
+/// the slot's current value, the build pass rewrote every in-region access
+/// into a register `Mov` (then propagated/deleted by the cleanup pass), and
+/// `store`-class registers are written back to the slot on every exit /
+/// bail / interrupt unwind. The entry check requires an
 /// [`crate::value::Internal::Ordinary`] receiver whose OWN data property
-/// `key` exists — holding a `Number` when `load` (reads must produce what
-/// the guard typed), writable when `store` — and declines the activation
-/// otherwise. Slot indices are stable for the activation because kernel
-/// regions contain no calls and no property creation/deletion.
+/// `key` exists, holds a `Number` (the register must carry the current
+/// value even for a store-only class, so a conditionally skipped store
+/// writes the original back), is writable when `store`, and does not alias
+/// another class's (object, slot) — declining the activation otherwise.
+/// Slot indices are stable for the activation because kernel regions
+/// contain no calls and no property creation/deletion.
 #[derive(Clone, Debug)]
 pub struct KProp {
     pub oslot: u16,

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1271,6 +1271,13 @@ pub struct Kernel {
     /// accessor'd name declines the kernel and the call runs generically.
     /// `None` for loop kernels and non-recursive function kernels.
     pub self_global: Option<Box<str>>,
+    /// Whether the code contains a [`KOp::StoreElem`]. A store may CREATE an
+    /// element (hole fill / exact append), and the spec's OrdinarySet
+    /// consults the prototype chain when the own property is absent — so the
+    /// activation entry guard must verify the array bases' chains carry no
+    /// reified index entry (`protos_allow_any_index_create`). Read-only
+    /// loops skip that walk entirely.
+    pub stores_elems: bool,
     /// The original loop-header op this kernel replaced; executed verbatim
     /// when the guard declines.
     pub fallback: Box<Op>,

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -961,6 +961,30 @@ pub enum KOp {
     Neg { dst: u16, src: u16 },
     /// `regs[dst] = ~ToInt32(regs[src])`
     BitNot { dst: u16, src: u16 },
+    /// SUPERINSTRUCTION (translation-time fusion of two adjacent ops; see
+    /// `fuse_kops`): two `Mov`s executed sequentially in one dispatch. The
+    /// unfused second op stays in the next code slot as a branch-target
+    /// landing pad; a fused arm skips it (`pc += 2`).
+    Mov2 { d1: u16, s1: u16, d2: u16, s2: u16 },
+    /// SUPERINSTRUCTION: `Arith` followed by `Add`, sequentially — the
+    /// `s += a <op> b` accumulation shape.
+    ArithAdd {
+        kind: crate::exec::ArithKind,
+        dst: u16,
+        a: u16,
+        b: u16,
+        d2: u16,
+        a2: u16,
+        b2: u16,
+    },
+    /// SUPERINSTRUCTION: `AddK` followed by an unconditional `Br` — the
+    /// `i += 1; continue` loop back-edge (same poll cadence as the `Br`).
+    AddKBr {
+        dst: u16,
+        a: u16,
+        k: f64,
+        target: u16,
+    },
     /// unconditional jump
     Br { target: u16 },
     /// numeric compare-and-branch: jump when `cmp(a, b) == if_true`

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -448,6 +448,22 @@ impl Vm {
                 return self.step(frame, &k.fallback);
             }
         }
+        // A `StoreElem` may CREATE an element (hole fill / exact append), and
+        // the spec's OrdinarySet consults the prototype chain when the own
+        // property is absent — so a chain carrying a reified index entry (a
+        // defineProperty'd accessor / non-writable index) or an exotic proto
+        // must intercept via the generic path. One entry check covers the
+        // whole activation: nothing inside a kernel region can run user code
+        // or restructure a property map. Read-only loops skip the walk.
+        if k.stores_elems {
+            for &l in k.oslots.iter() {
+                if let Value::Object(o) = &frame.locals[l as usize] {
+                    if !crate::value::protos_allow_any_index_create(o) {
+                        return self.step(frame, &k.fallback);
+                    }
+                }
+            }
+        }
         // Math intrinsics: the global `Math` binding must still be the
         // canonical object as a plain DATA property (an accessor or a
         // replacement would be observable), and each used method must still
@@ -1331,6 +1347,19 @@ impl Vm {
                 },
             }
         }
+        // Poll the cooperative interrupt flag per CALL as well as on kernel
+        // back-edges: a tiny comparator body has no back-edge, and the native
+        // merge loop between calls never ticks — without this, a hostile
+        // n·log n sort would be uninterruptible.
+        p.poll = p.poll.wrapping_add(1);
+        if p.poll & 0xFF == 0 {
+            if let Some(flag) = &p.interrupt {
+                if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                    self.op_budget = Some(0);
+                    return Some(Err(self.throw_range("execution interrupted")));
+                }
+            }
+        }
         match exec_fn_kernel_code(&k.code, &mut p.regs, &p.interrupt, &mut p.poll) {
             Some(v) => Some(Ok(v)),
             None => {
@@ -1338,6 +1367,97 @@ impl Vm {
                 // zero the budget so a JS catch cannot resume execution.
                 self.op_budget = Some(0);
                 Some(Err(self.throw_range("execution interrupted")))
+            }
+        }
+    }
+
+    /// Verify the guards `exec_prepared_kernel` re-checks per call — no op
+    /// accounting, canonical `Math`, all-`Number` upvalues (pre-loaded into
+    /// the registers here) — ONCE, for a run during which no user code can
+    /// execute between calls: the all-Number sort specialization, where
+    /// every value fed to the comparator is a raw `f64` and everything
+    /// between two comparator calls is engine Rust + the pure kernel, so
+    /// nothing can patch `Math`, write a captured cell, or install a budget
+    /// mid-run. Returns the register indices of the two comparator
+    /// parameters (`None` for a parameter the body never consumes); `None`
+    /// overall declines the specialization.
+    pub(crate) fn prime_prepared_cmp(
+        &self,
+        p: &mut PreparedKernel,
+    ) -> Option<(Option<usize>, Option<usize>)> {
+        if self.op_budget.is_some() {
+            return None;
+        }
+        let k = p.bf.proto.fn_kernel.as_ref().expect("prepared");
+        if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
+            return None;
+        }
+        let mut ra = None;
+        let mut rb = None;
+        for (r, slot) in k.locals.iter().enumerate() {
+            match slot {
+                crate::bytecode::KSlot::Arg(0) => ra = Some(r),
+                crate::bytecode::KSlot::Arg(1) => rb = Some(r),
+                // Consumes a third argument the comparator is never given.
+                crate::bytecode::KSlot::Arg(_) => return None,
+                crate::bytecode::KSlot::Local(_) => {}
+                crate::bytecode::KSlot::Upvalue(u) => match &*p.bf.upvalues[*u as usize].borrow() {
+                    Value::Number(n) => p.regs[r] = *n,
+                    _ => return None,
+                },
+            }
+        }
+        Some((ra, rb))
+    }
+
+    /// One primed comparator call over raw `f64`s (see
+    /// [`Vm::prime_prepared_cmp`]): write the two parameter registers, run
+    /// the kernel, fold the `Number`/`Bool` result to the sort's -1/0/1
+    /// (NaN → 0, as SortCompare's ToNumber+comparison does). The per-call
+    /// interrupt poll stands in for the native merge loop, which never
+    /// ticks.
+    pub(crate) fn exec_prepared_cmp_f64(
+        &mut self,
+        p: &mut PreparedKernel,
+        regs_ab: (Option<usize>, Option<usize>),
+        x: f64,
+        y: f64,
+    ) -> Result<i32, Value> {
+        if let Some(r) = regs_ab.0 {
+            p.regs[r] = x;
+        }
+        if let Some(r) = regs_ab.1 {
+            p.regs[r] = y;
+        }
+        p.poll = p.poll.wrapping_add(1);
+        let interrupted = if p.poll & 0xFF == 0 {
+            if let Some(flag) = &p.interrupt {
+                flag.load(std::sync::atomic::Ordering::Relaxed)
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        let k = p.bf.proto.fn_kernel.as_ref().expect("prepared");
+        let ret = if interrupted {
+            None
+        } else {
+            exec_fn_kernel_code(&k.code, &mut p.regs, &p.interrupt, &mut p.poll)
+        };
+        match ret {
+            Some(Value::Number(n)) => Ok(if n < 0.0 {
+                -1
+            } else if n > 0.0 {
+                1
+            } else {
+                0
+            }),
+            Some(Value::Bool(b)) => Ok(if b { 1 } else { 0 }),
+            Some(_) => unreachable!("fn kernels return Number or Bool"),
+            None => {
+                self.op_budget = Some(0);
+                Err(self.throw_range("execution interrupted"))
             }
         }
     }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -473,13 +473,22 @@ impl Vm {
             return self.step(frame, &k.fallback);
         }
         // Named-property access classes resolve ONCE per activation to raw
-        // slot indices (see `KProp`): each base must be an ORDINARY object
-        // whose own data property exists — a Number where loaded, writable
-        // where stored. Slots stay valid for the whole activation because
-        // nothing inside a kernel region can create/delete properties or run
-        // user code; in-kernel `StoreProp` only overwrites values in place.
+        // slot indices (see `KProp`) — and, since prop LOCALIZATION, to a
+        // dedicated REGISTER each: the entry loads every slot's current
+        // value below, the build pass rewrote the in-region accesses to
+        // register Movs, and store-class registers are written back to the
+        // slots on every exit/bail/interrupt unwind. Each base must be an
+        // ORDINARY object whose own data property exists, holds a Number
+        // (the register must carry the CURRENT value even for a store-only
+        // class — a conditionally skipped store writes the original back),
+        // and is writable where stored. Slots stay valid for the whole
+        // activation because nothing inside a kernel region can
+        // create/delete properties or run user code. Two classes resolving
+        // to the SAME (object, slot) — aliased bases — would split one
+        // property across two registers, so they decline.
         let mut prop_slots = std::mem::take(&mut self.kernel_prop_slots);
         prop_slots.clear();
+        let mut prop_ids: Vec<(usize, u32)> = Vec::with_capacity(k.props_used.len());
         for p in k.props_used.iter() {
             let mut ok = false;
             if let Value::Object(o) = &frame.locals[k.oslots[p.oslot as usize] as usize] {
@@ -494,10 +503,13 @@ impl Vm {
                         },
                     )) = b.props.get_full(&PropertyKey::str(&p.key))
                     {
-                        if (!p.load || matches!(value, Value::Number(_))) && (!p.store || *writable)
-                        {
-                            prop_slots.push(idx as u32);
-                            ok = true;
+                        if matches!(value, Value::Number(_)) && (!p.store || *writable) {
+                            let id = (o.ptr_id(), idx as u32);
+                            if !prop_ids.contains(&id) {
+                                prop_ids.push(id);
+                                prop_slots.push(idx as u32);
+                                ok = true;
+                            }
                         }
                     }
                 }
@@ -537,6 +549,28 @@ impl Vm {
         for &l in k.oslots.iter() {
             if let Value::Object(o) = &frame.locals[l as usize] {
                 objs.push(o.clone());
+            }
+        }
+        // Prop registers (the tail of the register file): load each resolved
+        // slot's current value. The guard above proved every one a Number.
+        if !k.props_used.is_empty() {
+            let prop_base = k.n_regs as usize - k.props_used.len();
+            for (i, p) in k.props_used.iter().enumerate() {
+                let b = objs[p.oslot as usize].borrow();
+                match b.props.get_index(prop_slots[i] as usize) {
+                    Some((
+                        _,
+                        Property {
+                            kind:
+                                PropertyKind::Data {
+                                    value: Value::Number(n),
+                                    ..
+                                },
+                            ..
+                        },
+                    )) => regs[prop_base + i] = *n,
+                    _ => unreachable!("kernel prop slot invariant"),
+                }
             }
         }
         // Pinned closure callees (`KOp::CallKernel`): ONE guard per
@@ -650,6 +684,7 @@ impl Vm {
                                         frame.locals[l as usize] =
                                             Value::Bool(regs[bool_base + j] != 0.0);
                                     }
+                                    writeback_kernel_props(k, &objs, &prop_slots, &regs);
                                     self.kernel_regs = regs;
                                     objs.clear();
                                     self.kernel_objs = objs;
@@ -828,40 +863,11 @@ impl Vm {
                         branch!(bail)
                     }
                 }
-                // Entry-resolved named property access: raw slot, no check —
-                // the activation invariant (no map restructuring inside a
-                // kernel) keeps the slot AND its Number-ness valid.
-                KOp::LoadProp { dst, prop } => {
-                    let p = &k.props_used[prop as usize];
-                    let b = objs[p.oslot as usize].borrow();
-                    match b.props.get_index(prop_slots[prop as usize] as usize) {
-                        Some((
-                            _,
-                            Property {
-                                kind:
-                                    PropertyKind::Data {
-                                        value: Value::Number(n),
-                                        ..
-                                    },
-                                ..
-                            },
-                        )) => regs[dst as usize] = *n,
-                        _ => unreachable!("kernel prop slot invariant"),
-                    }
-                }
-                KOp::StoreProp { prop, src } => {
-                    let p = &k.props_used[prop as usize];
-                    let mut b = objs[p.oslot as usize].borrow_mut();
-                    match b.props.get_index_mut(prop_slots[prop as usize] as usize) {
-                        Some((
-                            _,
-                            Property {
-                                kind: PropertyKind::Data { value, .. },
-                                ..
-                            },
-                        )) => *value = Value::Number(regs[src as usize]),
-                        _ => unreachable!("kernel prop slot invariant"),
-                    }
+                // Prop LOCALIZATION rewrote every LoadProp/StoreProp into a
+                // register Mov at kernel build; the slots live only in the
+                // entry load and the exit/unwind write-back now.
+                KOp::LoadProp { .. } | KOp::StoreProp { .. } => {
+                    unreachable!("prop op survived kernel build")
                 }
                 KOp::Mov2 { d1, s1, d2, s2 } => {
                     regs[d1 as usize] = regs[s1 as usize];
@@ -914,6 +920,7 @@ impl Vm {
                         for (j, &l) in k.bool_locals.iter().enumerate() {
                             frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
                         }
+                        writeback_kernel_props(k, &objs, &prop_slots, &regs);
                         self.kernel_regs = regs;
                         objs.clear();
                         self.kernel_objs = objs;
@@ -945,6 +952,7 @@ impl Vm {
         for (j, &l) in k.bool_locals.iter().enumerate() {
             frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
         }
+        writeback_kernel_props(k, &objs, &prop_slots, &regs);
         for slot in k.shapes[shape as usize].iter() {
             match slot {
                 crate::bytecode::KShapeSlot::Num(r) => {
@@ -5445,6 +5453,40 @@ fn bin_arith(vm: &mut Vm, frame: &mut Frame, kind: ArithKind) -> Result<(), Valu
 /// `false` when the cooperative interrupt fired on a callee back-edge — the
 /// caller then unwinds exactly like one of its own interrupted edges.
 #[inline(never)]
+/// Write the STORE-class prop registers back to their entry-resolved
+/// property slots — the activation-exit half of kernel prop localization
+/// (the entry half loads every slot into the register file's tail). Runs on
+/// every path that leaves the register world: normal exits, bails (which
+/// route through an Exit), and interrupt unwinds. Load-only classes never
+/// change, so their slots are left untouched.
+fn writeback_kernel_props(
+    k: &crate::bytecode::Kernel,
+    objs: &[JsObject],
+    prop_slots: &[u32],
+    regs: &[f64],
+) {
+    if k.props_used.is_empty() {
+        return;
+    }
+    let prop_base = k.n_regs as usize - k.props_used.len();
+    for (i, p) in k.props_used.iter().enumerate() {
+        if !p.store {
+            continue;
+        }
+        let mut b = objs[p.oslot as usize].borrow_mut();
+        match b.props.get_index_mut(prop_slots[i] as usize) {
+            Some((
+                _,
+                Property {
+                    kind: PropertyKind::Data { value, .. },
+                    ..
+                },
+            )) => *value = Value::Number(regs[prop_base + i]),
+            _ => unreachable!("kernel prop slot invariant"),
+        }
+    }
+}
+
 /// Execute a plain (non-recursive, frameless) FUNCTION kernel body over
 /// `regs`, returning the call's result — `Value::Number`, or `Value::Bool`
 /// for a boolean-typed `Ret`. Shared by the per-call [`Vm::run_fn_kernel`]

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -377,18 +377,19 @@ impl Vm {
         })
     }
 
-    /// Entry check for kernels containing [`KOp::ArrayPush`]: the canonical
-    /// Array prototype's `push` property must still be a plain DATA property
-    /// holding the pinned canonical function (methods are writable). The
-    /// receiver-side conditions (unshadowed, extensible, direct proto IS the
-    /// canonical prototype) re-check per push; the element-creation chain
-    /// walk is the `stores_elems` entry guard.
-    fn kernel_array_push_ok(&self) -> bool {
-        let Some(canon) = &self.realm.array_push else {
+    /// Entry check for kernels containing [`KOp::ArrayPush`]/[`KOp::ArrayPop`]:
+    /// the canonical Array prototype's method property must still be a plain
+    /// DATA property holding the pinned canonical function (methods are
+    /// writable). The receiver-side conditions (unshadowed, extensible,
+    /// direct proto IS the canonical prototype) are entry-checked per
+    /// receiver and re-checked per op; the element-creation chain walk is
+    /// the `stores_elems` entry guard.
+    fn kernel_array_method_ok(&self, name: &str, canon: &Option<JsObject>) -> bool {
+        let Some(canon) = canon else {
             return false;
         };
         matches!(
-            self.realm.array_proto.borrow().props.get(&PropertyKey::str("push")),
+            self.realm.array_proto.borrow().props.get(&PropertyKey::str(name)),
             Some(Property {
                 kind: PropertyKind::Data { value: Value::Object(o), .. },
                 ..
@@ -501,27 +502,35 @@ impl Vm {
         // materialize the canonical method object into a resumed operand
         // stack (`KShapeSlot::ArrayPushFn`). A shadowed/patched/re-proto'd
         // receiver declines here and the generic loop owns it.
-        if k.uses_array_push {
-            if !self.kernel_array_push_ok() {
+        if k.uses_array_push || k.uses_array_pop {
+            if k.uses_array_push
+                && !self.kernel_array_method_ok("push", &self.realm.array_push.clone())
+            {
+                return self.step(frame, &k.fallback);
+            }
+            if k.uses_array_pop
+                && !self.kernel_array_method_ok("pop", &self.realm.array_pop.clone())
+            {
                 return self.step(frame, &k.fallback);
             }
             for op in k.code.iter() {
-                if let KOp::ArrayPush { obj, .. } = op {
-                    let ok =
-                        if let Value::Object(o) = &frame.locals[k.oslots[*obj as usize] as usize] {
-                            let b = o.borrow();
-                            matches!(b.internal, Internal::Array(_))
-                                && b.props.is_empty()
-                                && b.extensible
-                                && b.proto
-                                    .as_ref()
-                                    .is_some_and(|p| p.ptr_eq(&self.realm.array_proto))
-                        } else {
-                            false
-                        };
-                    if !ok {
-                        return self.step(frame, &k.fallback);
-                    }
+                let obj = match op {
+                    KOp::ArrayPush { obj, .. } | KOp::ArrayPop { obj, .. } => *obj,
+                    _ => continue,
+                };
+                let ok = if let Value::Object(o) = &frame.locals[k.oslots[obj as usize] as usize] {
+                    let b = o.borrow();
+                    matches!(b.internal, Internal::Array(_))
+                        && b.props.is_empty()
+                        && b.extensible
+                        && b.proto
+                            .as_ref()
+                            .is_some_and(|p| p.ptr_eq(&self.realm.array_proto))
+                } else {
+                    false
+                };
+                if !ok {
+                    return self.step(frame, &k.fallback);
                 }
             }
         }
@@ -861,6 +870,28 @@ impl Vm {
                         branch!(bail)
                     }
                 }
+                // Pinned-native pop: remove + yield the last element when it
+                // is a plain Number. An empty array (undefined result), a
+                // trailing hole (prototype consult), or a non-Number element
+                // re-runs the generic Call via the bail.
+                KOp::ArrayPop { obj, dst, bail } => {
+                    let mut ok = false;
+                    {
+                        let mut b = objs[obj as usize].borrow_mut();
+                        if b.props.is_empty() && b.extensible {
+                            if let Internal::Array(arr) = &mut b.internal {
+                                if let Some(Value::Number(n)) = arr.last() {
+                                    regs[dst as usize] = *n;
+                                    arr.pop();
+                                    ok = true;
+                                }
+                            }
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                }
                 // Dense element write: in-place overwrite (exactly the
                 // `Op::SetPropDynamic` fast-path conditions), an in-bounds
                 // HOLE fill, or an exact one-past-the-end APPEND. Filling and
@@ -1060,6 +1091,9 @@ impl Vm {
                 )),
                 crate::bytecode::KShapeSlot::ArrayPushFn => frame.stack.push(Value::Object(
                     self.realm.array_push.clone().expect("guarded"),
+                )),
+                crate::bytecode::KShapeSlot::ArrayPopFn => frame.stack.push(Value::Object(
+                    self.realm.array_pop.clone().expect("guarded"),
                 )),
             }
         }
@@ -1390,6 +1424,7 @@ impl Vm {
                     }
                 }
                 KOp::ArrayPush { .. }
+                | KOp::ArrayPop { .. }
                 | KOp::LoadElem { .. }
                 | KOp::StoreElem { .. }
                 | KOp::LoadLen { .. }
@@ -5710,6 +5745,7 @@ fn exec_fn_kernel_code(
             // fn-mode translation rejects anything needing one. A
             // SelfCall implies `self_global`, dispatched by the caller.
             KOp::ArrayPush { .. }
+            | KOp::ArrayPop { .. }
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
@@ -5855,6 +5891,7 @@ fn run_callee_window(
             // Impossible in a guarded callee: no bails, no exits, no
             // recursion, no nested closure calls.
             KOp::ArrayPush { .. }
+            | KOp::ArrayPop { .. }
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -27,6 +27,19 @@ fn peek_plain_bytecode(v: &Value) -> Option<Rc<BytecodeFunction>> {
     None
 }
 
+/// A callback prepared once per native higher-order invocation — the
+/// invocation-invariant slice of the `run_fn_kernel` entry guard plus the
+/// register buffer, hoisted out of the per-element call. Built by
+/// [`Vm::prepare_kernel_callback`], executed by [`Vm::exec_prepared_kernel`].
+pub(crate) struct PreparedKernel {
+    bf: Rc<BytecodeFunction>,
+    /// Kernel register file, allocated once for the whole invocation.
+    regs: Vec<f64>,
+    /// Back-edge interrupt poll counter (cadence spans calls).
+    poll: u32,
+    interrupt: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+}
+
 /// Control-flow signal from a single opcode step.
 enum Ctl {
     Next,
@@ -975,122 +988,19 @@ impl Vm {
         }
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
-        let code = &k.code;
-        let mut pc = 0usize;
-        let ret = loop {
-            // Back-edges poll the cooperative interrupt flag, as in
-            // `run_kernel_op`; registers are pure scratch, nothing to write
-            // back on the unwind.
-            macro_rules! branch {
-                ($t:expr) => {{
-                    let t = $t as usize;
-                    if t <= pc {
-                        poll = poll.wrapping_add(1);
-                        if poll & 0xFF == 0 {
-                            if let Some(flag) = &interrupt {
-                                if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                                    self.kernel_regs = regs;
-                                    self.op_budget = Some(0);
-                                    return Some(Err(self.throw_range("execution interrupted")));
-                                }
-                            }
-                        }
-                    }
-                    pc = t;
-                    continue;
-                }};
+        match exec_fn_kernel_code(&k.code, &mut regs, &interrupt, &mut poll) {
+            Some(ret) => {
+                self.kernel_regs = regs;
+                Some(Ok(ret))
             }
-            match code[pc] {
-                KOp::Mov { dst, src } => regs[dst as usize] = regs[src as usize],
-                KOp::Const { dst, k } => regs[dst as usize] = k,
-                KOp::Add { dst, a, b } => regs[dst as usize] = regs[a as usize] + regs[b as usize],
-                KOp::AddK { dst, a, k } => regs[dst as usize] = regs[a as usize] + k,
-                KOp::Arith { kind, dst, a, b } => {
-                    regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind)
-                }
-                KOp::ArithK { kind, dst, a, k } => {
-                    regs[dst as usize] = number_arith_raw(regs[a as usize], k, kind)
-                }
-                KOp::Neg { dst, src } => regs[dst as usize] = -regs[src as usize],
-                KOp::BitNot { dst, src } => {
-                    regs[dst as usize] = !crate::vm::to_int32(regs[src as usize]) as f64
-                }
-                KOp::Br { target } => branch!(target),
-                KOp::BrCmp {
-                    cmp,
-                    a,
-                    b,
-                    if_true,
-                    target,
-                } => {
-                    if knum_cmp(cmp, regs[a as usize], regs[b as usize]) == if_true {
-                        branch!(target)
-                    }
-                }
-                KOp::BrCmpK {
-                    cmp,
-                    a,
-                    k,
-                    if_true,
-                    target,
-                } => {
-                    if knum_cmp(cmp, regs[a as usize], k) == if_true {
-                        branch!(target)
-                    }
-                }
-                KOp::BrFalsy { src, target } => {
-                    if !knum_truthy(regs[src as usize]) {
-                        branch!(target)
-                    }
-                }
-                KOp::BrTruthy { src, target } => {
-                    if knum_truthy(regs[src as usize]) {
-                        branch!(target)
-                    }
-                }
-                KOp::CmpSet { cmp, dst, a, b } => {
-                    regs[dst as usize] = if knum_cmp(cmp, regs[a as usize], regs[b as usize]) {
-                        1.0
-                    } else {
-                        0.0
-                    }
-                }
-                KOp::BoolNot { dst, src } => {
-                    regs[dst as usize] = if knum_truthy(regs[src as usize]) {
-                        0.0
-                    } else {
-                        1.0
-                    }
-                }
-                KOp::Math1 { kind, dst, src } => {
-                    regs[dst as usize] = kmath1(kind, regs[src as usize])
-                }
-                KOp::Math2 { kind, dst, a, b } => {
-                    regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
-                }
-                KOp::Ret { src, boolean } => {
-                    break if boolean {
-                        Value::Bool(regs[src as usize] != 0.0)
-                    } else {
-                        Value::Number(regs[src as usize])
-                    }
-                }
-                // A frameless kernel has no bytecode frame to bail into;
-                // fn-mode translation rejects anything needing one. A
-                // SelfCall implies `self_global`, dispatched above.
-                KOp::LoadElem { .. }
-                | KOp::StoreElem { .. }
-                | KOp::LoadLen { .. }
-                | KOp::LoadProp { .. }
-                | KOp::StoreProp { .. }
-                | KOp::Exit { .. }
-                | KOp::CallKernel { .. }
-                | KOp::SelfCall { .. } => unreachable!("bail op in a function kernel"),
+            None => {
+                // Interrupted on a back-edge: registers are pure scratch,
+                // nothing to write back on the unwind.
+                self.kernel_regs = regs;
+                self.op_budget = Some(0);
+                Some(Err(self.throw_range("execution interrupted")))
             }
-            pc += 1;
-        };
-        self.kernel_regs = regs;
-        Some(Ok(ret))
+        }
     }
 
     /// The WINDOWED executor for self-recursive function kernels
@@ -1330,6 +1240,106 @@ impl Vm {
         };
         self.kernel_regs = regs;
         Some(Ok(ret))
+    }
+
+    /// Prepare a callback for REPEATED calls from a native higher-order
+    /// builtin (sort's comparator, map/filter/reduce/... callbacks): the
+    /// invocation-invariant parts of the `run_fn_kernel` entry — callee
+    /// resolution to a plain bytecode function with a non-recursive function
+    /// kernel, the trace/accounting/depth checks, the register allocation —
+    /// run ONCE here instead of on every element. `None` means the callback
+    /// has no usable kernel; the caller just uses `Vm::call` per element,
+    /// exactly as before.
+    ///
+    /// The prepared calls all happen at the builtin's (constant) call depth,
+    /// so a single depth check mirrors the per-call guard — the same
+    /// argument as the loop-kernel pinned-callee path. Tracing and per-op
+    /// accounting are host-controlled (no JS between two prepared calls can
+    /// enable them), so they too are entry checks; everything user code CAN
+    /// change between elements is re-checked per call in
+    /// [`Vm::exec_prepared_kernel`].
+    pub(crate) fn prepare_kernel_callback(&mut self, func: &Value) -> Option<PreparedKernel> {
+        let Value::Object(o) = func else { return None };
+        let bf = {
+            let b = o.borrow();
+            match &b.internal {
+                Internal::Function(FunctionInner::Bytecode(bf)) if !bf.is_class_ctor => bf.clone(),
+                _ => return None,
+            }
+        };
+        let kind = bf.proto.kind;
+        if kind.is_generator() || kind.is_async() {
+            return None;
+        }
+        {
+            let k = bf.proto.fn_kernel.as_ref()?;
+            if k.self_global.is_some() {
+                return None;
+            }
+        }
+        if self.op_budget.is_some() || self.trace_sink.is_some() {
+            return None;
+        }
+        if self.call_depth + 1 > self.max_call_depth {
+            return None;
+        }
+        let n_regs = bf.proto.fn_kernel.as_ref().expect("checked").n_regs as usize;
+        Some(PreparedKernel {
+            regs: vec![0.0; n_regs],
+            poll: 0,
+            interrupt: self.interrupt.clone(),
+            bf,
+        })
+    }
+
+    /// One prepared call (see [`Vm::prepare_kernel_callback`]). `None` = a
+    /// per-call guard failed — a non-`Number` argument or upvalue, per-op
+    /// accounting installed, a non-canonical `Math` — and the caller falls
+    /// back to the generic `Vm::call` for THIS element (keeping the handle
+    /// for the next). `Some` is the call's exact result, bit-identical to
+    /// the generic path by the `run_fn_kernel` argument.
+    ///
+    /// Math and upvalues are re-checked/re-read on EVERY call, unlike inside
+    /// a single kernel activation: user code can run between two prepared
+    /// calls (an element's getter or `valueOf` on the generic fallback path)
+    /// and patch `Math` or write a captured cell.
+    pub(crate) fn exec_prepared_kernel(
+        &mut self,
+        p: &mut PreparedKernel,
+        args: &[Value],
+    ) -> Option<Result<Value, Value>> {
+        if self.op_budget.is_some() {
+            return None;
+        }
+        let k = p.bf.proto.fn_kernel.as_ref().expect("prepared");
+        if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
+            return None;
+        }
+        for (r, slot) in k.locals.iter().enumerate() {
+            match slot {
+                crate::bytecode::KSlot::Arg(a) => match args.get(*a as usize) {
+                    Some(Value::Number(n)) => p.regs[r] = *n,
+                    _ => return None,
+                },
+                // Register scratch: translation proved a store dominates
+                // every read, so a stale value from the previous call is
+                // never observable.
+                crate::bytecode::KSlot::Local(_) => {}
+                crate::bytecode::KSlot::Upvalue(u) => match &*p.bf.upvalues[*u as usize].borrow() {
+                    Value::Number(n) => p.regs[r] = *n,
+                    _ => return None,
+                },
+            }
+        }
+        match exec_fn_kernel_code(&k.code, &mut p.regs, &p.interrupt, &mut p.poll) {
+            Some(v) => Some(Ok(v)),
+            None => {
+                // Same latch-and-unwind as an interrupted kernel back-edge:
+                // zero the budget so a JS catch cannot resume execution.
+                self.op_budget = Some(0);
+                Some(Err(self.throw_range("execution interrupted")))
+            }
+        }
     }
 
     fn describe(&self, v: &Value) -> String {
@@ -2865,24 +2875,55 @@ impl Vm {
                 let key_v = pop!();
                 let obj = pop!();
                 // Integer fast path mirroring `GetPropDynamic`: overwrite an
-                // EXISTING dense element in place. An in-bounds non-hole dense
-                // slot is a plain writable data property (per the array exotic
-                // [[Set]]), so no setter, no length change, and no
-                // extensibility interaction is observable. Appends, holes,
-                // out-of-bounds, and shadowed elements take the spec path.
+                // EXISTING dense element in place (an in-bounds non-hole dense
+                // slot is a plain writable data property per the array exotic
+                // [[Set]] — no setter, no length change, no extensibility
+                // interaction), fill an in-bounds HOLE, or append at exactly
+                // `length` — the same conditions as the kernel `StoreElem`
+                // fast path. Filling and appending CREATE a property, so they
+                // additionally require the array to be extensible (a sealed/
+                // prevented receiver must reject through the generic path)
+                // and to stay under the dense-storage bound (the generic path
+                // owns that RangeError). Gaps past the end, shadowed elements,
+                // and non-arrays take the spec path.
                 if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
                     if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
                         let mut b = o.borrow_mut();
                         if b.props.is_empty() {
+                            let extensible = b.extensible;
                             if let Internal::Array(arr) = &mut b.internal {
                                 let i = *n as usize;
-                                if let Some(slot) = arr.get_mut(i) {
-                                    if !matches!(slot, Value::Hole) {
+                                let ok = match arr.get_mut(i) {
+                                    Some(slot) if !matches!(slot, Value::Hole) => {
                                         *slot = value.clone();
-                                        drop(b);
-                                        push!(value);
-                                        return Ok(Ctl::Next);
+                                        true
                                     }
+                                    Some(slot) => {
+                                        // In-bounds hole: creation.
+                                        if extensible {
+                                            *slot = value.clone();
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                    None => {
+                                        // Exact append (no hole gap).
+                                        if extensible
+                                            && i == arr.len()
+                                            && i < crate::value::MAX_DENSE_ARRAY
+                                        {
+                                            arr.push(value.clone());
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                };
+                                if ok {
+                                    drop(b);
+                                    push!(value);
+                                    return Ok(Ctl::Next);
                                 }
                             }
                         }
@@ -5225,6 +5266,126 @@ fn bin_arith(vm: &mut Vm, frame: &mut Frame, kind: ArithKind) -> Result<(), Valu
 /// `false` when the cooperative interrupt fired on a callee back-edge — the
 /// caller then unwinds exactly like one of its own interrupted edges.
 #[inline(never)]
+/// Execute a plain (non-recursive, frameless) FUNCTION kernel body over
+/// `regs`, returning the call's result — `Value::Number`, or `Value::Bool`
+/// for a boolean-typed `Ret`. Shared by the per-call [`Vm::run_fn_kernel`]
+/// entry and the prepared-callback path ([`Vm::exec_prepared_kernel`]).
+/// Returns `None` when the cooperative interrupt flag latched on a back-edge
+/// poll — the caller owns the budget-zeroing unwind.
+fn exec_fn_kernel_code(
+    code: &[KOp],
+    regs: &mut [f64],
+    interrupt: &Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    poll: &mut u32,
+) -> Option<Value> {
+    let mut pc = 0usize;
+    loop {
+        macro_rules! branch {
+            ($t:expr) => {{
+                let t = $t as usize;
+                if t <= pc {
+                    *poll = poll.wrapping_add(1);
+                    if *poll & 0xFF == 0 {
+                        if let Some(flag) = interrupt {
+                            if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                return None;
+                            }
+                        }
+                    }
+                }
+                pc = t;
+                continue;
+            }};
+        }
+        match code[pc] {
+            KOp::Mov { dst, src } => regs[dst as usize] = regs[src as usize],
+            KOp::Const { dst, k } => regs[dst as usize] = k,
+            KOp::Add { dst, a, b } => regs[dst as usize] = regs[a as usize] + regs[b as usize],
+            KOp::AddK { dst, a, k } => regs[dst as usize] = regs[a as usize] + k,
+            KOp::Arith { kind, dst, a, b } => {
+                regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind)
+            }
+            KOp::ArithK { kind, dst, a, k } => {
+                regs[dst as usize] = number_arith_raw(regs[a as usize], k, kind)
+            }
+            KOp::Neg { dst, src } => regs[dst as usize] = -regs[src as usize],
+            KOp::BitNot { dst, src } => {
+                regs[dst as usize] = !crate::vm::to_int32(regs[src as usize]) as f64
+            }
+            KOp::Br { target } => branch!(target),
+            KOp::BrCmp {
+                cmp,
+                a,
+                b,
+                if_true,
+                target,
+            } => {
+                if knum_cmp(cmp, regs[a as usize], regs[b as usize]) == if_true {
+                    branch!(target)
+                }
+            }
+            KOp::BrCmpK {
+                cmp,
+                a,
+                k,
+                if_true,
+                target,
+            } => {
+                if knum_cmp(cmp, regs[a as usize], k) == if_true {
+                    branch!(target)
+                }
+            }
+            KOp::BrFalsy { src, target } => {
+                if !knum_truthy(regs[src as usize]) {
+                    branch!(target)
+                }
+            }
+            KOp::BrTruthy { src, target } => {
+                if knum_truthy(regs[src as usize]) {
+                    branch!(target)
+                }
+            }
+            KOp::CmpSet { cmp, dst, a, b } => {
+                regs[dst as usize] = if knum_cmp(cmp, regs[a as usize], regs[b as usize]) {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            KOp::BoolNot { dst, src } => {
+                regs[dst as usize] = if knum_truthy(regs[src as usize]) {
+                    0.0
+                } else {
+                    1.0
+                }
+            }
+            KOp::Math1 { kind, dst, src } => regs[dst as usize] = kmath1(kind, regs[src as usize]),
+            KOp::Math2 { kind, dst, a, b } => {
+                regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
+            }
+            KOp::Ret { src, boolean } => {
+                return Some(if boolean {
+                    Value::Bool(regs[src as usize] != 0.0)
+                } else {
+                    Value::Number(regs[src as usize])
+                })
+            }
+            // A frameless kernel has no bytecode frame to bail into;
+            // fn-mode translation rejects anything needing one. A
+            // SelfCall implies `self_global`, dispatched by the caller.
+            KOp::LoadElem { .. }
+            | KOp::StoreElem { .. }
+            | KOp::LoadLen { .. }
+            | KOp::LoadProp { .. }
+            | KOp::StoreProp { .. }
+            | KOp::Exit { .. }
+            | KOp::CallKernel { .. }
+            | KOp::SelfCall { .. } => unreachable!("bail op in a function kernel"),
+        }
+        pc += 1;
+    }
+}
+
 fn run_callee_window(
     regs: &mut [f64],
     ck: &crate::bytecode::Kernel,

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -2879,48 +2879,60 @@ impl Vm {
                 // slot is a plain writable data property per the array exotic
                 // [[Set]] — no setter, no length change, no extensibility
                 // interaction), fill an in-bounds HOLE, or append at exactly
-                // `length` — the same conditions as the kernel `StoreElem`
-                // fast path. Filling and appending CREATE a property, so they
-                // additionally require the array to be extensible (a sealed/
-                // prevented receiver must reject through the generic path)
-                // and to stay under the dense-storage bound (the generic path
-                // owns that RangeError). Gaps past the end, shadowed elements,
-                // and non-arrays take the spec path.
+                // `length`. Filling and appending CREATE a property (the own
+                // property is absent), so they additionally require the array
+                // to be extensible (a sealed/prevented receiver must reject
+                // through the generic path), the dense-storage bound (the
+                // generic path owns that RangeError), and a prototype chain
+                // with no reified entry at the index — OrdinarySet consults
+                // the chain for an absent own property, so a proto accessor /
+                // non-writable index must intercept via the generic path
+                // (`protos_allow_index_create`). Gaps past the end, shadowed
+                // elements, and non-arrays take the spec path.
                 if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
                     if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                        let mut b = o.borrow_mut();
-                        if b.props.is_empty() {
-                            let extensible = b.extensible;
-                            if let Internal::Array(arr) = &mut b.internal {
-                                let i = *n as usize;
-                                let ok = match arr.get_mut(i) {
-                                    Some(slot) if !matches!(slot, Value::Hole) => {
-                                        *slot = value.clone();
-                                        true
-                                    }
-                                    Some(slot) => {
-                                        // In-bounds hole: creation.
-                                        if extensible {
+                        let i = *n as usize;
+                        let mut creates = None;
+                        {
+                            let mut b = o.borrow_mut();
+                            if b.props.is_empty() {
+                                let extensible = b.extensible;
+                                if let Internal::Array(arr) = &mut b.internal {
+                                    match arr.get_mut(i) {
+                                        Some(slot) if !matches!(slot, Value::Hole) => {
                                             *slot = value.clone();
-                                            true
-                                        } else {
-                                            false
+                                            drop(b);
+                                            push!(value);
+                                            return Ok(Ctl::Next);
+                                        }
+                                        Some(_) => {
+                                            if extensible {
+                                                creates = Some(b.proto.clone());
+                                            }
+                                        }
+                                        None => {
+                                            if extensible
+                                                && i == arr.len()
+                                                && i < crate::value::MAX_DENSE_ARRAY
+                                            {
+                                                creates = Some(b.proto.clone());
+                                            }
                                         }
                                     }
-                                    None => {
-                                        // Exact append (no hole gap).
-                                        if extensible
-                                            && i == arr.len()
-                                            && i < crate::value::MAX_DENSE_ARRAY
-                                        {
-                                            arr.push(value.clone());
-                                            true
-                                        } else {
-                                            false
-                                        }
+                                }
+                            }
+                        }
+                        if let Some(proto) = creates {
+                            if crate::value::protos_allow_index_create(proto, i as u32, 1) {
+                                // No user code ran since the conditions were
+                                // checked (same native frame), so they still
+                                // hold.
+                                let mut b = o.borrow_mut();
+                                if let Internal::Array(arr) = &mut b.internal {
+                                    match arr.get_mut(i) {
+                                        Some(slot) => *slot = value.clone(),
+                                        None => arr.push(value.clone()),
                                     }
-                                };
-                                if ok {
                                     drop(b);
                                     push!(value);
                                     return Ok(Ctl::Next);

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -863,6 +863,30 @@ impl Vm {
                         _ => unreachable!("kernel prop slot invariant"),
                     }
                 }
+                KOp::Mov2 { d1, s1, d2, s2 } => {
+                    regs[d1 as usize] = regs[s1 as usize];
+                    regs[d2 as usize] = regs[s2 as usize];
+                    // The unfused second op remains in the next slot as a
+                    // branch-target landing pad; skip it.
+                    pc += 1;
+                }
+                KOp::ArithAdd {
+                    kind,
+                    dst,
+                    a,
+                    b,
+                    d2,
+                    a2,
+                    b2,
+                } => {
+                    regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind);
+                    regs[d2 as usize] = regs[a2 as usize] + regs[b2 as usize];
+                    pc += 1;
+                }
+                KOp::AddKBr { dst, a, k, target } => {
+                    regs[dst as usize] = regs[a as usize] + k;
+                    branch!(target)
+                }
                 // A pinned-closure call: copy the arguments into the
                 // callee's window and run its (guarded) kernel inline.
                 KOp::CallKernel {
@@ -1188,6 +1212,29 @@ impl Vm {
                 KOp::Math2 { kind, dst, a, b } => {
                     regs[base + dst as usize] =
                         kmath2(kind, regs[base + a as usize], regs[base + b as usize])
+                }
+                KOp::Mov2 { d1, s1, d2, s2 } => {
+                    regs[base + d1 as usize] = regs[base + s1 as usize];
+                    regs[base + d2 as usize] = regs[base + s2 as usize];
+                    pc += 1;
+                }
+                KOp::ArithAdd {
+                    kind,
+                    dst,
+                    a,
+                    b,
+                    d2,
+                    a2,
+                    b2,
+                } => {
+                    regs[base + dst as usize] =
+                        number_arith_raw(regs[base + a as usize], regs[base + b as usize], kind);
+                    regs[base + d2 as usize] = regs[base + a2 as usize] + regs[base + b2 as usize];
+                    pc += 1;
+                }
+                KOp::AddKBr { dst, a, k, target } => {
+                    regs[base + dst as usize] = regs[base + a as usize] + k;
+                    branch!(target)
                 }
                 KOp::SelfCall {
                     dst,
@@ -5495,6 +5542,30 @@ fn exec_fn_kernel_code(
             KOp::Math2 { kind, dst, a, b } => {
                 regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
             }
+            KOp::Mov2 { d1, s1, d2, s2 } => {
+                regs[d1 as usize] = regs[s1 as usize];
+                regs[d2 as usize] = regs[s2 as usize];
+                // The unfused second op remains in the next slot as a
+                // branch-target landing pad; skip it.
+                pc += 1;
+            }
+            KOp::ArithAdd {
+                kind,
+                dst,
+                a,
+                b,
+                d2,
+                a2,
+                b2,
+            } => {
+                regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind);
+                regs[d2 as usize] = regs[a2 as usize] + regs[b2 as usize];
+                pc += 1;
+            }
+            KOp::AddKBr { dst, a, k, target } => {
+                regs[dst as usize] = regs[a as usize] + k;
+                branch!(target)
+            }
             KOp::Ret { src, boolean } => {
                 return Some(if boolean {
                     Value::Bool(regs[src as usize] != 0.0)
@@ -5618,6 +5689,29 @@ fn run_callee_window(
             KOp::Math2 { kind, dst, a, b } => {
                 regs[win + dst as usize] =
                     kmath2(kind, regs[win + a as usize], regs[win + b as usize])
+            }
+            KOp::Mov2 { d1, s1, d2, s2 } => {
+                regs[win + d1 as usize] = regs[win + s1 as usize];
+                regs[win + d2 as usize] = regs[win + s2 as usize];
+                pc += 1;
+            }
+            KOp::ArithAdd {
+                kind,
+                dst,
+                a,
+                b,
+                d2,
+                a2,
+                b2,
+            } => {
+                regs[win + dst as usize] =
+                    number_arith_raw(regs[win + a as usize], regs[win + b as usize], kind);
+                regs[win + d2 as usize] = regs[win + a2 as usize] + regs[win + b2 as usize];
+                pc += 1;
+            }
+            KOp::AddKBr { dst, a, k, target } => {
+                regs[win + dst as usize] = regs[win + a as usize] + k;
+                branch!(target)
             }
             KOp::Ret { src, boolean: _ } => {
                 // Number-only (the caller guard rejected boolean returns).

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -377,6 +377,25 @@ impl Vm {
         })
     }
 
+    /// Entry check for kernels containing [`KOp::ArrayPush`]: the canonical
+    /// Array prototype's `push` property must still be a plain DATA property
+    /// holding the pinned canonical function (methods are writable). The
+    /// receiver-side conditions (unshadowed, extensible, direct proto IS the
+    /// canonical prototype) re-check per push; the element-creation chain
+    /// walk is the `stores_elems` entry guard.
+    fn kernel_array_push_ok(&self) -> bool {
+        let Some(canon) = &self.realm.array_push else {
+            return false;
+        };
+        matches!(
+            self.realm.array_proto.borrow().props.get(&PropertyKey::str("push")),
+            Some(Property {
+                kind: PropertyKind::Data { value: Value::Object(o), .. },
+                ..
+            }) if o.ptr_eq(canon)
+        )
+    }
+
     /// Execute the typed loop kernel at `Op::LoopKernel(idx)` (see
     /// `kernel.rs` for the model). Runs only when per-op accounting is off
     /// (no op budget), every mapped numeric local holds a `Number`, and every
@@ -471,6 +490,40 @@ impl Vm {
         // kernel region can mutate globals, so entry-time checks suffice.
         if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
             return self.step(frame, &k.fallback);
+        }
+        // Pinned `Array.prototype.push` (see `KOp::ArrayPush`): the realm
+        // canonical must still back `Array.prototype.push`, and EVERY push
+        // receiver must resolve `push` to it — an unshadowed (`props`
+        // empty) extensible dense array whose direct proto IS the canonical
+        // prototype. Checked ONCE: nothing inside a kernel region can add a
+        // shadowing property or change a prototype, so the resolution holds
+        // for the whole activation — which is what lets ANY mid-kernel exit
+        // materialize the canonical method object into a resumed operand
+        // stack (`KShapeSlot::ArrayPushFn`). A shadowed/patched/re-proto'd
+        // receiver declines here and the generic loop owns it.
+        if k.uses_array_push {
+            if !self.kernel_array_push_ok() {
+                return self.step(frame, &k.fallback);
+            }
+            for op in k.code.iter() {
+                if let KOp::ArrayPush { obj, .. } = op {
+                    let ok =
+                        if let Value::Object(o) = &frame.locals[k.oslots[*obj as usize] as usize] {
+                            let b = o.borrow();
+                            matches!(b.internal, Internal::Array(_))
+                                && b.props.is_empty()
+                                && b.extensible
+                                && b.proto
+                                    .as_ref()
+                                    .is_some_and(|p| p.ptr_eq(&self.realm.array_proto))
+                        } else {
+                            false
+                        };
+                    if !ok {
+                        return self.step(frame, &k.fallback);
+                    }
+                }
+            }
         }
         // Named-property access classes resolve ONCE per activation to raw
         // slot indices (see `KProp`) — and, since prop LOCALIZATION, to a
@@ -774,6 +827,40 @@ impl Vm {
                         branch!(bail)
                     }
                 }
+                // Pinned-native push: append + new length, in-kernel. The
+                // entry guard proved the canonical method still resolves
+                // and (stores_elems) that no proto can intercept element
+                // creation; the receiver conditions re-check per push —
+                // anything else re-runs the whole generic Call via the
+                // bail (the method object reconstructed from the realm).
+                KOp::ArrayPush {
+                    obj,
+                    val,
+                    dst,
+                    bail,
+                } => {
+                    let mut ok = false;
+                    {
+                        let mut b = objs[obj as usize].borrow_mut();
+                        if b.props.is_empty()
+                            && b.extensible
+                            && b.proto
+                                .as_ref()
+                                .is_some_and(|p| p.ptr_eq(&self.realm.array_proto))
+                        {
+                            if let Internal::Array(arr) = &mut b.internal {
+                                if arr.len() < crate::value::MAX_DENSE_ARRAY {
+                                    arr.push(Value::Number(regs[val as usize]));
+                                    regs[dst as usize] = arr.len() as f64;
+                                    ok = true;
+                                }
+                            }
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                }
                 // Dense element write: in-place overwrite (exactly the
                 // `Op::SetPropDynamic` fast-path conditions), an in-bounds
                 // HOLE fill, or an exact one-past-the-end APPEND. Filling and
@@ -970,6 +1057,9 @@ impl Vm {
                 )),
                 crate::bytecode::KShapeSlot::MathFn(kind) => frame.stack.push(Value::Object(
                     self.realm.math_kernel[*kind as usize].clone(),
+                )),
+                crate::bytecode::KShapeSlot::ArrayPushFn => frame.stack.push(Value::Object(
+                    self.realm.array_push.clone().expect("guarded"),
                 )),
             }
         }
@@ -1299,7 +1389,8 @@ impl Vm {
                         None => break Value::Number(v),
                     }
                 }
-                KOp::LoadElem { .. }
+                KOp::ArrayPush { .. }
+                | KOp::LoadElem { .. }
                 | KOp::StoreElem { .. }
                 | KOp::LoadLen { .. }
                 | KOp::LoadProp { .. }
@@ -5618,7 +5709,8 @@ fn exec_fn_kernel_code(
             // A frameless kernel has no bytecode frame to bail into;
             // fn-mode translation rejects anything needing one. A
             // SelfCall implies `self_global`, dispatched by the caller.
-            KOp::LoadElem { .. }
+            KOp::ArrayPush { .. }
+            | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
             | KOp::LoadProp { .. }
@@ -5762,7 +5854,8 @@ fn run_callee_window(
             }
             // Impossible in a guarded callee: no bails, no exits, no
             // recursion, no nested closure calls.
-            KOp::LoadElem { .. }
+            KOp::ArrayPush { .. }
+            | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
             | KOp::LoadProp { .. }

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -695,17 +695,47 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     for &(l, r) in &x.bool_reg {
         bool_locals[(r - BOOL_BASE) as usize] = l;
     }
+    // Prop LOCALIZATION: each named-property access class gets a dedicated
+    // register at the TAIL of the register file. The activation entry loads
+    // every resolved slot's current Number into its register and the
+    // exit/bail/interrupt paths write STORE-class registers back
+    // (`writeback_kernel_props`), so the in-region accesses are plain
+    // register moves — rewritten here (post-remap) and then propagated /
+    // deleted by the cleanup pass below like any other Mov. Sound for the
+    // same reason slot resolution is: nothing inside a kernel region can
+    // run user code or restructure a property map; the entry guard
+    // additionally declines two classes aliasing one (object, slot).
+    let prop_base = n_locals + n_bools + x.max_stack + 1;
+    let n_props = u16::try_from(x.props_used.len()).ok()?;
+    for op in &mut x.kops {
+        match *op {
+            KOp::LoadProp { dst, prop } => {
+                *op = KOp::Mov {
+                    dst,
+                    src: prop_base + prop,
+                }
+            }
+            KOp::StoreProp { prop, src } => {
+                *op = KOp::Mov {
+                    dst: prop_base + prop,
+                    src,
+                }
+            }
+            _ => {}
+        }
+    }
     // Post-translation cleanup (copy-prop + dead-Mov DCE, see
     // `cleanup_kops`). The always-live set is everything observed outside
     // straight-line execution: loop kernels write mapped Local and bool
-    // registers back to the frame on every exit and interrupt unwind, and
-    // exit shapes reference stack registers. Function kernels are frameless
-    // and pure — only `Ret` (a normal use) and the upvalue-window copies a
-    // `SelfCall` performs observe registers.
+    // registers back to the frame on every exit and interrupt unwind (and
+    // STORE-class prop registers back to their slots), and exit shapes
+    // reference stack registers. Function kernels are frameless and pure —
+    // only `Ret` (a normal use) and the upvalue-window copies a `SelfCall`
+    // performs observe registers.
     {
         let mut always_live: u128 = 0;
         let mut upvalue_uses: u128 = 0;
-        let n_regs = (n_locals + n_bools + x.max_stack + 1) as usize;
+        let n_regs = (prop_base + n_props) as usize;
         if n_regs <= 128 {
             if x.fn_mode {
                 for (r, slot) in locals.iter().enumerate() {
@@ -729,6 +759,11 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                         }
                     }
                 }
+                for (i, p) in x.props_used.iter().enumerate() {
+                    if p.store {
+                        always_live |= 1 << (prop_base as usize + i);
+                    }
+                }
             }
             cleanup_kops(&mut x.kops, always_live, upvalue_uses, n_regs);
         }
@@ -747,7 +782,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
         props_used: std::mem::take(&mut x.props_used).into_boxed_slice(),
         callee_slots: std::mem::take(&mut x.callees).into_boxed_slice(),
-        n_regs: n_locals + n_bools + x.max_stack + 1,
+        n_regs: prop_base + n_props,
         self_global: None, // `kernelize_function` fills it for recursive kernels
         fallback: Box::new(Op::Nop), // caller stores the real header op
     })

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -334,6 +334,8 @@ enum VE {
     /// [`KOp::ArrayPush`]); survives to exit shapes as
     /// [`KShapeSlot::ArrayPushFn`] (realm-reconstructed on bail).
     ArrayPushFn(u16),
+    /// `a.pop`, likewise (consumed by `Call(0)` → [`KOp::ArrayPop`]).
+    ArrayPopFn(u16),
 }
 
 struct Xlate<'a> {
@@ -393,6 +395,8 @@ struct Xlate<'a> {
     /// Whether the region contains a pinned `Array.prototype.push` call
     /// (entry guard verifies the canonical still resolves).
     uses_array_push: bool,
+    /// As `uses_array_push`, for `pop`.
+    uses_array_pop: bool,
     /// Named-property access classes over oslot bases (entry-resolved; see
     /// [`KProp`]). Deduplicated by (oslot, key); flags OR together.
     props_used: Vec<KProp>,
@@ -457,6 +461,7 @@ fn translate(
         exits: Vec::new(),
         math_used: Vec::new(),
         uses_array_push: false,
+        uses_array_pop: false,
         props_used: Vec::new(),
         callees: Vec::new(),
         absorbed: None,
@@ -651,6 +656,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *dst = remap(*dst);
                 *val = remap(*val);
             }
+            KOp::ArrayPop { dst, .. } => *dst = remap(*dst),
             KOp::StoreElem { idx, val, .. } => {
                 *idx = remap(*idx);
                 *val = remap(*val);
@@ -695,6 +701,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::MathObj => KShapeSlot::MathObj,
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
                     VE::ArrayPushFn(_) => KShapeSlot::ArrayPushFn,
+                    VE::ArrayPopFn(_) => KShapeSlot::ArrayPopFn,
                     VE::Undef | VE::Opaque | VE::SelfFn => {
                         unreachable!("undef/opaque/self never crosses block boundaries")
                     }
@@ -796,6 +803,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     Some(Kernel {
         stores_elems,
         uses_array_push: x.uses_array_push,
+        uses_array_pop: x.uses_array_pop,
         code: std::mem::take(&mut x.kops).into_boxed_slice(),
         locals: locals.into_boxed_slice(),
         bool_locals: bool_locals.into_boxed_slice(),
@@ -838,7 +846,8 @@ fn map_targets(op: &mut KOp, mut f: impl FnMut(u16) -> u16) {
         KOp::LoadElem { bail, .. }
         | KOp::StoreElem { bail, .. }
         | KOp::LoadLen { bail, .. }
-        | KOp::ArrayPush { bail, .. } => *bail = f(*bail),
+        | KOp::ArrayPush { bail, .. }
+        | KOp::ArrayPop { bail, .. } => *bail = f(*bail),
         _ => {}
     }
 }
@@ -1036,6 +1045,7 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
                 resolve!(val);
                 kill!(*dst);
             }
+            KOp::ArrayPop { dst, .. } => kill!(*dst),
             KOp::StoreProp { src, .. } => resolve!(src),
             // Argument-window RANGE reads: leave the window registers alone,
             // only the result register is a plain def.
@@ -1107,6 +1117,7 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
             see(*dst);
             see(*val);
         }
+        KOp::ArrayPop { dst, .. } => see(*dst),
         KOp::StoreProp { src, .. } => see(*src),
         KOp::CallKernel {
             dst, base, argc, ..
@@ -1197,6 +1208,10 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
             }
             KOp::ArrayPush { dst, val, bail, .. } => {
                 uses[i] = bit(*val);
+                defs[i] = bit(*dst);
+                succ[i] = (true, Some(*bail));
+            }
+            KOp::ArrayPop { dst, bail, .. } => {
                 defs[i] = bit(*dst);
                 succ[i] = (true, Some(*bail));
             }
@@ -1298,7 +1313,8 @@ fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
         KOp::LoadElem { bail, .. }
         | KOp::StoreElem { bail, .. }
         | KOp::LoadLen { bail, .. }
-        | KOp::ArrayPush { bail, .. } => *bail = pc,
+        | KOp::ArrayPush { bail, .. }
+        | KOp::ArrayPop { bail, .. } => *bail = pc,
         _ => unreachable!("patching a non-branch kop"),
     }
 }
@@ -1536,7 +1552,8 @@ impl Xlate<'_> {
             | VE::SelfFn
             | VE::MathObj
             | VE::MathFn(_)
-            | VE::ArrayPushFn(_) => None,
+            | VE::ArrayPushFn(_)
+            | VE::ArrayPopFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -1928,9 +1945,12 @@ impl Xlate<'_> {
                         self.vstack.push(VE::MathObj);
                         self.origins.push(None);
                     }
-                    VE::MathFn(_) | VE::Undef | VE::Opaque | VE::SelfFn | VE::ArrayPushFn(_) => {
-                        return None
-                    }
+                    VE::MathFn(_)
+                    | VE::Undef
+                    | VE::Opaque
+                    | VE::SelfFn
+                    | VE::ArrayPushFn(_)
+                    | VE::ArrayPopFn(_) => return None,
                 }
             }
             Op::Swap => {
@@ -2186,12 +2206,17 @@ impl Xlate<'_> {
                 // to this routing — the region then rejects at the
                 // consumer — which is acceptable for so method-shaped a
                 // name.
-                if !self.fn_mode && key == "push" {
+                if !self.fn_mode && (key == "push" || key == "pop") {
                     let obj = self.base_slot(0)?;
                     self.pop()?;
-                    self.vstack.push(VE::ArrayPushFn(obj));
+                    if key == "push" {
+                        self.vstack.push(VE::ArrayPushFn(obj));
+                        self.uses_array_push = true;
+                    } else {
+                        self.vstack.push(VE::ArrayPopFn(obj));
+                        self.uses_array_pop = true;
+                    }
                     self.origins.push(None);
-                    self.uses_array_push = true;
                     return Some(());
                 }
                 if key == "length" {
@@ -2289,6 +2314,24 @@ impl Xlate<'_> {
                     self.kops.push(K::ArrayPush {
                         obj: s,
                         val,
+                        dst,
+                        bail: u16::MAX,
+                    });
+                    self.exits.push((kidx, self.base_ip + i as u32, shape));
+                    return Some(());
+                }
+                // `a.pop()`: [.., ArrayPopFn(s), Obj(s)], no arguments.
+                if let VE::ArrayPopFn(s) = *self.vstack.get(fn_pos)? {
+                    if n != 0 || !matches!(self.vstack.get(fn_pos + 1)?, VE::Obj(s2) if *s2 == s) {
+                        return None;
+                    }
+                    let shape = self.vstack.clone();
+                    self.pop()?; // this (the array)
+                    self.pop()?; // fn
+                    let dst = self.push_num()?;
+                    let kidx = self.kops.len();
+                    self.kops.push(K::ArrayPop {
+                        obj: s,
                         dst,
                         bail: u16::MAX,
                     });

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -691,6 +691,44 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     for &(l, r) in &x.bool_reg {
         bool_locals[(r - BOOL_BASE) as usize] = l;
     }
+    // Post-translation cleanup (copy-prop + dead-Mov DCE, see
+    // `cleanup_kops`). The always-live set is everything observed outside
+    // straight-line execution: loop kernels write mapped Local and bool
+    // registers back to the frame on every exit and interrupt unwind, and
+    // exit shapes reference stack registers. Function kernels are frameless
+    // and pure — only `Ret` (a normal use) and the upvalue-window copies a
+    // `SelfCall` performs observe registers.
+    {
+        let mut always_live: u128 = 0;
+        let mut upvalue_uses: u128 = 0;
+        let n_regs = (n_locals + n_bools + x.max_stack + 1) as usize;
+        if n_regs <= 128 {
+            if x.fn_mode {
+                for (r, slot) in locals.iter().enumerate() {
+                    if matches!(slot, KSlot::Upvalue(_)) {
+                        upvalue_uses |= 1 << r;
+                    }
+                }
+            } else {
+                for (r, slot) in locals.iter().enumerate() {
+                    if matches!(slot, KSlot::Local(_)) {
+                        always_live |= 1 << r;
+                    }
+                }
+                for j in 0..n_bools {
+                    always_live |= 1 << (n_locals + j);
+                }
+                for s in &shapes {
+                    for e in s.iter() {
+                        if let KShapeSlot::Num(r) | KShapeSlot::Bool(r) = e {
+                            always_live |= 1 << *r;
+                        }
+                    }
+                }
+            }
+            cleanup_kops(&mut x.kops, always_live, upvalue_uses, n_regs);
+        }
+    }
     let stores_elems = x.kops.iter().any(|op| matches!(op, KOp::StoreElem { .. }));
     Some(Kernel {
         stores_elems,
@@ -722,6 +760,393 @@ fn static_cmp(cmp: CmpOp, a_bool: bool, b_bool: bool) -> Option<bool> {
         CmpOp::StrictNe => Some(true),
         _ => None,
     }
+}
+
+/// Rewrite every branch/bail target in `op` through `f`.
+fn map_targets(op: &mut KOp, mut f: impl FnMut(u16) -> u16) {
+    match op {
+        KOp::Br { target }
+        | KOp::BrCmp { target, .. }
+        | KOp::BrCmpK { target, .. }
+        | KOp::BrFalsy { target, .. }
+        | KOp::BrTruthy { target, .. } => *target = f(*target),
+        KOp::LoadElem { bail, .. } | KOp::StoreElem { bail, .. } | KOp::LoadLen { bail, .. } => {
+            *bail = f(*bail)
+        }
+        _ => {}
+    }
+}
+
+/// Post-translation cleanup over the finished KOp array: forward
+/// copy-propagation plus dead-`Mov` elimination with real liveness over the
+/// kernel's tiny CFG. The stack-machine lowering routes nearly every value
+/// through a canonical stack register, so `Mov`s dominate hot kernels — the
+/// arith-loop body is 13 ops of which 5 are `Mov`s, and a `(x, y) => x - y`
+/// comparator is 6 `Mov`s around one `Arith`. Purely register-level: every
+/// surviving op reads the same VALUES and writes the same results as
+/// before, so kernel output stays bit-identical to the generic path.
+///
+/// `always_live` marks registers observed outside straight-line execution —
+/// loop kernels write mapped `Local`/bool registers back to the frame on
+/// every exit AND on interrupt unwinds at back-edge polls, and exit shapes
+/// reference stack registers — so writes to them are never dead.
+/// `upvalue_uses` marks the upvalue-slot registers a `SelfCall` implicitly
+/// copies into the callee window (function kernels).
+fn cleanup_kops(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: usize) {
+    if n_regs > 128 {
+        return;
+    }
+    // Alternate the two transforms to a fixpoint: propagation exposes dead
+    // copies; deletion shortens chains for the next round. Each round
+    // strictly reduces rewrites+ops, so this terminates quickly.
+    loop {
+        let mut changed = copy_prop_kops(kops);
+        changed |= dce_movs(kops, always_live, upvalue_uses, n_regs);
+        if !changed {
+            break;
+        }
+    }
+}
+
+/// Forward copy propagation within basic blocks: after `Mov d, s`, reads of
+/// `d` are rewritten to `s` until either register is written. The map is
+/// cleared at every branch/bail target (join points may disagree) — the
+/// per-block window is enough for the lowering's `local → stack-slot → use`
+/// shuttles. Range reads (`SelfCall`/`CallKernel` argument windows) are
+/// never rewritten: the callee reads those exact registers.
+fn copy_prop_kops(kops: &mut [KOp]) -> bool {
+    let n = kops.len();
+    let mut label = vec![false; n];
+    let mut preds = vec![0u32; n];
+    for (j, op) in kops.iter_mut().enumerate() {
+        let falls = !matches!(op, KOp::Br { .. } | KOp::Ret { .. } | KOp::Exit { .. });
+        if falls && j + 1 < n {
+            preds[j + 1] += 1;
+        }
+        map_targets(op, |t| {
+            label[t as usize] = true;
+            preds[t as usize] += 1;
+            t
+        });
+    }
+    // copy[d] = Some(s): regs[d] currently equals regs[s], `s` itself a root.
+    let mut copy: Vec<Option<u16>> = vec![None; 1 + kops.iter().fold(0, max_reg) as usize];
+    // A FORWARD branch to a single-predecessor target carries its copy map
+    // to that target (branch ops write nothing, so the state at the branch
+    // IS the state at the target) — the if/else join shape. Everything else
+    // clears at the label (a join's predecessors may disagree).
+    let mut snapshots: Vec<Option<Vec<Option<u16>>>> = vec![None; n];
+    let mut changed = false;
+    macro_rules! resolve {
+        ($r:expr) => {
+            if let Some(root) = copy[*$r as usize] {
+                if root != *$r {
+                    *$r = root;
+                    changed = true;
+                }
+            }
+        };
+    }
+    macro_rules! kill {
+        ($d:expr) => {{
+            let d = $d;
+            copy[d as usize] = None;
+            for e in copy.iter_mut() {
+                if *e == Some(d) {
+                    *e = None;
+                }
+            }
+        }};
+    }
+    for (i, op) in kops.iter_mut().enumerate() {
+        if label[i] {
+            match snapshots[i].take() {
+                Some(s) => copy = s,
+                None => copy.iter_mut().for_each(|e| *e = None),
+            }
+        }
+        match op {
+            KOp::Mov { dst, src } => {
+                resolve!(src);
+                let (d, s) = (*dst, *src);
+                kill!(d);
+                if d != s {
+                    copy[d as usize] = Some(s);
+                }
+            }
+            KOp::Const { dst, .. } => kill!(*dst),
+            KOp::Add { dst, a, b } | KOp::Arith { dst, a, b, .. } => {
+                resolve!(a);
+                resolve!(b);
+                kill!(*dst);
+            }
+            KOp::AddK { dst, a, .. } | KOp::ArithK { dst, a, .. } => {
+                resolve!(a);
+                kill!(*dst);
+            }
+            KOp::Neg { dst, src } | KOp::BitNot { dst, src } | KOp::BoolNot { dst, src } => {
+                resolve!(src);
+                kill!(*dst);
+            }
+            KOp::CmpSet { dst, a, b, .. } => {
+                resolve!(a);
+                resolve!(b);
+                kill!(*dst);
+            }
+            KOp::Math1 { dst, src, .. } => {
+                resolve!(src);
+                kill!(*dst);
+            }
+            KOp::Math2 { dst, a, b, .. } => {
+                resolve!(a);
+                resolve!(b);
+                kill!(*dst);
+            }
+            KOp::BrCmp { a, b, .. } => {
+                resolve!(a);
+                resolve!(b);
+            }
+            KOp::BrCmpK { a, .. } => resolve!(a),
+            KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } => resolve!(src),
+            KOp::Ret { src, .. } => resolve!(src),
+            KOp::LoadElem { dst, idx, .. } => {
+                resolve!(idx);
+                kill!(*dst);
+            }
+            KOp::StoreElem { idx, val, .. } => {
+                resolve!(idx);
+                resolve!(val);
+            }
+            KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => kill!(*dst),
+            KOp::StoreProp { src, .. } => resolve!(src),
+            // Argument-window RANGE reads: leave the window registers alone,
+            // only the result register is a plain def.
+            KOp::CallKernel { dst, .. } | KOp::SelfCall { dst, .. } => kill!(*dst),
+            KOp::Br { .. } | KOp::Exit { .. } => {}
+        }
+        let target = match op {
+            KOp::Br { target }
+            | KOp::BrCmp { target, .. }
+            | KOp::BrCmpK { target, .. }
+            | KOp::BrFalsy { target, .. }
+            | KOp::BrTruthy { target, .. } => Some(*target),
+            _ => None,
+        };
+        if let Some(t) = target {
+            if t as usize > i && preds[t as usize] == 1 {
+                snapshots[t as usize] = Some(copy.clone());
+            }
+        }
+    }
+    changed
+}
+
+/// Highest register index referenced by `op` (fold seed for sizing).
+fn max_reg(acc: u16, op: &KOp) -> u16 {
+    let mut m = acc;
+    let mut see = |r: u16| m = m.max(r);
+    match op {
+        KOp::Mov { dst, src }
+        | KOp::Neg { dst, src }
+        | KOp::BitNot { dst, src }
+        | KOp::BoolNot { dst, src }
+        | KOp::Math1 { dst, src, .. } => {
+            see(*dst);
+            see(*src);
+        }
+        KOp::Const { dst, .. } | KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => see(*dst),
+        KOp::Add { dst, a, b }
+        | KOp::Arith { dst, a, b, .. }
+        | KOp::CmpSet { dst, a, b, .. }
+        | KOp::Math2 { dst, a, b, .. } => {
+            see(*dst);
+            see(*a);
+            see(*b);
+        }
+        KOp::AddK { dst, a, .. } | KOp::ArithK { dst, a, .. } => {
+            see(*dst);
+            see(*a);
+        }
+        KOp::BrCmp { a, b, .. } => {
+            see(*a);
+            see(*b);
+        }
+        KOp::BrCmpK { a, .. } => see(*a),
+        KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } | KOp::Ret { src, .. } => see(*src),
+        KOp::LoadElem { dst, idx, .. } => {
+            see(*dst);
+            see(*idx);
+        }
+        KOp::StoreElem { idx, val, .. } => {
+            see(*idx);
+            see(*val);
+        }
+        KOp::StoreProp { src, .. } => see(*src),
+        KOp::CallKernel {
+            dst, base, argc, ..
+        }
+        | KOp::SelfCall {
+            dst, base, argc, ..
+        } => {
+            see(*dst);
+            see(base + argc);
+        }
+        KOp::Br { .. } | KOp::Exit { .. } => {}
+    }
+    m
+}
+
+/// Delete `Mov`s whose destination is dead: backward liveness to a fixpoint
+/// over the kernel CFG (fall-throughs, branch targets, bail edges), then
+/// index compaction with branch retargeting. A branch INTO a deleted `Mov`
+/// lands on the next surviving op — sound precisely because the deleted op
+/// wrote a register nothing observes.
+fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: usize) -> bool {
+    let n = kops.len();
+    if n == 0 || n_regs > 128 {
+        return false;
+    }
+    let bit = |r: u16| 1u128 << r;
+    // Per-op use/def masks and successor edges.
+    let mut uses = vec![0u128; n];
+    let mut defs = vec![0u128; n];
+    // (fall-through?, branch target)
+    let mut succ: Vec<(bool, Option<u16>)> = vec![(true, None); n];
+    for (i, op) in kops.iter().enumerate() {
+        match op {
+            KOp::Mov { dst, src }
+            | KOp::Neg { dst, src }
+            | KOp::BitNot { dst, src }
+            | KOp::BoolNot { dst, src }
+            | KOp::Math1 { dst, src, .. } => {
+                uses[i] = bit(*src);
+                defs[i] = bit(*dst);
+            }
+            KOp::Const { dst, .. } => defs[i] = bit(*dst),
+            KOp::Add { dst, a, b }
+            | KOp::Arith { dst, a, b, .. }
+            | KOp::CmpSet { dst, a, b, .. }
+            | KOp::Math2 { dst, a, b, .. } => {
+                uses[i] = bit(*a) | bit(*b);
+                defs[i] = bit(*dst);
+            }
+            KOp::AddK { dst, a, .. } | KOp::ArithK { dst, a, .. } => {
+                uses[i] = bit(*a);
+                defs[i] = bit(*dst);
+            }
+            KOp::Br { target } => succ[i] = (false, Some(*target)),
+            KOp::BrCmp { a, b, target, .. } => {
+                uses[i] = bit(*a) | bit(*b);
+                succ[i] = (true, Some(*target));
+            }
+            KOp::BrCmpK { a, target, .. } => {
+                uses[i] = bit(*a);
+                succ[i] = (true, Some(*target));
+            }
+            KOp::BrFalsy { src, target } | KOp::BrTruthy { src, target } => {
+                uses[i] = bit(*src);
+                succ[i] = (true, Some(*target));
+            }
+            KOp::Ret { src, .. } => {
+                uses[i] = bit(*src);
+                succ[i] = (false, None);
+            }
+            KOp::Exit { .. } => succ[i] = (false, None),
+            KOp::LoadElem { dst, idx, bail, .. } => {
+                uses[i] = bit(*idx);
+                defs[i] = bit(*dst);
+                succ[i] = (true, Some(*bail));
+            }
+            KOp::StoreElem { idx, val, bail, .. } => {
+                uses[i] = bit(*idx) | bit(*val);
+                succ[i] = (true, Some(*bail));
+            }
+            KOp::LoadLen { dst, bail, .. } => {
+                defs[i] = bit(*dst);
+                succ[i] = (true, Some(*bail));
+            }
+            KOp::LoadProp { dst, .. } => defs[i] = bit(*dst),
+            KOp::StoreProp { src, .. } => uses[i] = bit(*src),
+            // The executor copies the argument window (and, for SelfCall,
+            // every upvalue-slot register) into the callee window.
+            KOp::CallKernel {
+                dst, base, argc, ..
+            } => {
+                for r in *base..base + argc {
+                    uses[i] |= bit(r);
+                }
+                defs[i] = bit(*dst);
+            }
+            KOp::SelfCall {
+                dst, base, argc, ..
+            } => {
+                for r in *base..base + argc {
+                    uses[i] |= bit(r);
+                }
+                uses[i] |= upvalue_uses;
+                defs[i] = bit(*dst);
+            }
+        }
+    }
+    // Backward liveness to a fixpoint (tiny op counts; converges in a few
+    // sweeps).
+    let mut live_in = vec![0u128; n];
+    let mut live_out = vec![0u128; n];
+    loop {
+        let mut changed = false;
+        for i in (0..n).rev() {
+            let mut out = 0u128;
+            let (fall, target) = succ[i];
+            if fall && i + 1 < n {
+                out |= live_in[i + 1];
+            }
+            if let Some(t) = target {
+                out |= live_in[t as usize];
+            }
+            let inn = uses[i] | (out & !defs[i]);
+            if out != live_out[i] || inn != live_in[i] {
+                live_out[i] = out;
+                live_in[i] = inn;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    // A Mov is dead when nothing can observe its destination: not live on
+    // any path out, not written back / shape-referenced (always_live), or a
+    // self-move.
+    let dead: Vec<bool> = kops
+        .iter()
+        .enumerate()
+        .map(|(i, op)| match op {
+            KOp::Mov { dst, src } => *dst == *src || (live_out[i] | always_live) & bit(*dst) == 0,
+            _ => false,
+        })
+        .collect();
+    if !dead.iter().any(|&d| d) {
+        return false;
+    }
+    // Compact: old index -> index of the first surviving op at-or-after it.
+    let mut newidx = vec![0u16; n];
+    let mut next = 0u16;
+    for i in 0..n {
+        newidx[i] = next;
+        if !dead[i] {
+            next += 1;
+        }
+    }
+    let mut i = 0;
+    kops.retain(|_| {
+        let keep = !dead[i];
+        i += 1;
+        keep
+    });
+    for op in kops.iter_mut() {
+        map_targets(op, |t| newidx[t as usize]);
+    }
+    true
 }
 
 fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -662,6 +662,10 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *b = remap(*b);
             }
             KOp::Br { .. } | KOp::Exit { .. } => {}
+            // Fusion (`fuse_kops`) runs after this remap.
+            KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+                unreachable!("fused op before fusion")
+            }
         }
     }
     let shapes: Vec<Box<[KShapeSlot]>> = shapes
@@ -729,6 +733,9 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
             cleanup_kops(&mut x.kops, always_live, upvalue_uses, n_regs);
         }
     }
+    // Superinstruction fusion — last, so the analyses above never see fused
+    // variants.
+    fuse_kops(&mut x.kops);
     let stores_elems = x.kops.iter().any(|op| matches!(op, KOp::StoreElem { .. }));
     Some(Kernel {
         stores_elems,
@@ -769,11 +776,60 @@ fn map_targets(op: &mut KOp, mut f: impl FnMut(u16) -> u16) {
         | KOp::BrCmp { target, .. }
         | KOp::BrCmpK { target, .. }
         | KOp::BrFalsy { target, .. }
-        | KOp::BrTruthy { target, .. } => *target = f(*target),
+        | KOp::BrTruthy { target, .. }
+        | KOp::AddKBr { target, .. } => *target = f(*target),
         KOp::LoadElem { bail, .. } | KOp::StoreElem { bail, .. } | KOp::LoadLen { bail, .. } => {
             *bail = f(*bail)
         }
         _ => {}
+    }
+}
+
+/// Fuse adjacent op pairs into superinstructions — the final pass, after
+/// `cleanup_kops` (which never sees fused variants). The fused op performs
+/// BOTH originals' effects sequentially and skips the second slot; the
+/// unfused second op REMAINS in that slot, so a branch into it executes
+/// identically — fusion only accelerates fall-through execution, no
+/// analysis needed. Overlapping fusions compose for the same reason: every
+/// slot is a valid entry point built from the ORIGINAL pair at that
+/// position.
+fn fuse_kops(kops: &mut [KOp]) {
+    let orig: Vec<KOp> = kops.to_vec();
+    for i in 0..orig.len().saturating_sub(1) {
+        let fused = match (&orig[i], &orig[i + 1]) {
+            (KOp::Mov { dst: d1, src: s1 }, KOp::Mov { dst: d2, src: s2 }) => Some(KOp::Mov2 {
+                d1: *d1,
+                s1: *s1,
+                d2: *d2,
+                s2: *s2,
+            }),
+            (
+                KOp::Arith { kind, dst, a, b },
+                KOp::Add {
+                    dst: d2,
+                    a: a2,
+                    b: b2,
+                },
+            ) => Some(KOp::ArithAdd {
+                kind: *kind,
+                dst: *dst,
+                a: *a,
+                b: *b,
+                d2: *d2,
+                a2: *a2,
+                b2: *b2,
+            }),
+            (KOp::AddK { dst, a, k }, KOp::Br { target }) => Some(KOp::AddKBr {
+                dst: *dst,
+                a: *a,
+                k: *k,
+                target: *target,
+            }),
+            _ => None,
+        };
+        if let Some(f) = fused {
+            kops[i] = f;
+        }
     }
 }
 
@@ -923,6 +979,10 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
             // only the result register is a plain def.
             KOp::CallKernel { dst, .. } | KOp::SelfCall { dst, .. } => kill!(*dst),
             KOp::Br { .. } | KOp::Exit { .. } => {}
+            // Fusion (`fuse_kops`) runs after cleanup.
+            KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+                unreachable!("fused op before fusion")
+            }
         }
         let target = match op {
             KOp::Br { target }
@@ -992,6 +1052,10 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
             see(base + argc);
         }
         KOp::Br { .. } | KOp::Exit { .. } => {}
+        // Fusion (`fuse_kops`) runs after cleanup.
+        KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+            unreachable!("fused op before fusion")
+        }
     }
     m
 }
@@ -1085,6 +1149,10 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
                 }
                 uses[i] |= upvalue_uses;
                 defs[i] = bit(*dst);
+            }
+            // Fusion (`fuse_kops`) runs after cleanup.
+            KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+                unreachable!("fused op before fusion")
             }
         }
     }

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -327,6 +327,13 @@ enum VE {
     /// holds the very closure being invoked. Its ONLY legal consumer is a
     /// `Call` (which fuses to [`KOp::SelfCall`]); everything else rejects.
     SelfFn,
+    /// `a.push` on the array base in the oslot — speculative: the entry
+    /// guard verifies the canonical `Array.prototype.push` still backs the
+    /// `push` property of the canonical prototype, and the op re-checks the
+    /// receiver per call. Consumed by `Call(1)` (fusing to
+    /// [`KOp::ArrayPush`]); survives to exit shapes as
+    /// [`KShapeSlot::ArrayPushFn`] (realm-reconstructed on bail).
+    ArrayPushFn(u16),
 }
 
 struct Xlate<'a> {
@@ -383,6 +390,9 @@ struct Xlate<'a> {
     exits: Vec<(usize, u32, Vec<VE>)>,
     /// Math intrinsics used (entry guard checks each against the realm).
     math_used: Vec<KMath>,
+    /// Whether the region contains a pinned `Array.prototype.push` call
+    /// (entry guard verifies the canonical still resolves).
+    uses_array_push: bool,
     /// Named-property access classes over oslot bases (entry-resolved; see
     /// [`KProp`]). Deduplicated by (oslot, key); flags OR together.
     props_used: Vec<KProp>,
@@ -446,6 +456,7 @@ fn translate(
         fixups: Vec::new(),
         exits: Vec::new(),
         math_used: Vec::new(),
+        uses_array_push: false,
         props_used: Vec::new(),
         callees: Vec::new(),
         absorbed: None,
@@ -636,6 +647,10 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *dst = remap(*dst);
                 *idx = remap(*idx);
             }
+            KOp::ArrayPush { dst, val, .. } => {
+                *dst = remap(*dst);
+                *val = remap(*val);
+            }
             KOp::StoreElem { idx, val, .. } => {
                 *idx = remap(*idx);
                 *val = remap(*val);
@@ -679,6 +694,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::Obj(o) => KShapeSlot::Obj(*o),
                     VE::MathObj => KShapeSlot::MathObj,
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
+                    VE::ArrayPushFn(_) => KShapeSlot::ArrayPushFn,
                     VE::Undef | VE::Opaque | VE::SelfFn => {
                         unreachable!("undef/opaque/self never crosses block boundaries")
                     }
@@ -771,9 +787,15 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     // Superinstruction fusion — last, so the analyses above never see fused
     // variants.
     fuse_kops(&mut x.kops);
-    let stores_elems = x.kops.iter().any(|op| matches!(op, KOp::StoreElem { .. }));
+    // ArrayPush CREATES an element like a StoreElem append — same entry
+    // chain guard.
+    let stores_elems = x
+        .kops
+        .iter()
+        .any(|op| matches!(op, KOp::StoreElem { .. } | KOp::ArrayPush { .. }));
     Some(Kernel {
         stores_elems,
+        uses_array_push: x.uses_array_push,
         code: std::mem::take(&mut x.kops).into_boxed_slice(),
         locals: locals.into_boxed_slice(),
         bool_locals: bool_locals.into_boxed_slice(),
@@ -813,9 +835,10 @@ fn map_targets(op: &mut KOp, mut f: impl FnMut(u16) -> u16) {
         | KOp::BrFalsy { target, .. }
         | KOp::BrTruthy { target, .. }
         | KOp::AddKBr { target, .. } => *target = f(*target),
-        KOp::LoadElem { bail, .. } | KOp::StoreElem { bail, .. } | KOp::LoadLen { bail, .. } => {
-            *bail = f(*bail)
-        }
+        KOp::LoadElem { bail, .. }
+        | KOp::StoreElem { bail, .. }
+        | KOp::LoadLen { bail, .. }
+        | KOp::ArrayPush { bail, .. } => *bail = f(*bail),
         _ => {}
     }
 }
@@ -1009,6 +1032,10 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
                 resolve!(val);
             }
             KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => kill!(*dst),
+            KOp::ArrayPush { dst, val, .. } => {
+                resolve!(val);
+                kill!(*dst);
+            }
             KOp::StoreProp { src, .. } => resolve!(src),
             // Argument-window RANGE reads: leave the window registers alone,
             // only the result register is a plain def.
@@ -1074,6 +1101,10 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
         }
         KOp::StoreElem { idx, val, .. } => {
             see(*idx);
+            see(*val);
+        }
+        KOp::ArrayPush { dst, val, .. } => {
+            see(*dst);
             see(*val);
         }
         KOp::StoreProp { src, .. } => see(*src),
@@ -1161,6 +1192,11 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
                 succ[i] = (true, Some(*bail));
             }
             KOp::LoadLen { dst, bail, .. } => {
+                defs[i] = bit(*dst);
+                succ[i] = (true, Some(*bail));
+            }
+            KOp::ArrayPush { dst, val, bail, .. } => {
+                uses[i] = bit(*val);
                 defs[i] = bit(*dst);
                 succ[i] = (true, Some(*bail));
             }
@@ -1259,9 +1295,10 @@ fn patch(kops: &mut [KOp], kidx: usize, pc: u16) {
         | KOp::BrCmpK { target, .. }
         | KOp::BrFalsy { target, .. }
         | KOp::BrTruthy { target, .. } => *target = pc,
-        KOp::LoadElem { bail, .. } | KOp::StoreElem { bail, .. } | KOp::LoadLen { bail, .. } => {
-            *bail = pc
-        }
+        KOp::LoadElem { bail, .. }
+        | KOp::StoreElem { bail, .. }
+        | KOp::LoadLen { bail, .. }
+        | KOp::ArrayPush { bail, .. } => *bail = pc,
         _ => unreachable!("patching a non-branch kop"),
     }
 }
@@ -1493,7 +1530,13 @@ impl Xlate<'_> {
         let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
         match self.vstack[p] {
             VE::Obj(s) => Some(s),
-            VE::Bool | VE::Undef | VE::Opaque | VE::SelfFn | VE::MathObj | VE::MathFn(_) => None,
+            VE::Bool
+            | VE::Undef
+            | VE::Opaque
+            | VE::SelfFn
+            | VE::MathObj
+            | VE::MathFn(_)
+            | VE::ArrayPushFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -1863,6 +1906,7 @@ impl Xlate<'_> {
                 let top = *self.vstack.last()?;
                 match top {
                     VE::Num | VE::Bool => {
+                        let origin = *self.origins.last()?;
                         let src = self.top_reg(0)?;
                         let dst = if top == VE::Bool {
                             self.push_bool()?
@@ -1870,6 +1914,11 @@ impl Xlate<'_> {
                             self.push_num()?
                         };
                         self.kops.push(K::Mov { dst, src });
+                        // The copy IS the same value of the same local
+                        // version — propagate the origin so phase-1 base
+                        // discovery sees through the method-call prologue's
+                        // `Dup` (receiver duplicated for `this`).
+                        *self.origins.last_mut()? = origin;
                     }
                     VE::Obj(s) => {
                         self.vstack.push(VE::Obj(s));
@@ -1879,7 +1928,9 @@ impl Xlate<'_> {
                         self.vstack.push(VE::MathObj);
                         self.origins.push(None);
                     }
-                    VE::MathFn(_) | VE::Undef | VE::Opaque | VE::SelfFn => return None,
+                    VE::MathFn(_) | VE::Undef | VE::Opaque | VE::SelfFn | VE::ArrayPushFn(_) => {
+                        return None
+                    }
                 }
             }
             Op::Swap => {
@@ -2128,6 +2179,21 @@ impl Xlate<'_> {
                     Const::String(s) => s.as_str().to_string(),
                     _ => return None,
                 };
+                // `a.push` on an array base, in loop mode: the pinned
+                // canonical `Array.prototype.push` (entry-verified like a
+                // Math intrinsic; see `KOp::ArrayPush`). An Ordinary object
+                // with a plain data property named "push" loses its kernel
+                // to this routing — the region then rejects at the
+                // consumer — which is acceptable for so method-shaped a
+                // name.
+                if !self.fn_mode && key == "push" {
+                    let obj = self.base_slot(0)?;
+                    self.pop()?;
+                    self.vstack.push(VE::ArrayPushFn(obj));
+                    self.origins.push(None);
+                    self.uses_array_push = true;
+                    return Some(());
+                }
                 if key == "length" {
                     // Arrays: derived length, per-access checked, bailable.
                     let shape = self.vstack.clone();
@@ -2201,6 +2267,32 @@ impl Xlate<'_> {
                         base,
                         argc: u16::try_from(n).ok()?,
                     });
+                    return Some(());
+                }
+                // `a.push(x)`: the compiler's method-call pattern
+                // [.., ArrayPushFn(s), Obj(s), arg] with exactly one
+                // statically-Number argument. Emits the bailable
+                // [`KOp::ArrayPush`]; the generic `Call` (method object
+                // reconstructed from the realm canonical) owns every
+                // declined receiver.
+                if let VE::ArrayPushFn(s) = *self.vstack.get(fn_pos)? {
+                    if n != 1 || !matches!(self.vstack.get(fn_pos + 1)?, VE::Obj(s2) if *s2 == s) {
+                        return None;
+                    }
+                    let val = self.top_num_reg(0)?;
+                    let shape = self.vstack.clone();
+                    self.pop()?; // arg
+                    self.pop()?; // this (the array)
+                    self.pop()?; // fn
+                    let dst = self.push_num()?;
+                    let kidx = self.kops.len();
+                    self.kops.push(K::ArrayPush {
+                        obj: s,
+                        val,
+                        dst,
+                        bail: u16::MAX,
+                    });
+                    self.exits.push((kidx, self.base_ip + i as u32, shape));
                     return Some(());
                 }
                 // LOOP mode: a call of a PINNED closure — the callee is an

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -691,7 +691,9 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     for &(l, r) in &x.bool_reg {
         bool_locals[(r - BOOL_BASE) as usize] = l;
     }
+    let stores_elems = x.kops.iter().any(|op| matches!(op, KOp::StoreElem { .. }));
     Some(Kernel {
+        stores_elems,
         code: std::mem::take(&mut x.kops).into_boxed_slice(),
         locals: locals.into_boxed_slice(),
         bool_locals: bool_locals.into_boxed_slice(),

--- a/crates/chidori-js/src/realm.rs
+++ b/crates/chidori-js/src/realm.rs
@@ -20,6 +20,11 @@ pub struct Realm {
     /// exact objects; anything else declines to the generic path.
     pub math_object: Option<JsObject>,
     pub math_kernel: Vec<JsObject>,
+    /// The canonical `Array.prototype.push` function object, pinned at
+    /// install so the kernel `ArrayPush` entry guard can identity-check the
+    /// live `push` property (and a bail can reconstruct the method on the
+    /// operand stack). `None` only mid-bootstrap.
+    pub array_push: Option<JsObject>,
 
     pub object_proto: JsObject,
     pub function_proto: JsObject,
@@ -173,6 +178,7 @@ impl Realm {
             eval_fn: None,
             math_object: None,
             math_kernel: Vec::new(),
+            array_push: None,
             object_proto: bare(),
             function_proto: bare(),
             array_proto: bare(),

--- a/crates/chidori-js/src/realm.rs
+++ b/crates/chidori-js/src/realm.rs
@@ -25,6 +25,8 @@ pub struct Realm {
     /// live `push` property (and a bail can reconstruct the method on the
     /// operand stack). `None` only mid-bootstrap.
     pub array_push: Option<JsObject>,
+    /// As `array_push`, for `Array.prototype.pop` (`KOp::ArrayPop`).
+    pub array_pop: Option<JsObject>,
 
     pub object_proto: JsObject,
     pub function_proto: JsObject,
@@ -179,6 +181,7 @@ impl Realm {
             math_object: None,
             math_kernel: Vec::new(),
             array_push: None,
+            array_pop: None,
             object_proto: bare(),
             function_proto: bare(),
             array_proto: bare(),

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -732,6 +732,32 @@ pub fn protos_allow_index_create(proto: Option<JsObject>, idx: u32, count: u32) 
     true
 }
 
+/// The activation-scoped variant of [`protos_allow_index_create`] for the
+/// kernel `StoreElem` fast path: true when no object on `start`'s prototype
+/// chain could observably intercept the creation of ANY array-index property
+/// on `start` — every prototype a plain `Ordinary`/dense-`Array` object with
+/// no reified index-keyed `props` entry at all. Checked ONCE per kernel
+/// activation (nothing inside a kernel region can run user code or
+/// restructure a property map, so the verdict holds for the whole
+/// activation); the per-key probes stay in the per-write helper above.
+pub fn protos_allow_any_index_create(start: &JsObject) -> bool {
+    let mut cur = start.borrow().proto.clone();
+    while let Some(p) = cur {
+        let b = p.borrow();
+        match &b.internal {
+            Internal::Ordinary | Internal::Array(_) => {}
+            _ => return false,
+        }
+        if !b.props.is_empty() && b.props.keys().any(|k| k.array_index().is_some()) {
+            return false;
+        }
+        let next = b.proto.clone();
+        drop(b);
+        cur = next;
+    }
+    true
+}
+
 #[derive(Clone)]
 pub struct Property {
     pub kind: PropertyKind,

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -569,10 +569,48 @@ impl PrivateEnv {
 
 /// A property key: string or symbol. Integer-index keys are stored as their
 /// string form; enumeration re-derives integer ordering.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum PropertyKey {
     Str(JsString),
     Sym(JsSymbol),
+}
+
+/// Manual (not derived) so [`StrKeyRef`] — the alloc-free `&str` probe — can
+/// reproduce the exact same stream for string keys.
+impl std::hash::Hash for PropertyKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            PropertyKey::Str(s) => {
+                state.write_u8(0);
+                s.hash(state);
+            }
+            PropertyKey::Sym(s) => {
+                state.write_u8(1);
+                s.hash(state);
+            }
+        }
+    }
+}
+
+/// A borrowed string key for probing a property map WITHOUT allocating a
+/// `PropertyKey` (whose `JsString` is heap-backed). Hashes exactly like
+/// `PropertyKey::Str` of a well-formed string, so
+/// `props.contains_key(&StrKeyRef(s))` is equivalent to building the key.
+pub struct StrKeyRef<'a>(pub &'a str);
+
+impl std::hash::Hash for StrKeyRef<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // `PropertyKey::Str` hashes tag 0 + the string's canonical WTF-8
+        // bytes; a well-formed &str's bytes ARE its WTF-8 bytes.
+        state.write_u8(0);
+        self.0.as_bytes().hash(state);
+    }
+}
+
+impl indexmap::Equivalent<PropertyKey> for StrKeyRef<'_> {
+    fn equivalent(&self, key: &PropertyKey) -> bool {
+        matches!(key, PropertyKey::Str(s) if s.wtf8_bytes() == self.0.as_bytes())
+    }
 }
 
 impl PropertyKey {
@@ -631,6 +669,67 @@ pub fn canonical_index(s: &str) -> Option<u32> {
         Ok(n) if (n as u64) < (u32::MAX as u64) => Some(n),
         _ => None,
     }
+}
+
+/// Format an array index into `buf`, returning the digit string. Alloc-free
+/// backing for the property-map probes below.
+fn fmt_index(idx: u32, buf: &mut [u8; 10]) -> &str {
+    let mut i = buf.len();
+    let mut n = idx;
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
+        }
+    }
+    std::str::from_utf8(&buf[i..]).expect("ASCII digits")
+}
+
+/// True when no object on the PROTOTYPE chain starting at `proto` could
+/// observably intercept the CREATION of the array-index properties
+/// `idx..idx+count` on the receiver (an append or in-bounds hole fill, whose
+/// own property is absent — so the spec's OrdinarySet consults the chain):
+/// every prototype must be a plain `Ordinary` or dense-`Array` object with
+/// no reified `props` entry at those indices. A dense proto ELEMENT is a
+/// plain writable data property — OrdinarySet then creates the property on
+/// the receiver anyway, so skipping it is unobservable; only a reified entry
+/// (which may be an accessor or non-writable) can intercept or veto the
+/// write. The hot dense-array write fast paths call this before creating;
+/// anything else declines to the generic path.
+pub fn protos_allow_index_create(proto: Option<JsObject>, idx: u32, count: u32) -> bool {
+    // Stack-format the first index once — the common `count == 1` case
+    // (a push of one element, one `a[i] = v` store) reuses it at every level.
+    let mut buf = [0u8; 10];
+    let first = fmt_index(idx, &mut buf);
+    let mut cur = proto;
+    while let Some(p) = cur {
+        let b = p.borrow();
+        match &b.internal {
+            Internal::Ordinary | Internal::Array(_) => {}
+            // Exotic protos (Proxy traps, TypedArray index absorption,
+            // String character slots, mapped Arguments, …) own their [[Set]].
+            _ => return false,
+        }
+        if !b.props.is_empty() {
+            if b.props.contains_key(&StrKeyRef(first)) {
+                return false;
+            }
+            for j in 1..count {
+                let mut buf = [0u8; 10];
+                if b.props
+                    .contains_key(&StrKeyRef(fmt_index(idx + j, &mut buf)))
+                {
+                    return false;
+                }
+            }
+        }
+        let next = b.proto.clone();
+        drop(b);
+        cur = next;
+    }
+    true
 }
 
 #[derive(Clone)]
@@ -720,6 +819,17 @@ impl ObjectData {
     }
     pub fn private_get(&self, id: u64) -> Option<&PrivateElement> {
         self.privates.as_ref().and_then(|p| p.get(&id))
+    }
+    /// Does `props` hold a (reified) entry for the array index `idx`?
+    /// Alloc-free: the index is formatted into a stack buffer and probed via
+    /// [`StrKeyRef`], so hot fast-path guards can call this per element.
+    pub fn has_index_prop(&self, idx: u32) -> bool {
+        if self.props.is_empty() {
+            return false;
+        }
+        let mut buf = [0u8; 10];
+        self.props
+            .contains_key(&StrKeyRef(fmt_index(idx, &mut buf)))
     }
     /// Append a private element; `false` (no insert) when `id` is already
     /// present — the caller's duplicate-initialization TypeError.

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -179,6 +179,19 @@ const CORPUS: &[&str] = &[
     "const a = []; for (let i = 0; i < 3; i++) { a.push('s' + i); } console.log(a.join(','));",
     // Method extracted, not called: the region rejects; still correct.
     "const a = [1]; let t = ''; for (let i = 0; i < 2; i++) { const f = a.push; t = typeof f; } console.log(t, a.length);",
+    // ---- pinned-native `a.pop()` (KOp::ArrayPop) ----
+    // Drain loop: pop while non-empty (length re-read per iteration).
+    "const a = [1, 2, 3, 4, 5]; let s = 0; while (a.length > 0) { s += a.pop(); } console.log(s, a.length);",
+    // Pop past empty: undefined result arrives via the generic bail.
+    "const a = [7]; let r = 0; for (let i = 0; i < 3; i++) { const v = a.pop(); r += v === undefined ? 100 : v; } console.log(r, a.length);",
+    // Trailing HOLE reads through the prototype on the generic path.
+    "Array.prototype[1] = 55; const a = [9, , ]; const v = a.pop(); delete Array.prototype[1]; console.log(v, a.length);",
+    // Non-Number last element: per-op bail, exact value via generic.
+    "const a = [1, 'two', 3]; let s = ''; for (let i = 0; i < 3; i++) { s += a.pop() + '|'; } console.log(s, a.length);",
+    // MONKEYPATCHED pop declines at entry.
+    "const orig = Array.prototype.pop; let calls = 0; Array.prototype.pop = function () { calls++; return orig.call(this); }; const a = [1, 2, 3]; let s = 0; for (let i = 0; i < 3; i++) { s += a.pop(); } Array.prototype.pop = orig; console.log(calls, s, a.length);",
+    // push + pop mixed in one region.
+    "const a = []; let s = 0; for (let i = 0; i < 10; i++) { a.push(i); if (i % 2) { s += a.pop(); } } console.log(s, a.length, a.join(','));",
     // Base REASSIGNED inside the loop: translation must reject (store to a
     // base local) and the generic loop must swap arrays mid-flight.
     "let a = [1,2,3,4]; const b = [100,200,300,400]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; if (i === 1) a = b; } console.log(s);",

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -147,6 +147,15 @@ const CORPUS: &[&str] = &[
     "const a = [1,2,3]; let got = 0; Object.defineProperty(a, 1, { get() { got++; return 50; } }); let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } console.log(s, got);",
     // Array GROWTH inside the loop (appends bail; length re-read each pass).
     "const a = [1]; for (let i = 0; i < a.length && i < 5; i++) { a[a.length] = a[i] + 1; } console.log(a.join(','));",
+    // A reified Array.prototype index ACCESSOR intercepts loop APPENDS (the
+    // own property is absent, so OrdinarySet consults the chain): the kernel
+    // entry guard must decline and route through the setter every iteration.
+    "let calls = 0; Object.defineProperty(Array.prototype, 3, { set(v) { calls += v; }, configurable: true }); const a = [0, 1, 2]; for (let i = 1; i <= 3; i++) { a[3] = i; } delete Array.prototype[3]; console.log(calls, a.length, a[3]);",
+    // ... and HOLE FILLS (same chain consult for an absent own property).
+    "let calls = 0; Object.defineProperty(Array.prototype, 1, { set(v) { calls++; }, configurable: true }); const a = [7, , 9]; for (let i = 0; i < 2; i++) { a[1] = i; } delete Array.prototype[1]; console.log(calls, 1 in a, a.length);",
+    // A dense proto ELEMENT (plain writable data, no reified entry) must NOT
+    // decline: the spec creates the property on the receiver anyway.
+    "Array.prototype[2] = 99; const a = [0, 1]; for (let i = 0; i < 3; i++) { a[2] = i; } delete Array.prototype[2]; console.log(a[2], a.length, a.join(','));",
     // Base REASSIGNED inside the loop: translation must reject (store to a
     // base local) and the generic loop must swap arrays mid-flight.
     "let a = [1,2,3,4]; const b = [100,200,300,400]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; if (i === 1) a = b; } console.log(s);",

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -339,6 +339,18 @@ const CORPUS: &[&str] = &[
     "const d = new Date(0); d.foo = 0; let s = 0; for (let i = 0; i < 3; i++) { d.foo = i; s += d.foo; } console.log(s);",
     // Props mixed with dense-element access in one region.
     "const o = { sum: 0 }; const a = [5, 6, 7]; for (let i = 0; i < a.length; i++) { o.sum = o.sum + a[i]; } console.log(o.sum);",
+    // CONDITIONAL store: iterations that skip the store must leave the
+    // property untouched (prop localization writes the entry-loaded value
+    // back through the register).
+    "const o = { a: 5 }; for (let i = 0; i < 6; i++) { if (i % 2) { o.a = i * 10; } } console.log(o.a);",
+    "const o = { a: 5 }; for (let i = 0; i < 6; i++) { if (i > 99) { o.a = i; } } console.log(o.a);",
+    // Mid-loop BAIL (non-Number element) with a prop store already executed
+    // this activation: the bail must write the prop register back before
+    // the generic interpreter resumes and reads the property normally.
+    "const o = { t: 0 }; const a = [1, 'x', 3]; let s = ''; for (let i = 0; i < a.length; i++) { o.t = o.t + i; s += a[i]; } console.log(o.t, s);",
+    // Store-only class whose CURRENT value is a non-Number: declines (the
+    // register must carry the entry value for conditional stores).
+    "const o = { v: 'init' }; for (let i = 0; i < 3; i++) { o.v = i; } console.log(o.v);",
     // -0 / NaN through property writes; typeof pins.
     "const o = { z: 1, n: 1 }; for (let i = 0; i < 3; i++) { o.z = -0 * i; o.n = i === 1 ? NaN : i; } console.log(Object.is(o.z, -0), o.n !== o.n, typeof o.z);",
     // `length` as a plain object property takes the array bail path per

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -156,6 +156,29 @@ const CORPUS: &[&str] = &[
     // A dense proto ELEMENT (plain writable data, no reified entry) must NOT
     // decline: the spec creates the property on the receiver anyway.
     "Array.prototype[2] = 99; const a = [0, 1]; for (let i = 0; i < 3; i++) { a[2] = i; } delete Array.prototype[2]; console.log(a[2], a.length, a.join(','));",
+    // ---- pinned-native `a.push(x)` (KOp::ArrayPush) ----
+    // The canonical push loop; result (new length) used numerically.
+    "const a = []; let n = 0; for (let i = 0; i < 50; i++) { n = a.push(i * 2); } console.log(n, a.length, a[0], a[49]);",
+    // Push interleaved with reads, length, and a second array.
+    "const a = [], b = [9]; let s = 0; for (let i = 0; i < 20; i++) { a.push(i); b.push(a[i] + b[0]); s += a.length + b.length; } console.log(s, a[19], b[20]);",
+    // Argument with a SIDE EFFECT (post-increment) — no replay on any path.
+    "const a = []; let j = 0; for (let i = 0; i < 5; i++) { a.push(j++); } console.log(j, a.join(','));",
+    // Conditional push (skipped iterations).
+    "const a = []; for (let i = 0; i < 10; i++) { if (i % 3 === 0) { a.push(i); } } console.log(a.join(','));",
+    // MONKEYPATCHED Array.prototype.push: the entry guard must decline and
+    // run the patch every iteration.
+    "const orig = Array.prototype.push; let calls = 0; Array.prototype.push = function (x) { calls++; return orig.call(this, x + 100); }; const a = []; for (let i = 0; i < 4; i++) { a.push(i); } Array.prototype.push = orig; console.log(calls, a.join(','));",
+    // OWN `push` property shadowing the prototype's: declines, custom runs.
+    "const a = []; a.push = function (x) { this[this.length] = x * 10; return this.length; }; for (let i = 0; i < 4; i++) { a.push(i); } console.log(a.join(','), a.length);",
+    // Receiver with a CUSTOM prototype (not %Array.prototype%): declines.
+    "const a = []; Object.setPrototypeOf(a, { push(x) { Array.prototype.push.call(this, x + 5); return this.length; } }); for (let i = 0; i < 3; i++) { a.push(i); } console.log(a.join(','));",
+    // Non-extensible receiver: sloppy push throws (spec Set semantics) via
+    // the generic path — the entry guard declines.
+    "const a = [1]; Object.preventExtensions(a); let err = ''; try { for (let i = 0; i < 3; i++) { a.push(i); } } catch (e) { err = e.constructor.name; } console.log(err, a.length);",
+    // Non-Number argument: the region rejects; generic push runs.
+    "const a = []; for (let i = 0; i < 3; i++) { a.push('s' + i); } console.log(a.join(','));",
+    // Method extracted, not called: the region rejects; still correct.
+    "const a = [1]; let t = ''; for (let i = 0; i < 2; i++) { const f = a.push; t = typeof f; } console.log(t, a.length);",
     // Base REASSIGNED inside the loop: translation must reject (store to a
     // base local) and the generic loop must swap arrays mid-flight.
     "let a = [1,2,3,4]; const b = [100,200,300,400]; let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; if (i === 1) a = b; } console.log(s);",

--- a/docs/js-object-shapes-design.md
+++ b/docs/js-object-shapes-design.md
@@ -1,0 +1,220 @@
+# Object shapes (hidden classes): design + phased migration plan
+
+> **Status:** design (2026-07-06). This answers the question
+> [`js-performance-roadmap.md`](./js-performance-roadmap.md) §3.7 deferred —
+> "revisit with fresh callgrind data; if `get_index_of` still dominates
+> property-heavy code, shapes are the next step" — with fresh data, and it
+> comes to a more nuanced conclusion: hashing is no longer the headline cost;
+> **per-object construction is**. Shapes are still the right structural
+> answer, but their value here is structure *sharing* (allocation + key
+> interning + enumeration for free) more than lookup acceleration, and the
+> phasing below is chosen accordingly.
+>
+> The three invariants are unchanged: **zero `unsafe`**, **no new
+> heavyweight dependencies**, **byte-identical deterministic replay**.
+> Shapes are derived purely from insertion order and property attributes,
+> are never serialized, and never influence observable enumeration order —
+> the determinism story is identical to the inline caches'.
+
+---
+
+## 1. Fresh data (callgrind, 2026-07-06, current branch head)
+
+`json_roundtrip` (20k stringify+parse round-trips of a 5-key record with
+nested objects/arrays), 1.20 G instructions total:
+
+| cost center | Ir share | what it is |
+| --- | ---: | --- |
+| `malloc`/`free`/`memcpy` family | **~25%** | per-object `IndexMap` tables, per-key strings, `Vec`s, `Value` boxes |
+| `IndexMap::get_index_of` + `insert_full` | ~8.4% | key hashing on parse-insert and stringify/get lookups |
+| `json_stringify` + `json_quote_into` | ~7.7% | inherent serialization work |
+| `JsonParser::parse_*` | ~6.2% | inherent parsing work |
+| `Vm::get_from_object` + `get_prop` + `step` | ~11% | generic property walks + interpreter dispatch |
+| `own_keys` + `enumerable_own_keys_excluding` | ~3.2% | stringify enumeration (clones every key per object per pass) |
+
+Two conclusions:
+
+1. **The kernel tier already ate the lookup problem where it matters.**
+   Monomorphic property loops (`property_access`) run as register programs
+   with entry-resolved slots (kernel prop localization); `get_index_of` no
+   longer dominates any loop-shaped workload. What's left of it lives in
+   *cold* structure — one lookup per key per object during parse/stringify,
+   IC-verified interpreter accesses outside loops.
+2. **Construction is the bottleneck shapes actually fix.** Every
+   `JSON.parse` object allocates its own hash table and (until the Phase-0
+   interning below) its own copies of key strings that every sibling record
+   spells identically; every `{x, y}` literal in a loop does the same.
+   Structure sharing turns "N same-shape objects" into "one shared shape +
+   N slot vectors."
+
+Phase 0 (landed with this doc): interning parse keys by source slice cut
+~4% of `json_roundtrip` — confirming keys were a real but minor slice, and
+that the per-object *table* churn is the dominant remainder.
+
+## 2. Current model, and what 309 touch points mean
+
+`ObjectData` today:
+
+```rust
+pub struct ObjectData {
+    pub props: FxIndexMap<PropertyKey, Property>, // insertion-ordered
+    pub internal: Internal,                       // exotic payloads
+    pub proto: Option<JsObject>,
+    pub extensible: bool,
+}
+```
+
+`props` is public and directly manipulated at **309 sites** across the
+engine (`.props` field accesses: gets, `get_full`/`get_index[_mut]`,
+inserts, `shift_remove`, iteration, `contains_key`). The inline caches and
+the kernel prop machinery both already exploit `IndexMap`'s stable
+insertion-order slot indices — that is, the engine has organically grown
+*half* a shape system: slot-indexed access with identity verified per use.
+What's missing is the sharable identity (one pointer comparison instead of
+key equality checks) and the shared storage (no per-object table).
+
+A big-bang replacement of `props` is therefore not the plan. The plan is to
+make the existing map *cheap to have* for shaped objects, by splitting the
+key→slot index (shared, in the shape) from the slot values (per-object).
+
+## 3. Design
+
+### 3.1 Representation
+
+```rust
+/// One node in the shape tree. Immutable once created; shared via Rc.
+pub struct Shape {
+    /// Parent shape (None = the empty root for a given birth proto).
+    parent: Option<Rc<Shape>>,
+    /// The property this node appends to the parent, and its attributes.
+    /// Attribute CHANGES (defineProperty) demote to dictionary mode rather
+    /// than fork attribute-variant shape chains (rare; keeps the tree small).
+    key: PropertyKey,
+    enumerable: bool,
+    // writable/configurable: shaped properties are always plain data
+    // properties with default attributes; anything else demotes (§3.4).
+    /// Slot index of `key` in the owning object's slot vector (== depth-1).
+    slot: u32,
+    /// key → child shape for the next appended property.
+    /// Lazily allocated; most shapes have 0 or 1 transition.
+    transitions: RefCell<FxHashMap<PropertyKey, Rc<Shape>>>,
+    /// key → slot for O(1) lookup once the chain grows past a threshold;
+    /// below it, lookup walks the parent chain (shorter than a hash for the
+    /// 2-5 key objects that dominate real code). Built lazily per shape.
+    index: OnceCell<FxHashMap<PropertyKey, u32>>,
+}
+```
+
+Object storage becomes an enum behind accessors:
+
+```rust
+pub enum PropStorage {
+    /// Plain data properties with default attributes, insertion-ordered:
+    /// the shape holds the keys, `slots[i]` holds the value for the
+    /// property at chain depth i.
+    Shaped { shape: Rc<Shape>, slots: Vec<Value> },
+    /// Everything else: accessors, non-default attributes, deleted keys,
+    /// symbol-keyed exotics mid-mutation — today's map, verbatim.
+    Dict(FxIndexMap<PropertyKey, Property>),
+}
+```
+
+### 3.2 Invariants
+
+- **Enumeration order** is insertion order in both modes (shape chain order
+  == insertion order by construction; spec integer-key ordering is applied
+  at enumeration time exactly as today). Mode is unobservable.
+- **Replay determinism**: shapes are derived from program behavior only
+  (keys, insertion order, attribute operations). No addresses, no RNG. The
+  transition tree is per-`Vm` (rooted in `Realm`), so cross-realm sharing
+  never happens and identity checks stay realm-local — same policy as the
+  proto-identity ICs.
+- **A shaped object's slot indices are stable for its lifetime in that
+  shape** — append-only transitions; any destructive change demotes.
+
+### 3.3 Fast paths enabled
+
+- **Construction**: object literals compile to "reserve slots, walk the
+  transition chain once per site" — after warm-up the chain walk is N
+  pointer hops with no hashing and ONE allocation (the slot vec).
+  `JSON.parse` gets the same via a per-parser cursor cache: record shapes
+  repeat, so each record after the first is `Vec::with_capacity(n)` + n
+  value writes.
+- **ICs**: today's key-verified ICs upgrade to (shape ptr, slot) —
+  verification is one `Rc::ptr_eq` instead of a key compare + map probe.
+  Misses re-resolve exactly as now; no invalidation protocol is added
+  (same "verify on every use" discipline).
+- **Kernel prop localization**: entry resolution becomes a shape-chain walk
+  (or `index` probe) instead of `get_full`; the per-activation invariants
+  are unchanged. Slot vec replaces `get_index_mut` in the write-back.
+- **`own_keys`/stringify**: the key list is the shape chain — no per-object
+  key cloning for the common all-enumerable case.
+
+### 3.4 Demotion (dictionary mode) triggers
+
+`delete`, `defineProperty` with any non-default attribute or accessor,
+`preventExtensions`/`seal`/`freeze` (reify then mark), index-keyed
+properties on non-arrays past a small bound, and proto mutation do NOT
+demote (shape is keyed by birth proto only for the root; proto lives on
+`ObjectData` as today and IC/kernel guards already verify it). Demotion
+materializes the map from the chain once; objects never re-promote.
+
+### 3.5 What does NOT change
+
+- `Internal` exotics (arrays' dense storage, typed arrays, proxies) — all
+  already bypass `props` on their fast paths.
+- The array kernel ops, dense-element machinery, prototype-chain guards.
+- The journal/replay surface: nothing shape-related is recorded.
+
+## 4. Phased migration (each phase gates test262 language+built-ins)
+
+1. **Phase 0 — parse-key interning** *(landed with this doc)*: JSON object
+   keys interned by source slice; ~4% on `json_roundtrip`, zero structural
+   risk.
+2. **Phase 1 — accessor extraction**: replace direct `.props` field access
+   with a narrow `ObjectData` API (`own_get`, `own_get_full`, `own_insert`,
+   `own_remove`, `own_iter`, `own_index/get_index_mut` for the IC/kernel
+   paths). Pure mechanical refactor of the 309 sites, zero behavior change,
+   landable in slices. This is the bulk of the diff and de-risks everything
+   after it.
+3. **Phase 2 — `PropStorage` behind the API**: introduce the enum with
+   `Dict` as the only constructor (still zero behavior change), then flip
+   plain-object birth to `Shaped` with demotion triggers per §3.4.
+   Differential coverage: the kernels corpus + a new shapes-focused corpus
+   (delete/defineProperty/freeze mid-loop, enumeration order, proxies).
+4. **Phase 3 — consumers**: IC upgrade to (shape, slot); kernel prop entry
+   resolution via shape; literal-site transition caching; `JSON.parse`
+   record-shape cursor; stringify keys-from-shape.
+5. **Phase 4 — measurement + demotion tuning**: re-profile json/closures/
+   property-heavy workloads; tune the chain-walk vs `index` threshold and
+   the literal-site cache.
+
+Expected wins (from the profile shares): json_roundtrip construction+lookup
+slices total ~35% of its instructions today; shapes address most of the
+map/key allocation and hashing within it — a 1.3–1.6× on json is realistic,
+plus across-the-board gains on object-literal-heavy code (closures
+workload allocates a record per iteration) and colder property access.
+
+## 5. Risks and mitigations
+
+- **The 309-site refactor** is where mistakes hide. Mitigation: Phase 1 is
+  semantically inert and mechanical; land it in reviewable slices, each
+  gated on the full test262 baseline (the gate caught two real bugs during
+  the kernel work on this branch; it is the effective spec oracle).
+- **Engines grow their worst bugs in transitions** (`delete`, redefinition,
+  proto swaps). Mitigation: demote on every destructive edge — the
+  dictionary path IS today's battle-tested code; shapes only ever serve the
+  append-only common case.
+- **Memory**: transition trees can retain dead shapes. Per-`Vm` rooting +
+  the existing cycle collector's registry covers reclamation at quiescence;
+  shapes hold no `Value`s, only keys.
+- **`u128` liveness / slot bounds**: slot vecs cap at the same bound as
+  dictionary properties today (no new limit).
+
+## 6. Relationship to register bytecode (§3.5 of the roadmap)
+
+Independent. Register bytecode removes interpreter dispatch/operand-stack
+costs; shapes remove per-object storage costs. The kernel tier's typed-slot
+experience (entry-resolved indices, verify-per-use, decline-to-generic)
+is the proven pattern both reuse. Shapes first: they also make the
+register-bytecode ICs cheaper when that lands.


### PR DESCRIPTION
Two changes attacking the worst remaining benchmark ratios:

1. Dense-array fast paths for builtin writes. Array.prototype.push/pop on
   an unshadowed extensible dense array now operate directly on the backing
   vec (one borrow, no per-element index->String key, hashing, or prototype
   walk) — the same conditions the kernel StoreElem fast path already uses.
   create_data_index additionally fills in-bounds HOLES directly (map's
   ArrayCreate(len)-pre-sized result previously reified every element
   through define_own_property), and Op::SetPropDynamic now accepts hole
   fills and exact appends under the kernel StoreElem conditions.

2. Prepared fn-kernel callbacks for native higher-order builtins. sort's
   comparator and the forEach/map/filter/find*/some/every/reduce* callbacks
   resolve their function kernel ONCE per invocation (Vm::prepare_kernel_callback)
   and then execute per element in unboxed registers via a shared executor
   (exec_fn_kernel_code, also now backing run_fn_kernel), skipping the
   per-call entry ceremony. Everything user code can change between two
   calls — argument types, upvalue cells, a patched Math, an installed op
   budget — is re-checked per call, declining to the generic Vm::call for
   that element. TypedArray.prototype.sort/toSorted share the comparator
   handle.

Benchmarks (this machine, vs node, execution-only):
  array_push_sum  325ms 11.8x -> 157ms 5.5x
  array_hof       208ms  6.1x ->  97ms 2.3x
  sort            784ms  5.4x -> 466ms 3.0x

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P7mW87tDhKKxcJW79rWuLa