### PR TITLE
Add memory-utilization benchmarks (in-process heap + cross-runtime max RSS)

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -1,8 +1,9 @@
 name: JS benchmarks
 
 # Runs the chidori-js cross-runtime benchmark suite (chidori-js vs Node.js vs
-# Bun) on PRs that touch the engine, and posts the results table as a single
-# sticky comment on the PR (updated in place on each run, not re-posted).
+# Bun, wall-clock + peak memory) on PRs that touch the engine, and posts the
+# results tables as a single sticky comment on the PR (updated in place on
+# each run, not re-posted).
 #
 # These numbers come from a shared GitHub-hosted runner, so treat them as
 # ratios for a quick smell-test, not as a precise performance gate — the job
@@ -44,6 +45,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # GNU time gives the harness exact peak-RSS (ru_maxrss) for the memory
+      # table. Best-effort: without it the harness falls back to polling
+      # /proc/<pid>/status VmHWM, which is near-exact for these workloads.
+      - name: Install GNU time (exact peak-RSS measurement)
+        run: sudo apt-get install -y time || true
 
       - name: Build chidori-js run example (release)
         run: cargo build --release -p chidori-js --example run

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -1,9 +1,10 @@
 name: JS benchmarks
 
 # Runs the chidori-js cross-runtime benchmark suite (chidori-js vs Node.js vs
-# Bun, wall-clock + peak memory) on PRs that touch the engine, and posts the
-# results tables as a single sticky comment on the PR (updated in place on
-# each run, not re-posted).
+# Bun, wall-clock + peak memory) plus the in-process heap-utilization bench
+# (`cargo bench -p chidori-js --bench memory`) on PRs that touch the engine,
+# and posts the results tables as a single sticky comment on the PR (updated
+# in place on each run, not re-posted).
 #
 # These numbers come from a shared GitHub-hosted runner, so treat them as
 # ratios for a quick smell-test, not as a precise performance gate — the job
@@ -55,12 +56,34 @@ jobs:
       - name: Build chidori-js run example (release)
         run: cargo build --release -p chidori-js --example run
 
+      # In-process heap numbers (tracking allocator: realm footprint, per-run
+      # peak/churn/retained, leak check). Deterministic byte counts, so unlike
+      # the timings they ARE comparable across runs; still informational only —
+      # the step fails solely if the bench itself errors.
+      - name: Run in-process memory benchmarks
+        run: |
+          set -o pipefail
+          cargo bench -p chidori-js --bench memory | tee memory-report.txt
+
       - name: Run cross-runtime benchmarks
         run: |
           node crates/chidori-js/benchmarks/run.mjs \
             --no-build \
             --markdown benchmark-report.md \
             --json benchmark-report.json
+
+      # Fold the heap numbers into the same sticky-comment report, after the
+      # cross-runtime tables.
+      - name: Append memory report to Markdown report
+        run: |
+          {
+            echo ""
+            echo "### In-process heap utilization (exact bytes, tracking allocator)"
+            echo ""
+            echo '```'
+            cat memory-report.txt
+            echo '```'
+          } >> benchmark-report.md
 
       - name: Upload benchmark report
         if: always()
@@ -70,6 +93,7 @@ jobs:
           path: |
             benchmark-report.md
             benchmark-report.json
+            memory-report.txt
 
       # Post/update the sticky PR comment. Skipped for fork PRs (their token is
       # read-only and can't comment) and for manual workflow_dispatch runs.

--- a/crates/chidori-js/Cargo.toml
+++ b/crates/chidori-js/Cargo.toml
@@ -58,3 +58,10 @@ criterion = "0.5"
 [[bench]]
 name = "execution"
 harness = false
+
+# Heap-utilization benchmarks over the same workloads: realm footprint,
+# bytecode footprint, per-run peak/churn/retained, and a repeat-run leak
+# check. Run with `cargo bench -p chidori-js --bench memory`.
+[[bench]]
+name = "memory"
+harness = false

--- a/crates/chidori-js/benches/common/workloads.rs
+++ b/crates/chidori-js/benches/common/workloads.rs
@@ -1,0 +1,48 @@
+//! Shared workload corpus for the chidori-js in-process benchmarks.
+//!
+//! Both `benches/execution.rs` (wall-clock, criterion) and `benches/memory.rs`
+//! (heap utilization) run this same set, so a time number and a memory number
+//! for the same name describe the same program. Lives in a subdirectory so
+//! cargo does not auto-discover it as a bench target of its own; each bench
+//! pulls it in with `#[path = "common/workloads.rs"] mod workloads;`.
+//!
+//! Each workload is an IIFE so it returns a value and declares no globals
+//! (lets a bench reuse one engine across iterations).
+
+pub const WORKLOADS: &[(&str, &str)] = &[
+    // Tight numeric loop — interpreter dispatch + integer/float arithmetic.
+    (
+        "arith_loop",
+        "(function(){ let s = 0; for (let i = 0; i < 20000; i++) { s += i * 2 - (i % 3); } return s; })()",
+    ),
+    // Recursion + function-call overhead (frame setup/teardown).
+    (
+        "fib_recursive",
+        "(function(){ function fib(n){ return n < 2 ? n : fib(n-1) + fib(n-2); } return fib(24); })()",
+    ),
+    // Object property get/set in a loop (shape lookups, map access).
+    (
+        "property_access",
+        "(function(){ let o = { a: 0, b: 0, c: 0 }; for (let i = 0; i < 10000; i++) { o.a = i; o.b = o.a + 1; o.c = o.b + o.a; } return o.c; })()",
+    ),
+    // Array growth + indexed read loop.
+    (
+        "array_push_sum",
+        "(function(){ let a = []; for (let i = 0; i < 5000; i++) a.push(i); let s = 0; for (let i = 0; i < a.length; i++) s += a[i]; return s; })()",
+    ),
+    // Higher-order array methods (map/filter/reduce + per-element closures).
+    (
+        "array_hof",
+        "(function(){ let a = []; for (let i = 0; i < 2000; i++) a.push(i); return a.map(x => x * x).filter(x => x % 2 === 0).reduce((p, c) => p + c, 0); })()",
+    ),
+    // String building (concatenation + number→string coercion).
+    (
+        "string_build",
+        "(function(){ let s = ''; for (let i = 0; i < 3000; i++) s += 'x' + i; return s.length; })()",
+    ),
+    // Closures + higher-order calls in a loop (upvalue capture/read).
+    (
+        "closures",
+        "(function(){ function adder(n){ return function(x){ return x + n; }; } let f = adder(5); let s = 0; for (let i = 0; i < 10000; i++) s = f(s) - 4; return s; })()",
+    ),
+];

--- a/crates/chidori-js/benches/execution.rs
+++ b/crates/chidori-js/benches/execution.rs
@@ -24,45 +24,11 @@ use chidori_js::compiler::compile_script;
 use chidori_js::{Engine, Value};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-/// Representative workloads, each an IIFE so it returns a value and declares no
-/// globals (lets the `interp` group reuse one engine across iterations).
-const WORKLOADS: &[(&str, &str)] = &[
-    // Tight numeric loop — interpreter dispatch + integer/float arithmetic.
-    (
-        "arith_loop",
-        "(function(){ let s = 0; for (let i = 0; i < 20000; i++) { s += i * 2 - (i % 3); } return s; })()",
-    ),
-    // Recursion + function-call overhead (frame setup/teardown).
-    (
-        "fib_recursive",
-        "(function(){ function fib(n){ return n < 2 ? n : fib(n-1) + fib(n-2); } return fib(24); })()",
-    ),
-    // Object property get/set in a loop (shape lookups, map access).
-    (
-        "property_access",
-        "(function(){ let o = { a: 0, b: 0, c: 0 }; for (let i = 0; i < 10000; i++) { o.a = i; o.b = o.a + 1; o.c = o.b + o.a; } return o.c; })()",
-    ),
-    // Array growth + indexed read loop.
-    (
-        "array_push_sum",
-        "(function(){ let a = []; for (let i = 0; i < 5000; i++) a.push(i); let s = 0; for (let i = 0; i < a.length; i++) s += a[i]; return s; })()",
-    ),
-    // Higher-order array methods (map/filter/reduce + per-element closures).
-    (
-        "array_hof",
-        "(function(){ let a = []; for (let i = 0; i < 2000; i++) a.push(i); return a.map(x => x * x).filter(x => x % 2 === 0).reduce((p, c) => p + c, 0); })()",
-    ),
-    // String building (concatenation + number→string coercion).
-    (
-        "string_build",
-        "(function(){ let s = ''; for (let i = 0; i < 3000; i++) s += 'x' + i; return s.length; })()",
-    ),
-    // Closures + higher-order calls in a loop (upvalue capture/read).
-    (
-        "closures",
-        "(function(){ function adder(n){ return function(x){ return x + n; }; } let f = adder(5); let s = 0; for (let i = 0; i < 10000; i++) s = f(s) - 4; return s; })()",
-    ),
-];
+// Workload corpus shared with `benches/memory.rs` so time and memory numbers
+// describe the same programs.
+#[path = "common/workloads.rs"]
+mod workloads;
+use workloads::WORKLOADS;
 
 /// Build a fresh closure for `proto` and run it to completion on `engine`.
 fn run_proto(engine: &mut Engine, proto: &Rc<FuncProto>) -> Value {

--- a/crates/chidori-js/benches/memory.rs
+++ b/crates/chidori-js/benches/memory.rs
@@ -1,0 +1,322 @@
+//! Heap-utilization benchmarks for the chidori-js engine: how much memory the
+//! realm, the compiler, and the interpreter actually use — the complement to
+//! the wall-clock numbers in `benches/execution.rs`, over the same workloads.
+//!
+//! A counting `#[global_allocator]` (wrapping std's `System`) tracks live
+//! bytes, the high-water mark, and cumulative allocation traffic, so every
+//! number below is exact for this process, not an RSS approximation. Because
+//! the engine is deterministic by design, the numbers are stable run-to-run;
+//! each measurement is taken once rather than sampled.
+//!
+//! Four angles:
+//!   * `realm` — footprint of a fresh `Engine::new()`: bytes retained by the
+//!     realm (globals + built-in prototypes), the peak while constructing it,
+//!     and total allocation traffic.
+//!   * `compile` — bytecode footprint: bytes retained by the compiled
+//!     `FuncProto` for each workload, plus front-end churn.
+//!   * `eval` — end-to-end run on a fresh engine: peak heap over the realm
+//!     baseline, allocation churn, bytes the engine retains after the run,
+//!     and after `collect_cycles()`.
+//!   * `steady_state` — leak check: run each workload many times on one
+//!     engine (compile once) and report retained growth per run after
+//!     warmup + cycle collection. For a durable execution engine this should
+//!     be ~0.
+//!
+//! Run with: `cargo bench -p chidori-js --bench memory`
+//! Filter:   `cargo bench -p chidori-js --bench memory -- fib`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+use chidori_js::bytecode::FuncProto;
+use chidori_js::compiler::compile_script;
+use chidori_js::{Engine, Value};
+
+// Workload corpus shared with `benches/execution.rs` so time and memory
+// numbers describe the same programs.
+#[path = "common/workloads.rs"]
+mod workloads;
+use workloads::WORKLOADS;
+
+// ---------------------------------------------------------------------------
+// Tracking allocator
+// ---------------------------------------------------------------------------
+
+/// Live (allocated-minus-freed) bytes.
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+/// High-water mark of `LIVE`. Reset to the current level at the start of each
+/// measurement (see [`Section::measure`]).
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+/// Cumulative bytes ever allocated (churn; never decremented).
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
+/// Cumulative allocation events (growing reallocs count as one event).
+static EVENTS: AtomicUsize = AtomicUsize::new(0);
+
+fn charge(bytes: usize) {
+    let live = LIVE.fetch_add(bytes, Relaxed) + bytes;
+    PEAK.fetch_max(live, Relaxed);
+    TOTAL.fetch_add(bytes, Relaxed);
+    EVENTS.fetch_add(1, Relaxed);
+}
+
+/// `System` plus byte accounting. The bench runs single-threaded, so relaxed
+/// atomics are exact here, and resetting `PEAK` between measurements is sound.
+struct TrackingAlloc;
+
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = System.alloc(layout);
+        if !p.is_null() {
+            charge(layout.size());
+        }
+        p
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let p = System.alloc_zeroed(layout);
+        if !p.is_null() {
+            charge(layout.size());
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        LIVE.fetch_sub(layout.size(), Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = System.realloc(ptr, layout, new_size);
+        if !p.is_null() {
+            // Charge only the delta: a grow is one event of `new - old` fresh
+            // bytes, a shrink just returns the difference to the pool.
+            if new_size >= layout.size() {
+                charge(new_size - layout.size());
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Relaxed);
+            }
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAlloc = TrackingAlloc;
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
+
+/// Heap deltas across one measured closure.
+struct Measure {
+    /// Live-byte growth from entry to exit (negative = net free).
+    retained: isize,
+    /// High-water mark reached inside the closure, relative to entry.
+    peak: usize,
+    /// Bytes allocated inside the closure, freed or not (churn).
+    churn: usize,
+    /// Allocation events inside the closure.
+    events: usize,
+}
+
+/// Run `f` and report its heap deltas. The peak high-water mark is reset to
+/// the current live level on entry so `peak` is relative to this measurement.
+fn measure<R>(f: impl FnOnce() -> R) -> (Measure, R) {
+    let live0 = LIVE.load(Relaxed);
+    PEAK.store(live0, Relaxed);
+    let total0 = TOTAL.load(Relaxed);
+    let events0 = EVENTS.load(Relaxed);
+    let r = f();
+    let m = Measure {
+        retained: LIVE.load(Relaxed) as isize - live0 as isize,
+        peak: PEAK.load(Relaxed).saturating_sub(live0),
+        churn: TOTAL.load(Relaxed) - total0,
+        events: EVENTS.load(Relaxed) - events0,
+    };
+    (m, r)
+}
+
+fn fmt_bytes(n: f64) -> String {
+    let (mag, sign) = (n.abs(), if n < 0.0 { "-" } else { "" });
+    if mag >= 1024.0 * 1024.0 {
+        format!("{sign}{:.2} MiB", mag / (1024.0 * 1024.0))
+    } else if mag >= 1024.0 {
+        format!("{sign}{:.1} KiB", mag / 1024.0)
+    } else {
+        format!("{sign}{mag:.0} B")
+    }
+}
+
+fn fmt_count(n: usize) -> String {
+    if n >= 1_000_000 {
+        format!("{:.2}M", n as f64 / 1e6)
+    } else if n >= 10_000 {
+        format!("{:.1}k", n as f64 / 1e3)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Build a fresh closure for `proto` and run it to completion on `engine`
+/// (same shape as the `interp` group in `benches/execution.rs`).
+fn run_proto(engine: &mut Engine, proto: &Rc<FuncProto>) -> Value {
+    let func = engine.vm.make_closure(proto.clone(), Vec::new());
+    engine
+        .vm
+        .call(Value::Object(func), Value::Undefined, &[])
+        .expect("benchmark workload must not throw")
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+fn bench_realm() {
+    println!("== realm: Engine::new() footprint ==");
+    let (m, engine) = measure(Engine::new);
+    println!(
+        "  retained {:>10}   construction peak {:>10}   churn {:>10} in {} allocs   {} live objects",
+        fmt_bytes(m.retained as f64),
+        fmt_bytes(m.peak as f64),
+        fmt_bytes(m.churn as f64),
+        fmt_count(m.events),
+        fmt_count(engine.vm.gc_tracked_live()),
+    );
+    drop(engine);
+    println!();
+}
+
+fn bench_compile(filter: Option<&str>) {
+    println!("== compile: bytecode footprint (parse + lower, no execution) ==");
+    println!(
+        "  {:<16} {:>10} {:>10} {:>10} {:>8}",
+        "workload", "retained", "peak", "churn", "allocs"
+    );
+    for (name, src) in selected(filter) {
+        let (m, proto) = measure(|| compile_script(src).expect("compiles"));
+        println!(
+            "  {:<16} {:>10} {:>10} {:>10} {:>8}",
+            name,
+            fmt_bytes(m.retained as f64),
+            fmt_bytes(m.peak as f64),
+            fmt_bytes(m.churn as f64),
+            fmt_count(m.events),
+        );
+        drop(proto);
+    }
+    println!();
+}
+
+fn bench_eval(filter: Option<&str>) {
+    println!("== eval: full run on a fresh engine (peak/retained over the realm baseline) ==");
+    println!(
+        "  {:<16} {:>10} {:>10} {:>8} {:>10} {:>10}",
+        "workload", "peak", "churn", "allocs", "retained", "after gc"
+    );
+    for (name, src) in selected(filter) {
+        let mut engine = Engine::new();
+        let live0 = LIVE.load(Relaxed) as isize;
+        let (m, value) = measure(|| engine.eval(src).expect("evaluates"));
+        drop(value);
+        // What the engine still holds once the run's garbage cycles are gone
+        // (interned atoms, shapes, caches — the cost of keeping a warm realm).
+        engine.vm.collect_cycles();
+        let after_gc = LIVE.load(Relaxed) as isize - live0;
+        println!(
+            "  {:<16} {:>10} {:>10} {:>8} {:>10} {:>10}",
+            name,
+            fmt_bytes(m.peak as f64),
+            fmt_bytes(m.churn as f64),
+            fmt_count(m.events),
+            fmt_bytes(m.retained as f64),
+            fmt_bytes(after_gc as f64),
+        );
+    }
+    println!();
+}
+
+fn bench_steady_state(filter: Option<&str>) {
+    const RUNS: usize = 10;
+    println!("== steady_state: {RUNS} repeat runs on one engine (leak check; growth/run should be ~0) ==");
+    println!(
+        "  {:<16} {:>12} {:>12} {:>10}",
+        "workload", "growth/run", "peak/run", "churn/run"
+    );
+    for (name, src) in selected(filter) {
+        let proto = Rc::new(compile_script(src).expect("compiles"));
+        let mut engine = Engine::new();
+        // Warm up once so one-time lazy work (interned strings, caches) is
+        // attributed to warmup, not counted as steady-state growth.
+        drop(run_proto(&mut engine, &proto));
+        engine.vm.collect_cycles();
+
+        // Peak is tracked per run (reset to that run's live level each time),
+        // so `worst_peak` is the worst single run — the outer `m.peak` would
+        // be clobbered by those resets and is not used here.
+        let (m, worst_peak) = measure(|| {
+            let mut worst = 0usize;
+            for _ in 0..RUNS {
+                let base = LIVE.load(Relaxed);
+                PEAK.store(base, Relaxed);
+                drop(run_proto(&mut engine, &proto));
+                worst = worst.max(PEAK.load(Relaxed).saturating_sub(base));
+            }
+            engine.vm.collect_cycles();
+            worst
+        });
+        println!(
+            "  {:<16} {:>12} {:>12} {:>10}",
+            name,
+            fmt_bytes(m.retained as f64 / RUNS as f64),
+            fmt_bytes(worst_peak as f64),
+            fmt_bytes(m.churn as f64 / RUNS as f64),
+        );
+    }
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+fn selected(filter: Option<&str>) -> impl Iterator<Item = (&'static str, &'static str)> + '_ {
+    WORKLOADS
+        .iter()
+        .copied()
+        .filter(move |(name, _)| filter.is_none_or(|f| name.contains(f)))
+}
+
+fn main() {
+    let mut filter: Option<String> = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            // cargo passes `--bench` to every bench binary; criterion-style
+            // positional filters are supported for muscle-memory parity.
+            "--bench" => {}
+            "--filter" => filter = args.next(),
+            "-h" | "--help" => {
+                println!(
+                    "usage: cargo bench -p chidori-js --bench memory -- [FILTER]\n\n\
+                     Reports heap utilization (retained/peak/churn) for the realm,\n\
+                     the compiler, and the interpreter over the shared benchmark\n\
+                     workloads. FILTER is a substring match on workload names."
+                );
+                return;
+            }
+            other if !other.starts_with('-') => filter = Some(other.to_string()),
+            other => {
+                eprintln!("unknown option: {other}");
+                std::process::exit(2);
+            }
+        }
+    }
+    let filter = filter.as_deref();
+
+    println!("chidori-js heap utilization (exact, via tracking global allocator)\n");
+    bench_realm();
+    bench_compile(filter);
+    bench_eval(filter);
+    bench_steady_state(filter);
+}

--- a/crates/chidori-js/benchmarks/README.md
+++ b/crates/chidori-js/benchmarks/README.md
@@ -84,8 +84,10 @@ Markdown report.
 [`.github/workflows/js-benchmarks.yml`](../../../.github/workflows/js-benchmarks.yml)
 runs this suite on every PR that touches `crates/chidori-js/**` and posts the
 Markdown report (`--markdown`) as a **single sticky comment** on the PR —
-updated in place on each push, never re-posted. The full report is also uploaded
-as a build artifact (`js-benchmark-report`).
+updated in place on each push, never re-posted. The comment also carries the
+in-process heap numbers (`cargo bench -p chidori-js --bench memory`), appended
+as a final section. The full report is also uploaded as a build artifact
+(`js-benchmark-report`).
 
 The job only fails the build on a **correctness mismatch** between runtimes (the
 harness exits non-zero), never on timing — the numbers come from a shared

--- a/crates/chidori-js/benchmarks/README.md
+++ b/crates/chidori-js/benchmarks/README.md
@@ -1,7 +1,7 @@
 # chidori-js cross-runtime benchmarks
 
 A suite that runs the **same JavaScript workloads** under three runtimes and
-compares wall-clock execution time:
+compares wall-clock execution time and peak memory (max RSS):
 
 | runtime    | what it is                                                            |
 | ---------- | --------------------------------------------------------------------- |
@@ -9,11 +9,15 @@ compares wall-clock execution time:
 | `node`     | Node.js (V8)                                                          |
 | `bun`      | Bun (JavaScriptCore)                                                  |
 
-This sits alongside the in-process [`benches/execution.rs`](../benches/execution.rs)
-criterion micro-benchmarks. Those isolate chidori-js's own hot paths (compile /
-interpret / realm setup) in-process; **this** suite answers the different
-question "how does chidori-js compare to the JITs people actually ship?" by
-running each workload as a standalone script under all three runtimes.
+This sits alongside two in-process benchmarks over the same workload corpus:
+the [`benches/execution.rs`](../benches/execution.rs) criterion
+micro-benchmarks, which isolate chidori-js's own hot paths (compile /
+interpret / realm setup), and [`benches/memory.rs`](../benches/memory.rs)
+(`cargo bench -p chidori-js --bench memory`), which reports exact heap
+utilization (realm footprint, per-run peak/churn/retained, leak check) via a
+tracking allocator. **This** suite answers the different question "how does
+chidori-js compare to the JITs people actually ship?" by running each workload
+as a standalone script under all three runtimes.
 
 ## Quick start
 
@@ -46,7 +50,7 @@ fib_recursive    2.15s 228.4x  11.8ms 1.3x        9.4ms        bun
 ...
 ```
 
-Two tables are printed:
+Three tables are printed:
 
 - **Execution-only** — raw subprocess time **minus that runtime's startup
   baseline** (measured separately with `workloads/startup.js`). This is the
@@ -56,6 +60,20 @@ Two tables are printed:
   a small native binary and starts in ~3ms, whereas Node pays ~34ms of V8/runtime
   startup, so for very short scripts chidori can win the *total* even when it
   loses the *execution* — this table makes that visible.
+- **Peak memory** — max RSS of the subprocess, per workload plus a `(startup)`
+  row (the runtime's floor footprint before any workload allocates). Measured
+  in dedicated extra runs (default 3, median; `--mem-runs N`) so the timing
+  methodology is untouched, and reported absolute rather than
+  startup-subtracted — unlike wall-clock, RSS doesn't subtract linearly. The
+  `N.Nx` suffix is the blow-up relative to the smallest runtime on that row.
+  Skip it with `--no-memory`.
+
+Peak RSS comes from the best available source: GNU `time -v` (or Homebrew
+`gtime`) / BSD `time -l`, which report the kernel's exact `ru_maxrss`; without
+those, on Linux the harness polls the monotonic `VmHWM` high-water mark in
+`/proc/<pid>/status` every ~1ms — exact whenever a sample lands after the
+peak, slightly under-reading only for very short-lived processes. On other
+platforms with no usable `time`, the memory table is skipped with a warning.
 
 Pass `--json PATH` to also dump every sample (min/median/mean/max per runtime)
 for offline analysis, or `--markdown PATH` to write the same two tables as a

--- a/crates/chidori-js/benchmarks/run.mjs
+++ b/crates/chidori-js/benchmarks/run.mjs
@@ -2,10 +2,11 @@
 // Cross-runtime benchmark harness for the chidori-js JavaScript engine.
 //
 // Runs each workload in `workloads/` as a standalone script under chidori-js,
-// Node.js, and Bun, measuring subprocess wall-clock time. The same `.js` file
-// is fed to all three runtimes and every workload prints a single `RESULT=...`
-// line, so the harness can confirm the runtimes agree before trusting the
-// timings (a fast-but-wrong engine is not a faster engine).
+// Node.js, and Bun, measuring subprocess wall-clock time and peak memory
+// (max RSS). The same `.js` file is fed to all three runtimes and every
+// workload prints a single `RESULT=...` line, so the harness can confirm the
+// runtimes agree before trusting the numbers (a fast-but-wrong engine is not
+// a faster engine).
 //
 // Each runtime pays a fixed process-startup cost (binary load + realm setup).
 // We measure that separately with `workloads/startup.js` and subtract it to
@@ -23,14 +24,16 @@
 //   --no-build          do not `cargo build` the chidori binary first
 //   --json PATH         also write the full results as JSON to PATH
 //   --markdown PATH     also write a Markdown report to PATH (used by CI)
-//   --quick             shorthand for --runs 3 --warmup 0
+//   --mem-runs N        memory-measured runs per workload (default 3)
+//   --no-memory         skip the peak-memory (max RSS) measurement
+//   --quick             shorthand for --runs 3 --warmup 0 --mem-runs 1
 //   -h, --help          show this help
 //
 // Environment:
 //   CHIDORI_RUN_BIN     same as --chidori-bin
 
-import { execFile, execFileSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -54,6 +57,8 @@ function parseArgs(argv) {
     build: true,
     json: null,
     markdown: null,
+    memory: true,
+    memRuns: 3,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -67,7 +72,9 @@ function parseArgs(argv) {
       case "--no-build": opts.build = false; break;
       case "--json": opts.json = next(); break;
       case "--markdown": opts.markdown = next(); break;
-      case "--quick": opts.runs = 3; opts.warmup = 0; break;
+      case "--mem-runs": opts.memRuns = Number(next()); break;
+      case "--no-memory": opts.memory = false; break;
+      case "--quick": opts.runs = 3; opts.warmup = 0; opts.memRuns = 1; break;
       case "-h": case "--help": printHelp(); process.exit(0); break;
       default:
         console.error(`unknown option: ${a}`);
@@ -75,8 +82,8 @@ function parseArgs(argv) {
         process.exit(2);
     }
   }
-  if (!Number.isFinite(opts.runs) || opts.runs < 1) {
-    console.error("--runs must be a positive integer");
+  if (!Number.isFinite(opts.runs) || opts.runs < 1 || !Number.isFinite(opts.memRuns) || opts.memRuns < 1) {
+    console.error("--runs and --mem-runs must be positive integers");
     process.exit(2);
   }
   return opts;
@@ -98,7 +105,9 @@ function printHelp() {
       "  --no-build          do not cargo build the chidori binary first",
       "  --json PATH         also write the full results as JSON to PATH",
       "  --markdown PATH     also write a Markdown report to PATH (used by CI)",
-      "  --quick             shorthand for --runs 3 --warmup 0",
+      "  --mem-runs N        memory-measured runs per workload (default 3)",
+      "  --no-memory         skip the peak-memory (max RSS) measurement",
+      "  --quick             shorthand for --runs 3 --warmup 0 --mem-runs 1",
       "  -h, --help          show this help",
     ].join("\n"),
   );
@@ -217,6 +226,106 @@ function summarize(samples) {
 }
 
 // ---------------------------------------------------------------------------
+// Peak-memory (max RSS) measurement
+// ---------------------------------------------------------------------------
+//
+// Peak RSS of each subprocess is measured in dedicated extra runs (never the
+// timed ones, so the timing methodology is untouched). Best available
+// strategy wins:
+//
+//   1. GNU time (`/usr/bin/time -v`, or `gtime -v` from Homebrew) — exact
+//      ru_maxrss from wait4(), reported in kbytes.
+//   2. BSD time (`/usr/bin/time -l`, macOS) — exact, reported in bytes.
+//   3. Linux /proc poller — sample the kernel-maintained `VmHWM` high-water
+//      mark from `/proc/<pid>/status` every ~1ms while the child runs. Exact
+//      whenever a sample lands after the peak (VmHWM is monotonic); for very
+//      short-lived processes it can under-read slightly or miss entirely
+//      (reported as —).
+//
+// If none applies (non-Linux without a usable `time`), the memory tables are
+// skipped with a warning.
+
+function detectMemoryStrategy() {
+  const gnuParse = (s) => {
+    const m = s.match(/Maximum resident set size \(kbytes\): (\d+)/);
+    return m ? Number(m[1]) * 1024 : null;
+  };
+  const bsdParse = (s) => {
+    const m = s.match(/(\d+)\s+maximum resident set size/);
+    return m ? Number(m[1]) : null;
+  };
+  const candidates = [
+    { cmd: "/usr/bin/time", flag: "-v", parse: gnuParse, label: "GNU time" },
+    { cmd: whichSync("gtime"), flag: "-v", parse: gnuParse, label: "GNU time (gtime)" },
+    { cmd: "/usr/bin/time", flag: "-l", parse: bsdParse, label: "BSD time" },
+  ];
+  for (const c of candidates) {
+    if (!c.cmd || !existsSync(c.cmd)) continue;
+    const probe = spawnSync(c.cmd, [c.flag, "true"], { encoding: "utf8" });
+    if (probe.status === 0 && c.parse(probe.stderr ?? "") != null) {
+      return { kind: "time", ...c };
+    }
+  }
+  if (process.platform === "linux" && existsSync("/proc/self/status")) {
+    return { kind: "proc", label: "/proc VmHWM poller" };
+  }
+  return null;
+}
+
+// One measured run under the `time` wrapper: exact child ru_maxrss in bytes.
+async function rssOnceTime(strategy, runtime, file) {
+  const { stderr } = await execFileP(
+    strategy.cmd,
+    [strategy.flag, runtime.cmd, ...runtime.args, file],
+    { maxBuffer: 64 * 1024 * 1024 },
+  );
+  return strategy.parse(stderr ?? "");
+}
+
+// One measured run polling /proc/<pid>/status VmHWM (bytes; null if the
+// process exited before any sample landed).
+function rssOnceProc(runtime, file) {
+  return new Promise((resolvePromise, reject) => {
+    let hwm = null;
+    let timer = null;
+    const child = execFile(
+      runtime.cmd,
+      [...runtime.args, file],
+      { maxBuffer: 64 * 1024 * 1024 },
+      (err) => {
+        clearInterval(timer);
+        if (err) reject(new Error(`${runtime.name} failed on ${file}: ${err.message}`));
+        else resolvePromise(hwm);
+      },
+    );
+    const sample = () => {
+      try {
+        const status = readFileSync(`/proc/${child.pid}/status`, "utf8");
+        const m = status.match(/^VmHWM:\s+(\d+) kB/m);
+        if (m) hwm = Math.max(hwm ?? 0, Number(m[1]) * 1024);
+      } catch {
+        // Process already gone — keep whatever high-water mark we saw.
+      }
+    };
+    sample();
+    timer = setInterval(sample, 1);
+  });
+}
+
+// Median peak RSS in bytes over `runs` dedicated runs (null when unmeasurable).
+async function measureRss(strategy, runtime, file, runs) {
+  const samples = [];
+  for (let i = 0; i < runs; i++) {
+    const rss =
+      strategy.kind === "time"
+        ? await rssOnceTime(strategy, runtime, file)
+        : await rssOnceProc(runtime, file);
+    if (rss != null) samples.push(rss);
+  }
+  return samples.length ? summarize(samples).median : null;
+}
+
+// ---------------------------------------------------------------------------
 // Reporting
 // ---------------------------------------------------------------------------
 
@@ -224,6 +333,12 @@ function fmtMs(ms) {
   if (ms == null) return "—";
   if (ms >= 1000) return (ms / 1000).toFixed(2) + "s";
   return ms.toFixed(1) + "ms";
+}
+
+function fmtBytes(b) {
+  if (b == null) return "—";
+  if (b >= 1024 * 1024) return (b / (1024 * 1024)).toFixed(1) + "MiB";
+  return (b / 1024).toFixed(0) + "KiB";
 }
 
 function pad(s, w) {
@@ -298,12 +413,58 @@ function printTable(workloads, runtimes, baselines) {
   }
 }
 
+// Smallest peak RSS across runtimes for one row — the reference for the "x"
+// blow-up factors (smaller is better). Shared by the text and Markdown
+// reporters so they can't drift.
+function rssBest(rssByName, rtNames) {
+  const finite = rtNames.map((n) => rssByName[n]).filter((v) => v != null && v > 0);
+  const best = finite.length ? Math.min(...finite) : null;
+  let smallestName = "";
+  for (const n of rtNames) if (rssByName[n] != null && rssByName[n] === best) smallestName = n;
+  return { best, smallestName };
+}
+
+// The memory table rows: the startup probe (the runtime's floor footprint —
+// binary + realm, before any workload allocates) followed by each workload.
+// Peak RSS is reported absolute, not startup-subtracted: unlike wall-clock,
+// RSS does not subtract linearly (allocators reuse the startup pages).
+function memoryRows(workloads, startupRss) {
+  return [{ name: "(startup)", rssByRuntime: startupRss }, ...workloads.map((w) => ({ name: w.name, rssByRuntime: w.rssByRuntime }))];
+}
+
+function printMemoryTable(workloads, rtNames, mem) {
+  const COL = 13;
+  const nameW = Math.max(12, ...workloads.map((w) => w.name.length));
+  console.log(
+    `\nPeak memory (subprocess max RSS, median of ${mem.runs} dedicated run(s); via ${mem.strategy.label})`,
+  );
+  console.log("");
+  let header = pad("workload", nameW);
+  for (const n of rtNames) header += "  " + padLeft(n, COL);
+  header += "  " + padLeft("smallest", 9);
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const row of memoryRows(workloads, mem.startupRss)) {
+    let line = pad(row.name, nameW);
+    const { best, smallestName } = rssBest(row.rssByRuntime, rtNames);
+    for (const n of rtNames) {
+      const rss = row.rssByRuntime[n];
+      if (rss == null) { line += "  " + padLeft("—", COL); continue; }
+      const factor = best ? rss / best : 1;
+      const cell = factor <= 1.001 ? fmtBytes(rss) : `${fmtBytes(rss)} ${factor.toFixed(1)}x`;
+      line += "  " + padLeft(cell, COL);
+    }
+    line += "  " + padLeft(smallestName, 9);
+    console.log(line);
+  }
+}
+
 // Stable HTML marker so CI can find-and-update its single sticky comment
 // instead of posting a new one every run.
 const MARKDOWN_MARKER = "<!-- chidori-js-benchmarks -->";
 
 // Render the results as a Markdown report (used for the PR comment).
-function renderMarkdown(workloads, runtimes, baselines, opts) {
+function renderMarkdown(workloads, runtimes, baselines, opts, mem) {
   const rtNames = runtimes.map((r) => r.name);
   const lines = [];
   lines.push(MARKDOWN_MARKER);
@@ -353,11 +514,33 @@ function renderMarkdown(workloads, runtimes, baselines, opts) {
     lines.push(`| ${w.name} | ${cells.join(" | ")} |`);
   }
   lines.push("");
+
+  // Table 3: peak memory (max RSS), smallest bolded, blow-up factors shown.
+  if (mem) {
+    lines.push(
+      `### Peak memory (subprocess max RSS, median of ${mem.runs} dedicated run(s))`,
+    );
+    lines.push("");
+    lines.push(`| workload | ${rtNames.join(" | ")} | smallest |`);
+    lines.push(`|${"---|".repeat(rtNames.length + 2)}`);
+    for (const row of memoryRows(workloads, mem.startupRss)) {
+      const { best, smallestName } = rssBest(row.rssByRuntime, rtNames);
+      const cells = rtNames.map((n) => {
+        const rss = row.rssByRuntime[n];
+        if (rss == null) return "—";
+        const factor = best ? rss / best : 1;
+        return factor <= 1.001 ? `**${fmtBytes(rss)}**` : `${fmtBytes(rss)} (${factor.toFixed(1)}×)`;
+      });
+      lines.push(`| ${row.name} | ${cells.join(" | ")} | ${smallestName} |`);
+    }
+    lines.push("");
+  }
+
   lines.push(
     "<sub>Numbers are machine- and load-dependent (shared CI runner) — read them " +
       "as ratios, not absolutes. chidori-js is an interpreter, so it trails the " +
-      "V8/JSC JITs on compute but starts far faster. A ⚠️ marks a workload whose " +
-      "result disagreed across runtimes.</sub>",
+      "V8/JSC JITs on compute but starts far faster and in far less memory. " +
+      "A ⚠️ marks a workload whose result disagreed across runtimes.</sub>",
   );
   return lines.join("\n") + "\n";
 }
@@ -378,18 +561,32 @@ async function main() {
   if (opts.filter) files = files.filter((f) => f.includes(opts.filter));
   if (files.length === 0) throw new Error("no workloads matched");
 
+  const memStrategy = opts.memory ? detectMemoryStrategy() : null;
+  if (opts.memory && !memStrategy) {
+    process.stderr.write(
+      "warning: no peak-RSS measurement available on this platform (need GNU/BSD `time` or Linux /proc) — memory table skipped\n",
+    );
+  }
+
   console.log(
     `chidori-js cross-runtime benchmarks\n` +
       `runtimes: ${runtimes.map((r) => r.name).join(", ")}  |  ` +
-      `runs: ${opts.runs}  warmup: ${opts.warmup}  workloads: ${files.length}`,
+      `runs: ${opts.runs}  warmup: ${opts.warmup}  workloads: ${files.length}  |  ` +
+      `memory: ${memStrategy ? memStrategy.label : "off"}`,
   );
 
   // Startup baseline per runtime (median of a few extra runs — it's cheap).
+  // With memory on, also probe startup peak RSS: the runtime's floor
+  // footprint before any workload allocates.
   const baselines = {};
+  const startupRss = {};
   const startupFile = join(WORKLOAD_DIR, "startup.js");
   for (const rt of runtimes) {
     const { median } = await timeWorkload(rt, startupFile, Math.max(opts.runs, 5), 1);
     baselines[rt.name] = median;
+    if (memStrategy) {
+      startupRss[rt.name] = await measureRss(memStrategy, rt, startupFile, opts.memRuns);
+    }
   }
 
   const workloads = [];
@@ -399,10 +596,14 @@ async function main() {
     const name = f.replace(/\.js$/, "");
     process.stderr.write(`  ${name} ... `);
     const byRuntime = {};
+    const rssByRuntime = {};
     const results = new Set();
     for (const rt of runtimes) {
       const r = await timeWorkload(rt, file, opts.runs, opts.warmup);
       byRuntime[rt.name] = r;
+      if (memStrategy) {
+        rssByRuntime[rt.name] = await measureRss(memStrategy, rt, file, opts.memRuns);
+      }
       results.add(r.result);
     }
     const agree = results.size === 1;
@@ -415,10 +616,13 @@ async function main() {
     } else {
       process.stderr.write("ok\n");
     }
-    workloads.push({ name, byRuntime, agree, result: [...results][0] });
+    workloads.push({ name, byRuntime, rssByRuntime, agree, result: [...results][0] });
   }
 
+  const mem = memStrategy ? { strategy: memStrategy, startupRss, runs: opts.memRuns } : null;
+
   printTable(workloads, runtimes, baselines);
+  if (mem) printMemoryTable(workloads, runtimes.map((r) => r.name), mem);
 
   if (mismatches > 0) {
     console.log(
@@ -429,9 +633,12 @@ async function main() {
   if (opts.json) {
     const payload = {
       generatedAt: new Date().toISOString(),
-      options: { runs: opts.runs, warmup: opts.warmup },
+      options: { runs: opts.runs, warmup: opts.warmup, memRuns: opts.memRuns },
       runtimes: runtimes.map((r) => ({ name: r.name, cmd: r.cmd })),
       baselinesMs: baselines,
+      memory: mem
+        ? { strategy: mem.strategy.label, startupRssBytes: startupRss }
+        : null,
       workloads: workloads.map((w) => ({
         name: w.name,
         agree: w.agree,
@@ -439,7 +646,14 @@ async function main() {
         runtimes: Object.fromEntries(
           Object.entries(w.byRuntime).map(([n, r]) => [
             n,
-            { median: r.median, min: r.min, max: r.max, mean: r.mean, samples: r.samples },
+            {
+              median: r.median,
+              min: r.min,
+              max: r.max,
+              mean: r.mean,
+              samples: r.samples,
+              maxRssBytes: mem ? (w.rssByRuntime[n] ?? null) : null,
+            },
           ]),
         ),
       })),
@@ -449,7 +663,7 @@ async function main() {
   }
 
   if (opts.markdown) {
-    writeFileSync(opts.markdown, renderMarkdown(workloads, runtimes, baselines, opts));
+    writeFileSync(opts.markdown, renderMarkdown(workloads, runtimes, baselines, opts, mem));
     console.log(`\nwrote ${opts.markdown}`);
   }
 


### PR DESCRIPTION
Two new memory measurements, complementing the existing wall-clock-only
benchmarks:

- benches/memory.rs: a tracking #[global_allocator] reports exact heap
  numbers over the same workload corpus as benches/execution.rs — realm
  footprint of Engine::new() (retained/peak/churn), per-workload bytecode
  footprint, end-to-end eval peak/churn/retained (incl. after
  collect_cycles), and a repeat-run steady-state leak check. Run with
  `cargo bench -p chidori-js --bench memory`.
- benchmarks/run.mjs: the cross-runtime harness now also measures peak
  memory (subprocess max RSS) for chidori vs Node vs Bun, in dedicated
  extra runs so the timing methodology is untouched. Uses GNU/BSD time
  (exact ru_maxrss) when available, falling back to polling VmHWM in
  /proc/<pid>/status on Linux. Reported as a third table (text, Markdown,
  JSON) with a (startup) floor-footprint row; --mem-runs / --no-memory
  control it.

The workload corpus moves to benches/common/workloads.rs so the time and
memory benches can't drift apart. CI installs GNU time (best-effort) for
the exact measurement path.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P8QRjbssanFjDJYBigFCCV