### PR TITLE
Stop paying O(history) + module-graph disk walks on every host-call safepoint

### DIFF
--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -1471,15 +1471,12 @@ fn cmd_stats(dir: Option<&std::path::Path>) -> Result<()> {
 
     for entry in std::fs::read_dir(&runs_dir)? {
         let entry = entry?;
-        let checkpoint_path = entry.path().join("checkpoint.json");
-        if !checkpoint_path.exists() {
-            continue;
-        }
-        let Ok(text) = std::fs::read_to_string(&checkpoint_path) else {
-            continue;
-        };
-        let Ok(records): Result<Vec<crate::runtime::call_log::CallRecord>, _> =
-            serde_json::from_str(&text)
+        // Union the last checkpoint with the append-only tail: mid-run and
+        // crashed runs have records in `records.jsonl` that the checkpoint —
+        // rewritten only at compaction points — doesn't carry yet.
+        use crate::runtime::store::RunStore as _;
+        let Ok(Some(records)) =
+            crate::runtime::store::FsRunStore::new(entry.path()).load_call_log()
         else {
             continue;
         };

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -10,8 +10,7 @@ use crate::runtime::capability::{Capability, CapabilityLedger};
 use crate::runtime::otel::RunSpan;
 use crate::runtime::snapshot::{
     HostOperationId, HostPromiseRecord, HostPromiseTable, PendingHostOperation,
-    PendingHostOperationKind, QueuedSignal, HOST_PROMISE_TABLE_FILE, PENDING_HOST_OPERATION_FILE,
-    SIGNAL_INBOX_FILE,
+    PendingHostOperationKind, QueuedSignal, PENDING_HOST_OPERATION_FILE, SIGNAL_INBOX_FILE,
 };
 use crate::runtime::store::{FsRunStore, RunStore};
 use crate::runtime::vfs::Vfs;
@@ -1433,7 +1432,7 @@ impl RuntimeContext {
         let id = inner
             .host_promises
             .create_with_function(seq, kind, function, args);
-        persist_host_promises(&mut inner);
+        persist_host_promise_change(&mut inner, id);
         id
     }
 
@@ -1481,7 +1480,7 @@ impl RuntimeContext {
     ) -> anyhow::Result<()> {
         let mut inner = self.inner.lock().unwrap();
         inner.host_promises.resolve(id, value)?;
-        persist_host_promises(&mut inner);
+        persist_host_promise_change(&mut inner, id);
         Ok(())
     }
 
@@ -1492,7 +1491,7 @@ impl RuntimeContext {
     ) -> anyhow::Result<()> {
         let mut inner = self.inner.lock().unwrap();
         inner.host_promises.reject(id, error)?;
-        persist_host_promises(&mut inner);
+        persist_host_promise_change(&mut inner, id);
         Ok(())
     }
 
@@ -1577,15 +1576,22 @@ fn note_persist_result(inner: &mut RuntimeContextInner, result: anyhow::Result<(
     }
 }
 
-fn persist_host_promises(inner: &mut RuntimeContextInner) {
+fn persist_host_promise_change(inner: &mut RuntimeContextInner, id: HostOperationId) {
     let Some(store) = inner.store.clone() else {
         return;
     };
-    let records = inner.host_promises.records();
-    let result = serde_json::to_vec_pretty(&records)
-        .map_err(anyhow::Error::from)
-        .and_then(|json| store.put_blob(HOST_PROMISE_TABLE_FILE, &json));
-    note_persist_result(inner, result);
+    // One O(1) blob per state change (`host_promises/<id>.json`) instead of
+    // rewriting the whole table — which made every host call O(history) and
+    // every run O(history²). Compaction points fold the blobs back into
+    // `host_promises.json`; readers union both (`load_host_promise_records`).
+    if let Some(record) = inner.host_promises.record(id).cloned() {
+        let result = serde_json::to_vec_pretty(&record)
+            .map_err(anyhow::Error::from)
+            .and_then(|json| {
+                store.put_blob(&crate::runtime::snapshot::host_promise_blob_key(id), &json)
+            });
+        note_persist_result(inner, result);
+    }
 
     let pending = inner.host_promises.active_pending_operation();
     let result = match pending {
@@ -1747,20 +1753,24 @@ mod tests {
         );
 
         let pending_path = run_dir.join(PENDING_HOST_OPERATION_FILE);
-        let table_path = run_dir.join(HOST_PROMISE_TABLE_FILE);
         assert!(pending_path.exists());
-        assert!(table_path.exists());
         let pending: PendingHostOperation =
             serde_json::from_slice(&std::fs::read(&pending_path).unwrap()).unwrap();
         assert_eq!(pending.id, id);
         assert_eq!(pending.kind, PendingHostOperationKind::Prompt);
+        // The pending state is durable BEFORE the effect runs, via the O(1)
+        // per-op blob; the union loader is the read surface for the compacted
+        // table + blobs.
+        let store = crate::runtime::store::FsRunStore::new(&run_dir);
+        let records = crate::runtime::snapshot::load_host_promise_records(&store).unwrap();
+        assert_eq!(records.len(), 1);
+        assert!(matches!(records[0].state, HostPromiseState::Pending));
 
         ctx.resolve_host_operation(id, serde_json::json!("done"))
             .unwrap();
 
         assert!(!pending_path.exists());
-        let records: Vec<HostPromiseRecord> =
-            serde_json::from_slice(&std::fs::read(&table_path).unwrap()).unwrap();
+        let records = crate::runtime::snapshot::load_host_promise_records(&store).unwrap();
         assert_eq!(records.len(), 1);
         assert!(matches!(
             records[0].state,

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -121,6 +121,12 @@ struct RuntimeContextInner {
     /// Pre-loaded call log for replay mode. When set, host functions
     /// return cached results instead of executing for matching sequence numbers.
     pub replay_log: Option<Vec<CallRecord>>,
+    /// seq → index into `replay_log`, built once at construction (the replay
+    /// log is immutable for the context's lifetime). Turns the per-call
+    /// replay probe from a linear scan of the whole history — O(history²)
+    /// across one resume re-execution — into a hash lookup. First occurrence
+    /// wins, matching the scan semantics it replaces.
+    pub replay_index: std::collections::HashMap<u64, usize>,
     /// Unique identifier for this run. Used as the subdirectory name
     /// under `.chidori/runs/` when persistence is enabled.
     pub run_id: String,
@@ -357,6 +363,7 @@ impl RuntimeContext {
                 call_log_dirty: false,
                 seq: 0,
                 replay_log: None,
+                replay_index: std::collections::HashMap::new(),
                 run_id: uuid::Uuid::new_v4().to_string(),
                 persist_dir: None,
                 store: None,
@@ -429,6 +436,7 @@ impl RuntimeContext {
                 call_log: CallLog::new(),
                 call_log_dirty: false,
                 seq: 0,
+                replay_index: build_replay_index(&replay_log),
                 replay_log: Some(replay_log),
                 run_id: uuid::Uuid::new_v4().to_string(),
                 persist_dir: None,
@@ -475,6 +483,7 @@ impl RuntimeContext {
                 call_log_dirty: true,
                 seq,
                 replay_log: None,
+                replay_index: std::collections::HashMap::new(),
                 run_id,
                 persist_dir: None,
                 store: None,
@@ -528,6 +537,7 @@ impl RuntimeContext {
                 call_log_dirty: false,
                 seq: base_seq,
                 replay_log: None,
+                replay_index: std::collections::HashMap::new(),
                 run_id,
                 persist_dir: None,
                 store: None,
@@ -581,6 +591,7 @@ impl RuntimeContext {
                 call_log: CallLog::new(),
                 call_log_dirty: false,
                 seq: base_seq,
+                replay_index: build_replay_index(&replay_log),
                 replay_log: Some(replay_log),
                 run_id,
                 persist_dir: None,
@@ -646,6 +657,7 @@ impl RuntimeContext {
                 call_log: CallLog::new(),
                 call_log_dirty: false,
                 seq: base_seq,
+                replay_index: build_replay_index(&replay_log),
                 replay_log: Some(replay_log),
                 run_id: actor_id.clone(),
                 persist_dir: None,
@@ -834,30 +846,31 @@ impl RuntimeContext {
     /// If not, return None — the host function should execute normally.
     pub fn try_replay(&self, seq: u64) -> Option<CallRecord> {
         let mut inner = self.inner.lock().unwrap();
-        if let Some(ref replay_log) = inner.replay_log {
-            if let Some(record) = replay_log.iter().find(|r| r.seq == seq) {
-                let mut record = record.clone();
-                // Nest a replayed call under the call currently executing, exactly
-                // as `record_call` does for live calls. Without this a replayed
-                // *nested* host call — e.g. a tool's inner `input`, injected as a
-                // synthetic resume record with no parent — would record at top
-                // level, so a later resume's `absorb_replayed_subtree` wouldn't
-                // recognize it as part of the container's subtree and the
-                // sequence counter would collide with the next call (replay
-                // divergence on a second suspension).
-                if record.parent_seq.is_none() {
-                    record.parent_seq = inner.call_stack.last().copied();
-                }
-                // Record the replayed call in the new call log. Replay
-                // bypasses `record_call`'s journal append (the record is
-                // already durable from the turn that ran it live), so mark
-                // the log checkpoint-dirty: the first safepoint past the
-                // replay frontier writes one full checkpoint covering the
-                // replayed prefix plus any synthetic resume records.
-                inner.call_log.push(record.clone());
-                inner.call_log_dirty = true;
-                return Some(record);
+        let hit = match (&inner.replay_log, inner.replay_index.get(&seq)) {
+            (Some(replay_log), Some(&index)) => replay_log.get(index).cloned(),
+            _ => None,
+        };
+        if let Some(mut record) = hit {
+            // Nest a replayed call under the call currently executing, exactly
+            // as `record_call` does for live calls. Without this a replayed
+            // *nested* host call — e.g. a tool's inner `input`, injected as a
+            // synthetic resume record with no parent — would record at top
+            // level, so a later resume's `absorb_replayed_subtree` wouldn't
+            // recognize it as part of the container's subtree and the
+            // sequence counter would collide with the next call (replay
+            // divergence on a second suspension).
+            if record.parent_seq.is_none() {
+                record.parent_seq = inner.call_stack.last().copied();
             }
+            // Record the replayed call in the new call log. Replay
+            // bypasses `record_call`'s journal append (the record is
+            // already durable from the turn that ran it live), so mark
+            // the log checkpoint-dirty: the first safepoint past the
+            // replay frontier writes one full checkpoint covering the
+            // replayed prefix plus any synthetic resume records.
+            inner.call_log.push(record.clone());
+            inner.call_log_dirty = true;
+            return Some(record);
         }
         None
     }
@@ -905,7 +918,10 @@ impl RuntimeContext {
     /// is safe to call unconditionally on every replay hit.
     pub fn absorb_replayed_subtree(&self, root_seq: u64) {
         let mut inner = self.inner.lock().unwrap();
-        let Some(replay_log) = inner.replay_log.clone() else {
+        // Move the log out instead of cloning it: this runs on EVERY replay
+        // hit, and a deep clone of the whole history made each resume
+        // re-execution O(history²). Restored below.
+        let Some(replay_log) = inner.replay_log.take() else {
             return;
         };
         // Transitive descendants of `root_seq` via `parent_seq`. Records may be
@@ -938,6 +954,7 @@ impl RuntimeContext {
             }
         }
         inner.seq = inner.seq.max(max_seq);
+        inner.replay_log = Some(replay_log);
     }
 
     pub fn record_call(&self, mut record: CallRecord) {
@@ -1574,6 +1591,16 @@ fn note_persist_result(inner: &mut RuntimeContextInner, result: anyhow::Result<(
             tracing::warn!(run_id = %inner.run_id, error = %err, "run persistence write failed");
         }
     }
+}
+
+/// First occurrence of each seq wins, matching the linear `.find()` this
+/// index replaces.
+fn build_replay_index(replay_log: &[CallRecord]) -> std::collections::HashMap<u64, usize> {
+    let mut index = std::collections::HashMap::with_capacity(replay_log.len());
+    for (i, record) in replay_log.iter().enumerate() {
+        index.entry(record.seq).or_insert(i);
+    }
+    index
 }
 
 fn persist_host_promise_change(inner: &mut RuntimeContextInner, id: HostOperationId) {

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -952,24 +952,37 @@ impl RuntimeContext {
         }
         inner.seq = inner.seq.max(record.seq);
         inner.call_log.push(record.clone());
-        if let Some(store) = inner.store.clone() {
-            // O(1) append to the journal (`records.jsonl` + any durable
-            // mirror); safepoints rewrite the full checkpoint artifact.
+        let store = inner.store.clone();
+        let otel = inner.otel_run.clone();
+        let event_tx = if inner.emit_call_events {
+            inner.event_sender.clone()
+        } else {
+            None
+        };
+        drop(inner);
+        // O(1) append to the journal (`records.jsonl` + any durable mirror),
+        // OUTSIDE the context lock: under strict durability this write fsyncs,
+        // and a configured mirror adds a network round-trip — holding the lock
+        // across it would stall every other runtime-context access for the
+        // duration of the I/O. Concurrent appends may land out of seq order in
+        // the file; the loader's union sorts the tail by seq, so order on disk
+        // is not load-bearing. The append still happens BEFORE the record is
+        // surfaced on the event stream below, preserving the
+        // durable-before-visible ordering.
+        if let Some(store) = store {
             let result = store.append_record(&record);
-            note_persist_result(&mut inner, result);
+            if result.is_err() {
+                note_persist_result(&mut self.inner.lock().unwrap(), result);
+            }
         }
         // Stream this call's OTEL span now (buffered until its parent span
         // exists), so spans ship incrementally during the run rather than as one
         // tree at the end. Only live-executed calls reach `record_call`; replayed
         // calls (try_replay / absorb_replayed_subtree) don't re-emit. The
         // `RuntimeEvent::Call` stream below is the other real-time surface.
-        let otel = inner.otel_run.clone();
-        if inner.emit_call_events {
-            if let Some(ref tx) = inner.event_sender {
-                let _ = tx.send(RuntimeEvent::Call(record.clone()));
-            }
+        if let Some(tx) = event_tx {
+            let _ = tx.send(RuntimeEvent::Call(record.clone()));
         }
-        drop(inner);
         if let Some(otel) = otel {
             otel.stream_record(record);
         }

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -102,6 +102,48 @@ impl HostOperationCompletionSafepoint {
     }
 }
 
+/// Outcome of an actor's inline listen-point wait ([`ActorSignalWaiter`]).
+pub enum ActorSignalWait {
+    /// A matching message reached the actor's shared mailbox; the caller
+    /// should pump the mailbox into the run-level inbox and retry the drain.
+    Delivered,
+    /// The listen point's own `timeoutMs` deadline elapsed: resolve with the
+    /// timeout sentinel in place.
+    TimedOut,
+    /// Park the actor (stop requested or idle cap reached): fall back to the
+    /// pause/hibernate path.
+    Park,
+}
+
+/// Inline mailbox wait installed by the actor supervisor
+/// (`host_actor::supervise`). When present, a `chidori.signal`-family listen
+/// point with an empty inbox BLOCKS here for the next matching delivery and
+/// resumes in place — the actor's history is not re-executed per message,
+/// which is what made a signal-driven actor O(messages²) over its lifetime.
+/// Stop and idle still park through the ordinary pause path (`Park`), so
+/// hibernation and supervision semantics are unchanged. Args: the listen
+/// names and the listen point's `timeoutMs`.
+#[derive(Clone)]
+pub struct ActorSignalWaiter(Arc<dyn Fn(&[String], Option<u64>) -> ActorSignalWait + Send + Sync>);
+
+impl std::fmt::Debug for ActorSignalWaiter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActorSignalWaiter").finish_non_exhaustive()
+    }
+}
+
+impl ActorSignalWaiter {
+    pub fn new(
+        callback: impl Fn(&[String], Option<u64>) -> ActorSignalWait + Send + Sync + 'static,
+    ) -> Self {
+        Self(Arc::new(callback))
+    }
+
+    pub fn wait(&self, names: &[String], timeout_ms: Option<u64>) -> ActorSignalWait {
+        (self.0)(names, timeout_ms)
+    }
+}
+
 #[derive(Debug)]
 struct RuntimeContextInner {
     /// Agent-level defaults set via config().
@@ -190,6 +232,9 @@ struct RuntimeContextInner {
     /// Optional durable safepoint invoked after a host operation result is
     /// persisted and recorded, before control returns to JavaScript.
     pub host_operation_completion_safepoint: Option<HostOperationCompletionSafepoint>,
+    /// Optional inline mailbox wait for actor listen points (see
+    /// [`ActorSignalWaiter`]); installed per supervision iteration.
+    pub actor_signal_waiter: Option<ActorSignalWaiter>,
     /// Optional scoped workspace root exposed through `chidori.workspace`.
     pub workspace_root: Option<PathBuf>,
     /// Seqs of host calls currently executing (their `live()` is on the
@@ -381,6 +426,7 @@ impl RuntimeContext {
                 otel_run: None,
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
+                actor_signal_waiter: None,
                 workspace_root: default_workspace_root(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -455,6 +501,7 @@ impl RuntimeContext {
                 otel_run: None,
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
+                actor_signal_waiter: None,
                 workspace_root: default_workspace_root(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -501,6 +548,7 @@ impl RuntimeContext {
                 otel_run: None,
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
+                actor_signal_waiter: None,
                 workspace_root: default_workspace_root(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -555,6 +603,7 @@ impl RuntimeContext {
                 otel_run: parent_inner.otel_run.clone(),
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
+                actor_signal_waiter: None,
                 workspace_root: parent_inner.workspace_root.clone(),
                 call_stack: vec![parent_branch_seq],
                 capabilities: CapabilityLedger::new(),
@@ -610,6 +659,7 @@ impl RuntimeContext {
                 otel_run: None,
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
+                actor_signal_waiter: None,
                 workspace_root: default_workspace_root(),
                 call_stack: vec![parent_branch_seq],
                 capabilities: CapabilityLedger::new(),
@@ -676,6 +726,7 @@ impl RuntimeContext {
                 otel_run: parent_inner.otel_run.clone(),
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
+                actor_signal_waiter: None,
                 workspace_root: parent_inner.workspace_root.clone(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -1212,6 +1263,14 @@ impl RuntimeContext {
     }
 
     #[allow(dead_code)]
+    pub fn set_actor_signal_waiter(&self, waiter: ActorSignalWaiter) {
+        self.inner.lock().unwrap().actor_signal_waiter = Some(waiter);
+    }
+
+    pub fn actor_signal_waiter(&self) -> Option<ActorSignalWaiter> {
+        self.inner.lock().unwrap().actor_signal_waiter.clone()
+    }
+
     pub fn set_host_operation_completion_safepoint(
         &self,
         safepoint: HostOperationCompletionSafepoint,

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -109,6 +109,14 @@ struct RuntimeContextInner {
     pub config: AgentConfig,
     /// Accumulated call log for checkpointing / tracing.
     pub call_log: CallLog,
+    /// True when `call_log` holds records that never went through
+    /// `RunStore::append_record` — records pushed while replaying a resume
+    /// (`try_replay` / `absorb_replayed_subtree`), including the synthetic
+    /// resume record. The durable safepoints write the full `checkpoint.json`
+    /// only while this is set (or at explicit compaction points); live
+    /// records are already durable via the O(1) journal append in
+    /// `record_call`, so steady-state safepoints skip the O(history) rewrite.
+    pub call_log_dirty: bool,
     /// Sequence counter for call log entries.
     pub seq: u64,
     /// Pre-loaded call log for replay mode. When set, host functions
@@ -347,6 +355,7 @@ impl RuntimeContext {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: AgentConfig::default(),
                 call_log: CallLog::new(),
+                call_log_dirty: false,
                 seq: 0,
                 replay_log: None,
                 run_id: uuid::Uuid::new_v4().to_string(),
@@ -419,6 +428,7 @@ impl RuntimeContext {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: AgentConfig::default(),
                 call_log: CallLog::new(),
+                call_log_dirty: false,
                 seq: 0,
                 replay_log: Some(replay_log),
                 run_id: uuid::Uuid::new_v4().to_string(),
@@ -461,6 +471,9 @@ impl RuntimeContext {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: AgentConfig::default(),
                 call_log,
+                // Seeded records never went through this context's store
+                // handle; the first checkpoint write must include them.
+                call_log_dirty: true,
                 seq,
                 replay_log: None,
                 run_id,
@@ -513,6 +526,7 @@ impl RuntimeContext {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: parent_inner.config.clone(),
                 call_log: CallLog::new(),
+                call_log_dirty: false,
                 seq: base_seq,
                 replay_log: None,
                 run_id,
@@ -566,6 +580,7 @@ impl RuntimeContext {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: AgentConfig::default(),
                 call_log: CallLog::new(),
+                call_log_dirty: false,
                 seq: base_seq,
                 replay_log: Some(replay_log),
                 run_id,
@@ -630,6 +645,7 @@ impl RuntimeContext {
             inner: Arc::new(Mutex::new(RuntimeContextInner {
                 config: parent_inner.config.clone(),
                 call_log: CallLog::new(),
+                call_log_dirty: false,
                 seq: base_seq,
                 replay_log: Some(replay_log),
                 run_id: actor_id.clone(),
@@ -704,16 +720,24 @@ impl RuntimeContext {
             inner.seq = inner.seq.max(record.seq);
             inner.call_log.push(record);
         }
+        // Merged branch records bypass `record_call`'s journal append, so the
+        // log is checkpoint-dirty until the full write below (or, when this
+        // context has no store, a later safepoint) covers them.
+        inner.call_log_dirty = true;
         if let Some(store) = inner.store.clone() {
             let result = store.write_call_log(inner.call_log.records());
+            if result.is_ok() {
+                inner.call_log_dirty = false;
+            }
             note_persist_result(&mut inner, result);
         }
     }
 
     /// Enable persistence with the default filesystem layout. Each
-    /// `record_call` appends the record to `<base_dir>/<run_id>/records.jsonl`
-    /// (safepoints rewrite the full `checkpoint.json`). Returns the run
-    /// directory path.
+    /// `record_call` appends the record to `<base_dir>/<run_id>/records.jsonl`;
+    /// the full `checkpoint.json` is rewritten only at compaction points (run
+    /// start, pause, settle) or when the log is checkpoint-dirty. Returns the
+    /// run directory path.
     pub fn enable_persistence(&self, base_dir: PathBuf) -> PathBuf {
         let run_dir = base_dir.join(self.run_id());
         let _ = std::fs::create_dir_all(&run_dir);
@@ -825,8 +849,14 @@ impl RuntimeContext {
                 if record.parent_seq.is_none() {
                     record.parent_seq = inner.call_stack.last().copied();
                 }
-                // Record the replayed call in the new call log.
+                // Record the replayed call in the new call log. Replay
+                // bypasses `record_call`'s journal append (the record is
+                // already durable from the turn that ran it live), so mark
+                // the log checkpoint-dirty: the first safepoint past the
+                // replay frontier writes one full checkpoint covering the
+                // replayed prefix plus any synthetic resume records.
                 inner.call_log.push(record.clone());
+                inner.call_log_dirty = true;
                 return Some(record);
             }
         }
@@ -901,7 +931,10 @@ impl RuntimeContext {
             if r.seq != root_seq && subtree.contains(&r.seq) {
                 // Keep the nested record in the replayed trace and advance the
                 // counter past it so the next outer call can't reuse its seq.
+                // Same checkpoint-dirty contract as `try_replay`: these pushes
+                // bypass the journal append.
                 inner.call_log.push(r.clone());
+                inner.call_log_dirty = true;
                 max_seq = max_seq.max(r.seq);
             }
         }
@@ -1171,6 +1204,31 @@ impl RuntimeContext {
 
     pub fn call_log(&self) -> CallLog {
         self.inner.lock().unwrap().call_log.clone()
+    }
+
+    /// Number of records in the accumulated call log, without cloning it.
+    pub fn call_log_len(&self) -> usize {
+        self.inner.lock().unwrap().call_log.records().len()
+    }
+
+    /// Whether the call log holds records the O(1) journal appends did not
+    /// cover (replayed/synthetic records pushed during resume). While set,
+    /// the durable safepoints must write the full checkpoint; once cleared,
+    /// they can skip the O(history) rewrite because `record_call` keeps the
+    /// append-only journal complete on its own.
+    pub fn call_log_checkpoint_dirty(&self) -> bool {
+        self.inner.lock().unwrap().call_log_dirty
+    }
+
+    /// Clear the checkpoint-dirty flag after a successful full-checkpoint
+    /// write of a log snapshot taken at `persisted_len` records. Guarded by
+    /// length so records pushed between the snapshot and this call keep the
+    /// log dirty.
+    pub(crate) fn clear_call_log_checkpoint_dirty(&self, persisted_len: usize) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.call_log.records().len() == persisted_len {
+            inner.call_log_dirty = false;
+        }
     }
 
     pub fn set_input_mode(&self, mode: InputMode) {

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -102,6 +102,47 @@ impl HostOperationCompletionSafepoint {
     }
 }
 
+/// Outcome of a warm input pause ([`WarmInputBridge`]).
+pub enum WarmInputWait {
+    /// The `input()` response arrived while the VM stayed live: continue with
+    /// it in place.
+    Delivered(String),
+    /// Park (no supervisor waiting, eviction deadline, capacity): unwind via
+    /// the ordinary PAUSE_MARKER path and resume by replay later.
+    Park,
+}
+
+/// Warm-resume bridge installed by the session server: when an `input()`
+/// listen point in Pause mode has no cached response, the bridge surfaces the
+/// pause to the server (which answers the HTTP request) and BLOCKS the engine
+/// thread until the response is delivered — the continuation then costs O(1)
+/// instead of an O(history) replay re-execution. The pending operation is
+/// durable on disk BEFORE the bridge is consulted, so a crash while parked
+/// resumes by replay exactly as an unwound pause would; `Park` (eviction,
+/// capacity, shutdown) degrades to that same path at any time.
+#[derive(Clone)]
+pub struct WarmInputBridge(
+    Arc<dyn Fn(&RuntimeContext, &PendingInput) -> WarmInputWait + Send + Sync>,
+);
+
+impl std::fmt::Debug for WarmInputBridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WarmInputBridge").finish_non_exhaustive()
+    }
+}
+
+impl WarmInputBridge {
+    pub fn new(
+        callback: impl Fn(&RuntimeContext, &PendingInput) -> WarmInputWait + Send + Sync + 'static,
+    ) -> Self {
+        Self(Arc::new(callback))
+    }
+
+    pub fn wait(&self, ctx: &RuntimeContext, pending: &PendingInput) -> WarmInputWait {
+        (self.0)(ctx, pending)
+    }
+}
+
 /// Outcome of an actor's inline listen-point wait ([`ActorSignalWaiter`]).
 pub enum ActorSignalWait {
     /// A matching message reached the actor's shared mailbox; the caller
@@ -235,6 +276,9 @@ struct RuntimeContextInner {
     /// Optional inline mailbox wait for actor listen points (see
     /// [`ActorSignalWaiter`]); installed per supervision iteration.
     pub actor_signal_waiter: Option<ActorSignalWaiter>,
+    /// Optional warm-resume bridge for `input()` pauses (see
+    /// [`WarmInputBridge`]); installed by the session server's run legs.
+    pub warm_input_bridge: Option<WarmInputBridge>,
     /// Optional scoped workspace root exposed through `chidori.workspace`.
     pub workspace_root: Option<PathBuf>,
     /// Seqs of host calls currently executing (their `live()` is on the
@@ -427,6 +471,7 @@ impl RuntimeContext {
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
                 actor_signal_waiter: None,
+                warm_input_bridge: None,
                 workspace_root: default_workspace_root(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -502,6 +547,7 @@ impl RuntimeContext {
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
                 actor_signal_waiter: None,
+                warm_input_bridge: None,
                 workspace_root: default_workspace_root(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -549,6 +595,7 @@ impl RuntimeContext {
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
                 actor_signal_waiter: None,
+                warm_input_bridge: None,
                 workspace_root: default_workspace_root(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -604,6 +651,7 @@ impl RuntimeContext {
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
                 actor_signal_waiter: None,
+                warm_input_bridge: None,
                 workspace_root: parent_inner.workspace_root.clone(),
                 call_stack: vec![parent_branch_seq],
                 capabilities: CapabilityLedger::new(),
@@ -660,6 +708,7 @@ impl RuntimeContext {
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
                 actor_signal_waiter: None,
+                warm_input_bridge: None,
                 workspace_root: default_workspace_root(),
                 call_stack: vec![parent_branch_seq],
                 capabilities: CapabilityLedger::new(),
@@ -727,6 +776,7 @@ impl RuntimeContext {
                 host_operation_safepoint: None,
                 host_operation_completion_safepoint: None,
                 actor_signal_waiter: None,
+                warm_input_bridge: None,
                 workspace_root: parent_inner.workspace_root.clone(),
                 call_stack: Vec::new(),
                 capabilities: CapabilityLedger::new(),
@@ -1263,6 +1313,14 @@ impl RuntimeContext {
     }
 
     #[allow(dead_code)]
+    pub fn set_warm_input_bridge(&self, bridge: WarmInputBridge) {
+        self.inner.lock().unwrap().warm_input_bridge = Some(bridge);
+    }
+
+    pub fn warm_input_bridge(&self) -> Option<WarmInputBridge> {
+        self.inner.lock().unwrap().warm_input_bridge.clone()
+    }
+
     pub fn set_actor_signal_waiter(&self, waiter: ActorSignalWaiter) {
         self.inner.lock().unwrap().actor_signal_waiter = Some(waiter);
     }

--- a/crates/chidori/src/runtime/engine.rs
+++ b/crates/chidori/src/runtime/engine.rs
@@ -187,9 +187,9 @@ impl ScaffoldPersister {
         use std::sync::atomic::Ordering;
 
         let pending = ctx.active_pending_host_operation();
-        let host_promises = ctx.host_promise_records();
+        let compact = checkpoint == CheckpointWrite::Compact;
         let (modules, module_graph) = self.modules()?;
-        let manifest = SnapshotManifest::new(
+        let mut manifest = SnapshotManifest::new(
             &self.run_id,
             SnapshotAbi::current("chidori-quickjs"),
             self.policy.clone(),
@@ -199,9 +199,16 @@ impl ScaffoldPersister {
             ctx.call_log_len(),
         )
         .with_module_graph(module_graph.clone())
-        .with_host_promises(host_promises)
         .with_capabilities(ctx.capabilities())
         .with_vfs(ctx.vfs_snapshot());
+        // The embedded host-promise table has the same freshness contract as
+        // checkpoint.json: a compaction-time snapshot. Runtime resume never
+        // reads it (deliveries and replay load `host_promises.json` ∪ the
+        // per-op blobs); embedding the whole table per safepoint was the
+        // other O(history)-per-call term.
+        if compact {
+            manifest = manifest.with_host_promises(ctx.host_promise_records());
+        }
         // Write through the run's store handle when persistence is enabled, so
         // a configured durable mirror receives the scaffold too; identical
         // on-disk layout either way.
@@ -214,10 +221,13 @@ impl ScaffoldPersister {
             self.blob_written.store(true, Ordering::Release);
         }
         store.put_manifest(&manifest)?;
-        if checkpoint == CheckpointWrite::Compact || ctx.call_log_checkpoint_dirty() {
+        if compact || ctx.call_log_checkpoint_dirty() {
             let call_log = ctx.call_log().into_records();
             store.write_call_log(&call_log)?;
             ctx.clear_call_log_checkpoint_dirty(call_log.len());
+        }
+        if compact {
+            store.compact_host_promises(&manifest.host_promises)?;
         }
         store.put_pending(manifest.pending.as_ref())
     }
@@ -979,7 +989,7 @@ mod tests {
                 .next()
                 .ok_or_else(|| anyhow::anyhow!("expected persisted run dir before provider"))??
                 .path();
-            let loaded = SnapshotStore::new(run_dir).load()?;
+            let loaded = SnapshotStore::new(&run_dir).load()?;
             let pending = loaded
                 .manifest
                 .pending
@@ -1012,13 +1022,18 @@ mod tests {
                     "pre-provider snapshot blob did not match expected live VM snapshot"
                 );
             }
+            // The pending promise must be durable BEFORE the provider runs.
+            // It lives in the per-op blob ∪ table union (the manifest embeds
+            // the table only at compaction points, like checkpoint.json).
+            let store = crate::runtime::store::FsRunStore::new(&run_dir);
+            let promises = crate::runtime::snapshot::load_host_promise_records(&store)?;
             anyhow::ensure!(
-                loaded.manifest.host_promises.len() == 1,
+                promises.len() == 1,
                 "expected one pending host promise before provider"
             );
             anyhow::ensure!(
                 matches!(
-                    loaded.manifest.host_promises[0].state,
+                    promises[0].state,
                     crate::runtime::snapshot::HostPromiseState::Pending
                 ),
                 "expected pending host promise before provider"

--- a/crates/chidori/src/runtime/engine.rs
+++ b/crates/chidori/src/runtime/engine.rs
@@ -40,6 +40,12 @@ pub struct Engine {
     /// (`CHIDORI_RUN_STORE`, `docs/durable-storage.md`). Built alongside
     /// `persist_base`; None when persistence is disabled.
     run_store: Option<crate::runtime::store::RunStoreFactory>,
+    /// Warm-resume bridge installed on every run leg's context (see
+    /// [`crate::runtime::context::WarmInputBridge`]): the session server sets
+    /// this so an `input()` pause parks the live VM instead of unwinding, and
+    /// the resume continues in place. None (CLI, tests, embedders) keeps the
+    /// classic pause-unwind behavior.
+    warm_input_bridge: Option<crate::runtime::context::WarmInputBridge>,
     /// Default root for `chidori.workspace`, used when the run's context has no
     /// workspace root of its own. The CLI points this at the agent's project
     /// directory so `chidori.workspace` works out of the box; an explicit
@@ -287,8 +293,17 @@ impl Engine {
             approvals: Vec::new(),
             persist_base: None,
             run_store: None,
+            warm_input_bridge: None,
             workspace_root: None,
         }
+    }
+
+    pub fn with_warm_input_bridge(
+        mut self,
+        bridge: crate::runtime::context::WarmInputBridge,
+    ) -> Self {
+        self.warm_input_bridge = Some(bridge);
+        self
     }
 
     pub fn with_approvals(mut self, approvals: Vec<(String, serde_json::Value)>) -> Self {
@@ -689,6 +704,9 @@ impl Engine {
             if let Some(ref root) = self.workspace_root {
                 ctx.set_workspace_root(root.clone());
             }
+        }
+        if let Some(ref bridge) = self.warm_input_bridge {
+            ctx.set_warm_input_bridge(bridge.clone());
         }
 
         // Enable persistence if configured: the filesystem run dir, teed with

--- a/crates/chidori/src/runtime/engine.rs
+++ b/crates/chidori/src/runtime/engine.rs
@@ -13,8 +13,8 @@ use crate::runtime::context::{
     PendingInput, PendingSignal, RuntimeContext, RuntimeEvent,
 };
 use crate::runtime::snapshot::{
-    HostPromiseRecord, RuntimePolicy, SnapshotAbi, SnapshotManifest, SnapshotStore,
-    SourceFingerprint,
+    HostPromiseRecord, RuntimePolicy, SnapshotAbi, SnapshotManifest, SnapshotModuleGraphEntry,
+    SnapshotStore, SourceFingerprint,
 };
 use crate::runtime::template::TemplateEngine;
 use crate::tools::ToolRegistry;
@@ -95,14 +95,140 @@ pub(crate) fn persist_journal_scaffold(
     policy: &RuntimePolicy,
     ctx: &RuntimeContext,
 ) -> Result<()> {
-    persist_rust_journal_scaffold(base, run_id, path, source, policy, ctx)
+    ScaffoldPersister::new(base, run_id, path, source, policy)
+        .persist(ctx, CheckpointWrite::Compact)
+}
+
+/// Whether a scaffold persist rewrites the full `checkpoint.json`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckpointWrite {
+    /// Write only when the in-memory log holds records the O(1) journal
+    /// appends did not cover (`RuntimeContext::call_log_checkpoint_dirty`) —
+    /// the per-safepoint cadence. Live records are already durable in
+    /// `records.jsonl` via `record_call`, and the loader unions the last
+    /// checkpoint with the appended tail, so skipping the rewrite loses
+    /// nothing.
+    IfDirty,
+    /// Always write — the compaction points: pause, settle, one-shot scaffold
+    /// snapshots.
+    Compact,
+}
+
+/// Per-run persister for the durable journal scaffold. Caches the pieces that
+/// are invariant for the run's lifetime — the entry fingerprint, the module
+/// fingerprints + import graph (a disk walk over every imported module), and
+/// the serialized code-bundle blob — so the per-host-call safepoints pay for
+/// none of them. Before this existed, every safepoint re-walked the module
+/// graph from disk twice and rewrote the whole checkpoint: O(history) bytes
+/// and O(modules) disk reads per host call.
+pub(crate) struct ScaffoldPersister {
+    base: PathBuf,
+    run_id: String,
+    path: PathBuf,
+    source: String,
+    policy: RuntimePolicy,
+    entry: SourceFingerprint,
+    /// `(dependency fingerprints, full module graph)` — computed on first use
+    /// (set only on success, so a transient read failure retries).
+    modules: std::sync::OnceLock<(Vec<SourceFingerprint>, Vec<SnapshotModuleGraphEntry>)>,
+    /// The rust engine has no VM image to serialize; resume is call-log
+    /// replay. We still write a non-empty blob — the durable code bundle the
+    /// journal keys reference — so `SnapshotStore::load()` round-trips and
+    /// the on-disk shape matches the established scaffold shape
+    /// (manifest + blob + checkpoint + pending). The bytes are run-invariant,
+    /// so they are serialized once here and written once per run.
+    blob_bytes: Vec<u8>,
+    blob_written: std::sync::atomic::AtomicBool,
+}
+
+impl ScaffoldPersister {
+    pub(crate) fn new(
+        base: &Path,
+        run_id: &str,
+        path: &Path,
+        source: &str,
+        policy: &RuntimePolicy,
+    ) -> Self {
+        let blob = chidori_js::replay::DurableBlob {
+            bundle: source.to_string(),
+            effects: Vec::new(),
+            journal: Vec::new(),
+        };
+        Self {
+            base: base.to_path_buf(),
+            run_id: run_id.to_string(),
+            path: path.to_path_buf(),
+            source: source.to_string(),
+            policy: policy.clone(),
+            entry: SourceFingerprint::from_source(path, source),
+            modules: std::sync::OnceLock::new(),
+            blob_bytes: serde_json::to_vec(&blob).unwrap_or_default(),
+            blob_written: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    fn modules(&self) -> Result<&(Vec<SourceFingerprint>, Vec<SnapshotModuleGraphEntry>)> {
+        if let Some(cached) = self.modules.get() {
+            return Ok(cached);
+        }
+        // Sources are fixed for the run's lifetime (the engine read them once
+        // at start and never re-reads), so the manifest must describe what the
+        // run is actually executing — caching is more correct than re-walking,
+        // not just cheaper.
+        let computed = crate::runtime::typescript::module_graph::snapshot_modules(
+            &self.path,
+            &self.source,
+            &self.policy,
+        )?;
+        Ok(self.modules.get_or_init(|| computed))
+    }
+
+    pub(crate) fn persist(&self, ctx: &RuntimeContext, checkpoint: CheckpointWrite) -> Result<()> {
+        use std::sync::atomic::Ordering;
+
+        let pending = ctx.active_pending_host_operation();
+        let host_promises = ctx.host_promise_records();
+        let (modules, module_graph) = self.modules()?;
+        let manifest = SnapshotManifest::new(
+            &self.run_id,
+            SnapshotAbi::current("chidori-quickjs"),
+            self.policy.clone(),
+            self.entry.clone(),
+            modules.clone(),
+            pending,
+            ctx.call_log_len(),
+        )
+        .with_module_graph(module_graph.clone())
+        .with_host_promises(host_promises)
+        .with_capabilities(ctx.capabilities())
+        .with_vfs(ctx.vfs_snapshot());
+        // Write through the run's store handle when persistence is enabled, so
+        // a configured durable mirror receives the scaffold too; identical
+        // on-disk layout either way.
+        let store = match ctx.store() {
+            Some(store) => SnapshotStore::with_store(self.base.join(&self.run_id), store),
+            None => SnapshotStore::new(self.base.join(&self.run_id)),
+        };
+        if !self.blob_written.load(Ordering::Acquire) {
+            store.put_snapshot_blob(&manifest, &self.blob_bytes)?;
+            self.blob_written.store(true, Ordering::Release);
+        }
+        store.put_manifest(&manifest)?;
+        if checkpoint == CheckpointWrite::Compact || ctx.call_log_checkpoint_dirty() {
+            let call_log = ctx.call_log().into_records();
+            store.write_call_log(&call_log)?;
+            ctx.clear_call_log_checkpoint_dirty(call_log.len());
+        }
+        store.put_pending(manifest.pending.as_ref())
+    }
 }
 
 /// Install the durable-scaffold safepoints on a prepared context: the
-/// manifest + pending + checkpoint are persisted before every live host side
-/// effect and after every recorded completion, so a crash mid-run always
-/// leaves a resumable artifact. Shared by the engine's run path and the
-/// detached-agent supervisor (`host_agent`), which runs modules directly.
+/// manifest + pending (and, when the log is checkpoint-dirty, the full
+/// checkpoint) are persisted before every live host side effect and after
+/// every recorded completion, so a crash mid-run always leaves a resumable
+/// artifact. Shared by the engine's run path and the detached-agent
+/// supervisor (`host_agent`), which runs modules directly.
 pub(crate) fn install_journal_scaffold_safepoints(
     base: &Path,
     run_id: &str,
@@ -111,81 +237,28 @@ pub(crate) fn install_journal_scaffold_safepoints(
     policy: &RuntimePolicy,
     ctx: &RuntimeContext,
 ) {
-    let (base, run_id, path, source, policy) = (
-        base.to_path_buf(),
-        run_id.to_string(),
-        path.to_path_buf(),
-        source.to_string(),
-        policy.clone(),
-    );
+    let persister = Arc::new(ScaffoldPersister::new(base, run_id, path, source, policy));
+    install_scaffold_safepoints_with(persister, ctx);
+}
+
+/// Wire an existing per-run [`ScaffoldPersister`] into both host-operation
+/// safepoints (pre-effect and post-completion), each at the `IfDirty`
+/// checkpoint cadence.
+pub(crate) fn install_scaffold_safepoints_with(
+    persister: Arc<ScaffoldPersister>,
+    ctx: &RuntimeContext,
+) {
     {
-        let (base, run_id, path, source, policy) = (
-            base.clone(),
-            run_id.clone(),
-            path.clone(),
-            source.clone(),
-            policy.clone(),
-        );
+        let persister = persister.clone();
         let safepoint_ctx = ctx.clone();
         ctx.set_host_operation_safepoint(HostOperationSafepoint::new(move |_operation| {
-            persist_rust_journal_scaffold(&base, &run_id, &path, &source, &policy, &safepoint_ctx)
+            persister.persist(&safepoint_ctx, CheckpointWrite::IfDirty)
         }));
     }
     let completion_ctx = ctx.clone();
     ctx.set_host_operation_completion_safepoint(HostOperationCompletionSafepoint::new(
-        move |_record| {
-            persist_rust_journal_scaffold(&base, &run_id, &path, &source, &policy, &completion_ctx)
-        },
+        move |_record| persister.persist(&completion_ctx, CheckpointWrite::IfDirty),
     ));
-}
-
-fn persist_rust_journal_scaffold(
-    base: &Path,
-    run_id: &str,
-    path: &Path,
-    source: &str,
-    policy: &RuntimePolicy,
-    ctx: &RuntimeContext,
-) -> Result<()> {
-    let call_log = ctx.call_log().into_records();
-    let pending = ctx.active_pending_host_operation();
-    let host_promises = ctx.host_promise_records();
-    let modules = crate::runtime::typescript::module_graph::snapshot_module_fingerprints(
-        path, source, policy,
-    )?;
-    let module_graph =
-        crate::runtime::typescript::module_graph::snapshot_module_graph(path, source, policy)?;
-    let manifest = SnapshotManifest::new(
-        run_id,
-        SnapshotAbi::current("chidori-quickjs"),
-        policy.clone(),
-        SourceFingerprint::from_source(path, source),
-        modules,
-        pending.clone(),
-        call_log.len(),
-    )
-    .with_module_graph(module_graph)
-    .with_host_promises(host_promises)
-    .with_capabilities(ctx.capabilities())
-    .with_vfs(ctx.vfs_snapshot());
-    // The rust engine has no VM image to serialize; resume is call-log replay.
-    // We still write a non-empty blob — the durable code bundle the journal keys
-    // reference — so `SnapshotStore::load()` round-trips and the on-disk shape
-    // matches the established scaffold shape (manifest + blob + checkpoint + pending).
-    let blob = chidori_js::replay::DurableBlob {
-        bundle: source.to_string(),
-        effects: Vec::new(),
-        journal: Vec::new(),
-    };
-    let blob_bytes = serde_json::to_vec(&blob).unwrap_or_default();
-    // Write through the run's store handle when persistence is enabled, so a
-    // configured durable mirror receives the scaffold too; identical on-disk
-    // layout either way.
-    let store = match ctx.store() {
-        Some(store) => SnapshotStore::with_store(base.join(run_id), store),
-        None => SnapshotStore::new(base.join(run_id)),
-    };
-    store.save(&manifest, &blob_bytes, &call_log)
 }
 
 impl Engine {
@@ -687,43 +760,22 @@ impl Engine {
             );
             // Persist a durable journal scaffold before the run and at each
             // host-operation safepoint, so a pause/crash has a resumable
-            // artifact on disk (G2). Stores the engine's journal-shaped manifest.
-            if let Some(ref base) = self.persist_base {
-                let safepoint_base = base.clone();
-                let safepoint_run_id = run_id.clone();
-                let safepoint_path = path.to_path_buf();
-                let safepoint_source = source.clone();
-                let safepoint_policy = policy.clone();
-                let safepoint_ctx = ctx.clone();
-                ctx.set_host_operation_safepoint(HostOperationSafepoint::new(move |_operation| {
-                    persist_rust_journal_scaffold(
-                        &safepoint_base,
-                        &safepoint_run_id,
-                        &safepoint_path,
-                        &safepoint_source,
-                        &safepoint_policy,
-                        &safepoint_ctx,
-                    )
-                }));
-                let completion_base = base.clone();
-                let completion_run_id = run_id.clone();
-                let completion_path = path.to_path_buf();
-                let completion_source = source.clone();
-                let completion_policy = policy.clone();
-                let completion_ctx = ctx.clone();
-                ctx.set_host_operation_completion_safepoint(HostOperationCompletionSafepoint::new(
-                    move |_record| {
-                        persist_rust_journal_scaffold(
-                            &completion_base,
-                            &completion_run_id,
-                            &completion_path,
-                            &completion_source,
-                            &completion_policy,
-                            &completion_ctx,
-                        )
-                    },
-                ));
-                persist_rust_journal_scaffold(base, &run_id, path, &source, &policy, &ctx)?;
+            // artifact on disk (G2). Stores the engine's journal-shaped
+            // manifest. One persister per run: the module graph, entry
+            // fingerprint, and code-bundle blob are computed once and reused
+            // by every safepoint. The initial persist is `IfDirty`: a fresh
+            // run has nothing to checkpoint, and a resume must NOT rewrite
+            // `checkpoint.json` from its still-empty in-memory log — that
+            // would truncate the previous turn's journal while it is being
+            // replayed.
+            let persister = self.persist_base.as_ref().map(|base| {
+                Arc::new(ScaffoldPersister::new(
+                    base, &run_id, path, &source, &policy,
+                ))
+            });
+            if let Some(ref persister) = persister {
+                install_scaffold_safepoints_with(persister.clone(), &ctx);
+                persister.persist(&ctx, CheckpointWrite::IfDirty)?;
             }
 
             // Pause surfacing on the rust path (G1). A `chidori.input()` in
@@ -743,10 +795,8 @@ impl Engine {
                     tracing_error!(run_id = %ctx.run_id(), error = %err, "flushing run store at pause");
                 }
                 if let Some(pending) = ctx.take_pending_input() {
-                    if let Some(ref base) = self.persist_base {
-                        let _ = persist_rust_journal_scaffold(
-                            base, &run_id, path, &source, &policy, ctx,
-                        );
+                    if let Some(ref persister) = persister {
+                        let _ = persister.persist(ctx, CheckpointWrite::Compact);
                     }
                     emit_otel(ctx, None);
                     return Some(RunResult {
@@ -759,10 +809,8 @@ impl Engine {
                     });
                 }
                 if let Some(approval) = ctx.take_pending_approval() {
-                    if let Some(ref base) = self.persist_base {
-                        let _ = persist_rust_journal_scaffold(
-                            base, &run_id, path, &source, &policy, ctx,
-                        );
+                    if let Some(ref persister) = persister {
+                        let _ = persister.persist(ctx, CheckpointWrite::Compact);
                     }
                     emit_otel(ctx, None);
                     return Some(RunResult {
@@ -778,10 +826,8 @@ impl Engine {
                 // sets `pending_signal` and bails with `PAUSE_MARKER`, exactly
                 // like `input` — surface it as a paused run, not a failure.
                 if let Some(signal) = ctx.take_pending_signal() {
-                    if let Some(ref base) = self.persist_base {
-                        let _ = persist_rust_journal_scaffold(
-                            base, &run_id, path, &source, &policy, ctx,
-                        );
+                    if let Some(ref persister) = persister {
+                        let _ = persister.persist(ctx, CheckpointWrite::Compact);
                     }
                     emit_otel(ctx, None);
                     return Some(RunResult {
@@ -812,7 +858,7 @@ impl Engine {
                         return Ok(paused);
                     }
                     info!(agent = %agent_name, run_id = %run_id, "rust-engine agent run ok");
-                    if let Some(ref base) = self.persist_base {
+                    if let Some(ref persister) = persister {
                         if let Some(store) = ctx.store() {
                             let _ = store.put_blob(
                                 "output.json",
@@ -821,9 +867,7 @@ impl Engine {
                                     .as_bytes(),
                             );
                         }
-                        let _ = persist_rust_journal_scaffold(
-                            base, &run_id, path, &source, &policy, &ctx,
-                        );
+                        let _ = persister.persist(&ctx, CheckpointWrite::Compact);
                     }
                     // Output gate: the run's result is not surfaced until the
                     // journal is durable. A strict-mode persistence failure
@@ -846,10 +890,8 @@ impl Engine {
                     }
                     let err_msg = e.to_string();
                     tracing_error!(agent = %agent_name, run_id = %run_id, error = %err_msg, "rust-engine agent run failed");
-                    if let Some(ref base) = self.persist_base {
-                        let _ = persist_rust_journal_scaffold(
-                            base, &run_id, path, &source, &policy, &ctx,
-                        );
+                    if let Some(ref persister) = persister {
+                        let _ = persister.persist(&ctx, CheckpointWrite::Compact);
                     }
                     emit_otel(&ctx, Some(&err_msg));
                     Err(e)
@@ -2660,5 +2702,120 @@ def agent(value):
         assert_eq!(streamed, "reply two");
 
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Pins the checkpoint-write cadence: steady-state safepoints must NOT
+    /// rewrite `checkpoint.json` (the O(1) `records.jsonl` append plus the
+    /// loader's union already carry the log), while replay-seeded logs
+    /// (checkpoint-dirty) and explicit compaction points must.
+    #[test]
+    fn scaffold_safepoints_skip_checkpoint_rewrite_until_dirty_or_compaction() {
+        use crate::runtime::store::RunStore as _;
+
+        let base =
+            std::env::temp_dir().join(format!("chidori-scaffold-cadence-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let agent_path = base.join("agent.ts");
+        std::fs::write(&agent_path, "export async function agent() { return 1; }").unwrap();
+        let source = std::fs::read_to_string(&agent_path).unwrap();
+
+        let record = |seq: u64, function: &str| CallRecord {
+            seq,
+            parent_seq: None,
+            function: function.to_string(),
+            args: serde_json::Value::Null,
+            result: serde_json::Value::Null,
+            duration_ms: 0,
+            token_usage: None,
+            timestamp: chrono::Utc::now(),
+            error: None,
+        };
+
+        // Live run: records flow through `record_call`'s O(1) append.
+        let ctx = RuntimeContext::new();
+        let run_id = ctx.run_id();
+        let run_dir = ctx.enable_persistence(base.clone());
+        let policy = RuntimePolicy::durable_default(&run_id);
+        let persister = ScaffoldPersister::new(&base, &run_id, &agent_path, &source, &policy);
+
+        // Run-start persist: scaffold artifacts exist, no checkpoint yet.
+        persister.persist(&ctx, CheckpointWrite::IfDirty).unwrap();
+        assert!(run_dir
+            .join(crate::runtime::snapshot::SNAPSHOT_MANIFEST_FILE)
+            .is_file());
+        assert!(!run_dir.join("checkpoint.json").exists());
+
+        // A live record + its completion safepoint: still no checkpoint
+        // rewrite, but the journal loads complete via the union.
+        ctx.record_call(record(1, "prompt"));
+        persister.persist(&ctx, CheckpointWrite::IfDirty).unwrap();
+        assert!(
+            !run_dir.join("checkpoint.json").exists(),
+            "steady-state safepoint must not rewrite the checkpoint"
+        );
+        let loaded = crate::runtime::store::FsRunStore::new(&run_dir)
+            .load_call_log()
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].function, "prompt");
+
+        // A compaction point (pause/settle) writes the full checkpoint.
+        persister.persist(&ctx, CheckpointWrite::Compact).unwrap();
+        let checkpoint: Vec<CallRecord> =
+            serde_json::from_slice(&std::fs::read(run_dir.join("checkpoint.json")).unwrap())
+                .unwrap();
+        assert_eq!(checkpoint.len(), 1);
+
+        // Resume replay: replayed pushes bypass the append path, so the log
+        // is checkpoint-dirty and the first safepoint persists one full
+        // checkpoint covering the replayed prefix + synthetic record.
+        let resumed = RuntimeContext::with_replay(vec![record(1, "prompt"), record(2, "input")]);
+        resumed.enable_persistence_with_store(
+            run_dir.clone(),
+            Arc::new(crate::runtime::store::FsRunStore::new(&run_dir)),
+        );
+        assert!(resumed.try_replay(1).is_some());
+        assert!(resumed.try_replay(2).is_some());
+        assert!(resumed.call_log_checkpoint_dirty());
+        let resumed_persister =
+            ScaffoldPersister::new(&base, &run_id, &agent_path, &source, &policy);
+        resumed_persister
+            .persist(&resumed, CheckpointWrite::IfDirty)
+            .unwrap();
+        assert!(!resumed.call_log_checkpoint_dirty());
+        let checkpoint: Vec<CallRecord> =
+            serde_json::from_slice(&std::fs::read(run_dir.join("checkpoint.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            checkpoint.len(),
+            2,
+            "first safepoint past the replay frontier must persist replayed + synthetic records"
+        );
+
+        // Once clean, further live records go back to append-only cadence.
+        resumed.record_call(record(3, "tool"));
+        resumed_persister
+            .persist(&resumed, CheckpointWrite::IfDirty)
+            .unwrap();
+        let checkpoint: Vec<CallRecord> =
+            serde_json::from_slice(&std::fs::read(run_dir.join("checkpoint.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            checkpoint.len(),
+            2,
+            "clean safepoint must leave the checkpoint alone"
+        );
+        let loaded = crate::runtime::store::FsRunStore::new(&run_dir)
+            .load_call_log()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            loaded.len(),
+            3,
+            "the union must still see the appended tail"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/crates/chidori/src/runtime/host_actor.rs
+++ b/crates/chidori/src/runtime/host_actor.rs
@@ -15,9 +15,19 @@
 //! iteration = one pass of the actor's source module on a fresh VM, driven by
 //! the standard resume-by-replay model: the actor's accumulated call log is
 //! replayed from the top, recorded effects return from cache, and execution
-//! goes live at the frontier. The loop re-enters the module when the actor
-//! pauses on an empty mailbox (a message arrived → resume) and when it fails
-//! (a restart, if the spawn's supervision options allow one).
+//! goes live at the frontier.
+//!
+//! In the steady state an actor stays LIVE across messages: a
+//! `chidori.signal`-family listen point with an empty mailbox blocks in
+//! place on the shared-mailbox condvar (the [`ActorSignalWaiter`] installed
+//! per iteration) and continues when the next matching message (or the
+//! listen point's own timeout) arrives — the module is NOT re-executed per
+//! message. The loop re-enters the module only when the actor parks — the
+//! idle cap elapses or a stop is requested — and when it fails (a restart,
+//! if the spawn's supervision options allow one). `chidori.receive` blocks
+//! in place as it always has.
+//!
+//! [`ActorSignalWaiter`]: crate::runtime::context::ActorSignalWaiter
 //!
 //! ## Durability
 //!
@@ -1318,6 +1328,10 @@ fn supervise(
     let mut replay: Vec<CallRecord> = Vec::new();
     let mut carried_inbox: Vec<QueuedSignal> = Vec::new();
     let mut restarts: u32 = 0;
+    // Set when the inline listen-point wait already sat out the idle cap, so
+    // the pause-path fallback below parks immediately instead of waiting the
+    // idle window a second time.
+    let inline_idled = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let outcome = |status: &'static str,
                    output: Option<Value>,
@@ -1350,6 +1364,33 @@ fn supervise(
             hub.clone(),
         );
         pump_mailbox(shared, &ctx);
+        // Inline listen-point wait: a `chidori.signal` with an empty inbox
+        // blocks HERE for the next matching delivery (or its own timeout) and
+        // continues in place — the actor's history is not re-executed per
+        // message. Stop and idle return `Park`, falling back to the pause
+        // path this loop has always handled.
+        {
+            let waiter_shared = shared.clone();
+            let waiter_idled = inline_idled.clone();
+            let idle_timeout_ms = options.idle_timeout_ms;
+            ctx.set_actor_signal_waiter(crate::runtime::context::ActorSignalWaiter::new(
+                move |names, timeout_ms| {
+                    waiter_shared.set_lifecycle(Lifecycle::Waiting(names.to_vec()));
+                    let waited =
+                        wait_for_message(&waiter_shared, names, timeout_ms, idle_timeout_ms);
+                    waiter_shared.set_lifecycle(Lifecycle::Running);
+                    match waited {
+                        WaitOutcome::Matched => crate::runtime::context::ActorSignalWait::Delivered,
+                        WaitOutcome::TimedOut => crate::runtime::context::ActorSignalWait::TimedOut,
+                        WaitOutcome::Idle => {
+                            waiter_idled.store(true, std::sync::atomic::Ordering::SeqCst);
+                            crate::runtime::context::ActorSignalWait::Park
+                        }
+                        WaitOutcome::Stopped => crate::runtime::context::ActorSignalWait::Park,
+                    }
+                },
+            ));
+        }
         let Some(iter_backend) = backend.with_runtime_ctx(ctx.clone()) else {
             return outcome(
                 "failed",
@@ -1399,8 +1440,13 @@ fn supervise(
                         .to_string()
                     });
                 shared.set_lifecycle(Lifecycle::Waiting(names.clone()));
-                let waited =
-                    wait_for_message(shared, &names, pending.timeout_ms, options.idle_timeout_ms);
+                let waited = if inline_idled.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                    // The inline wait already exhausted the idle cap for this
+                    // listen point; park now rather than waiting it again.
+                    WaitOutcome::Idle
+                } else {
+                    wait_for_message(shared, &names, pending.timeout_ms, options.idle_timeout_ms)
+                };
                 shared.set_lifecycle(Lifecycle::Running);
 
                 let records = ctx.call_log().into_records();

--- a/crates/chidori/src/runtime/host_agent.rs
+++ b/crates/chidori/src/runtime/host_agent.rs
@@ -787,12 +787,8 @@ fn supervise_detached(hub: &DetachedAgentHub, entry: &Arc<AgentEntry>) {
         // Fresh VM + context under the agent's OWN durable identity: run id,
         // journal, policy seed, and persistence handle all belong to the
         // agent, not the spawner.
-        let host_promises = store
-            .get_blob(crate::runtime::snapshot::HOST_PROMISE_TABLE_FILE)
-            .ok()
-            .flatten()
-            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-            .unwrap_or_default();
+        let host_promises =
+            crate::runtime::snapshot::load_host_promise_records(store.as_ref()).unwrap_or_default();
         let vfs = crate::runtime::snapshot::SnapshotStore::with_store(&run_dir, store.clone())
             .load_manifest()
             .map(|manifest| manifest.vfs)
@@ -964,6 +960,17 @@ fn supervise_detached(hub: &DetachedAgentHub, entry: &Arc<AgentEntry>) {
                     let _ = store.delete_blob(crate::runtime::snapshot::HOST_PROMISE_TABLE_FILE);
                     let _ =
                         store.delete_blob(crate::runtime::snapshot::PENDING_HOST_OPERATION_FILE);
+                    // Per-op promise blobs are part of the table; a clean
+                    // restart retires them too or the union loader would
+                    // resurrect the wiped state.
+                    if let Ok(keys) = store.list_blobs() {
+                        for key in keys {
+                            if key.starts_with(crate::runtime::snapshot::HOST_PROMISE_EVENTS_PREFIX)
+                            {
+                                let _ = store.delete_blob(&key);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -2341,14 +2341,15 @@ mod tests {
         ));
         let ctx = RuntimeContext::new();
         let run_dir = ctx.enable_persistence(base.clone());
-        let table_path = run_dir.join(crate::runtime::snapshot::HOST_PROMISE_TABLE_FILE);
         let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let completion_events = events.clone();
-        let completion_table_path = table_path.clone();
+        let completion_run_dir = run_dir.clone();
         ctx.set_host_operation_completion_safepoint(HostOperationCompletionSafepoint::new(
             move |record| {
-                let records: Vec<HostPromiseRecord> =
-                    serde_json::from_slice(&std::fs::read(&completion_table_path)?)?;
+                // The resolved state must be durable (per-op blob ∪ table)
+                // by the time the completion safepoint observes it.
+                let store = crate::runtime::store::FsRunStore::new(&completion_run_dir);
+                let records = crate::runtime::snapshot::load_host_promise_records(&store)?;
                 assert_eq!(records.len(), 1);
                 assert_eq!(records[0].operation.id, record.operation.id);
                 assert!(matches!(

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -8,7 +8,7 @@ use crate::providers::{
 };
 use crate::runtime::call_log::{CallRecord, TokenUsage};
 use crate::runtime::context::{
-    InputMode, PendingInput, PendingSignal, RuntimeContext, PAUSE_MARKER,
+    ActorSignalWait, InputMode, PendingInput, PendingSignal, RuntimeContext, PAUSE_MARKER,
 };
 use crate::runtime::memory::execute_memory_action;
 use crate::runtime::snapshot::{HostPromiseState, PendingHostOperationKind};
@@ -342,6 +342,95 @@ pub fn signal_timeout_sentinel(names: &[String]) -> Value {
 ///      pause *type* is distinguished from `input` by which pending slot is set).
 /// The durable match key is `{ "name": name }` only — the payload is unknown at
 /// pause time and rides in the result.
+/// Resolve a signal-family listen point in place: mark the host op resolved,
+/// append the journal record (the same shape a queued drain, a server-side
+/// synthetic resolution, or a timeout sentinel produces), and run the
+/// completion safepoint. Shared by the queued-inbox hit, the actor inline
+/// wait, and the inline timeout.
+fn settle_signal_listen(
+    ctx: &RuntimeContext,
+    host_operation: crate::runtime::snapshot::HostOperationId,
+    seq: u64,
+    function: &str,
+    match_args: Value,
+    result: Value,
+) -> Result<Value> {
+    ctx.resolve_host_operation(host_operation, result.clone())?;
+    ctx.record_call(CallRecord {
+        seq,
+        parent_seq: None,
+        function: function.to_string(),
+        args: match_args,
+        result: result.clone(),
+        duration_ms: 0,
+        token_usage: None,
+        timestamp: Utc::now(),
+        error: None,
+    });
+    ctx.run_host_operation_completion_safepoint(host_operation)?;
+    Ok(result)
+}
+
+/// Actor fast path for a listen point whose inbox is empty: block in place
+/// for the next matching delivery on the actor's shared mailbox instead of
+/// parking the actor and re-executing its whole history per message (the
+/// O(messages²) supervision loop). Returns `Some(result)` when the wait
+/// settled the listen point inline (message or timeout sentinel); `None` when
+/// the actor should park through the ordinary pause path (stop/idle), or when
+/// no waiter is installed (non-actor contexts).
+fn actor_inline_signal_wait(
+    ctx: &RuntimeContext,
+    host_operation: crate::runtime::snapshot::HostOperationId,
+    seq: u64,
+    function: &str,
+    names: &[String],
+    timeout_ms: Option<u64>,
+    match_args: &Value,
+) -> Result<Option<Value>> {
+    let Some(waiter) = ctx.actor_signal_waiter() else {
+        return Ok(None);
+    };
+    match waiter.wait(names, timeout_ms) {
+        ActorSignalWait::Delivered => {
+            // The waiter observed a matching message in the shared mailbox;
+            // pump it into the run-level inbox and drain through the same
+            // path a pre-queued signal takes (ordering + durable-inbox
+            // semantics included).
+            crate::runtime::host_actor::pump_own_mailbox(ctx);
+            if let Some(queued) = ctx.take_queued_signal_any(names) {
+                let result = json!({
+                    "name": queued.name,
+                    "payload": queued.payload,
+                    "from": queued.from,
+                });
+                return settle_signal_listen(
+                    ctx,
+                    host_operation,
+                    seq,
+                    function,
+                    match_args.clone(),
+                    result,
+                )
+                .map(Some);
+            }
+            // Defensive: the drain missed (should not happen — the actor
+            // thread is the mailbox's only consumer). Park via the pause
+            // path, which handles it exactly as an empty mailbox.
+            Ok(None)
+        }
+        ActorSignalWait::TimedOut => settle_signal_listen(
+            ctx,
+            host_operation,
+            seq,
+            function,
+            match_args.clone(),
+            signal_timeout_sentinel(names),
+        )
+        .map(Some),
+        ActorSignalWait::Park => Ok(None),
+    }
+}
+
 pub fn execute_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
     let name = signal_name("signal", args)?;
     let match_args = json!({ "name": name });
@@ -394,10 +483,23 @@ pub fn execute_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
         return Ok(result);
     }
 
+    let names = vec![name.clone()];
+    if let Some(result) = actor_inline_signal_wait(
+        ctx,
+        host_operation,
+        seq,
+        "signal",
+        &names,
+        signal_timeout_ms(args),
+        &match_args,
+    )? {
+        return Ok(result);
+    }
+
     ctx.set_pending_signal(PendingSignal {
         seq,
         name: name.clone(),
-        names: vec![name.clone()],
+        names,
         timeout_ms: signal_timeout_ms(args),
         id: host_operation,
     });
@@ -460,6 +562,18 @@ pub fn execute_signal_any(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
             error: None,
         });
         ctx.run_host_operation_completion_safepoint(host_operation)?;
+        return Ok(result);
+    }
+
+    if let Some(result) = actor_inline_signal_wait(
+        ctx,
+        host_operation,
+        seq,
+        "signal_any",
+        &names,
+        signal_timeout_ms(args),
+        &match_args,
+    )? {
         return Ok(result);
     }
 
@@ -2850,6 +2964,89 @@ mod tests {
 
         let err = execute_signal_any(&ctx, &json!({ "names": null, "opts": null })).unwrap_err();
         assert!(err.to_string().contains("requires an array of names"));
+    }
+
+    /// The actor inline wait settles a listen point in place — message
+    /// consumed, journal record appended, NO pause — so a signal-driven actor
+    /// never re-executes its history per message.
+    #[test]
+    fn actor_inline_wait_settles_listen_point_without_pausing() {
+        let ctx = RuntimeContext::new();
+        let waiter_ctx = ctx.clone();
+        ctx.set_actor_signal_waiter(crate::runtime::context::ActorSignalWaiter::new(
+            move |names, _timeout_ms| {
+                // Simulate a delivery landing while the listen point waits.
+                waiter_ctx.enqueue_live_signal(&names[0], json!({ "n": 1 }), json!("tester"));
+                crate::runtime::context::ActorSignalWait::Delivered
+            },
+        ));
+        let result = execute_signal(&ctx, &json!({ "name": "go" })).unwrap();
+        assert_eq!(result["name"], json!("go"));
+        assert_eq!(result["payload"], json!({ "n": 1 }));
+        assert!(ctx.take_pending_signal().is_none(), "must not pause");
+        let log = ctx.call_log().into_records();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].function, "signal");
+        assert_eq!(log[0].result, result);
+    }
+
+    /// An inline wait that hits the listen point's own timeout resolves with
+    /// the sentinel in place — the same record the parked path's synthetic
+    /// injection produces, so replay is indistinguishable.
+    #[test]
+    fn actor_inline_wait_timeout_resolves_sentinel_inline() {
+        let ctx = RuntimeContext::new();
+        ctx.set_actor_signal_waiter(crate::runtime::context::ActorSignalWaiter::new(
+            |_names, timeout_ms| {
+                assert_eq!(timeout_ms, Some(5), "listen timeout must reach the waiter");
+                crate::runtime::context::ActorSignalWait::TimedOut
+            },
+        ));
+        let result =
+            execute_signal(&ctx, &json!({ "name": "go", "opts": { "timeoutMs": 5 } })).unwrap();
+        assert_eq!(result, signal_timeout_sentinel(&["go".to_string()]));
+        assert!(ctx.take_pending_signal().is_none(), "must not pause");
+        let log = ctx.call_log().into_records();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].function, "signal");
+    }
+
+    /// `Park` (stop requested / idle cap) falls back to the ordinary pause
+    /// path unchanged — pending signal set, PAUSE_MARKER raised.
+    #[test]
+    fn actor_inline_wait_park_falls_back_to_pause() {
+        let ctx = RuntimeContext::new();
+        ctx.set_actor_signal_waiter(crate::runtime::context::ActorSignalWaiter::new(
+            |_names, _timeout_ms| crate::runtime::context::ActorSignalWait::Park,
+        ));
+        let err = execute_signal(&ctx, &json!({ "name": "go" })).unwrap_err();
+        assert!(err.to_string().contains(PAUSE_MARKER));
+        let pending = ctx
+            .take_pending_signal()
+            .expect("pause path must set pending");
+        assert_eq!(pending.names, vec!["go".to_string()]);
+    }
+
+    /// The fan-in listen point takes the same inline path, draining whichever
+    /// name the delivery matched.
+    #[test]
+    fn actor_inline_wait_settles_signal_any() {
+        let ctx = RuntimeContext::new();
+        let waiter_ctx = ctx.clone();
+        ctx.set_actor_signal_waiter(crate::runtime::context::ActorSignalWaiter::new(
+            move |names, _timeout_ms| {
+                assert_eq!(names.len(), 2);
+                waiter_ctx.enqueue_live_signal(&names[1], json!("payload-b"), json!(null));
+                crate::runtime::context::ActorSignalWait::Delivered
+            },
+        ));
+        let result = execute_signal_any(&ctx, &json!({ "names": ["a", "b"] })).unwrap();
+        assert_eq!(result["name"], json!("b"));
+        assert_eq!(result["payload"], json!("payload-b"));
+        assert!(ctx.take_pending_signal().is_none());
+        let log = ctx.call_log().into_records();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].function, "signal_any");
     }
 
     #[test]

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -8,7 +8,8 @@ use crate::providers::{
 };
 use crate::runtime::call_log::{CallRecord, TokenUsage};
 use crate::runtime::context::{
-    ActorSignalWait, InputMode, PendingInput, PendingSignal, RuntimeContext, PAUSE_MARKER,
+    ActorSignalWait, InputMode, PendingInput, PendingSignal, RuntimeContext, WarmInputWait,
+    PAUSE_MARKER,
 };
 use crate::runtime::memory::execute_memory_action;
 use crate::runtime::snapshot::{HostPromiseState, PendingHostOperationKind};
@@ -260,6 +261,41 @@ pub fn execute_input(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
             Ok(Value::String(response))
         }
         InputMode::Pause => {
+            // Warm resume (server flow): keep the LIVE VM parked on this
+            // thread and wait for the response instead of unwinding — the
+            // continuation costs O(1) rather than an O(history) replay
+            // re-execution. Durability is unchanged: the pending op is
+            // already on disk (begin + safepoint above), so a crash while
+            // parked resumes by replay exactly as an unwound pause would,
+            // and `Park` (eviction / capacity / no supervisor) falls back
+            // to that path immediately. The record written here is the
+            // same one the replay path's synthetic injection produces.
+            if let Some(bridge) = ctx.warm_input_bridge() {
+                let pending = PendingInput {
+                    seq,
+                    prompt: prompt.clone(),
+                };
+                match bridge.wait(ctx, &pending) {
+                    WarmInputWait::Delivered(response) => {
+                        let result = Value::String(response);
+                        ctx.resolve_host_operation(host_operation, result.clone())?;
+                        ctx.record_call(CallRecord {
+                            seq,
+                            parent_seq: None,
+                            function: "input".to_string(),
+                            args: json!({ "prompt": prompt }),
+                            result: result.clone(),
+                            duration_ms: 0,
+                            token_usage: None,
+                            timestamp: Utc::now(),
+                            error: None,
+                        });
+                        ctx.run_host_operation_completion_safepoint(host_operation)?;
+                        return Ok(result);
+                    }
+                    WarmInputWait::Park => {}
+                }
+            }
             ctx.set_pending_input(PendingInput {
                 seq,
                 prompt: prompt.clone(),

--- a/crates/chidori/src/runtime/snapshot.rs
+++ b/crates/chidori/src/runtime/snapshot.rs
@@ -16,6 +16,13 @@ pub const SNAPSHOT_MANIFEST_FILE: &str = "runtime.snapshot.json";
 pub const SNAPSHOT_BLOB_FILE: &str = "runtime.snapshot";
 pub const PENDING_HOST_OPERATION_FILE: &str = "pending.json";
 pub const HOST_PROMISE_TABLE_FILE: &str = "host_promises.json";
+/// Per-operation host-promise blobs (`host_promises/<id>.json`), one written
+/// on every state change (begin/resolve/reject). This is the O(1) hot-path
+/// alternative to rewriting the whole `host_promises.json` table per host
+/// call (which cost O(history) per call, O(history²) per run). Compaction
+/// points fold the blobs into the table file and delete them; readers union
+/// both via [`load_host_promise_records`].
+pub const HOST_PROMISE_EVENTS_PREFIX: &str = "host_promises/";
 /// Durable per-run signal mailbox. Lives in a `signals/` subdirectory of the
 /// run directory (unlike the flat `pending.json`/`host_promises.json`), so
 /// writers must create the parent dir before writing. Holds the ordered
@@ -454,6 +461,52 @@ impl HostPromiseTable {
     pub fn records(&self) -> Vec<HostPromiseRecord> {
         self.records.values().cloned().collect()
     }
+}
+
+/// Blob key for one operation's durable host-promise state.
+pub fn host_promise_blob_key(id: HostOperationId) -> String {
+    format!("{HOST_PROMISE_EVENTS_PREFIX}{}.json", id.0)
+}
+
+/// Load the durable host-promise table: the compacted `host_promises.json`
+/// base unioned with any per-operation blobs written since the last
+/// compaction. A per-op blob wins over the base entry for its id — it is
+/// strictly newer (compaction deletes the blobs it folds in, and a blob that
+/// survives a crashed compaction carries the same state the table already
+/// folded). Returns an empty vec when the run has no table at all.
+pub fn load_host_promise_records(
+    store: &dyn crate::runtime::store::RunStore,
+) -> Result<Vec<HostPromiseRecord>> {
+    let mut records: Vec<HostPromiseRecord> = match store.get_blob(HOST_PROMISE_TABLE_FILE)? {
+        Some(bytes) => serde_json::from_slice(&bytes).context("parsing host promise table")?,
+        None => Vec::new(),
+    };
+    let mut tail: Vec<HostPromiseRecord> = Vec::new();
+    for key in store.list_blobs()? {
+        if !key.starts_with(HOST_PROMISE_EVENTS_PREFIX) {
+            continue;
+        }
+        let Some(bytes) = store.get_blob(&key)? else {
+            continue;
+        };
+        match serde_json::from_slice::<HostPromiseRecord>(&bytes) {
+            Ok(record) => tail.push(record),
+            // A crash can truncate a blob mid-write; the compacted base (or
+            // the pending re-execution path) covers that operation.
+            Err(_) => continue,
+        }
+    }
+    tail.sort_by_key(|record| record.operation.id.0);
+    for record in tail {
+        match records
+            .iter_mut()
+            .find(|existing| existing.operation.id == record.operation.id)
+        {
+            Some(existing) => *existing = record,
+            None => records.push(record),
+        }
+    }
+    Ok(records)
 }
 
 /// Args comparison for completed-operation replay, ignoring derived request
@@ -1013,6 +1066,26 @@ impl SnapshotStore {
             .context("writing checkpoint")
     }
 
+    /// Fold the host-promise table into its compacted artifact: write the
+    /// full `host_promises.json` and delete the per-operation blobs it now
+    /// covers. Write-then-delete ordering keeps a crash in between harmless —
+    /// a surviving blob carries the same state the table just folded, and the
+    /// union loader lets it win by id.
+    pub fn compact_host_promises(&self, records: &[HostPromiseRecord]) -> Result<()> {
+        self.store
+            .put_blob(
+                HOST_PROMISE_TABLE_FILE,
+                &serde_json::to_vec_pretty(records)?,
+            )
+            .with_context(|| format!("writing {HOST_PROMISE_TABLE_FILE}"))?;
+        for key in self.store.list_blobs()? {
+            if key.starts_with(HOST_PROMISE_EVENTS_PREFIX) {
+                self.store.delete_blob(&key)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Write (or, when `None`, remove) the pending-host-operation artifact.
     pub fn put_pending(&self, pending: Option<&PendingHostOperation>) -> Result<()> {
         match pending {
@@ -1444,4 +1517,90 @@ fn stable_source_hash(bytes: &[u8]) -> String {
         hash = hash.wrapping_mul(FNV_PRIME);
     }
     format!("fnv1a64:{hash:016x}")
+}
+
+#[cfg(test)]
+mod host_promise_union_tests {
+    use super::*;
+    use crate::runtime::store::{FsRunStore, RunStore as _};
+
+    fn record(id: u64, state: HostPromiseState) -> HostPromiseRecord {
+        HostPromiseRecord {
+            operation: PendingHostOperation::new(
+                HostOperationId(id),
+                id,
+                PendingHostOperationKind::Prompt,
+                serde_json::json!({ "n": id }),
+            ),
+            state,
+        }
+    }
+
+    /// Pins the per-op blob ∪ compacted table protocol: a per-op blob wins
+    /// over the table entry for its id (it is strictly newer), new ids from
+    /// blobs are unioned in, and compaction folds everything into the table
+    /// file and retires the blobs.
+    #[test]
+    fn per_op_blobs_union_with_table_and_compact_away() {
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-host-promise-union-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = FsRunStore::new(&dir);
+
+        // Compacted base: op 1 still Pending.
+        store
+            .put_blob(
+                HOST_PROMISE_TABLE_FILE,
+                &serde_json::to_vec_pretty(&vec![record(1, HostPromiseState::Pending)]).unwrap(),
+            )
+            .unwrap();
+        // Per-op blobs written since: op 1 resolved, op 2 begun.
+        let resolved = record(
+            1,
+            HostPromiseState::Resolved {
+                value: serde_json::json!("done"),
+                completed_at: chrono::Utc::now(),
+            },
+        );
+        store
+            .put_blob(
+                &host_promise_blob_key(HostOperationId(1)),
+                &serde_json::to_vec_pretty(&resolved).unwrap(),
+            )
+            .unwrap();
+        store
+            .put_blob(
+                &host_promise_blob_key(HostOperationId(2)),
+                &serde_json::to_vec_pretty(&record(2, HostPromiseState::Pending)).unwrap(),
+            )
+            .unwrap();
+
+        let records = load_host_promise_records(&store).unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(matches!(
+            records[0].state,
+            HostPromiseState::Resolved { .. }
+        ));
+        assert!(matches!(records[1].state, HostPromiseState::Pending));
+
+        // Compaction folds the union into the table file and retires the blobs.
+        SnapshotStore::new(&dir)
+            .compact_host_promises(&records)
+            .unwrap();
+        assert!(!store
+            .list_blobs()
+            .unwrap()
+            .iter()
+            .any(|key| key.starts_with(HOST_PROMISE_EVENTS_PREFIX)));
+        let reloaded = load_host_promise_records(&store).unwrap();
+        assert_eq!(reloaded.len(), 2);
+        assert!(matches!(
+            reloaded[0].state,
+            HostPromiseState::Resolved { .. }
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/chidori/src/runtime/snapshot.rs
+++ b/crates/chidori/src/runtime/snapshot.rs
@@ -977,32 +977,57 @@ impl SnapshotStore {
         manifest: &SnapshotManifest,
         call_log: &[CallRecord],
     ) -> Result<()> {
+        self.put_manifest(manifest)?;
+        self.write_call_log(call_log)?;
+        self.put_pending(manifest.pending.as_ref())
+    }
+
+    /// Write just the snapshot blob under the manifest's blob file name.
+    /// The blob is run-invariant (the durable code bundle), so per-safepoint
+    /// persisters write it once per run instead of on every safepoint.
+    pub fn put_snapshot_blob(&self, manifest: &SnapshotManifest, blob: &[u8]) -> Result<()> {
+        self.store
+            .put_blob(&manifest.snapshot_file, blob)
+            .with_context(|| format!("writing snapshot blob {}", manifest.snapshot_file))
+    }
+
+    /// Write just the manifest artifact.
+    pub fn put_manifest(&self, manifest: &SnapshotManifest) -> Result<()> {
         self.store
             .put_blob(
                 SNAPSHOT_MANIFEST_FILE,
                 &serde_json::to_vec_pretty(manifest)?,
             )
-            .with_context(|| format!("writing {SNAPSHOT_MANIFEST_FILE}"))?;
+            .with_context(|| format!("writing {SNAPSHOT_MANIFEST_FILE}"))
+    }
 
+    /// Write the full-log checkpoint artifact (compacting the append-only
+    /// journal to match). O(history) — callers on per-effect paths should
+    /// reach for this only when the in-memory log holds records the O(1)
+    /// journal appends did not cover (see `RuntimeContext::record_call` /
+    /// `try_replay`), or at explicit compaction points (run start, pause,
+    /// settle).
+    pub fn write_call_log(&self, call_log: &[CallRecord]) -> Result<()> {
         self.store
             .write_call_log(call_log)
-            .context("writing checkpoint")?;
+            .context("writing checkpoint")
+    }
 
-        match &manifest.pending {
+    /// Write (or, when `None`, remove) the pending-host-operation artifact.
+    pub fn put_pending(&self, pending: Option<&PendingHostOperation>) -> Result<()> {
+        match pending {
             Some(pending) => self
                 .store
                 .put_blob(
                     PENDING_HOST_OPERATION_FILE,
                     &serde_json::to_vec_pretty(pending)?,
                 )
-                .with_context(|| format!("writing {PENDING_HOST_OPERATION_FILE}"))?,
+                .with_context(|| format!("writing {PENDING_HOST_OPERATION_FILE}")),
             None => self
                 .store
                 .delete_blob(PENDING_HOST_OPERATION_FILE)
-                .with_context(|| format!("removing {PENDING_HOST_OPERATION_FILE}"))?,
+                .with_context(|| format!("removing {PENDING_HOST_OPERATION_FILE}")),
         }
-
-        Ok(())
     }
 
     pub fn load(&self) -> Result<RuntimeSnapshot> {

--- a/crates/chidori/src/runtime/store.rs
+++ b/crates/chidori/src/runtime/store.rs
@@ -55,8 +55,10 @@ pub trait RunStore: Send + Sync + std::fmt::Debug {
     fn append_record(&self, record: &CallRecord) -> Result<()>;
 
     /// Replace the whole journal with `records` (order-preserving). Called at
-    /// host-operation safepoints and merges; doubles as compaction of the
-    /// append-only artifact.
+    /// compaction points — run start after a resume replay, pause, settle,
+    /// branch merges, and any safepoint where the in-memory log holds records
+    /// the appends didn't cover (`RuntimeContext::call_log_checkpoint_dirty`).
+    /// Steady-state per-effect persistence is `append_record` alone.
     fn write_call_log(&self, records: &[CallRecord]) -> Result<()>;
 
     /// Load the journal: the last full checkpoint unioned with any appended

--- a/crates/chidori/src/runtime/store.rs
+++ b/crates/chidori/src/runtime/store.rs
@@ -530,6 +530,12 @@ impl RunStore for SqliteRunStore {
 pub struct HttpRunStore {
     relay: Arc<HttpRelay>,
     run_id: String,
+    /// Pipeline appends through the relay instead of blocking a network
+    /// round-trip per record. Off under `CHIDORI_DURABILITY=strict`, which
+    /// wants every append acknowledged before the next effect runs; in the
+    /// default besteffort mode the `flush()` barrier at pause/settle is the
+    /// durability gate (`RunStore::flush` contract).
+    pipelined: bool,
 }
 
 impl HttpRunStore {
@@ -537,6 +543,7 @@ impl HttpRunStore {
         Self {
             relay,
             run_id: run_id.into(),
+            pipelined: !strict_durability(),
         }
     }
 
@@ -578,8 +585,35 @@ struct HttpRelayRequest {
     content_type: &'static str,
     /// Extra headers, verbatim — the S3 backend's SigV4 signature headers.
     headers: Vec<(String, String)>,
-    reply: std::sync::mpsc::Sender<Result<(u16, Vec<u8>)>>,
+    reply: RelayReply,
 }
+
+enum RelayReply {
+    /// Caller blocks on the outcome.
+    Sync(std::sync::mpsc::Sender<Result<(u16, Vec<u8>)>>),
+    /// Pipelined: the outcome lands in the relay's shared async state; the
+    /// caller surfaces failures at the next [`HttpRelay::barrier`] (the
+    /// `RunStore::flush` durability gate). `describe` labels the request in
+    /// the collected error; `tolerate_not_found` treats a 404 as success
+    /// (deleting an absent blob is Ok, matching the sync paths).
+    Async {
+        describe: String,
+        tolerate_not_found: bool,
+    },
+}
+
+/// Bookkeeping for pipelined relay requests: how many are still in the
+/// relay's queue/network, and the failures collected so far.
+#[derive(Default)]
+struct AsyncRelayState {
+    in_flight: usize,
+    errors: Vec<String>,
+}
+
+/// Backpressure bound on pipelined requests: an agent producing records
+/// faster than the mirror's network drains them blocks here instead of
+/// growing the relay queue without limit.
+const RELAY_MAX_IN_FLIGHT: usize = 128;
 
 /// The dedicated request thread + its channel. Owning the blocking client on
 /// a plain thread sidesteps every "blocking client inside an async runtime"
@@ -587,6 +621,7 @@ struct HttpRelayRequest {
 pub struct HttpRelay {
     base_url: String,
     sender: std::sync::mpsc::Sender<HttpRelayRequest>,
+    async_state: Arc<(Mutex<AsyncRelayState>, std::sync::Condvar)>,
 }
 
 impl std::fmt::Debug for HttpRelay {
@@ -607,6 +642,8 @@ impl HttpRelay {
     pub fn new(base_url: impl Into<String>, token: Option<String>) -> Arc<Self> {
         let base_url = base_url.into().trim_end_matches('/').to_string();
         let (sender, receiver) = std::sync::mpsc::channel::<HttpRelayRequest>();
+        let async_state: Arc<(Mutex<AsyncRelayState>, std::sync::Condvar)> = Arc::default();
+        let worker_async_state = async_state.clone();
         std::thread::Builder::new()
             .name("chidori-run-store-relay".to_string())
             .spawn(move || {
@@ -616,45 +653,76 @@ impl HttpRelay {
                 for request in receiver {
                     let result = match &client {
                         Ok(client) => {
-                            let mut builder = match request.method {
-                                "GET" => client.get(&request.url),
-                                "PUT" => client.put(&request.url),
-                                "POST" => client.post(&request.url),
-                                "DELETE" => client.delete(&request.url),
-                                other => {
-                                    let _ = request.reply.send(Err(anyhow::anyhow!(
-                                        "unsupported relay method {other}"
-                                    )));
-                                    continue;
-                                }
+                            let builder = match request.method {
+                                "GET" => Some(client.get(&request.url)),
+                                "PUT" => Some(client.put(&request.url)),
+                                "POST" => Some(client.post(&request.url)),
+                                "DELETE" => Some(client.delete(&request.url)),
+                                _ => None,
                             };
-                            if let Some(ref token) = token {
-                                builder = builder.bearer_auth(token);
+                            match builder {
+                                None => Err(anyhow::anyhow!(
+                                    "unsupported relay method {}",
+                                    request.method
+                                )),
+                                Some(mut builder) => {
+                                    if let Some(ref token) = token {
+                                        builder = builder.bearer_auth(token);
+                                    }
+                                    for (name, value) in &request.headers {
+                                        builder = builder.header(name, value);
+                                    }
+                                    if let Some(body) = request.body {
+                                        builder = builder
+                                            .header("content-type", request.content_type)
+                                            .body(body);
+                                    }
+                                    builder.send().map_err(anyhow::Error::from).and_then(
+                                        |response| {
+                                            let status = response.status().as_u16();
+                                            let bytes =
+                                                response.bytes().map_err(anyhow::Error::from)?;
+                                            Ok((status, bytes.to_vec()))
+                                        },
+                                    )
+                                }
                             }
-                            for (name, value) in &request.headers {
-                                builder = builder.header(name, value);
-                            }
-                            if let Some(body) = request.body {
-                                builder = builder
-                                    .header("content-type", request.content_type)
-                                    .body(body);
-                            }
-                            builder
-                                .send()
-                                .map_err(anyhow::Error::from)
-                                .and_then(|response| {
-                                    let status = response.status().as_u16();
-                                    let bytes = response.bytes().map_err(anyhow::Error::from)?;
-                                    Ok((status, bytes.to_vec()))
-                                })
                         }
                         Err(err) => Err(anyhow::anyhow!("building relay http client: {err}")),
                     };
-                    let _ = request.reply.send(result);
+                    match request.reply {
+                        RelayReply::Sync(tx) => {
+                            let _ = tx.send(result);
+                        }
+                        RelayReply::Async {
+                            describe,
+                            tolerate_not_found,
+                        } => {
+                            let (lock, cvar) = &*worker_async_state;
+                            let mut state = lock.lock().unwrap();
+                            state.in_flight -= 1;
+                            match result {
+                                Ok((404, _)) if tolerate_not_found => {}
+                                Ok((status, body)) if !(200..300).contains(&status) => {
+                                    state.errors.push(format!(
+                                        "{describe}: HTTP {status} {}",
+                                        String::from_utf8_lossy(&body)
+                                    ));
+                                }
+                                Err(err) => state.errors.push(format!("{describe}: {err}")),
+                                Ok(_) => {}
+                            }
+                            cvar.notify_all();
+                        }
+                    }
                 }
             })
             .expect("spawning run-store relay thread");
-        Arc::new(Self { base_url, sender })
+        Arc::new(Self {
+            base_url,
+            sender,
+            async_state,
+        })
     }
 
     fn request(
@@ -694,12 +762,72 @@ impl HttpRelay {
                 body,
                 content_type,
                 headers,
-                reply,
+                reply: RelayReply::Sync(reply),
             })
             .map_err(|_| anyhow::anyhow!("run-store relay thread is gone"))?;
         receive
             .recv()
             .map_err(|_| anyhow::anyhow!("run-store relay dropped the reply"))?
+    }
+
+    /// Pipelined request: enqueue and return immediately, without waiting for
+    /// the network round-trip. The relay worker is a single FIFO thread, so
+    /// ordering against later sync requests (checkpoint PUTs, loads) is
+    /// preserved. Outcomes are collected in the relay's async state and
+    /// surfaced by [`Self::barrier`]. Bounded by [`RELAY_MAX_IN_FLIGHT`].
+    pub(crate) fn request_async(
+        &self,
+        method: &'static str,
+        url: String,
+        body: Option<Vec<u8>>,
+        content_type: &'static str,
+        headers: Vec<(String, String)>,
+        tolerate_not_found: bool,
+    ) -> Result<()> {
+        {
+            let (lock, cvar) = &*self.async_state;
+            let mut state = lock.lock().unwrap();
+            while state.in_flight >= RELAY_MAX_IN_FLIGHT {
+                state = cvar.wait(state).unwrap();
+            }
+            state.in_flight += 1;
+        }
+        let describe = format!("{method} {url}");
+        self.sender
+            .send(HttpRelayRequest {
+                method,
+                url,
+                body,
+                content_type,
+                headers,
+                reply: RelayReply::Async {
+                    describe,
+                    tolerate_not_found,
+                },
+            })
+            .map_err(|_| {
+                let (lock, cvar) = &*self.async_state;
+                lock.lock().unwrap().in_flight -= 1;
+                cvar.notify_all();
+                anyhow::anyhow!("run-store relay thread is gone")
+            })
+    }
+
+    /// Durability barrier for pipelined requests: waits until every
+    /// [`Self::request_async`] has completed, then surfaces any collected
+    /// failures (draining them).
+    pub(crate) fn barrier(&self) -> Result<()> {
+        let (lock, cvar) = &*self.async_state;
+        let mut state = lock.lock().unwrap();
+        while state.in_flight > 0 {
+            state = cvar.wait(state).unwrap();
+        }
+        if state.errors.is_empty() {
+            Ok(())
+        } else {
+            let errors = std::mem::take(&mut state.errors);
+            anyhow::bail!("run-store mirror writes failed: {}", errors.join("; "))
+        }
     }
 
     fn expect_ok(&self, method: &'static str, url: String, body: Option<Vec<u8>>) -> Result<()> {
@@ -725,6 +853,16 @@ impl HttpRelay {
 
 impl RunStore for HttpRunStore {
     fn append_record(&self, record: &CallRecord) -> Result<()> {
+        if self.pipelined {
+            return self.relay.request_async(
+                "POST",
+                self.records_url(),
+                Some(serde_json::to_vec(record)?),
+                "application/json",
+                Vec::new(),
+                false,
+            );
+        }
         self.relay.expect_ok(
             "POST",
             self.records_url(),
@@ -757,6 +895,16 @@ impl RunStore for HttpRunStore {
     }
 
     fn put_blob(&self, key: &str, bytes: &[u8]) -> Result<()> {
+        if self.pipelined {
+            return self.relay.request_async(
+                "PUT",
+                self.blob_url(key),
+                Some(bytes.to_vec()),
+                "application/octet-stream",
+                Vec::new(),
+                false,
+            );
+        }
         let (status, body) = self.relay.request_typed(
             "PUT",
             self.blob_url(key),
@@ -783,6 +931,16 @@ impl RunStore for HttpRunStore {
     }
 
     fn delete_blob(&self, key: &str) -> Result<()> {
+        if self.pipelined {
+            return self.relay.request_async(
+                "DELETE",
+                self.blob_url(key),
+                None,
+                "application/json",
+                Vec::new(),
+                true,
+            );
+        }
         let (status, _) = self.relay.request("DELETE", self.blob_url(key), None)?;
         if status == 404 || (200..300).contains(&status) {
             Ok(())
@@ -805,6 +963,13 @@ impl RunStore for HttpRunStore {
     }
 
     fn flush(&self) -> Result<()> {
+        // Surface pipelined-append failures at the durability gate. Only the
+        // besteffort mode pipelines (strict appends stay synchronous), and
+        // besteffort's contract is log-and-continue — matching what the
+        // per-append error handling did before pipelining.
+        if let Err(err) = self.relay.barrier() {
+            tracing::warn!(run_id = %self.run_id, error = %err, "durable mirror pipelined writes failed");
+        }
         Ok(())
     }
 }
@@ -1400,6 +1565,31 @@ mod tests {
             timestamp: chrono::Utc::now(),
             error: None,
         }
+    }
+
+    /// Pipelined appends never block or fail the hot path on mirror trouble:
+    /// the enqueue succeeds, the failure is collected at the relay barrier,
+    /// and the besteffort `flush()` logs and continues (matching the
+    /// pre-pipelining per-append warn-and-continue contract).
+    #[test]
+    fn pipelined_append_failures_surface_at_barrier_not_on_the_hot_path() {
+        // Port 1 on loopback: nothing listens there, connections are refused.
+        let relay = HttpRelay::new("http://127.0.0.1:1", None);
+        let store = HttpRunStore::new(relay.clone(), "run-pipelined-test");
+        if !store.pipelined {
+            // CHIDORI_DURABILITY=strict in the environment disables
+            // pipelining; the sync path is covered by the conformance tests.
+            return;
+        }
+        store.append_record(&record(1, "prompt")).unwrap();
+        store.append_record(&record(2, "tool")).unwrap();
+        let err = relay.barrier().expect_err("both appends must have failed");
+        assert!(err.to_string().contains("mirror writes failed"));
+        // Errors were drained; a second barrier is clean, and flush() on a
+        // fresh failure logs instead of failing.
+        relay.barrier().unwrap();
+        store.append_record(&record(3, "tool")).unwrap();
+        store.flush().unwrap();
     }
 
     fn conformance(store: &dyn RunStore) {

--- a/crates/chidori/src/runtime/store.rs
+++ b/crates/chidori/src/runtime/store.rs
@@ -373,6 +373,12 @@ impl SqliteRunStoreShared {
 pub struct SqliteRunStore {
     shared: Arc<SqliteRunStoreShared>,
     run_id: String,
+    /// Next `pos` ordinal for this handle's appends. Seeded from `MAX(pos)+1`
+    /// on first use and tracked in memory afterwards: `pos` has no index, so
+    /// the old per-append `MAX(pos)` subquery scanned every one of the run's
+    /// rows — O(history) per append, O(history²) per run. Lock order is
+    /// always `conn` before `next_pos`.
+    next_pos: Mutex<Option<i64>>,
 }
 
 impl SqliteRunStore {
@@ -380,6 +386,7 @@ impl SqliteRunStore {
         Self {
             shared,
             run_id: run_id.into(),
+            next_pos: Mutex::new(None),
         }
     }
 }
@@ -388,14 +395,25 @@ impl RunStore for SqliteRunStore {
     fn append_record(&self, record: &CallRecord) -> Result<()> {
         let data = serde_json::to_string(record)?;
         let conn = self.shared.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO run_records (run_id, seq, pos, data)
-             VALUES (?1, ?2,
-                     COALESCE((SELECT MAX(pos) FROM run_records WHERE run_id = ?1), 0) + 1,
-                     ?3)
+        let mut next_pos = self.next_pos.lock().unwrap();
+        let pos = match *next_pos {
+            Some(pos) => pos,
+            None => {
+                let mut stmt = conn.prepare_cached(
+                    "SELECT COALESCE(MAX(pos), 0) + 1 FROM run_records WHERE run_id = ?1",
+                )?;
+                stmt.query_row(rusqlite::params![self.run_id], |row| row.get(0))?
+            }
+        };
+        // Re-appending an existing seq (a synthetic resume record) keeps its
+        // original `pos` via the conflict clause; the skipped ordinal is a
+        // harmless gap — loads order by (pos, seq).
+        let mut stmt = conn.prepare_cached(
+            "INSERT INTO run_records (run_id, seq, pos, data) VALUES (?1, ?2, ?3, ?4)
              ON CONFLICT(run_id, seq) DO UPDATE SET data = excluded.data",
-            rusqlite::params![self.run_id, record.seq as i64, data],
         )?;
+        stmt.execute(rusqlite::params![self.run_id, record.seq as i64, pos, data])?;
+        *next_pos = Some(pos + 1);
         Ok(())
     }
 
@@ -406,20 +424,24 @@ impl RunStore for SqliteRunStore {
             "DELETE FROM run_records WHERE run_id = ?1",
             rusqlite::params![self.run_id],
         )?;
-        for (pos, record) in records.iter().enumerate() {
-            tx.execute(
+        {
+            let mut stmt = tx.prepare_cached(
                 "INSERT INTO run_records (run_id, seq, pos, data) VALUES (?1, ?2, ?3, ?4)
                  ON CONFLICT(run_id, seq) DO UPDATE SET
                      pos = excluded.pos, data = excluded.data",
-                rusqlite::params![
+            )?;
+            for (pos, record) in records.iter().enumerate() {
+                stmt.execute(rusqlite::params![
                     self.run_id,
                     record.seq as i64,
                     pos as i64,
                     serde_json::to_string(record)?
-                ],
-            )?;
+                ])?;
+            }
         }
         tx.commit()?;
+        // The rewrite renumbered `pos` to 0..len; continue appends from there.
+        *self.next_pos.lock().unwrap() = Some(records.len() as i64);
         Ok(())
     }
 

--- a/crates/chidori/src/runtime/store_blob.rs
+++ b/crates/chidori/src/runtime/store_blob.rs
@@ -255,13 +255,15 @@ impl S3BlobStore {
 
     /// Send one signed request. `key` is bucket-relative ("" for a bucket-level
     /// operation like LIST); `query` must be the exact query the request uses.
-    fn signed(
+    /// Build the SigV4-signed request parts (url, headers, content type)
+    /// without sending — shared by the sync and pipelined paths.
+    fn build_signed(
         &self,
         method: &'static str,
         key: &str,
         query: &[(String, String)],
         body: Option<&[u8]>,
-    ) -> Result<(u16, Vec<u8>)> {
+    ) -> Result<(String, Vec<(String, String)>, &'static str)> {
         let now = chrono::Utc::now();
         let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
         let date = now.format("%Y%m%d").to_string();
@@ -345,8 +347,42 @@ impl S3BlobStore {
         } else {
             format!("{}{canonical_uri}?{canonical_query}", self.endpoint)
         };
+        Ok((url, headers, content_type))
+    }
+
+    fn signed(
+        &self,
+        method: &'static str,
+        key: &str,
+        query: &[(String, String)],
+        body: Option<&[u8]>,
+    ) -> Result<(u16, Vec<u8>)> {
+        let (url, headers, content_type) = self.build_signed(method, key, query, body)?;
         self.relay
             .request_full(method, url, body.map(<[u8]>::to_vec), content_type, headers)
+    }
+
+    /// Pipelined PUT: signed like [`Self::signed`] but enqueued without
+    /// waiting for the round-trip; outcomes surface at the relay's barrier
+    /// (the `RunStore::flush` durability gate).
+    fn put_object_async(&self, key: &str, bytes: &[u8]) -> Result<()> {
+        let (url, headers, content_type) = self.build_signed("PUT", key, &[], Some(bytes))?;
+        self.relay.request_async(
+            "PUT",
+            url,
+            Some(bytes.to_vec()),
+            content_type,
+            headers,
+            false,
+        )
+    }
+
+    /// Pipelined DELETE; a 404 counts as success, matching
+    /// [`Self::delete_object`].
+    fn delete_object_async(&self, key: &str) -> Result<()> {
+        let (url, headers, content_type) = self.build_signed("DELETE", key, &[], None)?;
+        self.relay
+            .request_async("DELETE", url, None, content_type, headers, true)
     }
 }
 
@@ -413,6 +449,11 @@ fn xml_unescape(value: &str) -> String {
 pub struct BlobRunStore {
     store: Arc<S3BlobStore>,
     run_id: String,
+    /// Pipeline record appends through the relay instead of blocking one
+    /// network round-trip per record. Off under `CHIDORI_DURABILITY=strict`;
+    /// in besteffort mode the `flush()` barrier at pause/settle is the
+    /// durability gate (`RunStore::flush` contract).
+    pipelined: bool,
 }
 
 impl BlobRunStore {
@@ -420,6 +461,7 @@ impl BlobRunStore {
         Self {
             store,
             run_id: run_id.into(),
+            pipelined: !crate::runtime::store::strict_durability(),
         }
     }
 
@@ -437,8 +479,12 @@ impl RunStore for BlobRunStore {
         // One object per record: object stores have no append primitive, so
         // the journal tail is a keyspace and an append is a single PUT.
         // Re-appending a seq overwrites its object, matching the contract.
-        self.store
-            .put_object(&self.record_key(record.seq), &serde_json::to_vec(record)?)
+        let key = self.record_key(record.seq);
+        let bytes = serde_json::to_vec(record)?;
+        if self.pipelined {
+            return self.store.put_object_async(&key, &bytes);
+        }
+        self.store.put_object(&key, &bytes)
     }
 
     fn write_call_log(&self, records: &[CallRecord]) -> Result<()> {
@@ -478,8 +524,11 @@ impl RunStore for BlobRunStore {
     }
 
     fn put_blob(&self, key: &str, bytes: &[u8]) -> Result<()> {
-        self.store
-            .put_object(&self.run_key(&format!("blobs/{key}")), bytes)
+        let object_key = self.run_key(&format!("blobs/{key}"));
+        if self.pipelined {
+            return self.store.put_object_async(&object_key, bytes);
+        }
+        self.store.put_object(&object_key, bytes)
     }
 
     fn get_blob(&self, key: &str) -> Result<Option<Vec<u8>>> {
@@ -488,8 +537,11 @@ impl RunStore for BlobRunStore {
     }
 
     fn delete_blob(&self, key: &str) -> Result<()> {
-        self.store
-            .delete_object(&self.run_key(&format!("blobs/{key}")))
+        let object_key = self.run_key(&format!("blobs/{key}"));
+        if self.pipelined {
+            return self.store.delete_object_async(&object_key);
+        }
+        self.store.delete_object(&object_key)
     }
 
     fn list_blobs(&self) -> Result<Vec<String>> {
@@ -502,6 +554,12 @@ impl RunStore for BlobRunStore {
     }
 
     fn flush(&self) -> Result<()> {
+        // Surface pipelined-append failures at the durability gate; only
+        // besteffort mode pipelines, and its contract is log-and-continue —
+        // matching the pre-pipelining per-append error handling.
+        if let Err(err) = self.store.relay.barrier() {
+            tracing::warn!(run_id = %self.run_id, error = %err, "s3 mirror pipelined writes failed");
+        }
         Ok(())
     }
 }

--- a/crates/chidori/src/runtime/typescript/module_graph.rs
+++ b/crates/chidori/src/runtime/typescript/module_graph.rs
@@ -24,15 +24,7 @@ pub fn snapshot_module_fingerprints(
     source: &str,
     policy: &RuntimePolicy,
 ) -> Result<Vec<SourceFingerprint>> {
-    let entry_path = stable_path(path);
-    let mut builder = SnapshotModuleBuilder::new(policy);
-    builder.collect(path, source)?;
-    Ok(builder
-        .modules
-        .iter()
-        .filter(|module| module.path != entry_path)
-        .map(|module| SourceFingerprint::from_source(module.path.clone(), &module.source))
-        .collect())
+    Ok(snapshot_modules(path, source, policy)?.0)
 }
 
 /// The full module import graph (entry + dependencies) for the manifest.
@@ -41,9 +33,28 @@ pub fn snapshot_module_graph(
     source: &str,
     policy: &RuntimePolicy,
 ) -> Result<Vec<SnapshotModuleGraphEntry>> {
+    Ok(snapshot_modules(path, source, policy)?.1)
+}
+
+/// Both manifest views of the module walk — dependency fingerprints and the
+/// full import graph — from a single collection pass, so callers that need
+/// both (the per-run scaffold persister) read each module file once instead
+/// of twice.
+pub fn snapshot_modules(
+    path: &Path,
+    source: &str,
+    policy: &RuntimePolicy,
+) -> Result<(Vec<SourceFingerprint>, Vec<SnapshotModuleGraphEntry>)> {
+    let entry_path = stable_path(path);
     let mut builder = SnapshotModuleBuilder::new(policy);
     builder.collect(path, source)?;
-    Ok(builder
+    let fingerprints = builder
+        .modules
+        .iter()
+        .filter(|module| module.path != entry_path)
+        .map(|module| SourceFingerprint::from_source(module.path.clone(), &module.source))
+        .collect();
+    let graph = builder
         .modules
         .iter()
         .map(|module| SnapshotModuleGraphEntry {
@@ -57,7 +68,8 @@ pub fn snapshot_module_graph(
                 })
                 .collect(),
         })
-        .collect())
+        .collect();
+    Ok((fingerprints, graph))
 }
 
 struct SnapshotModuleBuilder<'policy> {

--- a/crates/chidori/src/runtime/typescript/transpile.rs
+++ b/crates/chidori/src/runtime/typescript/transpile.rs
@@ -102,32 +102,46 @@ pub fn transpile_module(path: &Path, source: &str, options: &TranspileOptions) -
     // output is memoized process-wide. This is the dominant fixed cost paid on
     // EVERY agent execution: initial runs, every pause→resume re-execution,
     // tool files, sub-agents, branch waves/resumes, and each imported module —
-    // all re-transpile byte-identical sources today. Keyed by the full
-    // `(path, source)` pair (hash + equality via the map), so a hit can never
-    // alias distinct inputs; only successes are cached (errors are cheap and
+    // all re-transpile byte-identical sources today. Keyed by path with the
+    // source matched by full string equality, so a hit can never alias
+    // distinct inputs; only successes are cached (errors are cheap and
     // deterministic to recompute).
     {
         let cache = transpile_cache().lock().expect("transpile cache poisoned");
-        if let Some(js) = cache.get(&(path.to_path_buf(), source.to_string())) {
-            return Ok(js.clone());
+        if let Some(entries) = cache.get(path) {
+            if let Some((_, js)) = entries.iter().find(|(cached, _)| cached == source) {
+                return Ok(js.clone());
+            }
         }
     }
     let js = transpile_source(path, source)?;
     {
         let mut cache = transpile_cache().lock().expect("transpile cache poisoned");
         // Bound the cache; a process sees dozens of distinct module sources.
-        // Clearing wholesale at the cap is simpler than LRU and has no
+        // Clearing wholesale at the caps is simpler than LRU and has no
         // order-dependent behavior.
         if cache.len() >= 256 {
             cache.clear();
         }
-        cache.insert((path.to_path_buf(), source.to_string()), js.clone());
+        let entries = cache.entry(path.to_path_buf()).or_default();
+        if entries.len() >= 8 {
+            entries.clear();
+        }
+        entries.push((source.to_string(), js.clone()));
     }
     Ok(js)
 }
 
-fn transpile_cache() -> &'static std::sync::Mutex<HashMap<(PathBuf, String), String>> {
-    static CACHE: std::sync::OnceLock<std::sync::Mutex<HashMap<(PathBuf, String), String>>> =
+/// Keyed by path, with the source carried in the per-path entries and matched
+/// by FULL string equality — a hit can never alias distinct inputs. The
+/// two-level shape lets a lookup borrow `&Path`/`&str` directly: the old
+/// `(PathBuf, String)` key forced a heap copy of the whole source (and a hash
+/// over every byte of it) on EVERY probe, hits included — per module, per
+/// execution, per resume.
+type TranspileCache = HashMap<PathBuf, Vec<(String, String)>>;
+
+fn transpile_cache() -> &'static std::sync::Mutex<TranspileCache> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<TranspileCache>> =
         std::sync::OnceLock::new();
     CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -62,6 +62,144 @@ struct AppState {
     /// inbox mutation atomic, matching how the server already serializes per-run
     /// state. See `docs/signals.md` §11.
     signal_inbox_locks: Arc<StdMutex<HashMap<String, Arc<StdMutex<()>>>>>,
+    /// Warm-parked runs by SESSION id (`docs/resume-performance.md` §5): while
+    /// a run is parked at an `input()` pause its VM stays live on its blocking
+    /// thread, and `/resume` delivers the response through `resolution`
+    /// instead of replaying the whole history. Entries degrade gracefully —
+    /// removing one (cancel, eviction, restart) drops the resolution sender,
+    /// the parked bridge wakes with `Park`, and the run unwinds into the
+    /// classic replay-resume artifact.
+    warm_runs: Arc<StdMutex<HashMap<String, Arc<WarmRun>>>>,
+    /// How long a warm-parked run waits for its resume before evicting itself
+    /// back to the unwind path (freeing the thread and VM).
+    warm_evict: std::time::Duration,
+}
+
+/// One session's warm run: the channel its parked engine thread listens on
+/// (`Some` exactly while parked at an input pause) and the stream of leg
+/// outcomes — one `RunResult` per pause plus the terminal result.
+struct WarmRun {
+    resolution: StdMutex<Option<std::sync::mpsc::Sender<String>>>,
+    outcomes: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<anyhow::Result<RunResult>>>,
+}
+
+/// Kill switch: `CHIDORI_WARM_RESUME=0|false|off` restores unwind-and-replay
+/// for every pause.
+fn warm_resume_enabled() -> bool {
+    !matches!(
+        std::env::var("CHIDORI_WARM_RESUME").as_deref(),
+        Ok("0") | Ok("false") | Ok("off")
+    )
+}
+
+fn warm_evict_from_env() -> std::time::Duration {
+    let ms = std::env::var("CHIDORI_WARM_RESUME_EVICT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(600_000);
+    std::time::Duration::from_millis(ms)
+}
+
+/// Register a fresh warm run for `session_id` (replacing any stale entry) and
+/// build the [`WarmInputBridge`] its engine leg installs: on an `input()`
+/// pause the bridge surfaces a paused `RunResult` on the outcome channel —
+/// the exact shape the unwind path returns — and parks the engine thread
+/// awaiting the response. The caller spawns the leg and forwards its final
+/// result into the same outcome channel, so each HTTP request consumes
+/// exactly one outcome.
+fn install_warm_run(
+    state: &AppState,
+    session_id: &str,
+) -> (
+    Arc<WarmRun>,
+    tokio::sync::mpsc::UnboundedSender<anyhow::Result<RunResult>>,
+    crate::runtime::context::WarmInputBridge,
+) {
+    let (outcome_tx, outcome_rx) = tokio::sync::mpsc::unbounded_channel();
+    let warm = Arc::new(WarmRun {
+        resolution: StdMutex::new(None),
+        outcomes: tokio::sync::Mutex::new(outcome_rx),
+    });
+    state
+        .warm_runs
+        .lock()
+        .unwrap()
+        .insert(session_id.to_string(), warm.clone());
+    // The bridge holds only a WEAK reference to the entry: the resolution
+    // sender lives inside `WarmRun`, so if the bridge kept a strong Arc the
+    // parked thread would hold its own wake channel alive and a dropped
+    // entry (cancel, restart, server shutdown, test teardown) could never
+    // disconnect it. With the weak ref, removing the entry from the map
+    // drops the sender and the parked thread wakes with `Park` immediately.
+    let bridge_warm = Arc::downgrade(&warm);
+    let bridge_outcomes = outcome_tx.clone();
+    let evict = state.warm_evict;
+    let bridge_run_base = state.run_base.clone();
+    let bridge = crate::runtime::context::WarmInputBridge::new(move |ctx, pending| {
+        use crate::runtime::context::WarmInputWait;
+        // The pause becomes externally visible when the outcome surfaces, so
+        // drain the durability barrier first (mirror pipelines included) —
+        // the same output gate the unwind path runs at a pause.
+        if ctx.flush_store().is_err() {
+            return WarmInputWait::Park;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        {
+            let Some(warm) = bridge_warm.upgrade() else {
+                return WarmInputWait::Park;
+            };
+            *warm.resolution.lock().unwrap() = Some(tx);
+            // The Arc drops here: while parked, this thread must NOT keep the
+            // entry (and thus its own sender) alive.
+        }
+        let leg = Ok(RunResult {
+            output: Value::Null,
+            call_log: ctx.call_log(),
+            run_id: ctx.run_id(),
+            paused: Some(pending.clone()),
+            paused_approval: None,
+            paused_signal: None,
+        });
+        if bridge_outcomes.send(leg).is_err() {
+            if let Some(warm) = bridge_warm.upgrade() {
+                *warm.resolution.lock().unwrap() = None;
+            }
+            return WarmInputWait::Park;
+        }
+        let outcome = match rx.recv_timeout(evict) {
+            Ok(response) => {
+                // Reload the durable signal inbox before continuing: a signal
+                // delivered while this run was parked landed in
+                // `signals/inbox.json` (the server enqueues around paused
+                // runs), which the live VM's in-memory inbox cannot see. The
+                // file is the union — live drains re-persist it — so the
+                // reload is exactly what a replay resume would have seeded.
+                let run_id = ctx.run_id();
+                ctx.set_signal_inbox(load_persisted_signal_inbox(&bridge_run_base, Some(&run_id)));
+                WarmInputWait::Delivered(response)
+            }
+            // Eviction deadline, or the entry was dropped (cancel/restart/
+            // shutdown — the sender disconnects): unwind into the ordinary
+            // paused artifact; a later /resume replays. The engine thread
+            // and VM are reclaimed.
+            Err(_) => WarmInputWait::Park,
+        };
+        if let Some(warm) = bridge_warm.upgrade() {
+            *warm.resolution.lock().unwrap() = None;
+        }
+        outcome
+    });
+    (warm, outcome_tx, bridge)
+}
+
+/// Drop a session's warm entry when its run settled terminally (or its live
+/// leg is gone), so the map holds only parked/parkable runs.
+fn release_warm_run_if_settled(state: &AppState, session: &StoredSession) {
+    if !matches!(session.status, SessionStatus::Paused) {
+        // Completed / Failed / AwaitingApproval / Cancelled: the leg ended (an
+        // approval pause always unwinds), so nothing is parked to deliver to.
+        state.warm_runs.lock().unwrap().remove(&session.id);
+    }
 }
 
 impl AppState {
@@ -503,6 +641,8 @@ pub async fn serve(
         acquire_timeout: std::time::Duration::from_millis(acquire_timeout_ms),
         active_sessions: Arc::new(StdMutex::new(HashMap::new())),
         signal_inbox_locks: Arc::new(StdMutex::new(HashMap::new())),
+        warm_runs: Arc::new(StdMutex::new(HashMap::new())),
+        warm_evict: warm_evict_from_env(),
     };
 
     // Re-arm signal-pause timeout timers (`timeoutMs`, `docs/signals.md`
@@ -1108,15 +1248,46 @@ async fn create_session(
     };
     let app_state = state.clone();
 
-    let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state, body.policy_profile.as_deref());
-        match replay_from {
-            Some(log) => engine.run_replay_pausable(&effective_agent_path, &body.input, log),
-            None => engine.run_pausable(&effective_agent_path, &body.input),
+    let result = if warm_resume_enabled() {
+        // Warm mode: run the leg under a supervisor task and consume ONE
+        // outcome — either an input pause surfaced by the bridge (the VM
+        // stays parked on its thread for `/resume` to continue in place) or
+        // the leg's final result.
+        let (warm, outcome_tx, bridge) = install_warm_run(&state, &id);
+        let leg_input = body.input.clone();
+        let leg_profile = body.policy_profile.clone();
+        tokio::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                let engine =
+                    build_engine(&app_state, leg_profile.as_deref()).with_warm_input_bridge(bridge);
+                match replay_from {
+                    Some(log) => engine.run_replay_pausable(&effective_agent_path, &leg_input, log),
+                    None => engine.run_pausable(&effective_agent_path, &leg_input),
+                }
+            })
+            .await
+            .unwrap_or_else(|join_err| Err(anyhow::anyhow!("agent run panicked: {join_err}")));
+            let _ = outcome_tx.send(result);
+        });
+        let outcome = {
+            let mut outcomes = warm.outcomes.lock().await;
+            outcomes.recv().await
+        };
+        match outcome {
+            Some(result) => result,
+            None => Err(anyhow::anyhow!("agent run ended without an outcome")),
         }
-    })
-    .await
-    .unwrap();
+    } else {
+        tokio::task::spawn_blocking(move || {
+            let engine = build_engine(&app_state, body.policy_profile.as_deref());
+            match replay_from {
+                Some(log) => engine.run_replay_pausable(&effective_agent_path, &body.input, log),
+                None => engine.run_pausable(&effective_agent_path, &body.input),
+            }
+        })
+        .await
+        .unwrap()
+    };
 
     let mut session = StoredSession {
         id: id.clone(),
@@ -1145,6 +1316,7 @@ async fn create_session(
         return err;
     }
     arm_signal_timeout(&state, &session);
+    release_warm_run_if_settled(&state, &session);
     drop(permit);
     (StatusCode::CREATED, Json(session_view(&session))).into_response()
 }
@@ -1823,6 +1995,9 @@ async fn cancel_session(
         .unwrap_or_else(|| "session cancelled".to_string());
 
     let active = state.active_sessions.lock().unwrap().remove(&id);
+    // Dropping a warm entry drops its resolution sender: a parked engine
+    // thread wakes with `Park` and unwinds, reclaiming the thread and VM.
+    state.warm_runs.lock().unwrap().remove(&id);
     let was_active = active.is_some();
     let active_attempt_number = active.as_ref().and_then(|active| active.attempt_number);
     if let Some(active) = &active {
@@ -2067,8 +2242,21 @@ async fn complete_pending_and_resume(
     let policy_profile = original.policy_profile.clone();
     let app_state = state.clone();
 
-    let result = tokio::task::spawn_blocking(move || {
-        let engine = build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
+    // The resumed leg gets its own warm bridge (when enabled), so a LATER
+    // `input()` pause in the continuation parks the live VM for the next
+    // /resume instead of unwinding — every replay-based resume upgrades the
+    // session back onto the warm path.
+    let warm = if warm_resume_enabled() {
+        Some(install_warm_run(state, &original.id))
+    } else {
+        None
+    };
+    let run_leg = move |bridge: Option<crate::runtime::context::WarmInputBridge>| {
+        let mut engine =
+            build_engine(&app_state, policy_profile.as_deref()).with_approvals(approvals);
+        if let Some(bridge) = bridge {
+            engine = engine.with_warm_input_bridge(bridge);
+        }
         // Continue under the original run id (when known) so the resumed run
         // keeps its persisted run directory and stays a single durable run,
         // matching the live-VM resume path. Falls back to a fresh id only when
@@ -2093,9 +2281,31 @@ async fn complete_pending_and_resume(
                 signal_inbox,
             ),
         }
-    })
-    .await
-    .unwrap();
+    };
+
+    let result = match warm {
+        Some((warm, outcome_tx, bridge)) => {
+            tokio::spawn(async move {
+                let result = tokio::task::spawn_blocking(move || run_leg(Some(bridge)))
+                    .await
+                    .unwrap_or_else(|join_err| {
+                        Err(anyhow::anyhow!("agent run panicked: {join_err}"))
+                    });
+                let _ = outcome_tx.send(result);
+            });
+            let outcome = {
+                let mut outcomes = warm.outcomes.lock().await;
+                outcomes.recv().await
+            };
+            match outcome {
+                Some(result) => result,
+                None => Err(anyhow::anyhow!("agent run ended without an outcome")),
+            }
+        }
+        None => tokio::task::spawn_blocking(move || run_leg(None))
+            .await
+            .unwrap(),
+    };
 
     let mut session = original;
     match result {
@@ -2108,12 +2318,14 @@ async fn complete_pending_and_resume(
                 return err;
             }
             arm_signal_timeout(state, &session);
+            release_warm_run_if_settled(state, &session);
             (StatusCode::OK, Json(session_view(&session))).into_response()
         }
         Err(e) => {
             session.status = SessionStatus::Failed;
             session.error = Some(e.to_string());
             let _ = state.session_store.put(&session);
+            state.warm_runs.lock().unwrap().remove(&session.id);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": e.to_string()})),
@@ -2167,6 +2379,49 @@ async fn resume_session(
         )
             .into_response();
     };
+
+    // Warm fast path: this session's VM is parked on its thread awaiting
+    // exactly this response — deliver it and await the leg's next outcome
+    // (the next pause or the terminal result). The parked engine records the
+    // same journal entry the synthetic replay injection below produces, so
+    // the durable artifacts are identical either way. Falls back to the
+    // replay path when nothing is parked (server restart, eviction, kill
+    // switch) — that path re-derives everything from the journal.
+    let warm_entry = state.warm_runs.lock().unwrap().get(&id).cloned();
+    if let Some(warm) = warm_entry {
+        let parked = warm.resolution.lock().unwrap().take();
+        match parked {
+            Some(tx) if tx.send(body.response.clone()).is_ok() => {
+                let result = {
+                    let mut outcomes = warm.outcomes.lock().await;
+                    outcomes.recv().await
+                };
+                let mut session = original;
+                match result {
+                    Some(Ok(run_result)) => apply_run_outcome(&mut session, run_result),
+                    Some(Err(e)) => {
+                        session.status = SessionStatus::Failed;
+                        session.error = Some(e.to_string());
+                    }
+                    None => {
+                        session.status = SessionStatus::Failed;
+                        session.error = Some("agent run ended without an outcome".to_string());
+                    }
+                }
+                if let Some(err) = store_or_500(&state, &session) {
+                    return err;
+                }
+                arm_signal_timeout(&state, &session);
+                release_warm_run_if_settled(&state, &session);
+                return (StatusCode::OK, Json(session_view(&session))).into_response();
+            }
+            _ => {
+                // Not parked (evicted, unwound, or a racing resume won):
+                // retire the stale entry and take the replay path.
+                state.warm_runs.lock().unwrap().remove(&id);
+            }
+        }
+    }
 
     if let Err(err) = validate_snapshot_manifest_for_resume(
         &state.run_base,
@@ -2734,6 +2989,8 @@ mod tests {
             acquire_timeout: std::time::Duration::from_millis(1),
             active_sessions: Arc::new(StdMutex::new(HashMap::new())),
             signal_inbox_locks: Arc::new(StdMutex::new(HashMap::new())),
+            warm_runs: Arc::new(StdMutex::new(HashMap::new())),
+            warm_evict: warm_evict_from_env(),
         }
     }
 
@@ -4014,6 +4271,232 @@ mod tests {
         let run_base = temp_dir.join(".chidori").join("runs");
         let state = test_state(run_base, agent_path);
         (temp_dir, state)
+    }
+
+    /// True while `id`'s engine thread is warm-parked at an input pause.
+    fn warm_parked(state: &AppState, id: &str) -> bool {
+        state
+            .warm_runs
+            .lock()
+            .unwrap()
+            .get(id)
+            .map(|warm| warm.resolution.lock().unwrap().is_some())
+            .unwrap_or(false)
+    }
+
+    const TWO_INPUT_AGENT: &str = r#"
+        export async function agent(input, chidori) {
+            const a = await chidori.input("first?");
+            const b = await chidori.input("second?");
+            return { a, b };
+        }
+    "#;
+
+    fn warm_create_request(session_id: &str) -> CreateSessionRequest {
+        CreateSessionRequest {
+            input: json!({}),
+            session_id: Some(session_id.to_string()),
+            attempt_number: None,
+            replay_from: None,
+            agent: None,
+            policy_profile: None,
+        }
+    }
+
+    async fn resume_with(state: &AppState, id: &str, response: &str) -> (StatusCode, Value) {
+        response_json(
+            resume_session(
+                State(state.clone()),
+                Path(id.to_string()),
+                Json(ResumeRequest {
+                    response: response.to_string(),
+                }),
+            )
+            .await,
+        )
+        .await
+    }
+
+    /// Records that matter for replay parity: (seq, function, args, result).
+    fn journal_shape(run_base: &FsPath, run_id: &str) -> Vec<(u64, String, Value, Value)> {
+        use crate::runtime::store::RunStore as _;
+        crate::runtime::store::FsRunStore::new(run_base.join(run_id))
+            .load_call_log()
+            .unwrap()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| (r.seq, r.function, r.args, r.result))
+            .collect()
+    }
+
+    /// End-to-end warm resume: the run parks its live VM at each input pause,
+    /// /resume continues it in place, and the terminal outcome retires the
+    /// warm entry.
+    #[tokio::test]
+    async fn warm_resume_continues_parked_run_in_place() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "chidori-server-warm-resume-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let agent_path = write_agent(&temp_dir, TWO_INPUT_AGENT);
+        let run_base = temp_dir.join(".chidori").join("runs");
+        std::fs::create_dir_all(&run_base).unwrap();
+        let state = test_state(run_base.clone(), agent_path);
+
+        let (status, body) = response_json(
+            create_session(State(state.clone()), Json(warm_create_request("warm-1"))).await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["status"], json!("paused"));
+        assert_eq!(body["pending_prompt"], json!("first?"));
+        assert!(
+            warm_parked(&state, "warm-1"),
+            "engine thread must be warm-parked at the first pause"
+        );
+
+        let (status, body) = resume_with(&state, "warm-1", "A").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("paused"));
+        assert_eq!(body["pending_prompt"], json!("second?"));
+        assert!(warm_parked(&state, "warm-1"), "second pause must park too");
+
+        let (status, body) = resume_with(&state, "warm-1", "B").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(body["output"], json!({ "a": "A", "b": "B" }));
+        assert!(
+            state.warm_runs.lock().unwrap().get("warm-1").is_none(),
+            "terminal outcome must retire the warm entry"
+        );
+
+        // Durable parity: the journal carries the same input records the
+        // replay path would have injected.
+        let run_id = state
+            .session_store
+            .get("warm-1")
+            .unwrap()
+            .unwrap()
+            .run_id
+            .unwrap();
+        let journal = journal_shape(&run_base, &run_id);
+        assert_eq!(journal.len(), 2);
+        assert_eq!(
+            journal[0],
+            (
+                1,
+                "input".to_string(),
+                json!({ "prompt": "first?" }),
+                json!("A")
+            )
+        );
+        assert_eq!(
+            journal[1],
+            (
+                2,
+                "input".to_string(),
+                json!({ "prompt": "second?" }),
+                json!("B")
+            )
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// The warm and replay paths must be interchangeable: force the fallback
+    /// (retire the entry mid-pause, as a crash/restart would) and assert the
+    /// journal comes out identical to the warm run's.
+    #[tokio::test]
+    async fn warm_fallback_replay_produces_identical_journal() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "chidori-server-warm-fallback-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let agent_path = write_agent(&temp_dir, TWO_INPUT_AGENT);
+        let run_base = temp_dir.join(".chidori").join("runs");
+        std::fs::create_dir_all(&run_base).unwrap();
+        let state = test_state(run_base.clone(), agent_path);
+
+        // Warm reference run.
+        let (_, body) = response_json(
+            create_session(State(state.clone()), Json(warm_create_request("warm-ref"))).await,
+        )
+        .await;
+        assert_eq!(body["status"], json!("paused"));
+        resume_with(&state, "warm-ref", "A").await;
+        let (_, body) = resume_with(&state, "warm-ref", "B").await;
+        assert_eq!(body["status"], json!("completed"));
+
+        // Fallback run: retire the entry at each pause so /resume must
+        // replay from the journal (the parked thread unwinds when its
+        // resolution sender drops with the entry).
+        let (_, body) = response_json(
+            create_session(State(state.clone()), Json(warm_create_request("warm-fb"))).await,
+        )
+        .await;
+        assert_eq!(body["status"], json!("paused"));
+        state.warm_runs.lock().unwrap().remove("warm-fb");
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let (_, body) = resume_with(&state, "warm-fb", "A").await;
+        assert_eq!(body["status"], json!("paused"));
+        state.warm_runs.lock().unwrap().remove("warm-fb");
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let (status, body) = resume_with(&state, "warm-fb", "B").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(body["output"], json!({ "a": "A", "b": "B" }));
+
+        let session = |id: &str| state.session_store.get(id).unwrap().unwrap();
+        let warm_journal = journal_shape(&run_base, &session("warm-ref").run_id.unwrap());
+        let fallback_journal = journal_shape(&run_base, &session("warm-fb").run_id.unwrap());
+        assert_eq!(
+            warm_journal, fallback_journal,
+            "warm and replay resumes must write the same journal"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Eviction: a parked run that nobody resumes unwinds after the deadline
+    /// and the session remains resumable through the replay path (which then
+    /// re-upgrades the continuation onto the warm path).
+    #[tokio::test]
+    async fn warm_park_evicts_and_session_stays_resumable() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "chidori-server-warm-evict-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let agent_path = write_agent(&temp_dir, TWO_INPUT_AGENT);
+        let run_base = temp_dir.join(".chidori").join("runs");
+        std::fs::create_dir_all(&run_base).unwrap();
+        let mut state = test_state(run_base.clone(), agent_path);
+        state.warm_evict = std::time::Duration::from_millis(50);
+
+        let (_, body) = response_json(
+            create_session(State(state.clone()), Json(warm_create_request("warm-ev"))).await,
+        )
+        .await;
+        assert_eq!(body["status"], json!("paused"));
+
+        // Wait out the eviction deadline: the parked thread must unwind.
+        let mut waited = 0;
+        while warm_parked(&state, "warm-ev") && waited < 5_000 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            waited += 25;
+        }
+        assert!(
+            !warm_parked(&state, "warm-ev"),
+            "parked run must evict after the deadline"
+        );
+
+        let (_, body) = resume_with(&state, "warm-ev", "A").await;
+        assert_eq!(body["status"], json!("paused"));
+        let (status, body) = resume_with(&state, "warm-ev", "B").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], json!("completed"));
+        assert_eq!(body["output"], json!({ "a": "A", "b": "B" }));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     fn create_request(policy_profile: Option<&str>) -> CreateSessionRequest {

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -28,7 +28,7 @@ use crate::runtime::host_core::signal_timeout_sentinel;
 use crate::runtime::snapshot::{
     HostOperationId, HostPromiseRecord, HostPromiseState, PendingHostOperation,
     PendingHostOperationKind, RuntimePolicy, SnapshotAbi, SnapshotStore, SourceFingerprint,
-    HOST_PROMISE_TABLE_FILE, PENDING_HOST_OPERATION_FILE,
+    PENDING_HOST_OPERATION_FILE,
 };
 use crate::runtime::template::TemplateEngine;
 use crate::scheduler::{self, SchedulerDeps};
@@ -248,10 +248,10 @@ fn complete_persisted_pending_host_operation(
         }
     }
 
-    let mut records: Vec<HostPromiseRecord> = match store.get_blob(HOST_PROMISE_TABLE_FILE)? {
-        Some(bytes) => serde_json::from_slice(&bytes)?,
-        None => Vec::new(),
-    };
+    // Union the compacted table with any per-op blobs written since the last
+    // compaction; a delivery is a natural compaction point, so the updated
+    // table is folded back to `host_promises.json` and the blobs retired.
+    let mut records = crate::runtime::snapshot::load_host_promise_records(store.as_ref())?;
     let completed_at = chrono::Utc::now();
     let record = records
         .iter_mut()
@@ -278,10 +278,8 @@ fn complete_persisted_pending_host_operation(
             completed_at,
         },
     };
-    store.put_blob(
-        HOST_PROMISE_TABLE_FILE,
-        &serde_json::to_vec_pretty(&records)?,
-    )?;
+    crate::runtime::snapshot::SnapshotStore::with_store(run_base.join(run_id), store.clone())
+        .compact_host_promises(&records)?;
     store.delete_blob(PENDING_HOST_OPERATION_FILE)?;
     Ok(Some(pending))
 }
@@ -296,10 +294,7 @@ fn complete_persisted_host_promise_record(
         return Ok(());
     };
     let store = crate::runtime::store::RunStoreFactory::shared(run_base).store_for(run_id);
-    let mut records: Vec<HostPromiseRecord> = match store.get_blob(HOST_PROMISE_TABLE_FILE)? {
-        Some(bytes) => serde_json::from_slice(&bytes)?,
-        None => Vec::new(),
-    };
+    let mut records = crate::runtime::snapshot::load_host_promise_records(store.as_ref())?;
     let completed_at = chrono::Utc::now();
     let record = records
         .iter_mut()
@@ -323,10 +318,8 @@ fn complete_persisted_host_promise_record(
             completed_at,
         },
     };
-    store.put_blob(
-        HOST_PROMISE_TABLE_FILE,
-        &serde_json::to_vec_pretty(&records)?,
-    )?;
+    crate::runtime::snapshot::SnapshotStore::with_store(run_base.join(run_id), store.clone())
+        .compact_host_promises(&records)?;
     Ok(())
 }
 
@@ -339,13 +332,11 @@ fn load_persisted_host_promises(
     };
     // Materialize the run dir from the durable mirror first when this machine
     // has never seen the run (the machine-loss recovery path).
-    let _ = crate::runtime::store::RunStoreFactory::shared(run_base).hydrate(run_id);
-    let table_path = run_base.join(run_id).join(HOST_PROMISE_TABLE_FILE);
-    if !table_path.exists() {
-        return Ok(Vec::new());
-    }
-    serde_json::from_slice(&std::fs::read(&table_path)?)
-        .map_err(|err| anyhow::anyhow!("parsing {}: {}", table_path.display(), err))
+    let factory = crate::runtime::store::RunStoreFactory::shared(run_base);
+    let _ = factory.hydrate(run_id);
+    // Union of the compacted table and any per-op blobs written since the
+    // last compaction (`docs/durable-storage.md`).
+    crate::runtime::snapshot::load_host_promise_records(factory.store_for(run_id).as_ref())
 }
 
 /// Load the virtual filesystem captured in a run's snapshot manifest so a
@@ -2718,6 +2709,7 @@ async fn handle_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::snapshot::HOST_PROMISE_TABLE_FILE;
     use axum::body;
 
     fn test_run_base(name: &str) -> PathBuf {

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -182,24 +182,28 @@ fn validate_snapshot_manifest_for_resume(
         anyhow::anyhow!("reading resume source {}: {}", agent_path.display(), err)
     })?;
     let current_entry = SourceFingerprint::from_source(agent_path, &entry_source);
-    let mut current_modules = Vec::with_capacity(manifest.modules.len());
-    for module in &manifest.modules {
-        let source = std::fs::read_to_string(&module.path).map_err(|err| {
-            anyhow::anyhow!(
-                "reading resume module source {}: {}",
-                module.path.display(),
-                err
-            )
-        })?;
-        current_modules.push(SourceFingerprint::from_source(&module.path, &source));
-    }
-
     let expected_abi = SnapshotAbi::current("chidori-quickjs");
     let expected_policy = RuntimePolicy::from_env_for_durable_run(run_id)?;
-    let current_module_graph = if manifest.module_graph.is_empty() {
-        Vec::new()
+    // One module walk yields both manifest views (fingerprints + graph), so
+    // each imported module is read from disk once per resume instead of twice
+    // (once for its fingerprint, again inside the graph walk). Manifests
+    // written before the graph existed fall back to fingerprinting exactly
+    // the paths they list.
+    let (current_modules, current_module_graph) = if manifest.module_graph.is_empty() {
+        let mut current_modules = Vec::with_capacity(manifest.modules.len());
+        for module in &manifest.modules {
+            let source = std::fs::read_to_string(&module.path).map_err(|err| {
+                anyhow::anyhow!(
+                    "reading resume module source {}: {}",
+                    module.path.display(),
+                    err
+                )
+            })?;
+            current_modules.push(SourceFingerprint::from_source(&module.path, &source));
+        }
+        (current_modules, Vec::new())
     } else {
-        crate::runtime::typescript::module_graph::snapshot_module_graph(
+        crate::runtime::typescript::module_graph::snapshot_modules(
             agent_path,
             &entry_source,
             &expected_policy,

--- a/docs/actors.md
+++ b/docs/actors.md
@@ -46,11 +46,17 @@ when a fan-out returns.
 **Each actor runs a supervision loop.** One iteration = one pass of the actor's
 module under the standard resume-by-replay model: the actor's accumulated call
 log replays from the top (recorded effects return from cache, side-effect
-free), then execution goes live at the frontier. The loop re-enters the module
-when:
+free), then execution goes live at the frontier.
 
-- a message arrives for an empty-mailbox listen point (`chidori.signal`
-  inside an actor parks the thread instead of ending the run);
+In the steady state an actor stays **live across messages**: a
+`chidori.signal` listen point with an empty mailbox blocks in place until the
+next matching message (or the listen point's own `timeoutMs`) arrives and
+then simply continues — the module is not re-executed per message, so
+processing M messages costs O(M), not O(M²). The loop re-enters the module
+only when:
+
+- the actor parks — the idle cap elapses with no message, or a stop is
+  requested — and a later delivery wakes it (resume-by-replay);
 - an iteration fails and the spawn's restart policy allows another attempt.
 
 **Messages are signals.** An actor's mailbox uses the same

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -39,14 +39,19 @@ Two artifacts per run:
 * **`records.jsonl`** — append-only, one JSON `CallRecord` per line. Every
   `record_call` appends O(1) bytes (previously each record rewrote the whole
   `checkpoint.json`, O(history) per call).
-* **`checkpoint.json`** — the full-log artifact, rewritten at host-operation
-  safepoints (and branch merges). Doubles as the compaction of the
-  append-only file: every safepoint rewrite truncates `records.jsonl` to
-  match, so neither file grows past one run's history.
+* **`checkpoint.json`** — the full-log artifact, rewritten at **compaction
+  points**: pause, settle, branch merges, and the first safepoint after a
+  resume replay (whose replayed + synthetic records bypass the append path —
+  the context tracks this as the checkpoint-dirty flag). Steady-state
+  per-effect safepoints persist only the manifest + pending artifacts: the
+  O(1) append already made the record durable, so rewriting the whole
+  checkpoint per host call would cost O(history²) bytes per run for nothing.
+  Each rewrite doubles as compaction of the append-only file: it truncates
+  `records.jsonl` to match, so neither file grows past one run's history.
 
 Loading unions the two: the last checkpoint wins per-seq, and any tail
-records a crash stranded after the last safepoint are recovered from
-`records.jsonl`.
+records appended after the last compaction — the steady-state case, not just
+crash recovery — are recovered from `records.jsonl`.
 
 ## Backends
 

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -53,6 +53,18 @@ Loading unions the two: the last checkpoint wins per-seq, and any tail
 records appended after the last compaction — the steady-state case, not just
 crash recovery — are recovered from `records.jsonl`.
 
+The **host-promise table** follows the same append+compact discipline. Each
+state change (begin/resolve/reject) writes one small per-operation blob
+(`host_promises/<id>.json`) — O(1) on every backend — instead of rewriting
+the whole `host_promises.json` table per host call. Compaction points (pause,
+settle, a server-side delivery) fold the blobs into the table file and delete
+them; readers union both, per-op blobs winning by id. The per-op blob is what
+keeps the crash-between-resolve-and-record dedup guarantee: a resolved effect
+whose journal record never landed is still recognized on resume and not
+re-executed. The manifest's embedded copy of the table has the same freshness
+contract as `checkpoint.json` (compaction-time snapshot; runtime resume never
+reads it).
+
 ## Backends
 
 Selected by `CHIDORI_RUN_STORE`:

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -93,6 +93,18 @@ Journal writes are no longer fire-and-forget:
   and the run's completion is gated on a final flush (the output-gate point:
   a result is not surfaced until its journal is durable).
 
+The durability mode also decides how remote-mirror appends are paced. Under
+`besteffort`, HTTP/S3 record appends are **pipelined**: each append is
+enqueued on the mirror's single FIFO relay thread and the agent continues
+immediately instead of blocking one network round-trip per host call
+(ordering against later checkpoint writes and loads is preserved by the
+FIFO; in-flight requests are bounded, so a slow mirror applies backpressure
+rather than growing an unbounded queue). Failures surface at the next
+`flush()` barrier — pause, settle, output gate — where besteffort logs and
+continues, exactly as its per-append handling always did. Under `strict`,
+every append stays synchronous: acknowledged by the mirror before the next
+effect runs.
+
 ## Recovery after machine loss: hydration
 
 With a mirror configured, the journal survives the machine. On a fresh

--- a/docs/resume-performance.md
+++ b/docs/resume-performance.md
@@ -1,8 +1,8 @@
 # Resume performance: what a resume costs, and how to make it cheap
 
 > **Status:** the two caches below are **landed** (branch
-> `claude/chidori-js-jit-compiler-btc3ec`); the warm-standby design in §5 is a
-> proposal. **Related:** [`docs/value-checkpoints.md`](./value-checkpoints.md)
+> `claude/chidori-js-jit-compiler-btc3ec`); the warm-standby design in §5 is
+> **landed** for `input()` pauses on the session server (see §5.1). **Related:** [`docs/value-checkpoints.md`](./value-checkpoints.md)
 > (the `chidori.step` memoization primitive),
 > [`docs/interpreter-optimization.md`](./interpreter-optimization.md) and
 > [`docs/jit.md`](./jit.md) (the retired dispatch-JIT experiment),
@@ -191,10 +191,39 @@ change — it should land behind a flag with the differential verifier on. It
 is the single largest remaining resume win: it removes the O(history) term
 entirely for the pause→deliver→resume class.
 
+### 5.1 Landed: warm input resume (session server)
+
+The conversion above landed in a simpler shape than the suspended-engine
+pool: the pause never tears the engine down in the first place. A
+`WarmInputBridge` installed on every server run leg intercepts the `input()`
+pause AFTER the pending operation is durable (begin + safepoint), surfaces
+the same paused `RunResult` the unwind path returns (so the HTTP handler
+responds normally), and **parks the engine thread** awaiting the response.
+`/resume` delivers through the parked channel: the continuation is O(1) —
+no realm rebuild, no transpile, no replay. The parked engine reloads the
+durable signal inbox before continuing (deliveries that arrived while
+parked), and records the exact journal entry the replay path's synthetic
+injection produces, so the durable artifacts are identical either way —
+pinned by a differential test (`warm_fallback_replay_produces_identical_journal`).
+
+Degradation is structural, not best-effort: `Park` (eviction deadline
+`CHIDORI_WARM_RESUME_EVICT_MS`, capacity, cancel, server shutdown — the
+entry's channel disconnecting) unwinds into the classic paused artifact,
+and `/resume` falls back to replay, which then re-upgrades the continuation
+back onto the warm path. `CHIDORI_WARM_RESUME=0` disables the whole
+mechanism. The blob/journal replay path remains the source of truth for
+crash recovery. Actor message loops got the equivalent treatment separately
+(inline listen-point waits in `host_actor`, `docs/actors.md`).
+
+Measured (debug build, 600-record history, via the HTTP server): resume
+23 ms warm vs 213 ms replay — and the warm number is flat in history size
+where the replay number grows with it.
+
 ## 6. Order of remaining work, by expected value
 
-1. **Warm-standby conversion (§5)** — removes the O(history) term for live
-   resumes.
+1. ~~**Warm-standby conversion (§5)**~~ — landed for input pauses (§5.1);
+   signal/approval pauses still resume by replay (now fast: the journal
+   replay path itself was made O(history) with small constants).
 2. **Lazy / shared-template realm construction** — removes most of the fixed
    ~3.6 ms per engine (`interpreter-optimization.md` §11.4 bonus row).
 3. **Per-segment replay-cost tracing** — a `chidori trace` view attributing


### PR DESCRIPTION
The durable-scaffold safepoints fire twice per host call (pre-effect and
post-completion). Each firing re-derived the snapshot manifest's module
fingerprints AND module graph — two independent walks that read every
imported module from disk and re-ran import validation, four walks per
host call for sources that are fixed for the run's lifetime — then
re-serialized the code-bundle blob and rewrote the entire checkpoint.json
from the in-memory log: O(history) bytes per call, O(history²) per run,
silently negating the O(1)-append design of records.jsonl.

Changes:

* `ScaffoldPersister` (engine.rs): one per run, shared by both safepoints
  and the pause/settle persists. Caches the entry fingerprint, the module
  fingerprints + import graph (now collected in a SINGLE walk,
  `module_graph::snapshot_modules`), and the serialized blob bytes; the
  blob is written once per run. Caching is more correct, not just cheaper:
  the manifest now always describes the sources the run actually loaded,
  instead of re-reading files that may have changed mid-run.

* Checkpoint writes are now cadenced (`CheckpointWrite`): steady-state
  safepoints skip the full rewrite entirely — `record_call`'s O(1) append
  plus the loader's checkpoint∪tail union already carry the log. The full
  write happens only at compaction points (pause, settle, branch merges)
  or while the log is "checkpoint-dirty": records pushed by replay
  (`try_replay` / `absorb_replayed_subtree`, including the synthetic
  resume record) bypass the append path, so the context tracks them and
  the first safepoint past the replay frontier persists one full
  checkpoint covering them.

* The run-start persist no longer rewrites the checkpoint. This also
  fixes a latent durability hazard: a resumed run starts with an EMPTY
  in-memory log (the journal streams in via replay), so the old
  unconditional write truncated the previous turn's checkpoint.json and
  records.jsonl at resume start — a crash mid-replay lost the journal
  tail. The on-disk journal is now untouched until the replay frontier.

* `chidori stats` now loads runs via the checkpoint∪tail union instead of
  checkpoint.json alone, so mid-run/crashed runs are counted correctly
  under the new cadence (trace/replay already did this).

Measured (debug build, 300 chidori.log calls + 3 imported modules,
filesystem store): 7.9s → 4.0s wall (~2×); checkpoint.json is written
once instead of ~600 times; the 4 module-graph disk walks per call are
gone (one per run). Byte-identical run artifacts. The remaining
superlinear term is the host-promise table (embedded in the manifest and
mirrored to host_promises.json, both rewritten per call) — tracked
separately.

New test pins the cadence: steady-state safepoints must not rewrite the
checkpoint, replay-dirty logs and compaction points must, and the union
must always load the complete log. Full chidori suite green (383 tests).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U38avtfn5svP8nWN9vWZTK