### PR TITLE
Native npm package management: chidori add / install / remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,12 +544,14 @@ dependencies = [
  "clap",
  "cron",
  "derive_more",
+ "flate2",
  "futures",
  "hex",
  "hmac",
  "landlock",
  "libc",
  "minijinja",
+ "nodejs-semver",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -557,6 +565,7 @@ dependencies = [
  "serde_yaml",
  "sha1 0.10.6",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1074,6 +1083,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1978,6 +1997,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2059,19 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nodejs-semver"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364dd919c4d6feef8c3a3f3e2b64af729187902156e17481618622cbbf1353a1"
+dependencies = [
+ "bytecount",
+ "miette",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow",
 ]
 
 [[package]]
@@ -2220,7 +2274,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3512,6 +3566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,7 +3626,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3954,6 +4019,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4371,6 +4442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4463,6 +4543,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/README.md
+++ b/README.md
@@ -271,6 +271,11 @@ human-in-the-loop pause/resume loop — see
 - **Cost-efficient prompting** — structural [prompt
   caching](./docs/context-management.md) re-bills stable prefixes at the cached
   rate, and replay pays zero tokens.
+- **npm packages without Node** — `chidori add zod` installs straight from the
+  npm registry into a content-addressed cache (SHA-512 verified, hardlinked
+  `node_modules`, merge-friendly JSONL lockfile, no install scripts ever), and
+  agents just `import { z } from "zod"`. See [package
+  management](./docs/package-management.md).
 
 Agents reach all of this through a fixed set of host functions on the `chidori`
 object — see [**Core concepts**](./docs/core-concepts.md) for the full list and
@@ -319,6 +324,7 @@ deterministic, replayable, and testable for free.
 | [Running modes](./docs/running-modes.md) | One-shot CLI, HTTP server + session API, event-driven agents |
 | [How replay works](./docs/replay.md) | Record/checkpoint/replay model and SDK replay |
 | [Value checkpoints](./docs/value-checkpoints.md) | `chidori.step` — journal expensive pure compute so resume never re-pays it |
+| [Package management](./docs/package-management.md) | `chidori add`/`install`/`remove`: npm packages without Node — content-addressed store, SHA-512 verification, JSONL lockfile |
 | [Architecture & project structure](./docs/architecture.md) | High-level component map and repository layout |
 | [JavaScript conformance (Test262)](./docs/conformance.md) | Running the pure-Rust JS engine against the TC39 suite |
 | [Sandbox & security model](./docs/sandbox-model.md) | Deny-by-default policy, capability injection, resource limits |

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -96,6 +96,9 @@ opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
 # `satisfies` in odd positions, and overload signatures. oxc parses to a real
 # AST and emits JS via codegen, so unsupported sugar can't slip through.
 oxc = { version = "0.133", features = ["transformer", "codegen", "semantic"] }
+nodejs-semver = "5.0.0"
+tar = "0.4.46"
+flate2 = "1.1.9"
 
 # Unix-only: apply per-process resource limits (setrlimit) and deadline-kill
 # (kill) to the OS-isolation worker child. See `runtime::isolate::limits`.

--- a/crates/chidori/src/lib.rs
+++ b/crates/chidori/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod acp;
 pub mod mcp;
 pub mod mem_guard;
+pub mod pkg;
 pub mod policy;
 pub mod providers;
 pub mod recipes;

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -2,6 +2,7 @@ mod acp;
 mod init;
 mod mcp;
 mod mem_guard;
+mod pkg;
 mod policy;
 mod providers;
 mod recipes;
@@ -109,6 +110,49 @@ enum Commands {
     Check {
         /// Path to the agent .ts file
         file: PathBuf,
+    },
+
+    /// Add npm packages to package.json and install them into node_modules.
+    /// Packages come from the npm registry (or CHIDORI_NPM_REGISTRY), are
+    /// verified against their SHA-512 integrity, cached once per machine in a
+    /// content-addressed store (~/.chidori/cache/packages), and hardlinked
+    /// into the project. Lifecycle scripts never run.
+    Add {
+        /// Packages to add: `name`, `name@1.2.3`, `name@^2`, `@scope/name@tag`
+        packages: Vec<String>,
+
+        /// Add to devDependencies instead of dependencies
+        #[arg(short = 'D', long)]
+        dev: bool,
+
+        /// Project directory (defaults to the current directory)
+        #[arg(long)]
+        dir: Option<PathBuf>,
+    },
+
+    /// Install dependencies from chidori.lock.jsonl (or resolve them from
+    /// package.json when the lockfile is missing or out of date). Warm
+    /// installs are fully offline: every package materializes from the
+    /// content-addressed store by hardlink.
+    Install {
+        /// Fail instead of re-resolving when the lockfile is missing or out
+        /// of sync with package.json (for CI).
+        #[arg(long)]
+        frozen: bool,
+
+        /// Project directory (defaults to the current directory)
+        #[arg(long)]
+        dir: Option<PathBuf>,
+    },
+
+    /// Remove npm packages from package.json, the lockfile, and node_modules.
+    Remove {
+        /// Package names to remove
+        packages: Vec<String>,
+
+        /// Project directory (defaults to the current directory)
+        #[arg(long)]
+        dir: Option<PathBuf>,
     },
 
     /// Scaffold a new agent project from a starter template.
@@ -328,6 +372,18 @@ fn main() {
         Commands::RunWorker => unreachable!("handled before the dispatch match"),
         Commands::Demo => (cmd_demo(), false),
         Commands::ModelLogin => (cmd_login(), false),
+        Commands::Add { packages, dev, dir } => (
+            pkg::cmd_add(&dir.unwrap_or_else(|| PathBuf::from(".")), &packages, dev),
+            false,
+        ),
+        Commands::Install { frozen, dir } => (
+            pkg::cmd_install(&dir.unwrap_or_else(|| PathBuf::from(".")), frozen),
+            false,
+        ),
+        Commands::Remove { packages, dir } => (
+            pkg::cmd_remove(&dir.unwrap_or_else(|| PathBuf::from(".")), &packages),
+            false,
+        ),
         Commands::Init { dir, template } => (
             init::run(
                 &dir.unwrap_or_else(|| PathBuf::from(".")),

--- a/crates/chidori/src/pkg/install.rs
+++ b/crates/chidori/src/pkg/install.rs
@@ -1,0 +1,479 @@
+//! Command orchestration for `chidori add` / `install` / `remove`.
+//!
+//! All three commands share one pipeline: produce a `Resolution` (from the
+//! registry or the lockfile), plan the hoisted layout, make sure every
+//! package is in the content-addressed store (downloading + verifying only
+//! misses), hardlink the plan into `node_modules`, and prune anything the
+//! plan doesn't claim.
+//!
+//! `remove` and an in-sync `install` never touch the network: the lockfile
+//! carries enough (exact versions, edges, tarball URLs, integrity) to rebuild
+//! the tree from the store alone.
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Context, Result};
+use futures::StreamExt as _;
+
+use super::layout::{chain_to_path, plan_layout, LayoutPlan};
+use super::lockfile::{Lockfile, LOCKFILE_NAME};
+use super::manifest::Manifest;
+use super::registry::{validate_package_name, RegistryClient};
+use super::resolve::{resolve, Resolution};
+use super::store::{Integrity, PackageStore};
+
+/// Concurrent tarball downloads. Hashing/extraction runs on the blocking
+/// pool, so this only bounds network fan-out.
+const DOWNLOAD_CONCURRENCY: usize = 8;
+
+/// `chidori add <spec>... [--dev]`
+pub fn cmd_add(dir: &Path, specs: &[String], dev: bool) -> Result<()> {
+    if specs.is_empty() {
+        bail!("nothing to add: pass one or more packages, e.g. `chidori add zod`");
+    }
+    let started = Instant::now();
+    let mut manifest = Manifest::load_or_default(dir)?;
+    let lockfile = load_lockfile_if_present(dir)?;
+
+    let requested: Vec<(String, Option<String>)> = specs
+        .iter()
+        .map(|s| parse_add_spec(s))
+        .collect::<Result<_>>()?;
+
+    // Root set = current manifest deps + the new specs (range or `latest`).
+    let mut root_deps = manifest.all_dependencies();
+    for (name, range) in &requested {
+        root_deps.insert(
+            name.clone(),
+            range.clone().unwrap_or_else(|| "latest".to_string()),
+        );
+    }
+
+    let registry = RegistryClient::from_env()?;
+    let preferred = preferred_versions(lockfile.as_ref());
+    let resolution = block_on(resolve(&registry, &root_deps, &preferred))?;
+
+    // Record what we added: an explicit range verbatim, otherwise a caret
+    // range on the resolved version (`^1.2.3`), like npm.
+    for (name, range) in &requested {
+        let resolved_version = resolution
+            .roots
+            .get(name)
+            .ok_or_else(|| anyhow!("`{name}` missing from resolution"))?;
+        let manifest_range = range
+            .clone()
+            .unwrap_or_else(|| format!("^{resolved_version}"));
+        manifest.set_dependency(name, &manifest_range, dev);
+    }
+    manifest.save()?;
+
+    let lockfile = Lockfile::from_resolution(
+        &resolution,
+        manifest.dependencies(),
+        manifest.dev_dependencies(),
+    );
+    lockfile.save(&dir.join(LOCKFILE_NAME))?;
+
+    let stats = sync_tree(dir, &resolution, Some(&registry))?;
+    for (name, _) in &requested {
+        let version = &resolution.roots[name];
+        println!("+ {name}@{version}");
+    }
+    report(&resolution, &stats, started);
+    Ok(())
+}
+
+/// `chidori install [--frozen]`
+pub fn cmd_install(dir: &Path, frozen: bool) -> Result<()> {
+    let started = Instant::now();
+    let manifest = Manifest::load_or_default(dir)?;
+    let lockfile = load_lockfile_if_present(dir)?;
+    let deps = manifest.dependencies();
+    let dev_deps = manifest.dev_dependencies();
+
+    if deps.is_empty() && dev_deps.is_empty() && lockfile.is_none() {
+        println!("nothing to install (no dependencies in package.json)");
+        return Ok(());
+    }
+
+    let (resolution, registry) = match &lockfile {
+        Some(lock) if lock.matches_manifest(&deps, &dev_deps) => {
+            // In sync: no resolution needed; network only for store misses.
+            (lock.to_resolution(), None)
+        }
+        Some(_) if frozen => bail!(
+            "{LOCKFILE_NAME} is out of sync with package.json (run `chidori install` without --frozen to update it)"
+        ),
+        None if frozen => bail!("--frozen requires an existing {LOCKFILE_NAME}"),
+        _ => {
+            let registry = RegistryClient::from_env()?;
+            let mut root_deps = deps.clone();
+            root_deps.extend(dev_deps.clone());
+            let preferred = preferred_versions(lockfile.as_ref());
+            let resolution = block_on(resolve(&registry, &root_deps, &preferred))?;
+            Lockfile::from_resolution(&resolution, deps, dev_deps)
+                .save(&dir.join(LOCKFILE_NAME))?;
+            (resolution, Some(registry))
+        }
+    };
+
+    let stats = sync_tree(dir, &resolution, registry.as_ref())?;
+    report(&resolution, &stats, started);
+    Ok(())
+}
+
+/// `chidori remove <name>...`
+pub fn cmd_remove(dir: &Path, names: &[String]) -> Result<()> {
+    if names.is_empty() {
+        bail!("nothing to remove: pass one or more package names");
+    }
+    let started = Instant::now();
+    let mut manifest = Manifest::load_or_default(dir)?;
+    for name in names {
+        validate_package_name(name)?;
+        if !manifest.remove_dependency(name) {
+            bail!("`{name}` is not a dependency in package.json");
+        }
+    }
+    manifest.save()?;
+    let deps = manifest.dependencies();
+    let dev_deps = manifest.dev_dependencies();
+
+    // Prefer the offline path: shrink the existing lockfile graph to what's
+    // still reachable from the remaining roots.
+    let lockfile = load_lockfile_if_present(dir)?;
+    let resolution = match lockfile {
+        Some(lock)
+            if names.iter().all(|n| lock.roots.contains_key(n))
+                && lock
+                    .requested
+                    .iter()
+                    .chain(lock.requested_dev.iter())
+                    .filter(|(n, _)| !names.contains(n))
+                    .all(|(n, r)| deps.get(n).or_else(|| dev_deps.get(n)) == Some(r)) =>
+        {
+            shrink_to_reachable(&lock, names)
+        }
+        _ => {
+            // Lockfile absent or drifted: re-resolve what's left.
+            let registry = RegistryClient::from_env()?;
+            let mut root_deps = deps.clone();
+            root_deps.extend(dev_deps.clone());
+            block_on(resolve(&registry, &root_deps, &HashMap::new()))?
+        }
+    };
+
+    Lockfile::from_resolution(&resolution, deps, dev_deps).save(&dir.join(LOCKFILE_NAME))?;
+    let stats = sync_tree(dir, &resolution, None)?;
+    for name in names {
+        println!("- {name}");
+    }
+    report(&resolution, &stats, started);
+    Ok(())
+}
+
+/// Drop removed roots and keep only packages still reachable via lockfile
+/// edges. Pure graph walk — no network.
+fn shrink_to_reachable(lock: &Lockfile, removed: &[String]) -> Resolution {
+    let mut resolution = lock.to_resolution();
+    for name in removed {
+        resolution.roots.remove(name);
+    }
+    let mut reachable: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut stack: Vec<(String, String)> = resolution
+        .roots
+        .iter()
+        .map(|(n, v)| (n.clone(), v.clone()))
+        .collect();
+    while let Some(id) = stack.pop() {
+        if !reachable.insert(id.clone()) {
+            continue;
+        }
+        if let Some(pkg) = resolution.packages.get(&id) {
+            for (n, v) in &pkg.dependencies {
+                stack.push((n.clone(), v.clone()));
+            }
+        }
+    }
+    resolution.packages.retain(|id, _| reachable.contains(id));
+    resolution
+}
+
+pub struct SyncStats {
+    pub installed: usize,
+    pub downloaded: usize,
+    pub linked: usize,
+    pub pruned: usize,
+}
+
+/// Make `node_modules` match the resolution exactly.
+fn sync_tree(
+    dir: &Path,
+    resolution: &Resolution,
+    registry: Option<&RegistryClient>,
+) -> Result<SyncStats> {
+    let plan = plan_layout(resolution)?;
+    let store = PackageStore::from_env()?;
+
+    // Phase 1: every unique package version present in the store.
+    let mut store_dirs: HashMap<(String, String), std::path::PathBuf> = HashMap::new();
+    let unique_ids: BTreeSet<&(String, String)> = plan
+        .values()
+        .map(|p| {
+            resolution
+                .packages
+                .get_key_value(&(p.name.clone(), p.version.clone()))
+                .map(|(k, _)| k)
+                .expect("plan only references resolved packages")
+        })
+        .collect();
+
+    let mut misses = Vec::new();
+    for id in unique_ids {
+        let pkg = &resolution.packages[id];
+        let integrity = Integrity::from_dist(pkg.integrity.as_deref(), pkg.shasum.as_deref())
+            .with_context(|| format!("{}@{}", pkg.name, pkg.version))?;
+        match store.lookup(&integrity) {
+            Some(dir) => {
+                store_dirs.insert(id.clone(), dir);
+            }
+            None => misses.push((id.clone(), pkg.tarball.clone(), integrity)),
+        }
+    }
+
+    let downloaded = misses.len();
+    if !misses.is_empty() {
+        let fallback_registry;
+        let registry = match registry {
+            Some(r) => r,
+            None => {
+                fallback_registry = RegistryClient::from_env()?;
+                &fallback_registry
+            }
+        };
+        let fetched: Vec<Result<((String, String), std::path::PathBuf)>> = block_on(async {
+            futures::stream::iter(misses.into_iter().map(|(id, tarball, integrity)| {
+                let store = store.clone();
+                async move {
+                    let bytes = registry.download_tarball(&tarball).await?;
+                    // Hashing + gunzip + untar are CPU-bound: run them on
+                    // the blocking pool, off the download threads.
+                    let store_dir =
+                        tokio::task::spawn_blocking(move || store.put_tarball(&integrity, &bytes))
+                            .await
+                            .expect("store task panicked")
+                            .with_context(|| format!("storing {}@{}", id.0, id.1))?;
+                    Ok((id, store_dir))
+                }
+            }))
+            .buffer_unordered(DOWNLOAD_CONCURRENCY)
+            .collect()
+            .await
+        });
+        for item in fetched {
+            let (id, store_dir) = item?;
+            store_dirs.insert(id, store_dir);
+        }
+    }
+
+    // Phase 2: materialize the plan. BTreeMap order guarantees parents are
+    // laid down before their nested children.
+    let mut linked = 0usize;
+    for (chain, planned) in &plan {
+        let dest = dir.join(chain_to_path(chain));
+        if installed_version_matches(&dest, &planned.name, &planned.version) {
+            continue;
+        }
+        if dest.exists() {
+            std::fs::remove_dir_all(&dest)
+                .with_context(|| format!("replacing {}", dest.display()))?;
+        }
+        let store_dir = &store_dirs[&(planned.name.clone(), planned.version.clone())];
+        store
+            .materialize(store_dir, &dest)
+            .with_context(|| format!("linking {}@{}", planned.name, planned.version))?;
+        linked += 1;
+    }
+
+    // Phase 3: prune everything the plan doesn't claim.
+    let mut pruned = 0usize;
+    prune_extraneous(&dir.join("node_modules"), &[], &plan, &mut pruned)?;
+
+    Ok(SyncStats {
+        installed: plan.len(),
+        downloaded,
+        linked,
+        pruned,
+    })
+}
+
+/// Does `dest` already hold `name@version`? (Trusts package.json, which is
+/// enough because materialized trees are only ever produced whole.)
+fn installed_version_matches(dest: &Path, name: &str, version: &str) -> bool {
+    let Ok(raw) = std::fs::read_to_string(dest.join("package.json")) else {
+        return false;
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    v.get("name").and_then(|x| x.as_str()) == Some(name)
+        && v.get("version").and_then(|x| x.as_str()) == Some(version)
+}
+
+/// Remove package directories under `nm_dir` that the plan doesn't place.
+/// Recurses through planned packages' nested `node_modules`. Non-directory
+/// entries (e.g. stray files) are left alone.
+fn prune_extraneous(
+    nm_dir: &Path,
+    prefix: &[String],
+    plan: &LayoutPlan,
+    pruned: &mut usize,
+) -> Result<()> {
+    if !nm_dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(nm_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let dir_name = entry.file_name().to_string_lossy().into_owned();
+        if dir_name.starts_with('@') {
+            // Scope directory: check each @scope/name child.
+            for sub in std::fs::read_dir(entry.path())? {
+                let sub = sub?;
+                if !sub.file_type()?.is_dir() {
+                    continue;
+                }
+                let full = format!("{dir_name}/{}", sub.file_name().to_string_lossy());
+                prune_one(&sub.path(), &full, prefix, plan, pruned)?;
+            }
+            // Drop the scope dir once emptied.
+            if std::fs::read_dir(entry.path())?.next().is_none() {
+                std::fs::remove_dir(entry.path())?;
+            }
+        } else {
+            prune_one(&entry.path(), &dir_name, prefix, plan, pruned)?;
+        }
+    }
+    Ok(())
+}
+
+fn prune_one(
+    path: &Path,
+    name: &str,
+    prefix: &[String],
+    plan: &LayoutPlan,
+    pruned: &mut usize,
+) -> Result<()> {
+    let mut chain = prefix.to_vec();
+    chain.push(name.to_string());
+    if plan.contains_key(&chain) {
+        prune_extraneous(&path.join("node_modules"), &chain, plan, pruned)
+    } else {
+        std::fs::remove_dir_all(path).with_context(|| format!("pruning {}", path.display()))?;
+        *pruned += 1;
+        Ok(())
+    }
+}
+
+fn report(resolution: &Resolution, stats: &SyncStats, started: Instant) {
+    let cached = stats.installed.saturating_sub(stats.downloaded);
+    println!(
+        "{} packages installed in {:?} ({} downloaded, {} from cache, {} linked, {} pruned)",
+        stats.installed,
+        started.elapsed(),
+        stats.downloaded,
+        cached,
+        stats.linked,
+        stats.pruned,
+    );
+    for warning in &resolution.warnings {
+        eprintln!("warning: {warning}");
+    }
+}
+
+fn load_lockfile_if_present(dir: &Path) -> Result<Option<Lockfile>> {
+    let path = dir.join(LOCKFILE_NAME);
+    if path.is_file() {
+        Ok(Some(Lockfile::load(&path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Versions pinned by the current lockfile, used to keep resolution stable
+/// across unrelated `add`s.
+fn preferred_versions(lockfile: Option<&Lockfile>) -> HashMap<String, BTreeSet<String>> {
+    let mut preferred: HashMap<String, BTreeSet<String>> = HashMap::new();
+    if let Some(lock) = lockfile {
+        for (name, version) in lock.packages.keys() {
+            preferred
+                .entry(name.clone())
+                .or_default()
+                .insert(version.clone());
+        }
+    }
+    preferred
+}
+
+/// Parse `name`, `name@range`, `@scope/name`, `@scope/name@range`.
+fn parse_add_spec(spec: &str) -> Result<(String, Option<String>)> {
+    let split_at = if let Some(rest) = spec.strip_prefix('@') {
+        // Scoped: the version separator is an `@` after the first `/`.
+        rest.find('/')
+            .and_then(|slash| rest[slash..].find('@').map(|at| 1 + slash + at))
+    } else {
+        spec.find('@')
+    };
+    let (name, range) = match split_at {
+        Some(idx) => (
+            spec[..idx].to_string(),
+            Some(spec[idx + 1..].trim().to_string()).filter(|r| !r.is_empty()),
+        ),
+        None => (spec.to_string(), None),
+    };
+    validate_package_name(&name)?;
+    Ok((name, range))
+}
+
+/// The pkg commands are synchronous CLI entry points; network work runs on a
+/// scoped runtime per call.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("building tokio runtime")
+        .block_on(fut)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_add_specs() {
+        assert_eq!(parse_add_spec("zod").unwrap(), ("zod".into(), None));
+        assert_eq!(
+            parse_add_spec("zod@^3.22.0").unwrap(),
+            ("zod".into(), Some("^3.22.0".into()))
+        );
+        assert_eq!(
+            parse_add_spec("@scope/pkg").unwrap(),
+            ("@scope/pkg".into(), None)
+        );
+        assert_eq!(
+            parse_add_spec("@scope/pkg@2.x").unwrap(),
+            ("@scope/pkg".into(), Some("2.x".into()))
+        );
+        assert_eq!(
+            parse_add_spec("left-pad@latest").unwrap(),
+            ("left-pad".into(), Some("latest".into()))
+        );
+        assert!(parse_add_spec("UPPER@1").is_err());
+        assert!(parse_add_spec("@scope").is_err());
+    }
+}

--- a/crates/chidori/src/pkg/layout.rs
+++ b/crates/chidori/src/pkg/layout.rs
@@ -1,0 +1,259 @@
+//! Hoisted `node_modules` layout planning.
+//!
+//! Given a resolved package set, decide where each copy lives on disk. The
+//! layout must satisfy the Node resolution algorithm that
+//! `runtime::typescript::resolver` implements: an import of `dep` from a
+//! package installed at `node_modules/a/node_modules/b` probes, in order,
+//! `node_modules/a/node_modules/b/node_modules/dep`,
+//! `node_modules/a/node_modules/dep`*, `node_modules/dep`.
+//! (*per Node, every non-`node_modules` ancestor directory gets a probe.)
+//!
+//! Strategy is npm-style greedy hoisting: root dependencies claim the top
+//! level, every transitive dependency is hoisted to the top when its name is
+//! free there, and version conflicts are nested under their dependent. The
+//! walk is breadth-first over sorted keys, so the plan is deterministic for a
+//! given resolution.
+
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+
+use super::resolve::Resolution;
+
+/// Guard against pathological version-conflict cycles (A1→B1→A2→B2→A1…),
+/// which are effectively nonexistent in the real registry but would otherwise
+/// nest forever.
+const MAX_NESTING: usize = 32;
+
+/// A planned install location. `chain` is the package-name path from the
+/// project root, e.g. `["a", "b"]` = `node_modules/a/node_modules/b`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedPackage {
+    pub name: String,
+    pub version: String,
+}
+
+/// Map from location chain to the package installed there. BTreeMap ordering
+/// puts parents before their nested children (a chain sorts before its
+/// extensions), which materialization relies on.
+pub type LayoutPlan = BTreeMap<Vec<String>, PlannedPackage>;
+
+/// Compute the install location of every package copy.
+pub fn plan_layout(resolution: &Resolution) -> Result<LayoutPlan> {
+    let mut plan: LayoutPlan = BTreeMap::new();
+    let mut queue: VecDeque<(Vec<String>, (String, String))> = VecDeque::new();
+
+    // Root direct dependencies own the top level.
+    for (name, version) in &resolution.roots {
+        plan.insert(
+            vec![name.clone()],
+            PlannedPackage {
+                name: name.clone(),
+                version: version.clone(),
+            },
+        );
+        queue.push_back((vec![name.clone()], (name.clone(), version.clone())));
+    }
+
+    while let Some((chain, id)) = queue.pop_front() {
+        let Some(pkg) = resolution.packages.get(&id) else {
+            bail!(
+                "layout plan references unresolved package {}@{}",
+                id.0,
+                id.1
+            );
+        };
+        for (dep_name, dep_version) in &pkg.dependencies {
+            // Probe ancestor levels nearest-first, mirroring Node's walk-up.
+            let mut satisfied = false;
+            let mut shadowed = false;
+            for prefix_len in (0..=chain.len()).rev() {
+                let mut candidate = chain[..prefix_len].to_vec();
+                candidate.push(dep_name.clone());
+                if let Some(existing) = plan.get(&candidate) {
+                    if existing.version == *dep_version {
+                        satisfied = true;
+                    } else {
+                        // Nearest visible copy is the wrong version; anything
+                        // above it is shadowed. Must nest below.
+                        shadowed = true;
+                    }
+                    break;
+                }
+            }
+            if satisfied {
+                continue;
+            }
+            let new_chain = if shadowed {
+                // Nest directly under the dependent.
+                let mut c = chain.clone();
+                c.push(dep_name.clone());
+                c
+            } else {
+                // Name unused anywhere on the probe path: hoist to top level.
+                vec![dep_name.clone()]
+            };
+            if new_chain.len() > MAX_NESTING {
+                bail!(
+                    "dependency nesting exceeded {MAX_NESTING} levels at {} — conflicting version cycle?",
+                    new_chain.join(" > ")
+                );
+            }
+            // The probe loop always checks `new_chain` (either at prefix 0 for
+            // a hoist or at the full chain for a nest) before choosing it, so
+            // the slot is guaranteed free.
+            let prev = plan.insert(
+                new_chain.clone(),
+                PlannedPackage {
+                    name: dep_name.clone(),
+                    version: dep_version.clone(),
+                },
+            );
+            debug_assert!(prev.is_none(), "layout slot {new_chain:?} double-planned");
+            queue.push_back((new_chain, (dep_name.clone(), dep_version.clone())));
+        }
+    }
+    Ok(plan)
+}
+
+/// On-disk path (relative to the project root) for a location chain:
+/// `["a","b"]` -> `node_modules/a/node_modules/b`. Scoped names (`@s/x`)
+/// expand to two path segments naturally via `join`.
+pub fn chain_to_path(chain: &[String]) -> PathBuf {
+    let mut path = PathBuf::new();
+    for name in chain {
+        path.push("node_modules");
+        path.push(name);
+    }
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pkg::resolve::ResolvedPackage;
+
+    fn pkg(name: &str, version: &str, deps: &[(&str, &str)]) -> ResolvedPackage {
+        ResolvedPackage {
+            name: name.into(),
+            version: version.into(),
+            tarball: format!("https://example.test/{name}-{version}.tgz"),
+            integrity: None,
+            shasum: None,
+            dependencies: deps
+                .iter()
+                .map(|(n, v)| (n.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    fn resolution(roots: &[(&str, &str)], packages: Vec<ResolvedPackage>) -> Resolution {
+        Resolution {
+            roots: roots
+                .iter()
+                .map(|(n, v)| (n.to_string(), v.to_string()))
+                .collect(),
+            packages: packages.into_iter().map(|p| (p.id(), p)).collect(),
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn hoists_shared_transitive_dep() {
+        // a -> c@1, b -> c@1: c hoists to top level, one copy.
+        let r = resolution(
+            &[("a", "1.0.0"), ("b", "1.0.0")],
+            vec![
+                pkg("a", "1.0.0", &[("c", "1.0.0")]),
+                pkg("b", "1.0.0", &[("c", "1.0.0")]),
+                pkg("c", "1.0.0", &[]),
+            ],
+        );
+        let plan = plan_layout(&r).unwrap();
+        assert_eq!(plan.len(), 3);
+        assert_eq!(plan[&vec!["c".to_string()]].version, "1.0.0");
+    }
+
+    #[test]
+    fn nests_conflicting_versions() {
+        // root -> c@2 directly; a -> c@1 nests under a.
+        let r = resolution(
+            &[("a", "1.0.0"), ("c", "2.0.0")],
+            vec![
+                pkg("a", "1.0.0", &[("c", "1.0.0")]),
+                pkg("c", "2.0.0", &[]),
+                pkg("c", "1.0.0", &[]),
+            ],
+        );
+        let plan = plan_layout(&r).unwrap();
+        assert_eq!(plan[&vec!["c".to_string()]].version, "2.0.0");
+        assert_eq!(
+            plan[&vec!["a".to_string(), "c".to_string()]].version,
+            "1.0.0"
+        );
+    }
+
+    #[test]
+    fn first_hoist_wins_later_conflict_nests() {
+        // a -> c@1 (hoists c@1), b -> c@2 (nests under b).
+        let r = resolution(
+            &[("a", "1.0.0"), ("b", "1.0.0")],
+            vec![
+                pkg("a", "1.0.0", &[("c", "1.0.0")]),
+                pkg("b", "1.0.0", &[("c", "2.0.0")]),
+                pkg("c", "1.0.0", &[]),
+                pkg("c", "2.0.0", &[]),
+            ],
+        );
+        let plan = plan_layout(&r).unwrap();
+        assert_eq!(plan[&vec!["c".to_string()]].version, "1.0.0");
+        assert_eq!(
+            plan[&vec!["b".to_string(), "c".to_string()]].version,
+            "2.0.0"
+        );
+    }
+
+    #[test]
+    fn circular_dependencies_terminate() {
+        let r = resolution(
+            &[("a", "1.0.0")],
+            vec![
+                pkg("a", "1.0.0", &[("b", "1.0.0")]),
+                pkg("b", "1.0.0", &[("a", "1.0.0")]),
+            ],
+        );
+        let plan = plan_layout(&r).unwrap();
+        assert_eq!(plan.len(), 2);
+    }
+
+    #[test]
+    fn nested_conflict_dep_resolves_against_nested_copy() {
+        // root -> c@2; a -> c@1; c@1 -> d@1; d hoists to top.
+        let r = resolution(
+            &[("a", "1.0.0"), ("c", "2.0.0")],
+            vec![
+                pkg("a", "1.0.0", &[("c", "1.0.0")]),
+                pkg("c", "2.0.0", &[]),
+                pkg("c", "1.0.0", &[("d", "1.0.0")]),
+                pkg("d", "1.0.0", &[]),
+            ],
+        );
+        let plan = plan_layout(&r).unwrap();
+        assert_eq!(plan[&vec!["d".to_string()]].version, "1.0.0");
+        assert!(plan.contains_key(&vec!["a".to_string(), "c".to_string()]));
+    }
+
+    #[test]
+    fn chain_paths() {
+        assert_eq!(
+            chain_to_path(&["a".into(), "b".into()]),
+            PathBuf::from("node_modules/a/node_modules/b")
+        );
+        assert_eq!(
+            chain_to_path(&["@s/x".into()]),
+            PathBuf::from("node_modules/@s/x")
+        );
+    }
+}

--- a/crates/chidori/src/pkg/lockfile.rs
+++ b/crates/chidori/src/pkg/lockfile.rs
@@ -1,0 +1,254 @@
+//! `chidori.lock.jsonl` — a strictly sorted JSON-lines lockfile.
+//!
+//! Line 1 is a header carrying the lockfile version, the ranges that were
+//! requested (so `chidori install` can tell whether the lockfile is in sync
+//! with `package.json`), and the root's resolved direct dependencies. Every
+//! following line is one locked package, sorted by name then ascending
+//! semver.
+//!
+//! The JSONL + strict sort combination is deliberately git-friendly: two
+//! branches adding different dependencies touch disjoint lines, so merges
+//! apply cleanly instead of conflicting over one giant JSON blob.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use nodejs_semver::Version;
+use serde::{Deserialize, Serialize};
+
+use super::resolve::{Resolution, ResolvedPackage};
+
+pub const LOCKFILE_NAME: &str = "chidori.lock.jsonl";
+const LOCKFILE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Header {
+    /// Format marker; bump on breaking layout changes.
+    #[serde(rename = "chidoriLockfile")]
+    version: u32,
+    /// Ranges requested by package.json at lock time: name -> range.
+    /// Prod and dev are tracked separately so sync checks are exact.
+    #[serde(default)]
+    requested: BTreeMap<String, String>,
+    #[serde(default, rename = "requestedDev")]
+    requested_dev: BTreeMap<String, String>,
+    /// Root direct dependencies as resolved: name -> exact version.
+    #[serde(default)]
+    roots: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LockedPackage {
+    pub name: String,
+    pub version: String,
+    pub resolved: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shasum: Option<String>,
+    /// Resolved edges: dep name -> exact version.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dependencies: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Lockfile {
+    pub requested: BTreeMap<String, String>,
+    pub requested_dev: BTreeMap<String, String>,
+    pub roots: BTreeMap<String, String>,
+    /// Keyed by (name, version).
+    pub packages: BTreeMap<(String, String), LockedPackage>,
+}
+
+impl Lockfile {
+    pub fn from_resolution(
+        resolution: &Resolution,
+        requested: BTreeMap<String, String>,
+        requested_dev: BTreeMap<String, String>,
+    ) -> Self {
+        let packages = resolution
+            .packages
+            .values()
+            .map(|p| (p.id(), locked_from(p)))
+            .collect();
+        Self {
+            requested,
+            requested_dev,
+            roots: resolution.roots.clone(),
+            packages,
+        }
+    }
+
+    /// Rebuild a `Resolution` (for layout planning) without touching the
+    /// network.
+    pub fn to_resolution(&self) -> Resolution {
+        Resolution {
+            roots: self.roots.clone(),
+            packages: self
+                .packages
+                .iter()
+                .map(|(id, p)| {
+                    (
+                        id.clone(),
+                        ResolvedPackage {
+                            name: p.name.clone(),
+                            version: p.version.clone(),
+                            tarball: p.resolved.clone(),
+                            integrity: p.integrity.clone(),
+                            shasum: p.shasum.clone(),
+                            dependencies: p.dependencies.clone(),
+                        },
+                    )
+                })
+                .collect(),
+            warnings: vec![],
+        }
+    }
+
+    /// True when this lockfile was produced from exactly these requested
+    /// ranges — i.e. `install` can trust it without re-resolving.
+    pub fn matches_manifest(
+        &self,
+        deps: &BTreeMap<String, String>,
+        dev_deps: &BTreeMap<String, String>,
+    ) -> bool {
+        self.requested == *deps && self.requested_dev == *dev_deps
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let raw =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let mut lines = raw.lines().filter(|l| !l.trim().is_empty());
+        let header_line = match lines.next() {
+            Some(l) => l,
+            None => bail!("{} is empty", path.display()),
+        };
+        let header: Header = serde_json::from_str(header_line)
+            .with_context(|| format!("parsing {} header", path.display()))?;
+        if header.version != LOCKFILE_VERSION {
+            bail!(
+                "{} has lockfile version {}, this chidori supports {}",
+                path.display(),
+                header.version,
+                LOCKFILE_VERSION
+            );
+        }
+        let mut packages = BTreeMap::new();
+        for line in lines {
+            let pkg: LockedPackage = serde_json::from_str(line)
+                .with_context(|| format!("parsing lockfile entry: {line}"))?;
+            packages.insert((pkg.name.clone(), pkg.version.clone()), pkg);
+        }
+        Ok(Self {
+            requested: header.requested,
+            requested_dev: header.requested_dev,
+            roots: header.roots,
+            packages,
+        })
+    }
+
+    /// Serialize: header line, then packages sorted by name and semver.
+    pub fn to_jsonl(&self) -> String {
+        let header = Header {
+            version: LOCKFILE_VERSION,
+            requested: self.requested.clone(),
+            requested_dev: self.requested_dev.clone(),
+            roots: self.roots.clone(),
+        };
+        let mut out = serde_json::to_string(&header).expect("header serializes");
+        out.push('\n');
+
+        let mut entries: Vec<&LockedPackage> = self.packages.values().collect();
+        entries.sort_by(|a, b| {
+            a.name.cmp(&b.name).then_with(|| {
+                match (a.version.parse::<Version>(), b.version.parse::<Version>()) {
+                    (Ok(av), Ok(bv)) => av.cmp(&bv),
+                    _ => a.version.cmp(&b.version),
+                }
+            })
+        });
+        for pkg in entries {
+            out.push_str(&serde_json::to_string(pkg).expect("package serializes"));
+            out.push('\n');
+        }
+        out
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        std::fs::write(path, self.to_jsonl()).with_context(|| format!("writing {}", path.display()))
+    }
+}
+
+fn locked_from(p: &ResolvedPackage) -> LockedPackage {
+    LockedPackage {
+        name: p.name.clone(),
+        version: p.version.clone(),
+        resolved: p.tarball.clone(),
+        integrity: p.integrity.clone(),
+        shasum: p.shasum.clone(),
+        dependencies: p.dependencies.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Lockfile {
+        let mut lf = Lockfile::default();
+        lf.requested.insert("b".into(), "^2.0.0".into());
+        lf.requested.insert("a".into(), "^1.0.0".into());
+        lf.roots.insert("a".into(), "1.2.3".into());
+        lf.roots.insert("b".into(), "2.0.1".into());
+        for (name, version) in [("b", "2.0.1"), ("a", "1.2.3"), ("a", "1.10.0")] {
+            lf.packages.insert(
+                (name.into(), version.into()),
+                LockedPackage {
+                    name: name.into(),
+                    version: version.into(),
+                    resolved: format!("https://r.test/{name}/-/{name}-{version}.tgz"),
+                    integrity: Some("sha512-abc".into()),
+                    shasum: None,
+                    dependencies: BTreeMap::new(),
+                },
+            );
+        }
+        lf
+    }
+
+    #[test]
+    fn roundtrips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(LOCKFILE_NAME);
+        let lf = sample();
+        lf.save(&path).unwrap();
+        let loaded = Lockfile::load(&path).unwrap();
+        assert_eq!(loaded.requested, lf.requested);
+        assert_eq!(loaded.roots, lf.roots);
+        assert_eq!(loaded.packages, lf.packages);
+    }
+
+    #[test]
+    fn output_is_strictly_sorted_and_line_oriented() {
+        let text = sample().to_jsonl();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert!(lines[0].contains("chidoriLockfile"));
+        // a@1.2.3 sorts before a@1.10.0 (semver, not lexicographic), then b.
+        assert!(lines[1].contains(r#""version":"1.2.3""#));
+        assert!(lines[2].contains(r#""version":"1.10.0""#));
+        assert!(lines[3].contains(r#""name":"b""#));
+        // Deterministic: serializing twice is byte-identical.
+        assert_eq!(text, sample().to_jsonl());
+    }
+
+    #[test]
+    fn matches_manifest_detects_drift() {
+        let lf = sample();
+        assert!(lf.matches_manifest(&lf.requested.clone(), &BTreeMap::new()));
+        let mut changed = lf.requested.clone();
+        changed.insert("c".into(), "*".into());
+        assert!(!lf.matches_manifest(&changed, &BTreeMap::new()));
+    }
+}

--- a/crates/chidori/src/pkg/manifest.rs
+++ b/crates/chidori/src/pkg/manifest.rs
@@ -1,0 +1,164 @@
+//! `package.json` reading and surgical editing.
+//!
+//! The manifest is kept as a raw `serde_json::Value` so fields we don't
+//! understand (scripts, author, chidori-specific config, …) survive a
+//! round-trip untouched.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Map, Value};
+
+pub struct Manifest {
+    path: PathBuf,
+    value: Value,
+}
+
+impl Manifest {
+    /// Load `dir/package.json`, or start a fresh minimal manifest if the file
+    /// doesn't exist yet (it's written on the first `add`).
+    pub fn load_or_default(dir: &Path) -> Result<Self> {
+        let path = dir.join("package.json");
+        let value = if path.is_file() {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            let value: Value = serde_json::from_str(&raw)
+                .with_context(|| format!("parsing {}", path.display()))?;
+            if !value.is_object() {
+                bail!("{} is not a JSON object", path.display());
+            }
+            value
+        } else {
+            let name = dir
+                .canonicalize()
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                .filter(|n| super::registry::validate_package_name(n).is_ok())
+                .unwrap_or_else(|| "chidori-agent".to_string());
+            json!({ "name": name, "private": true })
+        };
+        Ok(Self { path, value })
+    }
+
+    fn section(&self, key: &str) -> BTreeMap<String, String> {
+        self.value
+            .get(key)
+            .and_then(Value::as_object)
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn dependencies(&self) -> BTreeMap<String, String> {
+        self.section("dependencies")
+    }
+
+    pub fn dev_dependencies(&self) -> BTreeMap<String, String> {
+        self.section("devDependencies")
+    }
+
+    /// All requested ranges (prod + dev). Dev wins on duplicate names, which
+    /// matches npm's arborist behavior for the local tree.
+    pub fn all_dependencies(&self) -> BTreeMap<String, String> {
+        let mut all = self.dependencies();
+        all.extend(self.dev_dependencies());
+        all
+    }
+
+    pub fn set_dependency(&mut self, name: &str, range: &str, dev: bool) {
+        let key = if dev {
+            "devDependencies"
+        } else {
+            "dependencies"
+        };
+        let other = if dev {
+            "dependencies"
+        } else {
+            "devDependencies"
+        };
+        // A package lives in exactly one section; moving it is intentional.
+        if let Some(map) = self.value.get_mut(other).and_then(Value::as_object_mut) {
+            map.remove(name);
+        }
+        let obj = self.value.as_object_mut().expect("validated as object");
+        let section = obj
+            .entry(key.to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(map) = section.as_object_mut() {
+            map.insert(name.to_string(), Value::String(range.to_string()));
+            sort_map_in_place(map);
+        }
+    }
+
+    /// Remove from both sections; true if it was present in either.
+    pub fn remove_dependency(&mut self, name: &str) -> bool {
+        let mut removed = false;
+        for key in ["dependencies", "devDependencies"] {
+            if let Some(map) = self.value.get_mut(key).and_then(Value::as_object_mut) {
+                removed |= map.remove(name).is_some();
+            }
+        }
+        removed
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let mut out = serde_json::to_string_pretty(&self.value).expect("manifest serializes");
+        out.push('\n');
+        std::fs::write(&self.path, out).with_context(|| format!("writing {}", self.path.display()))
+    }
+}
+
+/// serde_json preserves insertion order by default; rewrite the map sorted so
+/// dependency sections stay alphabetized like npm keeps them.
+fn sort_map_in_place(map: &mut Map<String, Value>) {
+    let mut entries: Vec<(String, Value)> = std::mem::take(map).into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    map.extend(entries);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_unknown_fields_and_sorts_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","customField":{"keep":true},"dependencies":{"zeta":"^1.0.0"}}"#,
+        )
+        .unwrap();
+        let mut m = Manifest::load_or_default(dir.path()).unwrap();
+        m.set_dependency("alpha", "^2.0.0", false);
+        m.save().unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        let v: Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["customField"]["keep"], Value::Bool(true));
+        let deps: Vec<&String> = v["dependencies"].as_object().unwrap().keys().collect();
+        assert_eq!(deps, ["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn add_moves_between_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = Manifest::load_or_default(dir.path()).unwrap();
+        m.set_dependency("p", "^1.0.0", false);
+        m.set_dependency("p", "^1.0.0", true);
+        assert!(m.dependencies().is_empty());
+        assert_eq!(m.dev_dependencies().get("p").unwrap(), "^1.0.0");
+    }
+
+    #[test]
+    fn remove_reports_presence() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = Manifest::load_or_default(dir.path()).unwrap();
+        m.set_dependency("p", "^1.0.0", false);
+        assert!(m.remove_dependency("p"));
+        assert!(!m.remove_dependency("p"));
+    }
+}

--- a/crates/chidori/src/pkg/mod.rs
+++ b/crates/chidori/src/pkg/mod.rs
@@ -1,0 +1,35 @@
+//! Native npm package management: `chidori add` / `chidori install` /
+//! `chidori remove`.
+//!
+//! Agents import npm packages through the Node-style resolver in
+//! `runtime::typescript::resolver`, which reads from `node_modules`. This
+//! module populates that directory without requiring Node, npm, or bun on the
+//! machine — the same "one Rust binary" stance as the rest of chidori.
+//!
+//! Design (see docs/package-management.md):
+//! - **Content-addressed global store** at `~/.chidori/cache/packages`:
+//!   each package version is downloaded and extracted exactly once, keyed by
+//!   its registry integrity hash, then materialized into a project's
+//!   `node_modules` by hardlinking (copy fallback). Warm installs touch no
+//!   network and duplicate no file contents.
+//! - **Integrity verification**: every tarball is verified against the
+//!   registry's `sha512` integrity (or legacy `sha1` shasum) before it enters
+//!   the store. Hashing runs on blocking worker threads, off the async
+//!   download path.
+//! - **Sorted JSONL lockfile** (`chidori.lock.jsonl`): one JSON object per
+//!   line, strictly sorted, so concurrent dependency changes merge in git
+//!   without conflict churn.
+//! - **No lifecycle scripts**: `preinstall`/`postinstall` never run. Installs
+//!   are pure data movement, which removes the single largest npm supply-chain
+//!   attack vector. Packages needing native builds don't apply here — agent
+//!   code runs on chidori's embedded engine.
+
+pub mod install;
+pub mod layout;
+pub mod lockfile;
+pub mod manifest;
+pub mod registry;
+pub mod resolve;
+pub mod store;
+
+pub use install::{cmd_add, cmd_install, cmd_remove};

--- a/crates/chidori/src/pkg/registry.rs
+++ b/crates/chidori/src/pkg/registry.rs
@@ -1,0 +1,194 @@
+//! npm registry client: abbreviated packument fetch + tarball download.
+//!
+//! Uses the `application/vnd.npm.install-v1+json` "abbreviated" packument
+//! format, which carries only what installation needs (versions, dist-tags,
+//! dependency maps, tarball URLs and integrity hashes) — typically 10-50x
+//! smaller than the full document.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+/// Env var overriding the registry base URL. Useful for corporate mirrors and
+/// for hermetic tests that point at a local mock registry.
+pub const REGISTRY_ENV: &str = "CHIDORI_NPM_REGISTRY";
+
+const DEFAULT_REGISTRY: &str = "https://registry.npmjs.org";
+
+/// Abbreviated packument: everything the registry knows about one package
+/// name, in install-v1 form.
+#[derive(Debug, Deserialize)]
+pub struct Packument {
+    #[serde(default, rename = "dist-tags")]
+    pub dist_tags: HashMap<String, String>,
+    #[serde(default)]
+    pub versions: BTreeMap<String, PackageVersion>,
+}
+
+/// One published version of a package.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PackageVersion {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, String>,
+    #[serde(default, rename = "optionalDependencies")]
+    pub optional_dependencies: BTreeMap<String, String>,
+    #[serde(default, rename = "peerDependencies")]
+    pub peer_dependencies: BTreeMap<String, String>,
+    pub dist: Dist,
+    #[serde(default)]
+    pub deprecated: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Dist {
+    pub tarball: String,
+    /// Subresource-integrity string, e.g. `sha512-<base64>`. Present for
+    /// everything published since ~2017.
+    #[serde(default)]
+    pub integrity: Option<String>,
+    /// Legacy hex SHA-1, always present.
+    #[serde(default)]
+    pub shasum: Option<String>,
+}
+
+pub struct RegistryClient {
+    base: String,
+    http: reqwest::Client,
+    packuments: Mutex<HashMap<String, Arc<Packument>>>,
+}
+
+impl RegistryClient {
+    /// Client against `CHIDORI_NPM_REGISTRY` or the public npm registry.
+    pub fn from_env() -> Result<Self> {
+        let base = std::env::var(REGISTRY_ENV)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_REGISTRY.to_string());
+        Self::new(base)
+    }
+
+    pub fn new(base: impl Into<String>) -> Result<Self> {
+        let mut base = base.into();
+        while base.ends_with('/') {
+            base.pop();
+        }
+        let http = reqwest::Client::builder()
+            .user_agent(concat!("chidori/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .context("building registry HTTP client")?;
+        Ok(Self {
+            base,
+            http,
+            packuments: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Fetch (and memoize) the abbreviated packument for `name`.
+    pub async fn packument(&self, name: &str) -> Result<Arc<Packument>> {
+        validate_package_name(name)?;
+        if let Some(hit) = self.packuments.lock().await.get(name) {
+            return Ok(hit.clone());
+        }
+        // Scoped names keep their `/` encoded, matching npm client behavior.
+        let url = format!("{}/{}", self.base, name.replace('/', "%2F"));
+        let resp = self
+            .http
+            .get(&url)
+            .header("accept", "application/vnd.npm.install-v1+json")
+            .send()
+            .await
+            .with_context(|| format!("fetching registry metadata for `{name}`"))?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            bail!("package `{name}` not found in registry {}", self.base);
+        }
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("registry error for `{name}`"))?;
+        let packument: Packument = resp
+            .json()
+            .await
+            .with_context(|| format!("parsing registry metadata for `{name}`"))?;
+        let packument = Arc::new(packument);
+        self.packuments
+            .lock()
+            .await
+            .insert(name.to_string(), packument.clone());
+        Ok(packument)
+    }
+
+    /// Download a package tarball, unverified. Verification happens in the
+    /// store before extraction (`store::PackageStore::ensure`).
+    pub async fn download_tarball(&self, url: &str) -> Result<Vec<u8>> {
+        let resp = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .with_context(|| format!("downloading {url}"))?
+            .error_for_status()
+            .with_context(|| format!("downloading {url}"))?;
+        let bytes = resp
+            .bytes()
+            .await
+            .with_context(|| format!("reading tarball body from {url}"))?;
+        Ok(bytes.to_vec())
+    }
+}
+
+/// Reject names that could escape into URL or filesystem tricks. Mirrors the
+/// constraints of `validate-npm-package-name`, minus legacy grandfathered
+/// names we have no reason to support.
+pub fn validate_package_name(name: &str) -> Result<()> {
+    let bad = |why: &str| anyhow!("invalid package name `{name}`: {why}");
+    if name.is_empty() || name.len() > 214 {
+        return Err(bad("must be 1-214 characters"));
+    }
+    let unscoped = if let Some(rest) = name.strip_prefix('@') {
+        let (scope, unscoped) = rest
+            .split_once('/')
+            .ok_or_else(|| bad("scoped name must be @scope/name"))?;
+        if scope.is_empty() || !scope.chars().all(is_name_char) {
+            return Err(bad("bad scope segment"));
+        }
+        unscoped
+    } else {
+        name
+    };
+    if unscoped.is_empty() || !unscoped.chars().all(is_name_char) {
+        return Err(bad(
+            "only lowercase letters, digits, `-`, `_`, and `.` are allowed",
+        ));
+    }
+    if unscoped.starts_with('.') || unscoped.starts_with('_') {
+        return Err(bad("must not start with `.` or `_`"));
+    }
+    Ok(())
+}
+
+fn is_name_char(c: char) -> bool {
+    c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_' | '.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_package_names() {
+        assert!(validate_package_name("left-pad").is_ok());
+        assert!(validate_package_name("@scope/pkg").is_ok());
+        assert!(validate_package_name("@scope/pkg.js").is_ok());
+        assert!(validate_package_name("").is_err());
+        assert!(validate_package_name("UPPER").is_err());
+        assert!(validate_package_name("../evil").is_err());
+        assert!(validate_package_name("@/x").is_err());
+        assert!(validate_package_name("@scope").is_err());
+        assert!(validate_package_name(".dot").is_err());
+        assert!(validate_package_name("a/b").is_err());
+    }
+}

--- a/crates/chidori/src/pkg/resolve.rs
+++ b/crates/chidori/src/pkg/resolve.rs
@@ -1,0 +1,279 @@
+//! Dependency resolution: from requested ranges to an exact package set.
+//!
+//! npm-flavored semver matching is delegated to the `nodejs_semver` crate
+//! (the node-semver port used by orogene). For each `(name, range)`
+//! requirement we pick the highest published version satisfying the range,
+//! preferring a version already pinned in the lockfile when it still
+//! satisfies — so `chidori add foo` doesn't churn unrelated pins.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+
+use anyhow::{bail, Context, Result};
+use nodejs_semver::{Range, Version};
+
+use super::registry::{PackageVersion, RegistryClient};
+
+/// An exact package selected by resolution.
+#[derive(Debug, Clone)]
+pub struct ResolvedPackage {
+    pub name: String,
+    pub version: String,
+    pub tarball: String,
+    pub integrity: Option<String>,
+    pub shasum: Option<String>,
+    /// Resolved dependency edges: dep name -> exact version chosen.
+    pub dependencies: BTreeMap<String, String>,
+}
+
+impl ResolvedPackage {
+    pub fn id(&self) -> (String, String) {
+        (self.name.clone(), self.version.clone())
+    }
+}
+
+/// The full resolved set plus the root's direct edges.
+#[derive(Debug, Default)]
+pub struct Resolution {
+    /// All packages, keyed by (name, exact version).
+    pub packages: BTreeMap<(String, String), ResolvedPackage>,
+    /// Root direct dependencies (prod + dev merged): name -> exact version.
+    pub roots: BTreeMap<String, String>,
+    /// Human-readable warnings (unsatisfied peers, deprecations, skipped
+    /// optionals) to surface after install.
+    pub warnings: Vec<String>,
+}
+
+/// Pick the version of `name` that satisfies `spec` from a packument.
+///
+/// `spec` may be a semver range (`^1.2.3`, `1.x`, `>=2 <3 || 4.x`, …) or a
+/// dist-tag (`latest`, `beta`). `preferred` versions win when they satisfy.
+fn select_version<'p>(
+    name: &str,
+    spec: &str,
+    packument: &'p super::registry::Packument,
+    preferred: &BTreeSet<String>,
+) -> Result<&'p PackageVersion> {
+    let spec = spec.trim();
+    for (prefix, kind) in [
+        ("git+", "git"),
+        ("git:", "git"),
+        ("github:", "git"),
+        ("file:", "file"),
+        ("link:", "link"),
+        ("workspace:", "workspace"),
+        ("npm:", "alias"),
+        ("http://", "url"),
+        ("https://", "url"),
+    ] {
+        if spec.starts_with(prefix) {
+            bail!("`{name}@{spec}`: {kind} dependencies are not supported by chidori's package manager");
+        }
+    }
+
+    let range: Option<Range> = if spec.is_empty() {
+        Some("*".parse().expect("wildcard range parses"))
+    } else {
+        spec.parse().ok()
+    };
+
+    let matching_version = |range: &Range| -> Option<&'p PackageVersion> {
+        // Preferred (lockfile-pinned) versions first, then highest overall.
+        let mut best: Option<(Version, &PackageVersion)> = None;
+        let mut best_preferred: Option<(Version, &PackageVersion)> = None;
+        for (raw, meta) in &packument.versions {
+            let Ok(version) = raw.parse::<Version>() else {
+                continue;
+            };
+            if !version.satisfies(range) {
+                continue;
+            }
+            if preferred.contains(raw) && best_preferred.as_ref().is_none_or(|(b, _)| version > *b)
+            {
+                best_preferred = Some((version.clone(), meta));
+            }
+            if best.as_ref().is_none_or(|(b, _)| version > *b) {
+                best = Some((version, meta));
+            }
+        }
+        best_preferred.or(best).map(|(_, meta)| meta)
+    };
+
+    if let Some(range) = range {
+        if let Some(meta) = matching_version(&range) {
+            return Ok(meta);
+        }
+        bail!(
+            "no version of `{name}` satisfies `{spec}` (available: {} versions)",
+            packument.versions.len()
+        );
+    }
+
+    // Not a parsable range: try it as a dist-tag.
+    if let Some(tagged) = packument.dist_tags.get(spec) {
+        if let Some(meta) = packument.versions.get(tagged) {
+            return Ok(meta);
+        }
+        bail!("dist-tag `{spec}` of `{name}` points at unpublished version {tagged}");
+    }
+    bail!("`{name}@{spec}` is neither a valid semver range nor a dist-tag");
+}
+
+/// Resolve `root_deps` (name -> range) plus their full transitive closure.
+///
+/// `preferred` seeds version choices from an existing lockfile: for each
+/// name, versions we'd like to keep if they still satisfy the range asking.
+pub async fn resolve(
+    registry: &RegistryClient,
+    root_deps: &BTreeMap<String, String>,
+    preferred: &HashMap<String, BTreeSet<String>>,
+) -> Result<Resolution> {
+    let empty = BTreeSet::new();
+    let mut resolution = Resolution::default();
+    // Memoized picks so one (name, range) pair resolves identically everywhere.
+    let mut picked: HashMap<(String, String), (String, String)> = HashMap::new();
+    // Queue of (name, range, optional, requested_by).
+    let mut queue: VecDeque<(String, String, bool, String)> = root_deps
+        .iter()
+        .map(|(n, r)| (n.clone(), r.clone(), false, "the project".to_string()))
+        .collect();
+    let mut root_pending: BTreeMap<String, String> = root_deps.clone();
+
+    while let Some((name, range, optional, requested_by)) = queue.pop_front() {
+        let key = (name.clone(), range.clone());
+        let already = picked.get(&key).cloned();
+        let meta = match already {
+            Some((n, v)) => {
+                if root_pending.remove(&name).is_some() {
+                    resolution.roots.insert(n, v);
+                }
+                continue;
+            }
+            None => {
+                let packument = match registry.packument(&name).await {
+                    Ok(p) => p,
+                    Err(e) if optional => {
+                        resolution
+                            .warnings
+                            .push(format!("skipped optional dependency `{name}`: {e}"));
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!("resolving `{name}@{range}` (required by {requested_by})")
+                        })
+                    }
+                };
+                let selected = select_version(
+                    &name,
+                    &range,
+                    &packument,
+                    preferred.get(&name).unwrap_or(&empty),
+                );
+                match selected {
+                    Ok(meta) => meta.clone(),
+                    Err(e) if optional => {
+                        resolution
+                            .warnings
+                            .push(format!("skipped optional dependency `{name}@{range}`: {e}"));
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!("resolving `{name}@{range}` (required by {requested_by})")
+                        })
+                    }
+                }
+            }
+        };
+
+        picked.insert(key, (meta.name.clone(), meta.version.clone()));
+        if root_pending.remove(&name).is_some() {
+            resolution
+                .roots
+                .insert(meta.name.clone(), meta.version.clone());
+        }
+        if let Some(msg) = &meta.deprecated {
+            if !msg.is_empty() {
+                resolution.warnings.push(format!(
+                    "`{}@{}` is deprecated: {msg}",
+                    meta.name, meta.version
+                ));
+            }
+        }
+
+        let id = (meta.name.clone(), meta.version.clone());
+        if resolution.packages.contains_key(&id) {
+            continue;
+        }
+
+        let requester = format!("{}@{}", meta.name, meta.version);
+        for (dep, dep_range) in &meta.dependencies {
+            queue.push_back((dep.clone(), dep_range.clone(), false, requester.clone()));
+        }
+        for (dep, dep_range) in &meta.optional_dependencies {
+            queue.push_back((dep.clone(), dep_range.clone(), true, requester.clone()));
+        }
+
+        resolution.packages.insert(
+            id,
+            ResolvedPackage {
+                name: meta.name.clone(),
+                version: meta.version.clone(),
+                tarball: meta.dist.tarball.clone(),
+                integrity: meta.dist.integrity.clone(),
+                shasum: meta.dist.shasum.clone(),
+                // Dependency edges get their exact versions filled in below,
+                // once every (name, range) pick is known.
+                dependencies: BTreeMap::new(),
+            },
+        );
+    }
+
+    // Second pass: turn each package's (name -> range) requirements into
+    // (name -> exact version) edges using the memoized picks.
+    let metas: Vec<(String, String)> = resolution.packages.keys().cloned().collect();
+    for id in metas {
+        let packument = registry.packument(&id.0).await?;
+        let Some(meta) = packument.versions.get(&id.1) else {
+            continue;
+        };
+        let mut edges = BTreeMap::new();
+        for (dep, dep_range) in &meta.dependencies {
+            if let Some((n, v)) = picked.get(&(dep.clone(), dep_range.clone())) {
+                edges.insert(n.clone(), v.clone());
+            }
+        }
+        for (dep, dep_range) in &meta.optional_dependencies {
+            if let Some((n, v)) = picked.get(&(dep.clone(), dep_range.clone())) {
+                edges.insert(n.clone(), v.clone());
+            }
+        }
+        // Peer dependency check: warn when nothing in the resolved set
+        // satisfies a peer range. We don't auto-install peers (v1).
+        for (peer, peer_range) in &meta.peer_dependencies {
+            let satisfied = resolution
+                .packages
+                .keys()
+                .filter(|(n, _)| n == peer)
+                .any(
+                    |(_, v)| match (v.parse::<Version>(), peer_range.parse::<Range>()) {
+                        (Ok(ver), Ok(range)) => ver.satisfies(&range),
+                        _ => true,
+                    },
+                );
+            if !satisfied {
+                resolution.warnings.push(format!(
+                    "`{}@{}` has unmet peer dependency `{peer}@{peer_range}` (install it explicitly if needed)",
+                    id.0, id.1
+                ));
+            }
+        }
+        resolution
+            .packages
+            .get_mut(&id)
+            .expect("id came from packages")
+            .dependencies = edges;
+    }
+
+    Ok(resolution)
+}

--- a/crates/chidori/src/pkg/store.rs
+++ b/crates/chidori/src/pkg/store.rs
@@ -1,0 +1,349 @@
+//! Content-addressed global package store + hardlink materialization.
+//!
+//! Every package version lives extracted under
+//! `~/.chidori/cache/packages/<integrity-key>/`, keyed by its registry
+//! integrity hash. A version is downloaded, verified, and extracted exactly
+//! once per machine; projects get it materialized into `node_modules` via
+//! hardlinks (falling back to copies across filesystems), so warm installs do
+//! no network I/O and duplicate no file contents.
+//!
+//! Store entries are written atomically: extract into a temp sibling
+//! directory, then `rename` into place. A concurrent install racing on the
+//! same package loses the rename and simply uses the winner's entry.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine as _;
+use sha2::Digest as _;
+
+/// Env var overriding the store location (tests, CI, shared caches).
+pub const STORE_ENV: &str = "CHIDORI_PKG_CACHE_DIR";
+
+/// What to verify a tarball against, in preference order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Integrity {
+    /// `sha512-<base64>` subresource-integrity string from the registry.
+    Sha512(Vec<u8>),
+    /// Legacy hex SHA-1 `shasum` for pre-2017 publishes.
+    Sha1(Vec<u8>),
+}
+
+impl Integrity {
+    /// Prefer the SRI `integrity` field, fall back to the legacy shasum.
+    pub fn from_dist(integrity: Option<&str>, shasum: Option<&str>) -> Result<Self> {
+        if let Some(sri) = integrity {
+            // SRI allows space-separated alternatives; take the strongest
+            // sha512 entry if present.
+            for candidate in sri.split_whitespace() {
+                if let Some(b64) = candidate.strip_prefix("sha512-") {
+                    let digest = base64::engine::general_purpose::STANDARD
+                        .decode(b64)
+                        .context("decoding sha512 integrity")?;
+                    if digest.len() != 64 {
+                        bail!("sha512 integrity has wrong digest length");
+                    }
+                    return Ok(Integrity::Sha512(digest));
+                }
+            }
+        }
+        if let Some(hex_sum) = shasum {
+            let digest = hex::decode(hex_sum.trim()).context("decoding sha1 shasum")?;
+            if digest.len() != 20 {
+                bail!("sha1 shasum has wrong digest length");
+            }
+            return Ok(Integrity::Sha1(digest));
+        }
+        bail!("registry entry has neither sha512 integrity nor sha1 shasum")
+    }
+
+    /// Filesystem-safe store key, e.g. `sha512-<hex>`.
+    pub fn store_key(&self) -> String {
+        match self {
+            Integrity::Sha512(d) => format!("sha512-{}", hex::encode(d)),
+            Integrity::Sha1(d) => format!("sha1-{}", hex::encode(d)),
+        }
+    }
+
+    /// Verify `bytes` against this integrity. CPU-heavy; callers should run
+    /// it via `spawn_blocking` so hashing never stalls the download executor.
+    pub fn verify(&self, bytes: &[u8]) -> Result<()> {
+        let ok = match self {
+            Integrity::Sha512(expected) => {
+                sha2::Sha512::digest(bytes).as_slice() == expected.as_slice()
+            }
+            Integrity::Sha1(expected) => {
+                use sha1::Digest as _;
+                sha1::Sha1::digest(bytes).as_slice() == expected.as_slice()
+            }
+        };
+        if !ok {
+            bail!(
+                "integrity verification failed (expected {})",
+                self.store_key()
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct PackageStore {
+    root: PathBuf,
+}
+
+impl PackageStore {
+    /// Store at `CHIDORI_PKG_CACHE_DIR`, else `~/.chidori/cache/packages`.
+    pub fn from_env() -> Result<Self> {
+        if let Some(dir) = std::env::var_os(STORE_ENV).filter(|s| !s.is_empty()) {
+            return Ok(Self::new(PathBuf::from(dir)));
+        }
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .filter(|p| !p.is_empty())
+            .ok_or_else(|| {
+                anyhow!("cannot locate home directory for the package store; set {STORE_ENV}")
+            })?;
+        Ok(Self::new(
+            PathBuf::from(home)
+                .join(".chidori")
+                .join("cache")
+                .join("packages"),
+        ))
+    }
+
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Directory holding the extracted contents for `integrity`, if cached.
+    pub fn lookup(&self, integrity: &Integrity) -> Option<PathBuf> {
+        let dir = self.root.join(integrity.store_key());
+        dir.is_dir().then_some(dir)
+    }
+
+    /// Verify `tarball` against `integrity`, extract it, and move it into the
+    /// store. Returns the store directory. No-op if already present.
+    pub fn put_tarball(&self, integrity: &Integrity, tarball: &[u8]) -> Result<PathBuf> {
+        let final_dir = self.root.join(integrity.store_key());
+        if final_dir.is_dir() {
+            return Ok(final_dir);
+        }
+        integrity.verify(tarball)?;
+
+        std::fs::create_dir_all(&self.root)
+            .with_context(|| format!("creating store root {}", self.root.display()))?;
+        // Temp sibling inside the store root so the final rename never
+        // crosses filesystems.
+        let tmp_path = self
+            .root
+            .join(format!(".extract-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir(&tmp_path).context("creating store temp dir")?;
+        if let Err(e) = extract_npm_tarball(tarball, &tmp_path) {
+            let _ = std::fs::remove_dir_all(&tmp_path);
+            return Err(e);
+        }
+
+        match std::fs::rename(&tmp_path, &final_dir) {
+            Ok(()) => Ok(final_dir),
+            Err(_) if final_dir.is_dir() => {
+                // Lost a race with a concurrent install of the same package.
+                let _ = std::fs::remove_dir_all(&tmp_path);
+                Ok(final_dir)
+            }
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&tmp_path);
+                Err(e).with_context(|| {
+                    format!("moving package into store at {}", final_dir.display())
+                })
+            }
+        }
+    }
+
+    /// Materialize a store entry into `dest` by hardlinking every file
+    /// (copying when linking fails, e.g. across devices). `dest` must not
+    /// already exist.
+    pub fn materialize(&self, store_dir: &Path, dest: &Path) -> Result<()> {
+        link_tree(store_dir, dest)
+    }
+}
+
+fn link_tree(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("creating {}", dst.display()))?;
+    for entry in std::fs::read_dir(src).with_context(|| format!("reading {}", src.display()))? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if ty.is_dir() {
+            link_tree(&from, &to)?;
+        } else if ty.is_file() && std::fs::hard_link(&from, &to).is_err() {
+            std::fs::copy(&from, &to)
+                .with_context(|| format!("copying {} -> {}", from.display(), to.display()))?;
+        }
+        // Symlinks and other special entries are skipped: extract_npm_tarball
+        // never writes them, so anything else in the store is foreign.
+    }
+    Ok(())
+}
+
+/// Extract an npm package tarball (gzipped tar) into `dest`, stripping the
+/// leading path component (`package/` by convention, but npm accepts any
+/// single root directory). Only regular files and directories are written;
+/// symlinks/hardlinks in a tarball are rejected as malicious.
+fn extract_npm_tarball(tarball: &[u8], dest: &Path) -> Result<()> {
+    let gz = flate2::read::GzDecoder::new(tarball);
+    let mut archive = tar::Archive::new(gz);
+    for entry in archive.entries().context("reading tarball")? {
+        let mut entry = entry.context("reading tarball entry")?;
+        let path = entry.path().context("tarball entry path")?.into_owned();
+        let rel = strip_root_component(&path)
+            .ok_or_else(|| anyhow!("tarball entry outside package root: {}", path.display()))?;
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+        let out = dest.join(&rel);
+        match entry.header().entry_type() {
+            tar::EntryType::Directory => {
+                std::fs::create_dir_all(&out)?;
+            }
+            tar::EntryType::Regular | tar::EntryType::Continuous => {
+                if let Some(parent) = out.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                let mut buf = Vec::with_capacity(entry.size() as usize);
+                entry.read_to_end(&mut buf)?;
+                std::fs::write(&out, &buf).with_context(|| format!("writing {}", out.display()))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(mode) = entry.header().mode() {
+                        if mode & 0o111 != 0 {
+                            let _ = std::fs::set_permissions(
+                                &out,
+                                std::fs::Permissions::from_mode(0o755),
+                            );
+                        }
+                    }
+                }
+            }
+            tar::EntryType::Link | tar::EntryType::Symlink => {
+                bail!(
+                    "refusing tarball containing a link entry: {}",
+                    path.display()
+                );
+            }
+            // pax headers, gnu extensions etc. — metadata, not content.
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Drop the first path component and reject traversal or absolute paths.
+fn strip_root_component(path: &Path) -> Option<PathBuf> {
+    let mut components = path.components();
+    match components.next()? {
+        std::path::Component::Normal(_) => {}
+        _ => return None,
+    }
+    let mut out = PathBuf::new();
+    for c in components {
+        match c {
+            std::path::Component::Normal(part) => out.push(part),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a gzipped npm-style tarball in memory.
+    pub(crate) fn make_tarball(files: &[(&str, &str)]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::fast(),
+        ));
+        for (path, body) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, format!("package/{path}"), body.as_bytes())
+                .unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    fn integrity_of(bytes: &[u8]) -> Integrity {
+        Integrity::Sha512(sha2::Sha512::digest(bytes).to_vec())
+    }
+
+    #[test]
+    fn put_verify_and_materialize_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = PackageStore::new(dir.path().join("store"));
+        let tarball = make_tarball(&[
+            ("package.json", r#"{"name":"x","version":"1.0.0"}"#),
+            ("lib/index.js", "module.exports = 1;"),
+        ]);
+        let integrity = integrity_of(&tarball);
+
+        assert!(store.lookup(&integrity).is_none());
+        let stored = store.put_tarball(&integrity, &tarball).unwrap();
+        assert!(stored.join("lib/index.js").is_file());
+        assert_eq!(store.lookup(&integrity), Some(stored.clone()));
+
+        let dest = dir.path().join("node_modules/x");
+        store.materialize(&stored, &dest).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("lib/index.js")).unwrap(),
+            "module.exports = 1;"
+        );
+    }
+
+    #[test]
+    fn rejects_corrupted_tarball() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = PackageStore::new(dir.path());
+        let tarball = make_tarball(&[("package.json", "{}")]);
+        let mut wrong = tarball.clone();
+        wrong[10] ^= 0xff;
+        let integrity = integrity_of(&tarball);
+        let err = store.put_tarball(&integrity, &wrong).unwrap_err();
+        assert!(err.to_string().contains("integrity verification failed"));
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert_eq!(strip_root_component(Path::new("package/../../etc/x")), None);
+        assert_eq!(strip_root_component(Path::new("/etc/passwd")), None);
+        assert_eq!(
+            strip_root_component(Path::new("package/a/b.js")),
+            Some(PathBuf::from("a/b.js"))
+        );
+    }
+
+    #[test]
+    fn integrity_prefers_sha512_and_falls_back_to_shasum() {
+        let sri = format!(
+            "sha512-{}",
+            base64::engine::general_purpose::STANDARD.encode([7u8; 64])
+        );
+        match Integrity::from_dist(Some(&sri), Some("aa".repeat(20).as_str())).unwrap() {
+            Integrity::Sha512(d) => assert_eq!(d, vec![7u8; 64]),
+            other => panic!("expected sha512, got {other:?}"),
+        }
+        match Integrity::from_dist(None, Some("ab".repeat(20).as_str())).unwrap() {
+            Integrity::Sha1(d) => assert_eq!(d.len(), 20),
+            other => panic!("expected sha1, got {other:?}"),
+        }
+        assert!(Integrity::from_dist(None, None).is_err());
+    }
+}

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -608,30 +608,15 @@ pub(crate) fn run_module(
     }
 }
 
-/// Resolve `specifier` relative to `importer_key`'s directory, read the file, and
-/// transpile it to ES module source — the host half of the rust engine's module
-/// loader (the linker lives in `chidori-js`).
+/// Resolve `specifier` from `importer_key` (relative for agent code, full
+/// Node-style resolution for bare npm specifiers and node_modules-internal
+/// imports), read the file, and produce ES module source — the host half of
+/// the rust engine's module loader (the linker lives in `chidori-js`).
 fn load_module_source(
     specifier: &str,
     importer_key: &str,
 ) -> std::result::Result<(String, String), String> {
-    let importer = Path::new(importer_key);
-    let dir = importer.parent().unwrap_or_else(|| Path::new("."));
-    let resolved =
-        crate::runtime::typescript::transpile::resolve_relative_import(importer, dir, specifier, 0)
-            .map_err(|e| e.to_string())?;
-    let key = resolved.to_string_lossy().to_string();
-    let src = std::fs::read_to_string(&resolved)
-        .map_err(|e| format!("reading module {}: {e}", resolved.display()))?;
-    let js = transpile_module(
-        &resolved,
-        &src,
-        &TranspileOptions {
-            import_policy: TypeScriptImportPolicy::Node,
-        },
-    )
-    .map_err(|e| e.to_string())?;
-    Ok((key, js))
+    crate::runtime::typescript::loader::load_module_source(specifier, importer_key)
 }
 
 /// The synchronous `__chidori_*` natives the `node:` builtin shims and the

--- a/crates/chidori/src/runtime/typescript/loader.rs
+++ b/crates/chidori/src/runtime/typescript/loader.rs
@@ -1,0 +1,240 @@
+//! Runtime module loading, shared by the rust engine's linker host and the
+//! tool loader.
+//!
+//! Given `(specifier, importer)` this resolves to an on-disk file, reads it,
+//! and returns `(module key, ES module source)`:
+//!
+//! - **Relative imports from agent code** keep the strict project-rooted
+//!   resolution (`resolve_relative_import`) that agent files always had.
+//! - **Bare specifiers** (`zod`, `@scope/pkg/sub`) and **any import from
+//!   inside `node_modules`** go through the full Node-style resolver
+//!   (`resolver::Resolver`), so packages installed by `chidori add` load the
+//!   way node/bun would load them.
+//! - **JSON modules** become `export default <json>`.
+//! - **Leaf CommonJS files** (no ESM syntax, uses `module.exports`) are
+//!   wrapped so `import pkg from "cjs-pkg"` receives `module.exports` as the
+//!   default export. `require()` is not emulated: a CJS file that calls it
+//!   throws with a message steering toward ESM builds. This is deliberately
+//!   minimal — real CJS graphs should ship an ESM build (most packages do).
+
+use std::path::Path;
+
+use crate::runtime::snapshot::TypeScriptImportPolicy;
+
+use super::resolver::{Resolver, DEFAULT_CONDITIONS};
+use super::transpile::{
+    find_workspace_root, resolve_relative_import, transpile_module, TranspileOptions,
+    NODE_BUILTIN_ALLOWLIST,
+};
+
+/// Resolve `specifier` from `importer_key`, read the module, and produce ES
+/// module source. `node:` builtins and vendored packages must be handled by
+/// the caller before this.
+pub fn load_module_source(
+    specifier: &str,
+    importer_key: &str,
+) -> std::result::Result<(String, String), String> {
+    let importer = Path::new(importer_key);
+    let in_node_modules = importer
+        .components()
+        .any(|c| c.as_os_str() == "node_modules");
+
+    let resolved = if is_bare_specifier(specifier) || in_node_modules {
+        // Full Node ESM resolution: node_modules walk-up, exports maps,
+        // extension probing. Also used for relative imports *between package
+        // files*, which may legitimately traverse `../` inside the package.
+        let root = find_workspace_root(importer);
+        let resolver = Resolver::new(
+            root,
+            DEFAULT_CONDITIONS.iter().copied(),
+            NODE_BUILTIN_ALLOWLIST.iter().copied(),
+        );
+        resolver
+            .resolve(specifier, importer)
+            .map_err(|e| e.to_string())?
+            .resolved_path
+    } else {
+        // Agent-code relative import: keep the historical strict behavior
+        // (rooted at the importer's directory, no escaping).
+        let dir = importer.parent().unwrap_or_else(|| Path::new("."));
+        resolve_relative_import(importer, dir, specifier, 0).map_err(|e| e.to_string())?
+    };
+
+    let key = resolved.to_string_lossy().to_string();
+    let src = std::fs::read_to_string(&resolved)
+        .map_err(|e| format!("reading module {}: {e}", resolved.display()))?;
+
+    if resolved.extension().and_then(|e| e.to_str()) == Some("json") {
+        // Validate, then embed: a JSON document is a valid JS expression.
+        serde_json::from_str::<serde::de::IgnoredAny>(&src)
+            .map_err(|e| format!("parsing JSON module {}: {e}", resolved.display()))?;
+        return Ok((key, format!("export default {src};\n")));
+    }
+
+    if in_dir_node_modules(&resolved) && looks_like_commonjs(&src) {
+        return Ok((key, wrap_commonjs(&src)));
+    }
+
+    let js = transpile_module(
+        &resolved,
+        &src,
+        &TranspileOptions {
+            import_policy: TypeScriptImportPolicy::Node,
+        },
+    )
+    .map_err(|e| e.to_string())?;
+    Ok((key, js))
+}
+
+fn is_bare_specifier(specifier: &str) -> bool {
+    !(specifier.starts_with("./")
+        || specifier.starts_with("../")
+        || specifier.starts_with('/')
+        || specifier == "."
+        || specifier == "..")
+}
+
+fn in_dir_node_modules(path: &Path) -> bool {
+    path.components().any(|c| c.as_os_str() == "node_modules")
+}
+
+/// Heuristic: a file is CommonJS when it has no ESM statements but touches
+/// the CJS module surface. Only ever applied to files under `node_modules`.
+fn looks_like_commonjs(src: &str) -> bool {
+    let has_esm = src.lines().any(|line| {
+        let t = line.trim_start();
+        (t.starts_with("import") || t.starts_with("export"))
+            && matches!(
+                t.as_bytes().get(6),
+                Some(b' ' | b'{' | b'"' | b'\'' | b'*' | b'(')
+            )
+    });
+    if has_esm {
+        return false;
+    }
+    src.contains("module.exports") || src.contains("exports.") || src.contains("exports[")
+}
+
+/// Adapt a leaf CommonJS module to ESM: run the body with `module`/`exports`
+/// in scope (and `this` bound to `exports`, which UMD wrappers rely on), then
+/// re-export `module.exports` as the default export.
+fn wrap_commonjs(src: &str) -> String {
+    format!(
+        "const module = {{ exports: {{}} }};\n\
+         const exports = module.exports;\n\
+         const require = (spec) => {{\n\
+             throw new Error(\"Cannot require('\" + spec + \"'): chidori loads npm packages as ES modules and does not emulate CommonJS require(). Use a package (or entry point) that ships an ESM build.\");\n\
+         }};\n\
+         (function () {{\n{src}\n}}).call(module.exports);\n\
+         export default module.exports;\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, body: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn bare_specifier_resolves_through_node_modules() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write(&root.join("package.json"), r#"{"name":"proj"}"#);
+        write(&root.join("agent.ts"), "");
+        write(
+            &root.join("node_modules/greeter/package.json"),
+            r#"{"name":"greeter","exports":"./index.js"}"#,
+        );
+        write(
+            &root.join("node_modules/greeter/index.js"),
+            "export const hi = 1;\n",
+        );
+        let (key, src) =
+            load_module_source("greeter", root.join("agent.ts").to_str().unwrap()).unwrap();
+        assert!(key.ends_with("node_modules/greeter/index.js"));
+        assert!(src.contains("export const hi"));
+    }
+
+    #[test]
+    fn package_internal_relative_import_may_traverse_up() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write(&root.join("package.json"), r#"{"name":"proj"}"#);
+        write(&root.join("node_modules/pkg/lib/deep/a.js"), "");
+        write(
+            &root.join("node_modules/pkg/util.js"),
+            "export default 1;\n",
+        );
+        let (key, _) = load_module_source(
+            "../../util.js",
+            root.join("node_modules/pkg/lib/deep/a.js")
+                .to_str()
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(key.ends_with("node_modules/pkg/util.js"));
+    }
+
+    #[test]
+    fn leaf_commonjs_gets_default_export_wrapper() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write(&root.join("package.json"), r#"{"name":"proj"}"#);
+        write(&root.join("agent.ts"), "");
+        write(
+            &root.join("node_modules/ms/package.json"),
+            r#"{"name":"ms","main":"./index.js"}"#,
+        );
+        write(
+            &root.join("node_modules/ms/index.js"),
+            "module.exports = function ms(v) { return v; };\n",
+        );
+        let (_, src) = load_module_source("ms", root.join("agent.ts").to_str().unwrap()).unwrap();
+        assert!(src.contains("export default module.exports;"));
+        assert!(src.contains("function ms"));
+    }
+
+    #[test]
+    fn esm_package_files_are_not_wrapped() {
+        assert!(!looks_like_commonjs(
+            "import x from 'y';\nexport default x;\n"
+        ));
+        assert!(!looks_like_commonjs("export function exportsAll() {}\n"));
+        assert!(looks_like_commonjs("module.exports = 1;\n"));
+        assert!(looks_like_commonjs("exports.foo = 1;\n"));
+    }
+
+    #[test]
+    fn json_modules_become_default_exports() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write(&root.join("package.json"), r#"{"name":"proj"}"#);
+        write(&root.join("agent.ts"), "");
+        write(
+            &root.join("node_modules/data/package.json"),
+            r#"{"name":"data","exports":{"./config.json":"./config.json"}}"#,
+        );
+        write(&root.join("node_modules/data/config.json"), r#"{"a":1}"#);
+        let (_, src) =
+            load_module_source("data/config.json", root.join("agent.ts").to_str().unwrap())
+                .unwrap();
+        assert_eq!(src, "export default {\"a\":1};\n");
+    }
+
+    #[test]
+    fn agent_relative_imports_stay_strict() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write(&root.join("proj/agent.ts"), "");
+        write(&root.join("secret.ts"), "export const s = 1;\n");
+        let err = load_module_source("../secret", root.join("proj/agent.ts").to_str().unwrap())
+            .unwrap_err();
+        assert!(err.contains("escapes project root"), "got: {err}");
+    }
+}

--- a/crates/chidori/src/runtime/typescript/mod.rs
+++ b/crates/chidori/src/runtime/typescript/mod.rs
@@ -4,6 +4,7 @@ pub mod bindings;
 pub mod builtins;
 pub mod check;
 pub mod helpers;
+pub mod loader;
 pub mod module_graph;
 pub mod resolver;
 pub mod tools;

--- a/crates/chidori/src/runtime/typescript/tools.rs
+++ b/crates/chidori/src/runtime/typescript/tools.rs
@@ -66,8 +66,6 @@ fn exports_async_function(source: &str, name: &str) -> bool {
 }
 
 fn evaluate_tool_definition(path: &Path, javascript: &str) -> Result<TypeScriptToolDefinition> {
-    use crate::runtime::snapshot::TypeScriptImportPolicy;
-
     let mut engine = chidori_js::Engine::new();
     // Deterministic, side-effect-free metadata evaluation: disable host effects,
     // network, timers, Date, and randomness. Mirror the agent runtime's benign
@@ -97,8 +95,9 @@ fn evaluate_tool_definition(path: &Path, javascript: &str) -> Result<TypeScriptT
         .eval(&prelude)
         .map_err(|err| anyhow::anyhow!("installing tool metadata prelude: {err}"))?;
 
-    // Resolve relative + `node:` imports the same way the runtime engine does,
-    // so a tool that splits its schema across sibling modules still discovers.
+    // Resolve relative, bare-npm, and `node:` imports the same way the
+    // runtime engine does, so a tool that splits its schema across sibling
+    // modules (or imports an installed package) still discovers.
     let mut load =
         |specifier: &str, importer_key: &str| -> std::result::Result<(String, String), String> {
             if let Some(name) = specifier.strip_prefix("node:") {
@@ -106,24 +105,7 @@ fn evaluate_tool_definition(path: &Path, javascript: &str) -> Result<TypeScriptT
                     .ok_or_else(|| format!("unsupported node: builtin '{specifier}'"))?;
                 return Ok((format!("node:{name}"), src.to_string()));
             }
-            let importer = Path::new(importer_key);
-            let dir = importer.parent().unwrap_or_else(|| Path::new("."));
-            let resolved = crate::runtime::typescript::transpile::resolve_relative_import(
-                importer, dir, specifier, 0,
-            )
-            .map_err(|e| e.to_string())?;
-            let key = resolved.to_string_lossy().to_string();
-            let src = std::fs::read_to_string(&resolved)
-                .map_err(|e| format!("reading module {}: {e}", resolved.display()))?;
-            let js = transpile_module(
-                &resolved,
-                &src,
-                &TranspileOptions {
-                    import_policy: TypeScriptImportPolicy::Node,
-                },
-            )
-            .map_err(|e| e.to_string())?;
-            Ok((key, js))
+            super::loader::load_module_source(specifier, importer_key)
         };
 
     let entry_key = path.display().to_string();

--- a/crates/chidori/tests/pkg_install.rs
+++ b/crates/chidori/tests/pkg_install.rs
@@ -1,0 +1,510 @@
+//! End-to-end tests for `chidori add` / `install` / `remove` against a
+//! hermetic in-process npm registry.
+//!
+//! The mock registry is a plain threaded HTTP server (no async) serving
+//! abbreviated packuments and gzipped tarballs it builds in memory, so the
+//! tests exercise the full pipeline — resolution, SHA-512 verification,
+//! content-addressed store, hardlink materialization, hoisting, lockfile,
+//! pruning — without any network.
+//!
+//! The pkg commands read `CHIDORI_NPM_REGISTRY` and `CHIDORI_PKG_CACHE_DIR`
+//! from the environment, which is process-global; every test takes ENV_LOCK.
+
+use std::collections::BTreeMap;
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use base64::Engine as _;
+use sha2::Digest as _;
+
+use chidori::pkg::lockfile::{Lockfile, LOCKFILE_NAME};
+use chidori::pkg::{cmd_add, cmd_install, cmd_remove};
+use chidori::runtime::typescript::resolver::{Resolver, DEFAULT_CONDITIONS};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serialize env-mutating tests and point the pkg commands at this test's
+/// registry + store.
+fn setup_env(registry_url: &str, store_dir: &Path) -> MutexGuard<'static, ()> {
+    let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    std::env::set_var("CHIDORI_NPM_REGISTRY", registry_url);
+    std::env::set_var("CHIDORI_PKG_CACHE_DIR", store_dir);
+    guard
+}
+
+// ---------------------------------------------------------------------------
+// Mock registry
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct MockRegistryData {
+    /// name -> version -> (deps, tarball bytes, corrupt_flag)
+    packages: BTreeMap<String, BTreeMap<String, MockVersion>>,
+}
+
+struct MockVersion {
+    deps: BTreeMap<String, String>,
+    tarball: Vec<u8>,
+    /// Serve bytes that don't match the advertised integrity.
+    corrupt: bool,
+}
+
+struct MockRegistry {
+    base: String,
+    data: Arc<Mutex<MockRegistryData>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl MockRegistry {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let data: Arc<Mutex<MockRegistryData>> = Arc::default();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let thread_data = data.clone();
+        let thread_base = base.clone();
+        let thread_shutdown = shutdown.clone();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if thread_shutdown.load(Ordering::SeqCst) {
+                    break;
+                }
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = [0u8; 4096];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).into_owned();
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/")
+                    .to_string();
+                let response = handle(&thread_data.lock().unwrap(), &thread_base, &path);
+                let _ = stream.write_all(&response);
+            }
+        });
+
+        Self {
+            base,
+            data,
+            shutdown,
+        }
+    }
+
+    fn stop(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        // Unblock accept() with one last connection.
+        let _ = std::net::TcpStream::connect(self.base.trim_start_matches("http://"));
+    }
+
+    /// Publish `name@version` with the given dependencies and a package.json
+    /// + index.js generated to match.
+    fn publish(&self, name: &str, version: &str, deps: &[(&str, &str)]) {
+        self.publish_inner(name, version, deps, false);
+    }
+
+    fn publish_corrupt(&self, name: &str, version: &str) {
+        self.publish_inner(name, version, &[], true);
+    }
+
+    fn publish_inner(&self, name: &str, version: &str, deps: &[(&str, &str)], corrupt: bool) {
+        let deps: BTreeMap<String, String> = deps
+            .iter()
+            .map(|(n, v)| (n.to_string(), v.to_string()))
+            .collect();
+        let manifest = serde_json::json!({
+            "name": name,
+            "version": version,
+            "main": "index.js",
+            "dependencies": deps,
+        });
+        let tarball = make_tarball(&[
+            ("package.json", &manifest.to_string()),
+            (
+                "index.js",
+                &format!("export default {:?};", format!("{name}@{version}")),
+            ),
+        ]);
+        self.data
+            .lock()
+            .unwrap()
+            .packages
+            .entry(name.to_string())
+            .or_default()
+            .insert(
+                version.to_string(),
+                MockVersion {
+                    deps,
+                    tarball,
+                    corrupt,
+                },
+            );
+    }
+}
+
+fn handle(data: &MockRegistryData, base: &str, path: &str) -> Vec<u8> {
+    if let Some(file) = path.strip_prefix("/tarballs/") {
+        // /tarballs/<name>__<version>.tgz ('/' in scoped names sanitized to '+')
+        let stem = file.trim_end_matches(".tgz").replace('+', "/");
+        if let Some((name, version)) = stem.rsplit_once("__") {
+            if let Some(v) = data.packages.get(name).and_then(|m| m.get(version)) {
+                let mut body = v.tarball.clone();
+                if v.corrupt {
+                    // Flip a byte inside the gzip payload.
+                    let last = body.len() - 1;
+                    body[last] ^= 0xff;
+                }
+                return http_response("application/octet-stream", &body);
+            }
+        }
+        return http_404();
+    }
+
+    let name = path.trim_start_matches('/').replace("%2F", "/");
+    let Some(versions) = data.packages.get(&name) else {
+        return http_404();
+    };
+    let latest = versions.keys().last().unwrap().clone();
+    let versions_json: serde_json::Map<String, serde_json::Value> = versions
+        .iter()
+        .map(|(version, v)| {
+            let integrity = format!(
+                "sha512-{}",
+                base64::engine::general_purpose::STANDARD
+                    .encode(sha2::Sha512::digest(&v.tarball))
+            );
+            (
+                version.clone(),
+                serde_json::json!({
+                    "name": name,
+                    "version": version,
+                    "dependencies": v.deps,
+                    "dist": {
+                        "tarball": format!("{base}/tarballs/{}__{version}.tgz", name.replace('/', "+")),
+                        "integrity": integrity,
+                    }
+                }),
+            )
+        })
+        .collect();
+    let packument = serde_json::json!({
+        "name": name,
+        "dist-tags": { "latest": latest },
+        "versions": versions_json,
+    });
+    http_response("application/json", packument.to_string().as_bytes())
+}
+
+fn http_response(content_type: &str, body: &[u8]) -> Vec<u8> {
+    let mut out = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    out.extend_from_slice(body);
+    out
+}
+
+fn http_404() -> Vec<u8> {
+    b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec()
+}
+
+fn make_tarball(files: &[(&str, &str)]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+        Vec::new(),
+        flate2::Compression::fast(),
+    ));
+    for (path, body) in files {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, format!("package/{path}"), body.as_bytes())
+            .unwrap();
+    }
+    builder.into_inner().unwrap().finish().unwrap()
+}
+
+fn installed_version(project: &Path, rel: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(project.join(rel).join("package.json")).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    Some(v["version"].as_str()?.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_installs_transitive_deps_hoisted_and_writes_lockfile() {
+    let registry = MockRegistry::start();
+    registry.publish("apple", "1.0.0", &[("berry", "^1.0.0")]);
+    registry.publish("berry", "1.0.0", &[]);
+    registry.publish("berry", "1.1.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    cmd_add(&project, &["apple".to_string()], false).unwrap();
+
+    // apple installed, berry hoisted to the top at the highest satisfying
+    // version.
+    assert_eq!(
+        installed_version(&project, "node_modules/apple").as_deref(),
+        Some("1.0.0")
+    );
+    assert_eq!(
+        installed_version(&project, "node_modules/berry").as_deref(),
+        Some("1.1.0")
+    );
+
+    // package.json got a caret range on the resolved version.
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(project.join("package.json")).unwrap())
+            .unwrap();
+    assert_eq!(manifest["dependencies"]["apple"], "^1.0.0");
+
+    // Lockfile: header + one line per package, in order.
+    let lock_text = std::fs::read_to_string(project.join(LOCKFILE_NAME)).unwrap();
+    let lines: Vec<&str> = lock_text.lines().collect();
+    assert_eq!(lines.len(), 3, "header + 2 packages:\n{lock_text}");
+    assert!(lines[0].contains("chidoriLockfile"));
+    assert!(lines[1].contains(r#""name":"apple""#));
+    assert!(lines[2].contains(r#""name":"berry""#));
+
+    // The store is content-addressed: 2 package dirs.
+    let store_entries = std::fs::read_dir(tmp.path().join("store")).unwrap().count();
+    assert_eq!(store_entries, 2);
+
+    registry.stop();
+}
+
+#[test]
+fn version_conflicts_nest_and_resolve_like_node() {
+    let registry = MockRegistry::start();
+    // apple pins berry@1.0.0 exactly; the root wants berry@^1.1.0.
+    registry.publish("apple", "1.0.0", &[("berry", "1.0.0")]);
+    registry.publish("berry", "1.0.0", &[]);
+    registry.publish("berry", "1.1.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    cmd_add(
+        &project,
+        &["apple".to_string(), "berry@^1.1.0".to_string()],
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(
+        installed_version(&project, "node_modules/berry").as_deref(),
+        Some("1.1.0")
+    );
+    assert_eq!(
+        installed_version(&project, "node_modules/apple/node_modules/berry").as_deref(),
+        Some("1.0.0")
+    );
+
+    // The runtime's Node-style resolver sees exactly what Node would.
+    std::fs::write(project.join("agent.ts"), "export {};").unwrap();
+    let resolver = Resolver::new(
+        &project,
+        DEFAULT_CONDITIONS.iter().copied(),
+        Vec::<String>::new(),
+    );
+    let from_root = resolver
+        .resolve("berry", &project.join("agent.ts"))
+        .unwrap();
+    assert_eq!(
+        from_root.resolved_path,
+        project.join("node_modules/berry/index.js")
+    );
+    let from_apple = resolver
+        .resolve("berry", &project.join("node_modules/apple/index.js"))
+        .unwrap();
+    assert_eq!(
+        from_apple.resolved_path,
+        project.join("node_modules/apple/node_modules/berry/index.js")
+    );
+
+    registry.stop();
+}
+
+#[test]
+fn warm_install_is_fully_offline_from_the_store() {
+    let registry = MockRegistry::start();
+    registry.publish("apple", "1.0.0", &[("berry", "^1.0.0")]);
+    registry.publish("berry", "1.2.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let first = tmp.path().join("first");
+    std::fs::create_dir(&first).unwrap();
+    let _env = setup_env(&registry.base, &store);
+
+    cmd_add(&first, &["apple".to_string()], false).unwrap();
+
+    // Second project reuses the manifest + lockfile (a fresh clone).
+    let second = tmp.path().join("second");
+    std::fs::create_dir(&second).unwrap();
+    for file in ["package.json", LOCKFILE_NAME] {
+        std::fs::copy(first.join(file), second.join(file)).unwrap();
+    }
+
+    // Kill the registry: the warm install must not need it.
+    registry.stop();
+    std::env::set_var("CHIDORI_NPM_REGISTRY", "http://127.0.0.1:1"); // unreachable
+
+    cmd_install(&second, true).unwrap();
+    assert_eq!(
+        installed_version(&second, "node_modules/apple").as_deref(),
+        Some("1.0.0")
+    );
+    assert_eq!(
+        installed_version(&second, "node_modules/berry").as_deref(),
+        Some("1.2.0")
+    );
+
+    // Hardlink materialization: same inode in both projects (same store file).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let a = std::fs::metadata(first.join("node_modules/apple/index.js")).unwrap();
+        let b = std::fs::metadata(second.join("node_modules/apple/index.js")).unwrap();
+        assert_eq!(
+            a.ino(),
+            b.ino(),
+            "warm install should hardlink from the store"
+        );
+    }
+}
+
+#[test]
+fn remove_prunes_package_and_unreachable_transitives_offline() {
+    let registry = MockRegistry::start();
+    registry.publish("apple", "1.0.0", &[("berry", "^1.0.0")]);
+    registry.publish("berry", "1.0.0", &[]);
+    registry.publish("cherry", "2.0.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    cmd_add(
+        &project,
+        &["apple".to_string(), "cherry".to_string()],
+        false,
+    )
+    .unwrap();
+    assert!(project.join("node_modules/berry").is_dir());
+
+    // Removal never needs the registry.
+    registry.stop();
+    std::env::set_var("CHIDORI_NPM_REGISTRY", "http://127.0.0.1:1");
+
+    cmd_remove(&project, &["apple".to_string()]).unwrap();
+    assert!(!project.join("node_modules/apple").exists());
+    assert!(
+        !project.join("node_modules/berry").exists(),
+        "berry is unreachable after apple's removal and must be pruned"
+    );
+    assert!(project.join("node_modules/cherry").is_dir());
+
+    let lock = Lockfile::load(&project.join(LOCKFILE_NAME)).unwrap();
+    assert_eq!(lock.packages.len(), 1);
+    assert!(lock.packages.keys().all(|(n, _)| n == "cherry"));
+}
+
+#[test]
+fn corrupted_tarball_is_rejected_by_integrity_check() {
+    let registry = MockRegistry::start();
+    registry.publish_corrupt("evil", "1.0.0");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    let err = cmd_add(&project, &["evil".to_string()], false).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("integrity verification failed"),
+        "unexpected error: {err:#}"
+    );
+    // Nothing corrupt entered the store.
+    assert!(
+        !tmp.path().join("store").is_dir()
+            || std::fs::read_dir(tmp.path().join("store"))
+                .unwrap()
+                .next()
+                .is_none()
+    );
+
+    registry.stop();
+}
+
+#[test]
+fn frozen_install_fails_on_manifest_drift() {
+    let registry = MockRegistry::start();
+    registry.publish("apple", "1.0.0", &[]);
+    registry.publish("berry", "1.0.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    cmd_add(&project, &["apple".to_string()], false).unwrap();
+
+    // Hand-edit package.json to request something the lockfile doesn't cover.
+    let manifest_path = project.join("package.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["dependencies"]["berry"] = "^1.0.0".into();
+    std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+    let err = cmd_install(&project, true).unwrap_err();
+    assert!(format!("{err:#}").contains("out of sync"), "got: {err:#}");
+
+    // Without --frozen the same state re-resolves and installs.
+    cmd_install(&project, false).unwrap();
+    assert_eq!(
+        installed_version(&project, "node_modules/berry").as_deref(),
+        Some("1.0.0")
+    );
+
+    registry.stop();
+}
+
+#[test]
+fn scoped_packages_install_under_scope_dirs() {
+    let registry = MockRegistry::start();
+    registry.publish("@acme/utils", "0.3.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    cmd_add(&project, &["@acme/utils".to_string()], false).unwrap();
+    assert_eq!(
+        installed_version(&project, "node_modules/@acme/utils").as_deref(),
+        Some("0.3.0")
+    );
+
+    // Removing it also drops the emptied scope directory.
+    cmd_remove(&project, &["@acme/utils".to_string()]).unwrap();
+    assert!(!project.join("node_modules/@acme").exists());
+
+    registry.stop();
+}

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -1,0 +1,131 @@
+# Package management
+
+Chidori ships a native npm package manager — `chidori add`, `chidori install`,
+`chidori remove` — so agents can use packages from the npm registry without
+Node, npm, or bun installed. It follows the same design that makes modern
+package managers (bun, pnpm, and single-binary toolchains like meow) fast:
+
+- **Content-addressed global store.** Every package version is downloaded,
+  verified, and extracted exactly once per machine, into
+  `~/.chidori/cache/packages/<integrity-hash>/`. Projects never hold their own
+  copy of file contents.
+- **Hardlink materialization.** `node_modules` is assembled by hardlinking
+  files out of the store (copying only when linking fails, e.g. across
+  filesystems). Warm installs are offline and take milliseconds — the smoke
+  benchmark installs a 3-package tree in ~1ms warm vs ~250ms cold.
+- **SHA-512 verification.** Every tarball is checked against the registry's
+  `sha512` subresource integrity (legacy `sha1` shasum for pre-2017 publishes)
+  before it can enter the store. Hashing and extraction run on blocking worker
+  threads, off the download path.
+- **Sorted JSONL lockfile.** `chidori.lock.jsonl` holds one JSON object per
+  line, strictly sorted (name, then semver). Two branches adding different
+  dependencies touch disjoint lines, so git merges apply cleanly instead of
+  conflicting inside one large JSON document.
+- **No lifecycle scripts.** `preinstall`/`postinstall`/`prepare` never run.
+  Installs are pure data movement, which closes off the largest npm
+  supply-chain attack vector. Agent code runs on chidori's embedded engine, so
+  native `node-gyp`-style builds don't apply.
+
+## Commands
+
+```bash
+chidori add zod                 # resolve latest, write ^range to package.json
+chidori add zod@^3.22.0         # explicit range
+chidori add left-pad@1.3.0      # exact version
+chidori add @scope/pkg@beta     # dist-tags work
+chidori add -D typescript       # devDependencies
+chidori install                 # from the lockfile (offline when warm)
+chidori install --frozen        # CI: fail instead of re-resolving on drift
+chidori remove zod              # manifest + lockfile + node_modules (offline)
+```
+
+Environment overrides:
+
+| Variable | Effect |
+| --- | --- |
+| `CHIDORI_NPM_REGISTRY` | Registry base URL (mirrors, private registries, tests) |
+| `CHIDORI_PKG_CACHE_DIR` | Store location (default `~/.chidori/cache/packages`) |
+
+## How installs work
+
+1. **Resolve.** Requested ranges (npm semver: `^`, `~`, `1.x`, hyphen ranges,
+   `||`, dist-tags) are resolved breadth-first against abbreviated registry
+   metadata (`application/vnd.npm.install-v1+json`). Versions already pinned
+   in the lockfile are preferred when they still satisfy, so adding one
+   package doesn't churn unrelated pins. The highest satisfying version wins
+   otherwise. `optionalDependencies` are skipped (with a warning) when they
+   fail to resolve; unmet `peerDependencies` warn but don't auto-install.
+2. **Plan.** The resolved set is laid out npm-style: root dependencies own the
+   top of `node_modules`, shared transitive dependencies hoist to the top, and
+   version conflicts nest under their dependent
+   (`node_modules/a/node_modules/b`). The plan is exactly what the runtime's
+   Node-style resolver (`runtime/typescript/resolver.rs`) expects to walk.
+3. **Fetch.** Only store misses are downloaded (up to 8 tarballs
+   concurrently), verified, and extracted into the store atomically (temp dir
+   + rename, so racing installs can't corrupt an entry).
+4. **Materialize + prune.** Each planned location is hardlinked from the
+   store; a location already holding the right `name@version` is left
+   untouched. Anything in `node_modules` the plan doesn't claim is removed —
+   `node_modules` is fully machine-managed.
+
+`chidori remove` and an in-sync `chidori install` never touch the network: the
+lockfile carries exact versions, dependency edges, tarball URLs, and integrity
+hashes, so the tree rebuilds from the store alone.
+
+## Using packages from agents
+
+Installed packages import the way they would under node or bun:
+
+```ts
+import { z } from "zod";
+import ms from "ms";
+
+export default async function agent(input: { minutes: number }) {
+  const schema = z.object({ minutes: z.number() });
+  return { human: ms(schema.parse(input).minutes * 60_000, { long: true }) };
+}
+```
+
+The module loader resolves bare specifiers through the full Node ESM
+algorithm: `exports` maps (with a `chidori` condition packages can target),
+`main` fallback, subpaths, scoped packages, and nested `node_modules`
+shadowing. ESM builds are preferred via the `import`/`module` conditions.
+
+CommonJS support is deliberately minimal: a *leaf* CJS file (no `require`
+calls at runtime) is wrapped so its `module.exports` becomes the default
+export — enough for classics like `ms` or UMD single-file bundles. A CJS file
+that calls `require()` throws with a clear message; prefer packages that ship
+an ESM build (most modern ones do). JSON subpath imports resolve to a default
+export.
+
+## Out of scope (v1) and why
+
+- **Lifecycle scripts** — by design, see above. Not "not yet": running
+  arbitrary registry-supplied shell on `install` is incompatible with
+  chidori's sandbox posture.
+- **`node_modules/.bin` linking** — chidori doesn't execute package binaries;
+  there's no Node process to run them.
+- **git / file / workspace / `npm:` alias dependencies** — rejected with a
+  clear error rather than half-supported.
+- **Full CommonJS emulation (`require`)** — would need a synchronous module
+  linker path in the engine; revisit if real agent dependencies demand it.
+- **Auto-installed peer dependencies** — warned instead; install explicitly.
+
+## Comparison notes (meow, bun, pnpm)
+
+This design deliberately matches the properties that make
+[meow](https://github.com/0xchasercat/meow)-style package management fast and
+safe — one binary, content-addressed store, link-based materialization,
+SHA-512 verification off the hot path, merge-resistant JSONL lockfile.
+Capabilities those toolchains have that chidori intentionally does *not* take
+from the package manager:
+
+- **Sandboxed execution of untrusted packages** (`meow x`): chidori already
+  has a stronger equivalent at the runtime layer — the deny-by-default
+  `--untrusted` policy profile and OS-level `--isolate` process sandbox apply
+  to *all* agent code, packages included, not just a special exec mode.
+- **Parse-once toolchain** (one AST feeding runtime/linter/formatter): chidori
+  already parses with oxc once per module on the load path; lint/format are
+  editor/CI concerns out of chidori's scope.
+- **Test runner / bundler / typechecker**: `chidori check` covers agent
+  validation; a full JS toolchain is a non-goal.

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -3,7 +3,7 @@
 Chidori ships a native npm package manager — `chidori add`, `chidori install`,
 `chidori remove` — so agents can use packages from the npm registry without
 Node, npm, or bun installed. It follows the same design that makes modern
-package managers (bun, pnpm, and single-binary toolchains like meow) fast:
+package managers like bun and pnpm fast:
 
 - **Content-addressed global store.** Every package version is downloaded,
   verified, and extracted exactly once per machine, into
@@ -111,19 +111,19 @@ export.
   linker path in the engine; revisit if real agent dependencies demand it.
 - **Auto-installed peer dependencies** — warned instead; install explicitly.
 
-## Comparison notes (meow, bun, pnpm)
+## Comparison notes (bun, pnpm)
 
-This design deliberately matches the properties that make
-[meow](https://github.com/0xchasercat/meow)-style package management fast and
-safe — one binary, content-addressed store, link-based materialization,
-SHA-512 verification off the hot path, merge-resistant JSONL lockfile.
-Capabilities those toolchains have that chidori intentionally does *not* take
-from the package manager:
+This design deliberately matches the properties that make modern single-binary
+package managers fast and safe — content-addressed store, link-based
+materialization, SHA-512 verification off the hot path, merge-resistant JSONL
+lockfile. Capabilities those toolchains have that chidori intentionally does
+*not* take from the package manager:
 
-- **Sandboxed execution of untrusted packages** (`meow x`): chidori already
-  has a stronger equivalent at the runtime layer — the deny-by-default
-  `--untrusted` policy profile and OS-level `--isolate` process sandbox apply
-  to *all* agent code, packages included, not just a special exec mode.
+- **Sandboxed execution of untrusted packages** (`bunx`-style exec modes):
+  chidori already has a stronger equivalent at the runtime layer — the
+  deny-by-default `--untrusted` policy profile and OS-level `--isolate`
+  process sandbox apply to *all* agent code, packages included, not just a
+  special exec mode.
 - **Parse-once toolchain** (one AST feeding runtime/linter/formatter): chidori
   already parses with oxc once per module on the load path; lint/format are
   editor/CI concerns out of chidori's scope.


### PR DESCRIPTION
## Summary

Agents could already import from `node_modules` through the Node-style resolver, but populating `node_modules` required an external npm/bun. This adds a built-in package manager — `chidori add` / `chidori install` / `chidori remove` — so npm packages work with only the chidori binary, following the design that makes modern package managers like bun and pnpm fast:

- **Content-addressed global store** (`~/.chidori/cache/packages`): each package version downloads, verifies, and extracts exactly once per machine, keyed by its integrity hash. Projects materialize from the store by hardlink (copy fallback), so warm installs are fully offline and take milliseconds — measured ~1ms warm vs ~250ms cold for a 3-package tree against the real registry.
- **SHA-512 verification** (legacy sha1 shasum fallback) before anything enters the store; hashing and extraction run on blocking worker threads, off the download path. Tarballs containing link entries or path traversal are rejected.
- **npm-flavored semver resolution** (`nodejs-semver`) with lockfile-pinned version preference (adding one package doesn't churn unrelated pins), optional-dependency skip, and peer-dependency warnings. git/file/workspace/alias specs are rejected with clear errors.
- **npm-style hoisted layout**: shared transitive deps hoist to the top of `node_modules`, version conflicts nest under their dependent — exactly the shape the runtime resolver walks.
- **`chidori.lock.jsonl`**: strictly sorted JSON-lines lockfile, one package per line, so concurrent dependency changes merge cleanly in git. `remove` and in-sync `install` rebuild the tree fully offline from it; `install --frozen` is the CI mode.
- **No lifecycle scripts, ever**: installs are pure data movement, closing off npm's largest supply-chain attack vector and matching chidori's sandbox posture.

## Runtime loader fix

The module loader previously treated every specifier as project-relative, so installed packages resolved at validation time but failed at load time. Bare specifiers (and any import originating inside `node_modules`) now route through the full Node ESM resolver (`exports` maps, subpaths, nested shadowing). JSON modules resolve to a default export, and leaf CommonJS files (no `require` calls) are wrapped so `module.exports` becomes the default export — enough for `ms`, `left-pad`, UMD single-file bundles. `require()` throws with a pointer toward ESM builds. Agent-code relative imports keep their historical strict project-rooted resolution.

End to end:

```bash
chidori add ms        # resolve, verify, cache, hardlink, lock
chidori run agent.ts  # import ms from "ms" just works — no Node installed
```

## Test plan

- 18 unit tests across store (integrity, traversal rejection, link round-trip), layout (hoisting, conflict nesting, cycles), lockfile (round-trip, deterministic sort, drift detection), manifest, registry name validation, and the loader (bare/ESM/CJS/JSON paths, strict agent-relative behavior).
- 7-case end-to-end suite against a hermetic in-process registry: hoisting + lockfile shape, conflict nesting cross-checked against the runtime resolver, offline warm install sharing store inodes, offline remove + prune of unreachable transitives, corrupted-tarball rejection, `--frozen` drift failure, scoped packages.
- Full crate suite passes (713 tests); clippy and rustfmt clean.
- Manual smoke against registry.npmjs.org: cold/warm install timings, deprecation warnings surfaced, agent run importing an installed package.

Docs: `docs/package-management.md` covers commands, install pipeline, env overrides (`CHIDORI_NPM_REGISTRY`, `CHIDORI_PKG_CACHE_DIR`), and deliberate scope exclusions (lifecycle scripts, `.bin` linking, full CJS emulation, auto-peers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRLK7JvBQZJJENwPXF7mKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRLK7JvBQZJJENwPXF7mKd)_