### PR TITLE
Loop kernels: own-frame cell slots — captured loop bounds and accumulators

### DIFF
--- a/crates/chidori-js/benches/common/workloads.rs
+++ b/crates/chidori-js/benches/common/workloads.rs
@@ -53,8 +53,8 @@ pub const WORKLOADS: &[(&str, &str)] = &[
         "(function(){ let s = ''; for (let i = 0; i < 512; i++) s += String.fromCharCode(97 + (i % 26)); let h = 0; for (let r = 0; r < 40; r++) { for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) % 1000000007; } } return h; })()",
     ),
     // Typed-array element traffic (fill, dot product, in-place transform).
-    // Same shape as the dense-array workloads but over Float64Array, which the
-    // loop kernels do not yet accept as a base.
+    // Same shape as the dense-array workloads but over Float64Array (a loop
+    // kernel base since docs/js-performance-roadmap.md §6.8).
     (
         "typed_array",
         "(function(){ const n = 8000; const a = new Float64Array(n); const b = new Float64Array(n); for (let i = 0; i < n; i++) { a[i] = i % 97; b[i] = i % 89; } let s = 0; for (let r = 0; r < 3; r++) { let d = 0; for (let i = 0; i < n; i++) d += a[i] * b[i]; for (let i = 0; i < n; i++) a[i] = (a[i] + b[i]) % 97; s += d; } return s; })()",
@@ -65,5 +65,17 @@ pub const WORKLOADS: &[(&str, &str)] = &[
     (
         "mutual_recursion",
         "(function(){ function isEven(n){ return n === 0 ? true : isOdd(n - 1); } function isOdd(n){ return n === 0 ? false : isEven(n - 1); } const gcd = (a, b) => b === 0 ? a : gcd(b, a % b); let c = 0; for (let i = 0; i < 600; i++) { if (isEven(i % 97)) c++; c += gcd(i + 1234, 991); } return c; })()",
+    ),
+    // Captured loop bounds/accumulators: bindings a closure captures stay
+    // heap CELLS, mapped into kernel registers since §6.10.
+    (
+        "cell_accumulate",
+        "(function(){ const N = 20000; let total = 0; const peek = () => total; for (let i = 0; i < N; i++) { total += (i % 7) - (i & 3); } for (let i = 0; i < N; i++) { total += i % 5; } return total + peek(); })()",
+    ),
+    // Array-typed function-kernel arguments: the `(a, i) => a[i]` accessor
+    // class, frameless with per-access re-checks since §6.10.
+    (
+        "fn_array_args",
+        "(function(){ function get(a, i){ return a[i]; } function dot(a, b, n){ let s = 0; for (let i = 0; i < n; i++) { s += a[i] * b[i]; } return s; } const n = 500; const x = new Array(n); const y = new Array(n); for (let i = 0; i < n; i++) { x[i] = i * 0.5; y[i] = (i % 7) + 1; } let h = 0; for (let r = 0; r < 20; r++) { for (let i = 0; i < n; i++) h = (h + get(x, i) * 2) % 1000003; h = (h + dot(x, y, n)) % 1000003; } return h; })()",
     ),
 ];

--- a/crates/chidori-js/benchmarks/workloads/cell_accumulate.js
+++ b/crates/chidori-js/benchmarks/workloads/cell_accumulate.js
@@ -1,0 +1,17 @@
+// Captured loop bounds and accumulators — bindings a nested closure
+// captures stay heap CELLS after localization (docs/js-performance-roadmap
+// §6.10), and this is the shape that exercises the kernel cell slots: the
+// bound and the running total are both cells, read and written on every
+// iteration, observed by the closures after. Deterministic content so every
+// runtime computes the same checksum.
+const N = 2000000;
+let total = 0;
+const peek = () => total; // captures `total` -> cell
+const bound = () => N; // captures `N` -> cell
+for (let i = 0; i < N; i++) {
+  total += (i % 7) - (i & 3);
+}
+for (let i = 0; i < N; i++) {
+  total += i % 5;
+}
+console.log("RESULT=" + (total + peek() + bound()));

--- a/crates/chidori-js/benchmarks/workloads/fn_array_args.js
+++ b/crates/chidori-js/benchmarks/workloads/fn_array_args.js
@@ -1,0 +1,33 @@
+// Array-typed function-kernel arguments — the `(a, i) => a[i]` accessor
+// class (docs/js-performance-roadmap §6.10): tiny helpers taking an array
+// parameter, called hot from loops the caller keeps generic (the call site
+// itself is what a function kernel accelerates). Covers element reads, a
+// dense `.length` read, and a whole loop inside the kernelized body.
+function get(a, i) {
+  return a[i];
+}
+function dot(a, b, n) {
+  let s = 0;
+  for (let i = 0; i < n; i++) {
+    s += a[i] * b[i];
+  }
+  return s;
+}
+function count(a) {
+  return a.length;
+}
+const N = 1000;
+const x = new Array(N);
+const y = new Array(N);
+for (let i = 0; i < N; i++) {
+  x[i] = i * 0.5;
+  y[i] = (i % 7) + 1;
+}
+let h = 0;
+for (let r = 0; r < 2000; r++) {
+  for (let i = 0; i < N; i++) {
+    h = (h + get(x, i) * 2) % 1000003;
+  }
+  h = (h + dot(x, y, N) + count(x)) % 1000003;
+}
+console.log("RESULT=" + h);

--- a/crates/chidori-js/src/builtins/string.rs
+++ b/crates/chidori-js/src/builtins/string.rs
@@ -117,6 +117,17 @@ pub fn install(vm: &mut Vm) {
     });
 
     install_proto(vm, &proto);
+    // Pin the canonical `charCodeAt` for the kernel `CharCodeAt` fast path
+    // (entry identity check + bail-shape reconstruction) — the same pattern
+    // as `Array.prototype.push`/`pop` in `builtins::array`.
+    let f = proto
+        .borrow()
+        .props
+        .get(&PropertyKey::str("charCodeAt"))
+        .and_then(|p| p.value().cloned());
+    if let Some(Value::Object(o)) = f {
+        vm.realm.string_char_code_at = Some(o);
+    }
 }
 
 /// ECMAScript's trim set: `WhiteSpace` ∪ `LineTerminator`. This matches Unicode

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1172,12 +1172,24 @@ pub struct KernelRec {
     pub globals: Box<[Box<str>]>,
 }
 
-/// A numeric register's source: a frame local (read/write), a captured
-/// upvalue cell (read-only snapshot), or — FUNCTION kernels only — a call
-/// argument (read-only; the entry guard requires it present and a `Number`).
+/// A numeric register's source: a frame local (read/write), an OWN-FRAME
+/// heap cell (read/write — a binding some nested closure captures, so
+/// localization left it a cell: the loop bound or accumulator shape), a
+/// captured upvalue cell (read-only snapshot), or — FUNCTION kernels only —
+/// a call argument (read-only; the entry guard requires it present and a
+/// `Number`).
+///
+/// `Cell` write-back is sound for the same reason upvalue snapshots are:
+/// nothing inside a kernel region can CALL the closure that captured the
+/// cell, so no observer exists between entry and the write-back at every
+/// exit/bail/interrupt. The one exception — pinned-closure calls
+/// ([`KOp::CallKernel`]), whose callees snapshot their upvalues once per
+/// activation — is excluded at translation: a region that WRITES any cell
+/// and calls a pinned closure stays generic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KSlot {
     Local(u32),
+    Cell(u32),
     Upvalue(u32),
     Arg(u32),
 }
@@ -1324,10 +1336,12 @@ impl KMath {
 pub struct Kernel {
     pub code: Box<[KOp]>,
     /// Numeric slots mirrored into registers `0..locals.len()`: frame locals
-    /// (read/write) and UPVALUES (read-only snapshots — no call can run
-    /// inside a kernel, so nothing can write a captured cell mid-activation;
-    /// in-region upvalue WRITES reject at translation). The guard requires
-    /// `Value::Number` in every one; only `Local` slots write back.
+    /// (read/write), OWN-FRAME CELLS (read/write — captured loop bounds and
+    /// accumulators; see [`KSlot`]) and UPVALUES (read-only snapshots — no
+    /// call can run inside a kernel, so nothing can write a captured cell
+    /// mid-activation; in-region upvalue WRITES reject at translation). The
+    /// guard requires `Value::Number` in every one; `Local` and `Cell` slots
+    /// write back.
     ///
     /// FUNCTION kernels additionally use `Arg` slots (read-only; the guard
     /// requires the argument present and a `Number`), and their `Local` slots

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1053,6 +1053,23 @@ pub enum KOp {
     /// `regs[dst] = <length>` of the dense array in object slot `obj`
     /// (unshadowed only — a reified `length` marker bails).
     LoadLen { dst: u16, obj: u16, bail: u16 },
+    /// `regs[dst] = s.charCodeAt(regs[idx])` over the pinned STRING in
+    /// string slot `sslot` — BAIL-FREE: the activation entry guard proved
+    /// the slot holds a primitive string (string-base locals are pinned
+    /// like array bases — in-region stores reject at translation, and
+    /// strings are immutable) and that the canonical
+    /// `String.prototype.charCodeAt` still backs the method (a primitive
+    /// receiver's property lookup goes through an own-index/length wrapper
+    /// straight to `String.prototype`, so nothing can shadow it). Every
+    /// `Number` index has a defined result: `ToIntegerOrInfinity` (NaN → 0,
+    /// truncation) then the code unit as f64 in bounds, NaN out of bounds —
+    /// exactly the builtin, sharing `JsString::code_unit_at` (O(1) on ASCII
+    /// strings via the cached unit count).
+    CharCodeAt { dst: u16, sslot: u16, idx: u16 },
+    /// `regs[dst] = s.length` of the pinned string in string slot `sslot` —
+    /// bail-free: `length` is an own property of the primitive's wrapper
+    /// (unshadowable), O(1) via the cached UTF-16 unit count.
+    StrLen { dst: u16, sslot: u16 },
     /// Materialize a comparison as a BOOLEAN register (`0.0`/`1.0`): the
     /// translator types the destination as Bool, so it writes back as
     /// `Value::Bool` and never feeds an array index.
@@ -1245,6 +1262,13 @@ pub enum KShapeSlot {
     /// materialized as `Value::Bool` — `typeof` must not see a number.
     Bool(u16),
     Obj(u16),
+    /// A pinned string base: materialized from the activation's string-slot
+    /// cache (the value is immutable and the local is pinned, so the cached
+    /// `JsString` IS the live value).
+    Str(u16),
+    /// The canonical `String.prototype.charCodeAt` function object (entry
+    /// guard proved the live value IS the canonical — like `ArrayPushFn`).
+    CharCodeFn,
     MathObj,
     MathFn(KMath),
 }
@@ -1359,6 +1383,12 @@ pub struct Kernel {
     /// guard requires each to hold an object; per-access checks do the rest.
     /// Disjoint from `locals`, and never stored to inside the region.
     pub oslots: Box<[u32]>,
+    /// `frame.locals` indices of STRING BASES (`s` in `s.charCodeAt(i)` /
+    /// `s.length`): string slot `s` caches that local's `JsString` at kernel
+    /// entry. The guard requires each to hold a primitive string; the
+    /// accesses are then bail-free (strings are immutable and the local is
+    /// pinned). Disjoint from `locals` and `oslots`.
+    pub sslots: Box<[u32]>,
     /// Operand-stack shapes for [`KOp::Exit`] (bottom-up).
     pub shapes: Box<[Box<[KShapeSlot]>]>,
     /// Named-property access classes ([`KOp::LoadProp`]/[`KOp::StoreProp`]),
@@ -1404,6 +1434,10 @@ pub struct Kernel {
     /// identity-check the canonical getter for any typed-array LoadLen base.
     /// Kernels without a LoadLen skip that scan entirely.
     pub loads_len: bool,
+    /// Whether the code contains a [`KOp::CharCodeAt`]: the activation entry
+    /// must verify the canonical `String.prototype.charCodeAt` still backs
+    /// the `charCodeAt` property of the canonical String prototype.
+    pub uses_char_code: bool,
     /// Whether the code contains a [`KOp::ArrayPush`]: the activation entry
     /// must verify the canonical `Array.prototype.push` still backs the
     /// `push` property of the canonical Array prototype.

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1070,6 +1070,14 @@ pub enum KOp {
     /// bail-free: `length` is an own property of the primitive's wrapper
     /// (unshadowable), O(1) via the cached UTF-16 unit count.
     StrLen { dst: u16, sslot: u16 },
+    /// FUNCTION kernels only: an array access over an argument base
+    /// ([`Kernel::arg_objs`]) missed its fast-path condition. A frameless
+    /// kernel has no bytecode frame to bail into, so the activation is
+    /// ABANDONED — sound because function kernels with array bases are
+    /// READ-ONLY pure (element/length reads; stores reject at translation),
+    /// so no effect has happened — and the caller reruns the whole call
+    /// generically, which performs the exact spec semantics.
+    Abandon,
     /// Materialize a comparison as a BOOLEAN register (`0.0`/`1.0`): the
     /// translator types the destination as Bool, so it writes back as
     /// `Value::Bool` and never feeds an array index.
@@ -1389,6 +1397,15 @@ pub struct Kernel {
     /// accesses are then bail-free (strings are immutable and the local is
     /// pinned). Disjoint from `locals` and `oslots`.
     pub sslots: Box<[u32]>,
+    /// FUNCTION kernels only: ARGUMENT indices used as READ-ONLY array bases
+    /// (`(a, i) => a[i]` — object slot `s` resolves to `args[arg_objs[s]]`).
+    /// Element and `length` reads re-check their dense-array fast path per
+    /// access and [`KOp::Abandon`] the pure activation on any miss (the
+    /// caller reruns generically). Stores, and recursive kernels, reject at
+    /// translation; CallKernel/prepared-comparator callees with a non-empty
+    /// `arg_objs` decline at their guards (their argument windows carry raw
+    /// `f64`s only).
+    pub arg_objs: Box<[u32]>,
     /// Operand-stack shapes for [`KOp::Exit`] (bottom-up).
     pub shapes: Box<[Box<[KShapeSlot]>]>,
     /// Named-property access classes ([`KOp::LoadProp`]/[`KOp::StoreProp`]),

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -770,8 +770,11 @@ impl Vm {
                         break;
                     };
                     // Number-returning, non-recursive, fully-supplied args,
-                    // canonical Math, Number upvalues — else stay generic.
+                    // no array-argument bases (the argument window carries
+                    // raw f64s only), canonical Math, Number upvalues —
+                    // else stay generic.
                     let ck_ok = ck.rec.is_none()
+                        && ck.arg_objs.is_empty()
                         && ck
                             .code
                             .iter()
@@ -1228,7 +1231,9 @@ impl Vm {
                 // contains CallKernel (translator invariant).
                 KOp::CallKernel { .. } => unreachable!("CallKernel in a plain kernel loop"),
                 // Function-kernel-only ops; loop translation never emits them.
-                KOp::Ret { .. } | KOp::SelfCall { .. } => unreachable!("fn op in a loop kernel"),
+                KOp::Ret { .. } | KOp::SelfCall { .. } | KOp::Abandon => {
+                    unreachable!("fn op in a loop kernel")
+                }
             }
             pc += 1;
         };
@@ -1343,17 +1348,24 @@ impl Vm {
         }
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
-        match exec_fn_kernel_code(&k.code, &mut regs, &interrupt, &mut poll) {
-            Some(ret) => {
+        match exec_fn_kernel_code(&k.code, &mut regs, &interrupt, &mut poll, args, &k.arg_objs) {
+            FnKernelFlow::Ret(ret) => {
                 self.kernel_regs = regs;
                 Some(Ok(ret))
             }
-            None => {
+            FnKernelFlow::Interrupted => {
                 // Interrupted on a back-edge: registers are pure scratch,
                 // nothing to write back on the unwind.
                 self.kernel_regs = regs;
                 self.op_budget = Some(0);
                 Some(Err(self.throw_range("execution interrupted")))
+            }
+            // An array-argument access missed its fast path: the pure
+            // activation is discarded (registers are scratch, reads only)
+            // and the caller takes the ordinary frame path.
+            FnKernelFlow::Abandoned => {
+                self.kernel_regs = regs;
+                None
             }
         }
     }
@@ -1401,6 +1413,13 @@ impl Vm {
             }
             let f = funcs[wl].clone();
             let k = f.proto.fn_kernel.as_ref()?;
+            // No member may consume an array argument: SelfCall windows
+            // carry raw f64s, and an Abandon mid-recursion would have no
+            // caller frame to rerun windows from. (The entry kernel already
+            // can't — `kernelize_function` rejects rec + arg_objs.)
+            if !k.arg_objs.is_empty() {
+                return None;
+            }
             // Every member's Ret type must match the entry kernel's: a
             // mismatched value would land in a caller register of the wrong
             // static type. (Also rejects mixed-type non-recursive members.)
@@ -1794,6 +1813,7 @@ impl Vm {
                     | KOp::LoadProp { .. }
                     | KOp::StoreProp { .. }
                     | KOp::CallKernel { .. }
+                    | KOp::Abandon
                     | KOp::Exit { .. } => unreachable!("bail op in a function kernel"),
                 }
                 pc += 1;
@@ -1907,14 +1927,24 @@ impl Vm {
                 }
             }
         }
-        match exec_fn_kernel_code(&k.code, &mut p.regs, &p.interrupt, &mut p.poll) {
-            Some(v) => Some(Ok(v)),
-            None => {
+        match exec_fn_kernel_code(
+            &k.code,
+            &mut p.regs,
+            &p.interrupt,
+            &mut p.poll,
+            args,
+            &k.arg_objs,
+        ) {
+            FnKernelFlow::Ret(v) => Some(Ok(v)),
+            FnKernelFlow::Interrupted => {
                 // Same latch-and-unwind as an interrupted kernel back-edge:
                 // zero the budget so a JS catch cannot resume execution.
                 self.op_budget = Some(0);
                 Some(Err(self.throw_range("execution interrupted")))
             }
+            // Array-argument access miss: this element falls back to the
+            // generic call (the prepared handle stays usable for the next).
+            FnKernelFlow::Abandoned => None,
         }
     }
 
@@ -1936,6 +1966,9 @@ impl Vm {
             return None;
         }
         let k = p.bf.proto.fn_kernel.as_ref().expect("prepared");
+        if !k.arg_objs.is_empty() {
+            return None;
+        }
         if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
             return None;
         }
@@ -1990,21 +2023,23 @@ impl Vm {
         };
         let k = p.bf.proto.fn_kernel.as_ref().expect("prepared");
         let ret = if interrupted {
-            None
+            FnKernelFlow::Interrupted
         } else {
-            exec_fn_kernel_code(&k.code, &mut p.regs, &p.interrupt, &mut p.poll)
+            exec_fn_kernel_code(&k.code, &mut p.regs, &p.interrupt, &mut p.poll, &[], &[])
         };
         match ret {
-            Some(Value::Number(n)) => Ok(if n < 0.0 {
+            FnKernelFlow::Ret(Value::Number(n)) => Ok(if n < 0.0 {
                 -1
             } else if n > 0.0 {
                 1
             } else {
                 0
             }),
-            Some(Value::Bool(b)) => Ok(if b { 1 } else { 0 }),
-            Some(_) => unreachable!("fn kernels return Number or Bool"),
-            None => {
+            FnKernelFlow::Ret(Value::Bool(b)) => Ok(if b { 1 } else { 0 }),
+            FnKernelFlow::Ret(_) => unreachable!("fn kernels return Number or Bool"),
+            // `prime_prepared_cmp` declined array-argument kernels.
+            FnKernelFlow::Abandoned => unreachable!("array-arg kernel primed for f64 cmp"),
+            FnKernelFlow::Interrupted => {
                 self.op_budget = Some(0);
                 Err(self.throw_range("execution interrupted"))
             }
@@ -6008,18 +6043,34 @@ fn writeback_kernel_props(
     }
 }
 
+/// Outcome of a frameless FUNCTION-kernel body run.
+enum FnKernelFlow {
+    /// The call's result — `Value::Number`, or `Value::Bool` for a
+    /// boolean-typed `Ret`.
+    Ret(Value),
+    /// The cooperative interrupt flag latched on a back-edge poll — the
+    /// caller owns the budget-zeroing unwind.
+    Interrupted,
+    /// An array access over an argument base missed its fast path
+    /// ([`KOp::Abandon`]): the pure activation is discarded and the caller
+    /// reruns the call generically.
+    Abandoned,
+}
+
 /// Execute a plain (non-recursive, frameless) FUNCTION kernel body over
-/// `regs`, returning the call's result — `Value::Number`, or `Value::Bool`
-/// for a boolean-typed `Ret`. Shared by the per-call [`Vm::run_fn_kernel`]
-/// entry and the prepared-callback path ([`Vm::exec_prepared_kernel`]).
-/// Returns `None` when the cooperative interrupt flag latched on a back-edge
-/// poll — the caller owns the budget-zeroing unwind.
+/// `regs`. Shared by the per-call [`Vm::run_fn_kernel`] entry and the
+/// prepared-callback path ([`Vm::exec_prepared_kernel`]). `args`/`arg_objs`
+/// resolve the READ-ONLY array-argument bases (`Kernel::arg_objs`); their
+/// element/length reads re-check the dense fast path per access and abandon
+/// on any miss.
 fn exec_fn_kernel_code(
     code: &[KOp],
     regs: &mut [f64],
     interrupt: &Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     poll: &mut u32,
-) -> Option<Value> {
+    args: &[Value],
+    arg_objs: &[u32],
+) -> FnKernelFlow {
     let mut pc = 0usize;
     loop {
         macro_rules! branch {
@@ -6030,7 +6081,7 @@ fn exec_fn_kernel_code(
                     if *poll & 0xFF == 0 {
                         if let Some(flag) = interrupt {
                             if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                                return None;
+                                return FnKernelFlow::Interrupted;
                             }
                         }
                     }
@@ -6130,20 +6181,82 @@ fn exec_fn_kernel_code(
                 branch!(target)
             }
             KOp::Ret { src, boolean } => {
-                return Some(if boolean {
+                return FnKernelFlow::Ret(if boolean {
                     Value::Bool(regs[src as usize] != 0.0)
                 } else {
                     Value::Number(regs[src as usize])
                 })
             }
+            // READ-ONLY array-argument element access: the dense fast-path
+            // conditions re-check per access (exactly the loop-kernel arm);
+            // any miss branches to the shared Abandon stub — the pure
+            // activation is discarded and the caller reruns generically.
+            KOp::LoadElem {
+                dst,
+                obj,
+                idx,
+                bail,
+            } => {
+                let i = regs[idx as usize];
+                let mut ok = false;
+                if let Some(Value::Object(o)) = args.get(arg_objs[obj as usize] as usize) {
+                    if i.fract() == 0.0 && (0.0..4294967295.0).contains(&i) {
+                        let b = o.borrow();
+                        match &b.internal {
+                            Internal::Array(arr) if b.props.is_empty() => {
+                                if let Some(Value::Number(n)) = arr.get(i as usize) {
+                                    regs[dst as usize] = *n;
+                                    ok = true;
+                                }
+                            }
+                            // Numeric typed arrays: a valid-index [[Get]]
+                            // reads element storage directly — no props or
+                            // prototype consult, so no guard is needed.
+                            Internal::TypedArray(t) if !t.kind.is_bigint() => {
+                                let iu = i as usize;
+                                if iu < crate::typed_array::ta_eff_length(t) {
+                                    let off = t.byte_offset + iu * t.kind.bytes();
+                                    let buf = t.buffer.borrow();
+                                    if let Internal::ArrayBuffer(Some(bytes)) = &buf.internal {
+                                        regs[dst as usize] =
+                                            crate::typed_array::decode(bytes, off, t.kind);
+                                        ok = true;
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                if !ok {
+                    branch!(bail)
+                }
+            }
+            // Dense-array `.length` only: a typed array resolves `.length`
+            // through a prototype ACCESSOR no frameless kernel can guard —
+            // it abandons to the generic path.
+            KOp::LoadLen { dst, obj, bail } => {
+                let mut ok = false;
+                if let Some(Value::Object(o)) = args.get(arg_objs[obj as usize] as usize) {
+                    let b = o.borrow();
+                    if let Internal::Array(arr) = &b.internal {
+                        if b.props.is_empty() {
+                            regs[dst as usize] = arr.len() as f64;
+                            ok = true;
+                        }
+                    }
+                }
+                if !ok {
+                    branch!(bail)
+                }
+            }
+            KOp::Abandon => return FnKernelFlow::Abandoned,
             // A frameless kernel has no bytecode frame to bail into;
             // fn-mode translation rejects anything needing one. A
             // SelfCall implies `self_global`, dispatched by the caller.
             KOp::ArrayPush { .. }
             | KOp::ArrayPop { .. }
-            | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
-            | KOp::LoadLen { .. }
             | KOp::CharCodeAt { .. }
             | KOp::StrLen { .. }
             | KOp::LoadProp { .. }
@@ -6297,6 +6410,7 @@ fn run_callee_window(
             | KOp::LoadProp { .. }
             | KOp::StoreProp { .. }
             | KOp::Exit { .. }
+            | KOp::Abandon
             | KOp::SelfCall { .. }
             | KOp::CallKernel { .. } => unreachable!("unsupported op in a callee kernel"),
         }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -482,6 +482,12 @@ impl Vm {
                 crate::bytecode::KSlot::Local(l) => {
                     matches!(frame.locals[*l as usize], Value::Number(_))
                 }
+                // An own-frame cell in the TDZ (`Uninitialized`) or holding a
+                // non-Number declines like any other slot; the generic path
+                // then raises the ReferenceError / runs the coercion.
+                crate::bytecode::KSlot::Cell(c) => {
+                    matches!(*frame.cells[*c as usize].borrow(), Value::Number(_))
+                }
                 crate::bytecode::KSlot::Upvalue(u) => {
                     matches!(*frame.func.upvalues[*u as usize].borrow(), Value::Number(_))
                 }
@@ -645,6 +651,7 @@ impl Vm {
         for (r, slot) in k.locals.iter().enumerate() {
             let v = match slot {
                 crate::bytecode::KSlot::Local(l) => frame.locals[*l as usize].clone(),
+                crate::bytecode::KSlot::Cell(c) => frame.cells[*c as usize].borrow().clone(),
                 crate::bytecode::KSlot::Upvalue(u) => {
                     frame.func.upvalues[*u as usize].borrow().clone()
                 }
@@ -731,6 +738,8 @@ impl Vm {
                             .all(|op| !matches!(op, KOp::Ret { boolean: true, .. }))
                         && ck.locals.iter().all(|sl| match sl {
                             crate::bytecode::KSlot::Arg(a) => *a < u32::from(c.min_argc),
+                            // Loop-kernel-only slot; never in a fn kernel.
+                            crate::bytecode::KSlot::Cell(_) => false,
                             _ => true,
                         })
                         && (ck.math_used.is_empty() || self.kernel_math_ok(&ck.math_used))
@@ -791,15 +800,7 @@ impl Vm {
                                     // Same latch-and-unwind as the interpreter
                                     // loop: zero the budget so a JS catch
                                     // cannot resume execution.
-                                    for (r, slot) in k.locals.iter().enumerate() {
-                                        if let crate::bytecode::KSlot::Local(l) = slot {
-                                            frame.locals[*l as usize] = Value::Number(regs[r]);
-                                        }
-                                    }
-                                    for (j, &l) in k.bool_locals.iter().enumerate() {
-                                        frame.locals[l as usize] =
-                                            Value::Bool(regs[bool_base + j] != 0.0);
-                                    }
+                                    writeback_kernel_slots(k, frame, &regs, bool_base);
                                     writeback_kernel_props(k, &objs, &prop_slots, &regs);
                                     self.kernel_regs = regs;
                                     objs.clear();
@@ -1142,14 +1143,7 @@ impl Vm {
                     if !run_callee_window(&mut regs, ck, win, dst as usize, &interrupt, &mut poll) {
                         // Interrupted on a callee back-edge: the same
                         // latch-and-unwind as an interrupted caller edge.
-                        for (r, slot) in k.locals.iter().enumerate() {
-                            if let crate::bytecode::KSlot::Local(l) = slot {
-                                frame.locals[*l as usize] = Value::Number(regs[r]);
-                            }
-                        }
-                        for (j, &l) in k.bool_locals.iter().enumerate() {
-                            frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
-                        }
+                        writeback_kernel_slots(k, frame, &regs, bool_base);
                         writeback_kernel_props(k, &objs, &prop_slots, &regs);
                         self.kernel_regs = regs;
                         objs.clear();
@@ -1170,18 +1164,11 @@ impl Vm {
             }
             pc += 1;
         };
-        // Materialize: every mapped numeric local back to the frame (as
+        // Materialize: every mapped numeric local/cell back to the frame (as
         // Numbers), then the operand stack from the exit's shape (bottom-up:
         // registers as Numbers, object slots as objects), then resume the
         // bytecode interpreter at the exit's target.
-        for (r, slot) in k.locals.iter().enumerate() {
-            if let crate::bytecode::KSlot::Local(l) = slot {
-                frame.locals[*l as usize] = Value::Number(regs[r]);
-            }
-        }
-        for (j, &l) in k.bool_locals.iter().enumerate() {
-            frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
-        }
+        writeback_kernel_slots(k, frame, &regs, bool_base);
         writeback_kernel_props(k, &objs, &prop_slots, &regs);
         for slot in k.shapes[shape as usize].iter() {
             match slot {
@@ -1257,6 +1244,12 @@ impl Vm {
                 // proved a store dominates every read, so no frame slot is
                 // needed (and none exists).
                 crate::bytecode::KSlot::Local(_) => {}
+                // Own-frame cells exist only in loop kernels (frameless
+                // bodies have no cells); decline defensively.
+                crate::bytecode::KSlot::Cell(_) => {
+                    self.kernel_regs = regs;
+                    return None;
+                }
                 crate::bytecode::KSlot::Upvalue(u) => match &*bf.upvalues[*u as usize].borrow() {
                     Value::Number(n) => regs[r] = *n,
                     _ => {
@@ -1442,6 +1435,8 @@ impl Vm {
                         }
                     }
                     crate::bytecode::KSlot::Local(_) => {}
+                    // Loop-kernel-only slot; a frameless body has no cells.
+                    crate::bytecode::KSlot::Cell(_) => return None,
                 }
             }
             arg_slots.push(aslots);
@@ -1811,6 +1806,8 @@ impl Vm {
                 // every read, so a stale value from the previous call is
                 // never observable.
                 crate::bytecode::KSlot::Local(_) => {}
+                // Loop-kernel-only slot; a frameless body has no cells.
+                crate::bytecode::KSlot::Cell(_) => return None,
                 crate::bytecode::KSlot::Upvalue(u) => match &*p.bf.upvalues[*u as usize].borrow() {
                     Value::Number(n) => p.regs[r] = *n,
                     _ => return None,
@@ -1871,6 +1868,8 @@ impl Vm {
                 // Consumes a third argument the comparator is never given.
                 crate::bytecode::KSlot::Arg(_) => return None,
                 crate::bytecode::KSlot::Local(_) => {}
+                // Loop-kernel-only slot; a frameless body has no cells.
+                crate::bytecode::KSlot::Cell(_) => return None,
                 crate::bytecode::KSlot::Upvalue(u) => match &*p.bf.upvalues[*u as usize].borrow() {
                     Value::Number(n) => p.regs[r] = *n,
                     _ => return None,
@@ -5874,6 +5873,33 @@ fn bin_arith(vm: &mut Vm, frame: &mut Frame, kind: ArithKind) -> Result<(), Valu
 /// every path that leaves the register world: normal exits, bails (which
 /// route through an Exit), and interrupt unwinds. Load-only classes never
 /// change, so their slots are left untouched.
+/// Write a loop kernel's register state back into the frame: `Local` slots
+/// as `Value::Number`, own-frame `Cell` slots through their `RefCell` (no
+/// borrow can be outstanding while a kernel runs), boolean locals as
+/// `Value::Bool`. `Upvalue`/`Arg` slots are read-only snapshots and never
+/// write back. Runs on every exit, bail, and interrupt unwind.
+fn writeback_kernel_slots(
+    k: &crate::bytecode::Kernel,
+    frame: &mut Frame,
+    regs: &[f64],
+    bool_base: usize,
+) {
+    for (r, slot) in k.locals.iter().enumerate() {
+        match slot {
+            crate::bytecode::KSlot::Local(l) => {
+                frame.locals[*l as usize] = Value::Number(regs[r])
+            }
+            crate::bytecode::KSlot::Cell(c) => {
+                *frame.cells[*c as usize].borrow_mut() = Value::Number(regs[r])
+            }
+            crate::bytecode::KSlot::Upvalue(_) | crate::bytecode::KSlot::Arg(_) => {}
+        }
+    }
+    for (j, &l) in k.bool_locals.iter().enumerate() {
+        frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
+    }
+}
+
 fn writeback_kernel_props(
     k: &crate::bytecode::Kernel,
     objs: &[JsObject],

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -431,6 +431,27 @@ impl Vm {
         )
     }
 
+    /// Entry check for kernels containing [`KOp::CharCodeAt`]: the canonical
+    /// String prototype's `charCodeAt` must still be a plain DATA property
+    /// holding the pinned canonical function (methods are writable). The
+    /// receiver side needs no per-access check at all: a primitive string's
+    /// property lookup goes through an own-index/length wrapper straight to
+    /// `String.prototype` (nothing can shadow the method), the base local is
+    /// pinned (in-region stores reject at translation), strings are
+    /// immutable, and the entry guard proved the slot holds a string.
+    fn kernel_char_code_ok(&self) -> bool {
+        let Some(canon) = &self.realm.string_char_code_at else {
+            return false;
+        };
+        matches!(
+            self.realm.string_proto.borrow().props.get(&PropertyKey::str("charCodeAt")),
+            Some(Property {
+                kind: PropertyKind::Data { value: Value::Object(o), .. },
+                ..
+            }) if o.ptr_eq(canon)
+        )
+    }
+
     /// Execute the typed loop kernel at `Op::LoopKernel(idx)` (see
     /// `kernel.rs` for the model). Runs only when per-op accounting is off
     /// (no op budget), every mapped numeric local holds a `Number`, and every
@@ -507,6 +528,18 @@ impl Vm {
             if !matches!(frame.locals[l as usize], Value::Object(_)) {
                 return self.step(frame, &k.fallback);
             }
+        }
+        // String bases must hold primitive strings (a String OBJECT — or
+        // anything else — declines: the generic path owns wrapper receivers,
+        // accessor shadows and coercions). Pinned local + immutable value =
+        // every in-kernel string access is then bail-free.
+        for &l in k.sslots.iter() {
+            if !matches!(frame.locals[l as usize], Value::String(_)) {
+                return self.step(frame, &k.fallback);
+            }
+        }
+        if k.uses_char_code && !self.kernel_char_code_ok() {
+            return self.step(frame, &k.fallback);
         }
         // A `StoreElem` may CREATE an element (hole fill / exact append), and
         // the spec's OrdinarySet consults the prototype chain when the own
@@ -674,6 +707,13 @@ impl Vm {
                 objs.push(o.clone());
             }
         }
+        let mut strs = std::mem::take(&mut self.kernel_strs);
+        strs.clear();
+        for &l in k.sslots.iter() {
+            if let Value::String(s) = &frame.locals[l as usize] {
+                strs.push(s.clone());
+            }
+        }
         // Prop registers (the tail of the register file): load each resolved
         // slot's current value. The guard above proved every one a Number.
         if !k.props_used.is_empty() {
@@ -762,6 +802,8 @@ impl Vm {
                 self.kernel_regs = regs;
                 objs.clear();
                 self.kernel_objs = objs;
+                strs.clear();
+                self.kernel_strs = strs;
                 self.kernel_prop_slots = prop_slots;
                 callee_bfs.clear();
                 self.kernel_callees = callee_bfs;
@@ -805,6 +847,8 @@ impl Vm {
                                     self.kernel_regs = regs;
                                     objs.clear();
                                     self.kernel_objs = objs;
+                                    strs.clear();
+                                    self.kernel_strs = strs;
                                     self.kernel_prop_slots = prop_slots;
                                     callee_bfs.clear();
                                     self.kernel_callees = callee_bfs;
@@ -1094,6 +1138,28 @@ impl Vm {
                         branch!(bail)
                     }
                 }
+                // Pinned-string code-unit read: BAIL-FREE. The entry guard
+                // proved the slot holds a primitive string and the canonical
+                // `String.prototype.charCodeAt` resolves; every Number index
+                // then has a defined result — ToIntegerOrInfinity (NaN → 0,
+                // truncation toward zero) and NaN out of bounds, exactly the
+                // builtin, through the same `code_unit_at` accessor (O(1) on
+                // ASCII via the cached unit count).
+                KOp::CharCodeAt { dst, sslot, idx } => {
+                    let s = &strs[sslot as usize];
+                    let n = regs[idx as usize];
+                    let i = if n.is_nan() { 0.0 } else { n.trunc() };
+                    regs[dst as usize] = if i >= 0.0 && i < s.len_utf16() as f64 {
+                        s.code_unit_at(i as usize).expect("index checked in range") as f64
+                    } else {
+                        f64::NAN
+                    };
+                }
+                // Pinned-string `.length`: an own wrapper property, O(1)
+                // after the first unit-count read.
+                KOp::StrLen { dst, sslot } => {
+                    regs[dst as usize] = strs[sslot as usize].len_utf16() as f64
+                }
                 // Prop LOCALIZATION rewrote every LoadProp/StoreProp into a
                 // register Mov at kernel build; the slots live only in the
                 // entry load and the exit/unwind write-back now.
@@ -1148,6 +1214,8 @@ impl Vm {
                         self.kernel_regs = regs;
                         objs.clear();
                         self.kernel_objs = objs;
+                        strs.clear();
+                        self.kernel_strs = strs;
                         self.kernel_prop_slots = prop_slots;
                         callee_bfs.clear();
                         self.kernel_callees = callee_bfs;
@@ -1181,6 +1249,14 @@ impl Vm {
                 crate::bytecode::KShapeSlot::Obj(o) => {
                     frame.stack.push(Value::Object(objs[*o as usize].clone()))
                 }
+                // The pinned local is unwritten and strings are immutable:
+                // the cached value IS the live value.
+                crate::bytecode::KShapeSlot::Str(s) => {
+                    frame.stack.push(Value::String(strs[*s as usize].clone()))
+                }
+                crate::bytecode::KShapeSlot::CharCodeFn => frame.stack.push(Value::Object(
+                    self.realm.string_char_code_at.clone().expect("guarded"),
+                )),
                 // The guard proved the live values ARE the canonicals.
                 crate::bytecode::KShapeSlot::MathObj => frame.stack.push(Value::Object(
                     self.realm.math_object.clone().expect("guarded"),
@@ -1199,6 +1275,8 @@ impl Vm {
         self.kernel_regs = regs;
         objs.clear();
         self.kernel_objs = objs;
+        strs.clear();
+        self.kernel_strs = strs;
         self.kernel_prop_slots = prop_slots;
         callee_bfs.clear();
         self.kernel_callees = callee_bfs;
@@ -1711,6 +1789,8 @@ impl Vm {
                     | KOp::LoadElem { .. }
                     | KOp::StoreElem { .. }
                     | KOp::LoadLen { .. }
+                    | KOp::CharCodeAt { .. }
+                    | KOp::StrLen { .. }
                     | KOp::LoadProp { .. }
                     | KOp::StoreProp { .. }
                     | KOp::CallKernel { .. }
@@ -6064,6 +6144,8 @@ fn exec_fn_kernel_code(
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
+            | KOp::CharCodeAt { .. }
+            | KOp::StrLen { .. }
             | KOp::LoadProp { .. }
             | KOp::StoreProp { .. }
             | KOp::Exit { .. }
@@ -6210,6 +6292,8 @@ fn run_callee_window(
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
+            | KOp::CharCodeAt { .. }
+            | KOp::StrLen { .. }
             | KOp::LoadProp { .. }
             | KOp::StoreProp { .. }
             | KOp::Exit { .. }

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -448,6 +448,12 @@ struct Xlate<'a> {
     /// Pinned closure callees (loop mode; see [`KCallee`]): per oslot, the
     /// smallest argc any call site supplies.
     callees: Vec<KCallee>,
+    /// Whether the region STORES to any own-frame cell. Incompatible with
+    /// pinned-closure calls (`callees`): a callee's upvalue snapshot is
+    /// taken once per activation and could be the very cell being written —
+    /// the generic path would observe the updated value, the snapshot would
+    /// not. Checked after translation (either may be discovered first).
+    cells_stored: bool,
     /// a compare op fused with its following conditional jump: skip that ip.
     absorbed: Option<usize>,
     max_stack: u16,
@@ -513,6 +519,7 @@ fn translate(
         uses_array_pop: false,
         props_used: Vec::new(),
         callees: Vec::new(),
+        cells_stored: false,
         absorbed: None,
         max_stack: 0,
     };
@@ -611,6 +618,13 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     // resume, so any path needing a generic-interpreter exit rejects the
     // whole function (element access, or a body not ending in `Return`).
     if x.fn_mode && !x.exits.is_empty() {
+        return None;
+    }
+    // Cell WRITES + pinned-closure calls don't mix: a callee's upvalue
+    // snapshot is loaded once per activation and could be the very cell the
+    // region writes (see `Xlate::cells_stored`). Either side may be
+    // discovered first during emission, so the exclusion is checked here.
+    if x.cells_stored && !x.callees.is_empty() {
         return None;
     }
     // Synthesize exit stubs (deduplicated by resume ip + shape) and collect
@@ -817,7 +831,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 }
             } else {
                 for (r, slot) in locals.iter().enumerate() {
-                    if matches!(slot, KSlot::Local(_)) {
+                    if matches!(slot, KSlot::Local(_) | KSlot::Cell(_)) {
                         always_live |= 1 << r;
                     }
                 }
@@ -1406,6 +1420,29 @@ impl Xlate<'_> {
         Some(r)
     }
 
+    /// Register mirroring the numeric OWN-FRAME cell `frame.cells[c]` — a
+    /// binding some nested closure captures (the captured loop bound /
+    /// accumulator shape), which localization therefore left on the heap.
+    /// Read AND written like a local: the entry guard requires the cell to
+    /// hold a `Number` (TDZ `Uninitialized` declines), and every exit / bail
+    /// / interrupt unwind writes the register back. Loop mode only — a
+    /// frameless function kernel has no cells.
+    fn creg(&mut self, c: u32) -> Option<u16> {
+        if self.fn_mode {
+            return None;
+        }
+        let slot = KSlot::Cell(c);
+        if let Some(&(_, r)) = self.local_reg.iter().find(|(sl, _)| *sl == slot) {
+            return Some(r);
+        }
+        let r = u16::try_from(self.local_reg.len()).ok()?;
+        if r >= BOOL_BASE {
+            return None;
+        }
+        self.local_reg.push((slot, r));
+        Some(r)
+    }
+
     /// Register snapshotting captured upvalue cell `u` (read-only: nothing
     /// can write the cell during a kernel — regions contain no calls — and
     /// in-region upvalue writes are not on the allowlist).
@@ -1869,6 +1906,97 @@ impl Xlate<'_> {
                     self.kops.push(K::Mov { dst, src });
                 }
             }
+            // ---- own-frame cells (loop mode; see `Xlate::creg`). The entry
+            // guard proves each mapped cell holds a `Number`, so the TDZ
+            // check every cell read carries is statically satisfied and a
+            // checked store cannot throw. ----
+            Op::LoadCell(c) => {
+                let src = self.creg(*c)?;
+                let dst = self.push_num()?;
+                self.kops.push(K::Mov { dst, src });
+            }
+            Op::LoadCellConst { cell, konst } => {
+                let src = self.creg(*cell)?;
+                let dst0 = self.push_num()?;
+                self.kops.push(K::Mov { dst: dst0, src });
+                let (kv, k_bool) = self.scalar_const(*konst)?;
+                let dst1 = if k_bool {
+                    self.push_bool()?
+                } else {
+                    self.push_num()?
+                };
+                self.kops.push(K::Const { dst: dst1, k: kv });
+            }
+            // Cells carry no static boolean typing (unlike locals), so only
+            // NUMBER stores translate — a boolean/undefined top rejects the
+            // region and it stays generic.
+            Op::StoreCell(c) | Op::StoreCellChecked(c) => {
+                let dst = self.creg(*c)?;
+                let src = self.pop_num()?;
+                self.kops.push(K::Mov { dst, src });
+                self.cells_stored = true;
+            }
+            Op::AddCellConst { cell, konst } => {
+                let a = self.creg(*cell)?;
+                let (kv, _) = self.scalar_const(*konst)?;
+                let dst = self.push_num()?;
+                self.kops.push(K::AddK { dst, a, k: kv });
+            }
+            Op::ArithCellConst { cell, konst, kind } => {
+                let a = self.creg(*cell)?;
+                let (kv, _) = self.scalar_const(*konst)?;
+                let dst = self.push_num()?;
+                self.kops.push(K::ArithK {
+                    kind: *kind,
+                    dst,
+                    a,
+                    k: kv,
+                });
+            }
+            Op::IncCellStmt { cell, dec } => {
+                let r = self.creg(*cell)?;
+                self.kops.push(K::AddK {
+                    dst: r,
+                    a: r,
+                    k: if *dec { -1.0 } else { 1.0 },
+                });
+                self.cells_stored = true;
+            }
+            Op::CmpCellConstBranchFalse {
+                cell,
+                konst,
+                cmp,
+                target,
+            }
+            | Op::CmpCellConstBranchTrue {
+                cell,
+                konst,
+                cmp,
+                target,
+            } => {
+                let if_true = matches!(op, Op::CmpCellConstBranchTrue { .. });
+                let a = self.creg(*cell)?;
+                let (kv, k_bool) = self.scalar_const(*konst)?;
+                // A mapped cell is always number-typed.
+                if let Some(outcome) = static_cmp(*cmp, false, k_bool) {
+                    if outcome == if_true {
+                        let kidx = self.kops.len();
+                        self.kops.push(K::Br { target: u16::MAX });
+                        self.branch_to(kidx, *target, self.vstack.clone())?;
+                    }
+                } else {
+                    let kidx = self.kops.len();
+                    self.kops.push(K::BrCmpK {
+                        cmp: *cmp,
+                        a,
+                        k: kv,
+                        if_true,
+                        target: u16::MAX,
+                    });
+                    self.branch_to(kidx, *target, self.vstack.clone())?;
+                }
+            }
+
             // FUNCTION kernels: a call argument (read-only; the entry guard
             // requires it present and a `Number`). Loop regions never see
             // `LoadArg` — parameters are copied to locals in the prologue.

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -132,21 +132,24 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
             continue;
         }
         // Iterate translation to a FIXPOINT over the discovered local types:
-        // array bases (`a` in `a[i]`) become object slots, and locals that
+        // array bases (`a` in `a[i]`) become object slots, string bases
+        // (`s` in `s.charCodeAt(i)`) become string slots, and locals that
         // receive boolean stores become Bool-typed registers. Each run feeds
         // its discoveries into the next; a stable run whose translation
         // succeeded installs the kernel. (Discovery is monotone over a
         // bounded set, so the cap is belt-and-braces.)
         let mut oslots: Vec<u32> = Vec::new();
+        let mut sslots: Vec<u32> = Vec::new();
         let mut bools: Vec<u32> = Vec::new();
         let mut installed: Option<Kernel> = None;
         for _ in 0..6 {
-            let (k, d_obj, d_bool) = translate(
+            let (k, d_obj, d_str, d_bool) = translate(
                 &code[start..=end],
                 start as u32,
                 consts,
                 &kernels,
                 &oslots,
+                &sslots,
                 &bools,
                 false,
                 None,
@@ -159,16 +162,32 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
                     grew = true;
                 }
             }
+            for s in d_str {
+                if !sslots.contains(&s) {
+                    sslots.push(s);
+                    grew = true;
+                }
+            }
             for b in d_bool {
                 if !bools.contains(&b) {
                     bools.push(b);
                     grew = true;
                 }
             }
-            if !grew {
-                installed = k;
-                break;
+            // A local can be discovered as BOTH an array and a string base:
+            // `.length` is ambiguous (phase 1 defaults it to an array base)
+            // while `charCodeAt` is string-specific — so strings win and the
+            // next run re-types the `.length` sites as `StrLen`. If the value
+            // really is an object, the entry guard just declines (the string
+            // slot demands a primitive string) and the loop runs generically.
+            // Monotone: once string-typed, a local's loads push `VE::Str`,
+            // which array-base discovery never re-claims.
+            if grew {
+                oslots.retain(|o| !sslots.contains(o));
+                continue;
             }
+            installed = k;
+            break;
         }
         if let Some(mut k) = installed {
             k.fallback = Box::new(code[start].clone());
@@ -213,22 +232,23 @@ pub fn kernelize_function(
     // non-recursive bodies the assumption is never consulted — the first
     // pass decides.
     'ret_ty: for ret_bool in [false, true] {
-        // Same boolean-local fixpoint as `kernelize`; array-base discoveries
-        // reject outright (element access can't run frameless).
+        // Same boolean-local fixpoint as `kernelize`; array- and string-base
+        // discoveries reject outright (element access can't run frameless).
         let mut bools: Vec<u32> = Vec::new();
         for _ in 0..6 {
-            let (k, d_obj, d_bool) = translate(
+            let (k, d_obj, d_str, d_bool) = translate(
                 code,
                 0,
                 consts,
                 inner,
+                &[],
                 &[],
                 &bools,
                 true,
                 self_name,
                 ret_bool,
             );
-            if !d_obj.is_empty() {
+            if !d_obj.is_empty() || !d_str.is_empty() {
                 return None;
             }
             let mut grew = false;
@@ -243,7 +263,9 @@ pub fn kernelize_function(
                     continue 'ret_ty;
                 };
                 // Frameless kernels are self-contained by construction.
-                debug_assert!(k.oslots.is_empty() && k.shapes.is_empty());
+                debug_assert!(
+                    k.oslots.is_empty() && k.sslots.is_empty() && k.shapes.is_empty()
+                );
                 k.args_used = k
                     .locals
                     .iter()
@@ -369,6 +391,16 @@ enum VE {
     ArrayPushFn(u16),
     /// `a.pop`, likewise (consumed by `Call(0)` → [`KOp::ArrayPop`]).
     ArrayPopFn(u16),
+    /// A pinned STRING base: string slot index (loop mode; discovered like
+    /// array bases, via `s.charCodeAt` consumption). The entry guard
+    /// requires the local to hold a primitive string.
+    Str(u16),
+    /// `s.charCodeAt` on the string base in the sslot — speculative: the
+    /// entry guard verifies the canonical `String.prototype.charCodeAt`
+    /// still backs the method. Consumed by `Call(1)` (fusing to the
+    /// bail-free [`KOp::CharCodeAt`]); survives to exit shapes as
+    /// [`KShapeSlot::CharCodeFn`].
+    CharCodeFn(u16),
 }
 
 struct Xlate<'a> {
@@ -401,6 +433,9 @@ struct Xlate<'a> {
     rec_globals: Vec<Box<str>>,
     /// Locals designated as array bases (phase 2) — empty in phase 1.
     oslot_locals: &'a [u32],
+    /// Locals designated as STRING bases (fixpoint-discovered from
+    /// `charCodeAt` consumption) — empty in phase 1.
+    sslot_locals: &'a [u32],
     /// Locals statically typed BOOLEAN (fixpoint-discovered from stores).
     bool_locals: &'a [u32],
     kops: Vec<KOp>,
@@ -424,6 +459,8 @@ struct Xlate<'a> {
     bool_reg: Vec<(u32, u16)>,
     /// phase 1: locals observed as array bases (with clean origins).
     discovered: Vec<u32>,
+    /// phase 1: locals observed as STRING bases (`charCodeAt` receivers).
+    discovered_strs: Vec<u32>,
     /// locals observed receiving BOOLEAN stores (fixpoint feedback).
     discovered_bools: Vec<u32>,
     /// phase 1 origin tracking: (local, version) of a pushed LoadLocal.
@@ -437,6 +474,9 @@ struct Xlate<'a> {
     exits: Vec<(usize, u32, Vec<VE>)>,
     /// Math intrinsics used (entry guard checks each against the realm).
     math_used: Vec<KMath>,
+    /// Whether the region contains a pinned `String.prototype.charCodeAt`
+    /// call (entry guard verifies the canonical still resolves).
+    uses_char_code: bool,
     /// Whether the region contains a pinned `Array.prototype.push` call
     /// (entry guard verifies the canonical still resolves).
     uses_array_push: bool,
@@ -472,11 +512,12 @@ fn translate(
     consts: &[Const],
     inner: &[Kernel],
     oslot_locals: &[u32],
+    sslot_locals: &[u32],
     bool_locals: &[u32],
     fn_mode: bool,
     self_name: Option<&str>,
     self_ret_bool: bool,
-) -> (Option<Kernel>, Vec<u32>, Vec<u32>) {
+) -> (Option<Kernel>, Vec<u32>, Vec<u32>, Vec<u32>) {
     let mut is_target = vec![false; region.len()];
     for op in region {
         for t in op_targets(op) {
@@ -498,6 +539,7 @@ fn translate(
         self_refs: Vec::new(),
         rec_globals: Vec::new(),
         oslot_locals,
+        sslot_locals,
         bool_locals,
         kops: Vec::new(),
         kpc: vec![u16::MAX; region.len()],
@@ -508,6 +550,7 @@ fn translate(
         local_reg: Vec::new(),
         bool_reg: Vec::new(),
         discovered: Vec::new(),
+        discovered_strs: Vec::new(),
         discovered_bools: Vec::new(),
         origins: Vec::new(),
         versions: std::collections::HashMap::new(),
@@ -515,6 +558,7 @@ fn translate(
         fixups: Vec::new(),
         exits: Vec::new(),
         math_used: Vec::new(),
+        uses_char_code: false,
         uses_array_push: false,
         uses_array_pop: false,
         props_used: Vec::new(),
@@ -527,8 +571,9 @@ fn translate(
     x.init_at[0] = Some(Vec::new());
     let kernel = translate_inner(&mut x);
     let d_obj = std::mem::take(&mut x.discovered);
+    let d_str = std::mem::take(&mut x.discovered_strs);
     let d_bool = std::mem::take(&mut x.discovered_bools);
-    (kernel, d_obj, d_bool)
+    (kernel, d_obj, d_str, d_bool)
 }
 
 fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
@@ -715,6 +760,11 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *dst = remap(*dst);
                 *idx = remap(*idx);
             }
+            KOp::CharCodeAt { dst, idx, .. } => {
+                *dst = remap(*dst);
+                *idx = remap(*idx);
+            }
+            KOp::StrLen { dst, .. } => *dst = remap(*dst),
             KOp::ArrayPush { dst, val, .. } => {
                 *dst = remap(*dst);
                 *val = remap(*val);
@@ -761,6 +811,8 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::Num => KShapeSlot::Num(remap(STACK_BASE + p as u16)),
                     VE::Bool => KShapeSlot::Bool(remap(STACK_BASE + p as u16)),
                     VE::Obj(o) => KShapeSlot::Obj(*o),
+                    VE::Str(s) => KShapeSlot::Str(*s),
+                    VE::CharCodeFn(_) => KShapeSlot::CharCodeFn,
                     VE::MathObj => KShapeSlot::MathObj,
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
                     VE::ArrayPushFn(_) => KShapeSlot::ArrayPushFn,
@@ -878,12 +930,14 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     Some(Kernel {
         stores_elems,
         loads_len,
+        uses_char_code: x.uses_char_code,
         uses_array_push: x.uses_array_push,
         uses_array_pop: x.uses_array_pop,
         code: std::mem::take(&mut x.kops).into_boxed_slice(),
         locals: locals.into_boxed_slice(),
         bool_locals: bool_locals.into_boxed_slice(),
         oslots: x.oslot_locals.to_vec().into_boxed_slice(),
+        sslots: x.sslot_locals.to_vec().into_boxed_slice(),
         shapes: shapes.into_boxed_slice(),
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
         props_used: std::mem::take(&mut x.props_used).into_boxed_slice(),
@@ -1110,7 +1164,7 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
             KOp::BrCmpK { a, .. } => resolve!(a),
             KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } => resolve!(src),
             KOp::Ret { src, .. } => resolve!(src),
-            KOp::LoadElem { dst, idx, .. } => {
+            KOp::LoadElem { dst, idx, .. } | KOp::CharCodeAt { dst, idx, .. } => {
                 resolve!(idx);
                 kill!(*dst);
             }
@@ -1118,7 +1172,9 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
                 resolve!(idx);
                 resolve!(val);
             }
-            KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => kill!(*dst),
+            KOp::LoadLen { dst, .. } | KOp::StrLen { dst, .. } | KOp::LoadProp { dst, .. } => {
+                kill!(*dst)
+            }
             KOp::ArrayPush { dst, val, .. } => {
                 resolve!(val);
                 kill!(*dst);
@@ -1164,7 +1220,10 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
             see(*dst);
             see(*src);
         }
-        KOp::Const { dst, .. } | KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => see(*dst),
+        KOp::Const { dst, .. }
+        | KOp::LoadLen { dst, .. }
+        | KOp::StrLen { dst, .. }
+        | KOp::LoadProp { dst, .. } => see(*dst),
         KOp::Add { dst, a, b }
         | KOp::Arith { dst, a, b, .. }
         | KOp::CmpSet { dst, a, b, .. }
@@ -1183,7 +1242,7 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
         }
         KOp::BrCmpK { a, .. } => see(*a),
         KOp::BrFalsy { src, .. } | KOp::BrTruthy { src, .. } | KOp::Ret { src, .. } => see(*src),
-        KOp::LoadElem { dst, idx, .. } => {
+        KOp::LoadElem { dst, idx, .. } | KOp::CharCodeAt { dst, idx, .. } => {
             see(*dst);
             see(*idx);
         }
@@ -1284,6 +1343,12 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
                 defs[i] = bit(*dst);
                 succ[i] = (true, Some(*bail));
             }
+            // Bail-free string reads: plain defs with fall-through.
+            KOp::CharCodeAt { dst, idx, .. } => {
+                uses[i] = bit(*idx);
+                defs[i] = bit(*dst);
+            }
+            KOp::StrLen { dst, .. } => defs[i] = bit(*dst),
             KOp::ArrayPush { dst, val, bail, .. } => {
                 uses[i] = bit(*val);
                 defs[i] = bit(*dst);
@@ -1403,6 +1468,7 @@ impl Xlate<'_> {
     /// rejects the region (some iteration would bail every time anyway).
     fn lreg(&mut self, l: u32) -> Option<u16> {
         if self.oslot_locals.contains(&l)
+            || self.sslot_locals.contains(&l)
             || self.bool_locals.contains(&l)
             || self.bool_reg.iter().any(|&(ll, _)| ll == l)
         {
@@ -1514,6 +1580,7 @@ impl Xlate<'_> {
             self.discovered_bools.push(l);
         }
         if self.oslot_locals.contains(&l)
+            || self.sslot_locals.contains(&l)
             || self.local_reg.iter().any(|&(sl, _)| sl == KSlot::Local(l))
         {
             return None;
@@ -1654,7 +1721,9 @@ impl Xlate<'_> {
             | VE::MathObj
             | VE::MathFn(_)
             | VE::ArrayPushFn(_)
-            | VE::ArrayPopFn(_) => None,
+            | VE::ArrayPopFn(_)
+            | VE::Str(_)
+            | VE::CharCodeFn(_) => None,
             VE::Num => {
                 // Phase 1 discovery only. (A local used BOTH as a base and
                 // numerically is caught in phase 2: its loads become `Obj`
@@ -1672,6 +1741,36 @@ impl Xlate<'_> {
                 };
                 Some(u16::try_from(s).ok()?)
             }
+        }
+    }
+
+    /// Resolve the entry at `depth_from_top` as a STRING BASE (the
+    /// `s.charCodeAt` receiver). Phase 1: a clean local origin records the
+    /// local as a discovered string base. Phase 2: it must be [`VE::Str`].
+    /// Loop mode only — string slots resolve against the frame.
+    fn str_slot(&mut self, depth_from_top: usize) -> Option<u16> {
+        if self.fn_mode {
+            return None;
+        }
+        let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
+        match self.vstack[p] {
+            VE::Str(s) => Some(s),
+            VE::Num => {
+                // Phase 1 discovery only (mirrors `base_slot`).
+                let (l, ver) = self.origins[p]?;
+                if *self.versions.get(&l).unwrap_or(&0) != ver {
+                    return None;
+                }
+                let s = match self.discovered_strs.iter().position(|&d| d == l) {
+                    Some(s) => s,
+                    None => {
+                        self.discovered_strs.push(l);
+                        self.discovered_strs.len() - 1
+                    }
+                };
+                u16::try_from(s).ok()
+            }
+            _ => None,
         }
     }
 
@@ -1869,6 +1968,10 @@ impl Xlate<'_> {
                 if let Some(pos) = self.oslot_locals.iter().position(|&o| o == *l) {
                     // This local is an array base — push the object.
                     self.vstack.push(VE::Obj(pos as u16));
+                    self.origins.push(None);
+                } else if let Some(pos) = self.sslot_locals.iter().position(|&s| s == *l) {
+                    // This local is a string base — push the pinned string.
+                    self.vstack.push(VE::Str(pos as u16));
                     self.origins.push(None);
                 } else if self.is_bool_local(*l) {
                     let src = self.blreg(*l)?;
@@ -2174,6 +2277,10 @@ impl Xlate<'_> {
                         self.vstack.push(VE::Obj(s));
                         self.origins.push(None);
                     }
+                    VE::Str(s) => {
+                        self.vstack.push(VE::Str(s));
+                        self.origins.push(None);
+                    }
                     VE::MathObj => {
                         self.vstack.push(VE::MathObj);
                         self.origins.push(None);
@@ -2183,7 +2290,8 @@ impl Xlate<'_> {
                     | VE::Opaque
                     | VE::SelfFn(_)
                     | VE::ArrayPushFn(_)
-                    | VE::ArrayPopFn(_) => return None,
+                    | VE::ArrayPopFn(_)
+                    | VE::CharCodeFn(_) => return None,
                 }
             }
             Op::Swap => {
@@ -2432,6 +2540,29 @@ impl Xlate<'_> {
                     Const::String(s) => s.as_str().to_string(),
                     _ => return None,
                 };
+                // `s.charCodeAt` — routes the receiver into a STRING slot
+                // (phase-1 discovery, exactly like an array base) and pushes
+                // the speculative method entry; the entry guard verifies the
+                // canonical `String.prototype.charCodeAt` still resolves.
+                // Loop mode only (string slots resolve against the frame).
+                if !self.fn_mode && key == "charCodeAt" {
+                    let s = self.str_slot(0)?;
+                    self.pop()?;
+                    self.vstack.push(VE::CharCodeFn(s));
+                    self.origins.push(None);
+                    self.uses_char_code = true;
+                    return Some(());
+                }
+                // `s.length` on a KNOWN string base: bail-free O(1) unit
+                // count (an own wrapper property — unshadowable).
+                if key == "length" {
+                    if let Some(VE::Str(s)) = self.vstack.last().copied() {
+                        self.pop()?;
+                        let dst = self.push_num()?;
+                        self.kops.push(K::StrLen { dst, sslot: s });
+                        return Some(());
+                    }
+                }
                 // `a.push` on an array base, in loop mode: the pinned
                 // canonical `Array.prototype.push` (entry-verified like a
                 // Math intrinsic; see `KOp::ArrayPush`). An Ordinary object
@@ -2560,6 +2691,34 @@ impl Xlate<'_> {
                         bail: u16::MAX,
                     });
                     self.exits.push((kidx, self.base_ip + i as u32, shape));
+                    return Some(());
+                }
+                // `s.charCodeAt(i)`: the compiler's method-call pattern
+                // [.., CharCodeFn(s), Str(s), idx] with exactly one
+                // statically-Number argument, fusing to the BAIL-FREE
+                // [`KOp::CharCodeAt`] (the entry guard pins the receiver's
+                // stringness and the canonical method for the whole
+                // activation; every Number index has a defined result). In
+                // phase 1 the receiver is still a Num-with-origin entry —
+                // `str_slot` resolves it to the same discovered slot.
+                if let VE::CharCodeFn(s) = *self.vstack.get(fn_pos)? {
+                    if n != 1 {
+                        return None;
+                    }
+                    match self.vstack.get(fn_pos + 1)? {
+                        VE::Str(s2) if *s2 == s => {}
+                        _ => {
+                            if self.str_slot(1)? != s {
+                                return None;
+                            }
+                        }
+                    }
+                    let idx = self.top_num_reg(0)?;
+                    self.pop()?; // arg
+                    self.pop()?; // this (the string)
+                    self.pop()?; // fn
+                    let dst = self.push_num()?;
+                    self.kops.push(K::CharCodeAt { dst, sslot: s, idx });
                     return Some(());
                 }
                 // `a.pop()`: [.., ArrayPopFn(s), Obj(s)], no arguments.

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -83,6 +83,11 @@ const STACK_BASE: u16 = 64;
 /// final remap to sit right after the numeric locals.
 const BOOL_BASE: u16 = 32;
 const SCRATCH0: u16 = 252;
+/// Origin tag for FUNCTION-kernel ARGUMENT origins (`Xlate::origins`): a
+/// pushed `LoadArg(a)` records `a | ARG_ORIGIN`, letting `base_slot`
+/// discover argument array bases exactly like local ones. Real local
+/// indices never reach this bit, and stores never bump a tagged version.
+const ARG_ORIGIN: u32 = 1 << 31;
 
 /// Find every eligible loop in `code` and install kernels for them. Returns
 /// the (possibly rewritten) code and the kernel table. Loop-header ops are
@@ -143,18 +148,21 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
         let mut bools: Vec<u32> = Vec::new();
         let mut installed: Option<Kernel> = None;
         for _ in 0..6 {
-            let (k, d_obj, d_str, d_bool) = translate(
+            let (k, d_obj, d_str, d_args, d_bool) = translate(
                 &code[start..=end],
                 start as u32,
                 consts,
                 &kernels,
                 &oslots,
                 &sslots,
+                &[],
+                &[],
                 &bools,
                 false,
                 None,
                 false,
             );
+            debug_assert!(d_args.is_empty(), "LoadArg is fn-mode-only");
             let mut grew = false;
             for o in d_obj {
                 if !oslots.contains(&o) {
@@ -232,26 +240,44 @@ pub fn kernelize_function(
     // non-recursive bodies the assumption is never consulted — the first
     // pass decides.
     'ret_ty: for ret_bool in [false, true] {
-        // Same boolean-local fixpoint as `kernelize`; array- and string-base
-        // discoveries reject outright (element access can't run frameless).
+        // Same boolean-local fixpoint as `kernelize`, plus array-base
+        // ARGUMENTS and the LOCALS the parameter prologue copies them into
+        // (`(a, i) => a[i]` compiles to `LoadArg; StoreLocal` then reads the
+        // local); string bases reject outright (no frame slot to pin).
         let mut bools: Vec<u32> = Vec::new();
+        let mut obj_args: Vec<u32> = Vec::new();
+        let mut obj_locals: Vec<u32> = Vec::new();
         for _ in 0..6 {
-            let (k, d_obj, d_str, d_bool) = translate(
+            let (k, d_obj, d_str, d_args, d_bool) = translate(
                 code,
                 0,
                 consts,
                 inner,
                 &[],
                 &[],
+                &obj_args,
+                &obj_locals,
                 &bools,
                 true,
                 self_name,
                 ret_bool,
             );
-            if !d_obj.is_empty() || !d_str.is_empty() {
+            if !d_str.is_empty() {
                 return None;
             }
             let mut grew = false;
+            for a in d_args {
+                if !obj_args.contains(&a) {
+                    obj_args.push(a);
+                    grew = true;
+                }
+            }
+            for l in d_obj {
+                if !obj_locals.contains(&l) {
+                    obj_locals.push(l);
+                    grew = true;
+                }
+            }
             for b in d_bool {
                 if !bools.contains(&b) {
                     bools.push(b);
@@ -273,9 +299,17 @@ pub fn kernelize_function(
                         KSlot::Arg(a) => Some(*a + 1),
                         _ => None,
                     })
+                    .chain(k.arg_objs.iter().map(|a| *a + 1))
                     .max()
                     .unwrap_or(0);
                 if k.rec.is_some() {
+                    // A recursive kernel cannot take array arguments: a
+                    // SelfCall's argument window carries raw f64s only (so
+                    // no call site could supply one), and an Abandon deep in
+                    // the window stack would have nothing to rerun from.
+                    if !k.arg_objs.is_empty() {
+                        return None;
+                    }
                     // RECURSIVE kernel. Every SELF-call must supply every
                     // argument the body consumes (a short call would need
                     // the generic `undefined` parameter; mutual-recursion
@@ -436,6 +470,15 @@ struct Xlate<'a> {
     /// Locals designated as STRING bases (fixpoint-discovered from
     /// `charCodeAt` consumption) — empty in phase 1.
     sslot_locals: &'a [u32],
+    /// fn mode: ARGUMENT indices designated as READ-ONLY array bases
+    /// (fixpoint-discovered) — empty in phase 1 and in loop mode.
+    obj_args: &'a [u32],
+    /// fn mode: LOCALS designated as array bases (fixpoint-discovered). The
+    /// compiler's parameter prologue copies `LoadArg(k)` into a local, so
+    /// the base the body reads is a local ALIASING an argument; each one
+    /// must bind to exactly one argument slot (`local_arg_alias`), and its
+    /// accesses resolve through `args[arg_objs[slot]]` at runtime.
+    obj_locals: &'a [u32],
     /// Locals statically typed BOOLEAN (fixpoint-discovered from stores).
     bool_locals: &'a [u32],
     kops: Vec<KOp>,
@@ -461,6 +504,12 @@ struct Xlate<'a> {
     discovered: Vec<u32>,
     /// phase 1: locals observed as STRING bases (`charCodeAt` receivers).
     discovered_strs: Vec<u32>,
+    /// fn mode, phase 1: ARGUMENTS observed as array bases.
+    discovered_obj_args: Vec<u32>,
+    /// fn mode: (obj-local, argument object slot) bindings established by
+    /// the prologue stores this run. A read before a binding, or a second
+    /// binding to a DIFFERENT slot, rejects the region.
+    local_arg_alias: Vec<(u32, u16)>,
     /// locals observed receiving BOOLEAN stores (fixpoint feedback).
     discovered_bools: Vec<u32>,
     /// phase 1 origin tracking: (local, version) of a pushed LoadLocal.
@@ -513,11 +562,13 @@ fn translate(
     inner: &[Kernel],
     oslot_locals: &[u32],
     sslot_locals: &[u32],
+    obj_args: &[u32],
+    obj_locals: &[u32],
     bool_locals: &[u32],
     fn_mode: bool,
     self_name: Option<&str>,
     self_ret_bool: bool,
-) -> (Option<Kernel>, Vec<u32>, Vec<u32>, Vec<u32>) {
+) -> (Option<Kernel>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>) {
     let mut is_target = vec![false; region.len()];
     for op in region {
         for t in op_targets(op) {
@@ -540,6 +591,8 @@ fn translate(
         rec_globals: Vec::new(),
         oslot_locals,
         sslot_locals,
+        obj_args,
+        obj_locals,
         bool_locals,
         kops: Vec::new(),
         kpc: vec![u16::MAX; region.len()],
@@ -551,6 +604,8 @@ fn translate(
         bool_reg: Vec::new(),
         discovered: Vec::new(),
         discovered_strs: Vec::new(),
+        discovered_obj_args: Vec::new(),
+        local_arg_alias: Vec::new(),
         discovered_bools: Vec::new(),
         origins: Vec::new(),
         versions: std::collections::HashMap::new(),
@@ -572,8 +627,9 @@ fn translate(
     let kernel = translate_inner(&mut x);
     let d_obj = std::mem::take(&mut x.discovered);
     let d_str = std::mem::take(&mut x.discovered_strs);
+    let d_args = std::mem::take(&mut x.discovered_obj_args);
     let d_bool = std::mem::take(&mut x.discovered_bools);
-    (kernel, d_obj, d_str, d_bool)
+    (kernel, d_obj, d_str, d_args, d_bool)
 }
 
 fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
@@ -660,10 +716,16 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         patch(&mut x.kops, kidx, pc);
     }
     // A FUNCTION kernel runs frameless — there is no bytecode frame to
-    // resume, so any path needing a generic-interpreter exit rejects the
-    // whole function (element access, or a body not ending in `Return`).
+    // resume into, so every would-be exit (an array access missing its fast
+    // path, or a stray fallthrough) is patched to ONE shared [`KOp::Abandon`]
+    // stub instead: the pure activation is discarded and the caller reruns
+    // the call generically. No shape table is needed — nothing is resumed.
     if x.fn_mode && !x.exits.is_empty() {
-        return None;
+        let stub = u16::try_from(x.kops.len()).ok()?;
+        x.kops.push(KOp::Abandon);
+        for (kidx, _, _) in std::mem::take(&mut x.exits) {
+            patch(&mut x.kops, kidx, stub);
+        }
     }
     // Cell WRITES + pinned-closure calls don't mix: a callee's upvalue
     // snapshot is loaded once per activation and could be the very cell the
@@ -795,7 +857,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *a = remap(*a);
                 *b = remap(*b);
             }
-            KOp::Br { .. } | KOp::Exit { .. } => {}
+            KOp::Br { .. } | KOp::Exit { .. } | KOp::Abandon => {}
             // Fusion (`fuse_kops`) runs after this remap.
             KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
                 unreachable!("fused op before fusion")
@@ -938,6 +1000,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         bool_locals: bool_locals.into_boxed_slice(),
         oslots: x.oslot_locals.to_vec().into_boxed_slice(),
         sslots: x.sslot_locals.to_vec().into_boxed_slice(),
+        arg_objs: x.obj_args.to_vec().into_boxed_slice(),
         shapes: shapes.into_boxed_slice(),
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
         props_used: std::mem::take(&mut x.props_used).into_boxed_slice(),
@@ -1074,7 +1137,10 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
     let mut label = vec![false; n];
     let mut preds = vec![0u32; n];
     for (j, op) in kops.iter_mut().enumerate() {
-        let falls = !matches!(op, KOp::Br { .. } | KOp::Ret { .. } | KOp::Exit { .. });
+        let falls = !matches!(
+            op,
+            KOp::Br { .. } | KOp::Ret { .. } | KOp::Exit { .. } | KOp::Abandon
+        );
         if falls && j + 1 < n {
             preds[j + 1] += 1;
         }
@@ -1184,7 +1250,7 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
             // Argument-window RANGE reads: leave the window registers alone,
             // only the result register is a plain def.
             KOp::CallKernel { dst, .. } | KOp::SelfCall { dst, .. } => kill!(*dst),
-            KOp::Br { .. } | KOp::Exit { .. } => {}
+            KOp::Br { .. } | KOp::Exit { .. } | KOp::Abandon => {}
             // Fusion (`fuse_kops`) runs after cleanup.
             KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
                 unreachable!("fused op before fusion")
@@ -1265,7 +1331,7 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
             see(*dst);
             see(base + argc);
         }
-        KOp::Br { .. } | KOp::Exit { .. } => {}
+        KOp::Br { .. } | KOp::Exit { .. } | KOp::Abandon => {}
         // Fusion (`fuse_kops`) runs after cleanup.
         KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
             unreachable!("fused op before fusion")
@@ -1329,7 +1395,7 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
                 uses[i] = bit(*src);
                 succ[i] = (false, None);
             }
-            KOp::Exit { .. } => succ[i] = (false, None),
+            KOp::Exit { .. } | KOp::Abandon => succ[i] = (false, None),
             KOp::LoadElem { dst, idx, bail, .. } => {
                 uses[i] = bit(*idx);
                 defs[i] = bit(*dst);
@@ -1469,6 +1535,7 @@ impl Xlate<'_> {
     fn lreg(&mut self, l: u32) -> Option<u16> {
         if self.oslot_locals.contains(&l)
             || self.sslot_locals.contains(&l)
+            || self.obj_locals.contains(&l)
             || self.bool_locals.contains(&l)
             || self.bool_reg.iter().any(|&(ll, _)| ll == l)
         {
@@ -1581,6 +1648,7 @@ impl Xlate<'_> {
         }
         if self.oslot_locals.contains(&l)
             || self.sslot_locals.contains(&l)
+            || self.obj_locals.contains(&l)
             || self.local_reg.iter().any(|&(sl, _)| sl == KSlot::Local(l))
         {
             return None;
@@ -1731,6 +1799,34 @@ impl Xlate<'_> {
                 let (l, ver) = self.origins[p]?;
                 if *self.versions.get(&l).unwrap_or(&0) != ver {
                     return None;
+                }
+                if self.fn_mode {
+                    // fn mode, phase 1: a tagged origin is a direct
+                    // argument base; an untagged one is a LOCAL the
+                    // prologue copied an argument into — discover it as an
+                    // obj local (the stable run then binds it to its
+                    // argument slot via `local_arg_alias`). The returned
+                    // slot only matters in the stable run, where no
+                    // discovery happens.
+                    if l & ARG_ORIGIN != 0 {
+                        let a = l & !ARG_ORIGIN;
+                        let s = match self.discovered_obj_args.iter().position(|&d| d == a) {
+                            Some(s) => s,
+                            None => {
+                                self.discovered_obj_args.push(a);
+                                self.discovered_obj_args.len() - 1
+                            }
+                        };
+                        return u16::try_from(s).ok();
+                    }
+                    let s = match self.discovered.iter().position(|&d| d == l) {
+                        Some(s) => s,
+                        None => {
+                            self.discovered.push(l);
+                            self.discovered.len() - 1
+                        }
+                    };
+                    return u16::try_from(s).ok();
                 }
                 let s = match self.discovered.iter().position(|&d| d == l) {
                     Some(s) => s,
@@ -1969,6 +2065,16 @@ impl Xlate<'_> {
                     // This local is an array base — push the object.
                     self.vstack.push(VE::Obj(pos as u16));
                     self.origins.push(None);
+                } else if self.obj_locals.contains(l) {
+                    // fn mode: a local aliasing an array ARGUMENT — the
+                    // prologue store must already have bound it.
+                    let slot = self
+                        .local_arg_alias
+                        .iter()
+                        .find(|&&(ll, _)| ll == *l)
+                        .map(|&(_, s)| s)?;
+                    self.vstack.push(VE::Obj(slot));
+                    self.origins.push(None);
                 } else if let Some(pos) = self.sslot_locals.iter().position(|&s| s == *l) {
                     // This local is a string base — push the pinned string.
                     self.vstack.push(VE::Str(pos as u16));
@@ -2104,9 +2210,19 @@ impl Xlate<'_> {
             // requires it present and a `Number`). Loop regions never see
             // `LoadArg` — parameters are copied to locals in the prologue.
             Op::LoadArg(a) if self.fn_mode => {
-                let src = self.argreg(*a)?;
-                let dst = self.push_num()?;
-                self.kops.push(K::Mov { dst, src });
+                if let Some(pos) = self.obj_args.iter().position(|&x| x == *a) {
+                    // This argument is an array base — push the object.
+                    self.vstack.push(VE::Obj(pos as u16));
+                    self.origins.push(None);
+                } else {
+                    let src = self.argreg(*a)?;
+                    let dst = self.push_num()?;
+                    self.kops.push(K::Mov { dst, src });
+                    // Tagged origin: lets `base_slot` discover this argument
+                    // as an array base (arguments are never stored to, so
+                    // version 0 is always current).
+                    *self.origins.last_mut()? = Some((*a | ARG_ORIGIN, 0));
+                }
             }
             // FUNCTION kernels: yield the (scalar) result and finish the
             // frameless call. Loop regions reject `Return` (the catch-all).
@@ -2127,6 +2243,45 @@ impl Xlate<'_> {
                     && !self.local_readable(*l)
                 {
                     return None;
+                }
+                // fn mode: binding an obj LOCAL — the top must be an
+                // argument-base object (the prologue's `LoadArg` value),
+                // consistently the SAME argument slot on every store. The
+                // store itself elides: the value lives in `args`, resolved
+                // per access.
+                if self.fn_mode && self.obj_locals.contains(l) {
+                    let s = match self.vstack.last() {
+                        Some(VE::Obj(s)) => *s,
+                        // The argument is not yet typed as a base (its
+                        // `LoadArg` pushed a tagged Num this run): record
+                        // the discovery — the fixpoint rerun types it
+                        // `VE::Obj` — and elide the store so later
+                        // discoveries in this (discarded) run still land.
+                        Some(VE::Num) => {
+                            let (o, _) = (*self.origins.last()?)?;
+                            if o & ARG_ORIGIN == 0 {
+                                return None;
+                            }
+                            let a = o & !ARG_ORIGIN;
+                            if !self.discovered_obj_args.contains(&a) {
+                                self.discovered_obj_args.push(a);
+                            }
+                            self.pop()?;
+                            self.store_of(*l);
+                            self.mark_init(*l);
+                            return Some(());
+                        }
+                        _ => return None,
+                    };
+                    match self.local_arg_alias.iter().find(|&&(ll, _)| ll == *l) {
+                        Some(&(_, prev)) if prev != s => return None,
+                        Some(_) => {}
+                        None => self.local_arg_alias.push((*l, s)),
+                    }
+                    self.pop()?;
+                    self.store_of(*l);
+                    self.mark_init(*l);
+                    return Some(());
                 }
                 match self.vstack.last() {
                     Some(VE::Undef) | Some(VE::Opaque) => {
@@ -2477,7 +2632,13 @@ impl Xlate<'_> {
                 self.exits.push((kidx, self.base_ip + i as u32, shape));
             }
             // `a[i] = v` write: pushes the value back (expression result).
+            // fn mode rejects: array-arg kernels must stay READ-ONLY pure —
+            // an ABANDON after a completed store could not be undone, and a
+            // generic rerun would observe its own earlier write.
             Op::SetPropDynamic => {
+                if self.fn_mode {
+                    return None;
+                }
                 let shape = self.vstack.clone();
                 let obj = self.base_slot(2)?;
                 let val = self.top_num_reg(0)?;
@@ -2599,6 +2760,11 @@ impl Xlate<'_> {
                 } else {
                     // Ordinary-object own data property: entry-resolved slot,
                     // no per-access check, no bail (see `KOp::LoadProp`).
+                    // Loop mode only — the per-activation slot resolution
+                    // machinery pins frame oslots, which fn kernels lack.
+                    if self.fn_mode {
+                        return None;
+                    }
                     let obj = self.base_slot(0)?;
                     let prop = self.kprop(obj, &key, true, false)?;
                     self.pop()?; // base

--- a/crates/chidori-js/src/realm.rs
+++ b/crates/chidori-js/src/realm.rs
@@ -33,6 +33,10 @@ pub struct Realm {
     pub array_push: Option<JsObject>,
     /// As `array_push`, for `Array.prototype.pop` (`KOp::ArrayPop`).
     pub array_pop: Option<JsObject>,
+    /// The canonical `String.prototype.charCodeAt`, pinned at install so the
+    /// kernel `CharCodeAt` entry guard can identity-check the live property
+    /// (and a bail can reconstruct the method on the operand stack).
+    pub string_char_code_at: Option<JsObject>,
 
     pub object_proto: JsObject,
     pub function_proto: JsObject,
@@ -189,6 +193,7 @@ impl Realm {
             ta_length_getter: None,
             array_push: None,
             array_pop: None,
+            string_char_code_at: None,
             object_proto: bare(),
             function_proto: bare(),
             array_proto: bare(),

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -349,6 +349,10 @@ pub struct Vm {
     /// `kernel_regs`); cleared after every activation so the pool never
     /// extends an object's lifetime.
     pub(crate) kernel_objs: Vec<crate::value::JsObject>,
+    /// Scratch cache of the string-base values for the active kernel
+    /// (`Kernel::sslots`); cleared after every activation so the pool never
+    /// extends a string's lifetime.
+    pub(crate) kernel_strs: Vec<crate::value::JsString>,
     /// Pooled entry-resolved property-slot indices for kernel
     /// `LoadProp`/`StoreProp` (see `KProp`).
     pub(crate) kernel_prop_slots: Vec<u32>,
@@ -389,6 +393,7 @@ impl Vm {
             frame_pool: Vec::new(),
             kernel_regs: Vec::new(),
             kernel_objs: Vec::new(),
+            kernel_strs: Vec::new(),
             kernel_prop_slots: Vec::new(),
             kernel_callees: Vec::new(),
             dummy_bf: Rc::new(BytecodeFunction {

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -566,6 +566,41 @@ const CORPUS: &[&str] = &[
     "const s = 'abc'; let r = ''; for (let i = 0; i < s.length; i++) { r += s.charAt(i); } console.log(r);",
     // Rope-built string (the += builder) scanned afterwards.
     "let b = ''; for (let i = 0; i < 40; i++) { b += 'ab'; } let q = 0; for (let i = 0; i < b.length; i++) { q += b.charCodeAt(i); } console.log(q, b.length);",
+    // --- FUNCTION kernels with ARRAY-typed arguments: (a, i) => a[i] -------
+    // The canonical accessor shapes, function and arrow.
+    "function get(a, i) { return a[i]; } const arr = [10, 20, 30]; let s = 0; for (let i = 0; i < 3; i++) { s += get(arr, i); } console.log(s, get(arr, 0));",
+    "const pick = (a, i) => a[i] * 2 + 1; const arr = [5, 6, 7, 8]; let s = 0; for (let i = 0; i < 4; i++) { s += pick(arr, i); } console.log(s);",
+    // `a.length` through a function kernel; a typed array must abandon (its
+    // length is a prototype accessor a frameless kernel cannot guard).
+    "const len = (a) => a.length; console.log(len([1, 2, 3]), len(new Float64Array(5)), len([]));",
+    // A whole loop INSIDE the kernelized body (dot product).
+    "function dot(a, b, n) { let s = 0; for (let i = 0; i < n; i++) { s += a[i] * b[i]; } return s; } const x = [1, 2, 3, 4], y = [5, 6, 7, 8]; console.log(dot(x, y, 4), dot(x, y, 0));",
+    // Holes, OOB, negative and fractional indices abandon to the exact
+    // generic semantics (undefined absorption, prototype consult).
+    "const get = (a, i) => a[i]; const h = [1, , 3]; console.log(get(h, 0), get(h, 1), get(h, 5), get(h, -1), get(h, 0.5));",
+    // A hole that reads THROUGH the prototype.
+    "const get = (a, i) => a[i]; const h = [1, , 3]; Array.prototype[1] = 99; console.log(get(h, 1)); delete Array.prototype[1];",
+    // Non-Number elements abandon per call (strings flow through generic).
+    "const get = (a, i) => a[i]; const m = [1, 'two', 3]; let out = ''; for (let i = 0; i < 3; i++) { out += get(m, i) + '|'; } console.log(out);",
+    // Non-array receivers: string (indexed chars), number (undefined),
+    // object with index props.
+    "const get = (a, i) => a[i]; console.log(get('xyz', 1), get(7, 0), get({ 0: 'zero' }, 0));",
+    // Typed arrays: valid-index reads run in-kernel; BigInt kinds abandon.
+    "const get = (a, i) => a[i]; const t = new Int32Array([4, 5, 6]); const f = new Float32Array([1.5, 2.5]); console.log(get(t, 1), get(f, 0), get(t, 9));",
+    "const get = (a, i) => a[i]; const b = new BigInt64Array(2); b[0] = 3n; console.log(typeof get(b, 0), String(get(b, 0)));",
+    // Element STORES keep the body generic (purity: abandon could not undo).
+    "function setz(a, i, v) { a[i] = v; return a[i]; } const arr = [0, 0]; console.log(setz(arr, 1, 42), arr.join(','));",
+    // Missing / extra arguments decline per call, generically.
+    "const get = (a, i) => a[i]; const arr = [9, 8]; console.log(get(arr), get(arr, 1, 'extra'), get());",
+    // Array mutated between calls: each access re-checks.
+    "const get = (a, i) => a[i]; const arr = [1]; console.log(get(arr, 0)); arr.push(2); console.log(get(arr, 1)); arr.length = 0; console.log(get(arr, 0));",
+    // Self-recursion consuming an array argument stays generic.
+    "function r(a, n) { return n <= 0 ? a[0] : r(a, n - 1); } console.log(r([7], 5));",
+    // An array-arg kernel used as a HOF callback (index into a sibling
+    // array) — reduce passes (acc, v, i, arr).
+    "const src2 = [10, 20, 30]; const sum = src2.reduce(function (acc, v, i, arr) { return acc + arr[i]; }, 0); console.log(sum);",
+    // Mixed: numeric args + array arg + Math in one kernelized body.
+    "function clampAt(a, i, lo) { return Math.max(a[i], lo); } const arr = [-5, 3, 12]; let s = 0; for (let i = 0; i < 3; i++) { s += clampAt(arr, i, 0); } console.log(s);",
 ];
 
 #[test]
@@ -753,6 +788,66 @@ fn string_scan_loops_get_kernels() {
     );
 }
 
+/// Array-argument bodies get FUNCTION kernels (`(a, i) => a[i]`) — and
+/// element stores / recursive array consumers never do (pins the arg-objs
+/// tier: reads abandon, stores and recursion stay generic).
+#[test]
+fn array_arg_functions_get_fn_kernels() {
+    fn first_fn_kernel(p: &FuncProto) -> Option<&chidori_js::bytecode::Kernel> {
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                if let Some(k) = &f.fn_kernel {
+                    return Some(k);
+                }
+                if let Some(k) = first_fn_kernel(f) {
+                    return Some(k);
+                }
+            }
+        }
+        None
+    }
+    // The canonical accessor kernelizes with one argument object slot.
+    let p = compile_script("const get = (a, i) => a[i]; get([1], 0);").expect("compiles");
+    let k = first_fn_kernel(&p).expect("(a, i) => a[i] must carry a function kernel");
+    assert_eq!(k.arg_objs.len(), 1, "one argument array base");
+    // `a.length` alone kernelizes too.
+    assert!(
+        first_fn_kernel(
+            &compile_script("const len = (a) => a.length; len([1]);").expect("compiles")
+        )
+        .is_some(),
+        "(a) => a.length must carry a function kernel"
+    );
+    // A loop over the array inside the body kernelizes (dot product).
+    assert!(
+        first_fn_kernel(
+            &compile_script("function dot(a, b, n) { let s = 0; for (let i = 0; i < n; i++) { s += a[i] * b[i]; } return s; } dot([1], [2], 1);")
+                .expect("compiles")
+        )
+        .is_some(),
+        "dot-product body must carry a function kernel"
+    );
+    // Element STORES are impure — no kernel.
+    assert!(
+        first_fn_kernel(
+            &compile_script("function setz(a, i, v) { a[i] = v; return 0; } setz([0], 0, 1);")
+                .expect("compiles")
+        )
+        .is_none(),
+        "element-storing body must stay generic"
+    );
+    // Recursion consuming an array argument — no kernel (an abandon deep in
+    // a recursion tree has nothing to rerun windows from).
+    assert!(
+        first_fn_kernel(
+            &compile_script("function r(a, n) { return n <= 0 ? a[0] : r(a, n - 1); } r([1], 2);")
+                .expect("compiles")
+        )
+        .is_none(),
+        "recursive array consumer must stay generic"
+    );
+}
+
 /// Tiny pure-scalar functions get a FUNCTION kernel (frameless call path) —
 /// and frame-dependent bodies never do (pins fn-kernel eligibility).
 #[test]
@@ -784,8 +879,9 @@ fn tiny_functions_get_fn_kernels() {
     for src in [
         // `arguments` needs a real frame.
         "function f() { return arguments.length; }",
-        // Property access needs a frame to bail into.
-        "const f = (a) => a.length;",
+        // NAMED property access (other than array-arg element/length reads,
+        // which the arg-objs tier abandons on) needs a frame to bail into.
+        "const f = (o) => o.x;",
         // Calls (incl. recursion) are off the allowlist.
         "function f(a, b) { return f(a) - b; }",
         // Allocation is off the allowlist.

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -539,6 +539,33 @@ const CORPUS: &[&str] = &[
     "const a = [1, , 3, 4]; let acc = 0; const look = () => acc; for (let i = 0; i < a.length; i++) { acc += a[i] || 0; } console.log(acc, look());",
     // -0 / NaN through a captured accumulator.
     "let z = 5; const zz = () => z; for (let i = 0; i < 3; i++) { z = -0 * i + z * 0; } console.log(Object.is(z, -0), Object.is(zz(), -0));",
+    // --- STRING BASES: charCodeAt / length in loop kernels -----------------
+    // The canonical tokenizer scan (string_scan workload shape).
+    "const s = 'hello, kernel world! 0123456789'; let h = 0; for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) | 0; } console.log(h);",
+    // Non-ASCII: multi-byte UTF-8 and an astral pair (surrogate units).
+    "const s = 'a\\u00e9\\u4e2d\\ud83d\\ude00z'; let out = ''; for (let i = 0; i < s.length; i++) { out += s.charCodeAt(i) + ','; } console.log(out, s.length);",
+    // A lone surrogate is preserved as its raw unit.
+    "const s = 'x\\ud800y'; let sum = 0; for (let i = 0; i < s.length; i++) { sum += s.charCodeAt(i); } console.log(sum);",
+    // Out-of-bounds, fractional, negative and NaN indices (NaN result paths).
+    "const s = 'abc'; let r = ''; for (let i = -2; i < 6; i++) { r += s.charCodeAt(i) + ','; } console.log(r);",
+    "const s = 'abcdef'; let x = 0; for (let i = 0; i < 4; i++) { x += s.charCodeAt(i + 0.5) + s.charCodeAt(i * 1.5); } console.log(x);",
+    "const s = 'abc'; let n = 0; for (let i = 0; i < 3; i++) { n += s.charCodeAt(0 / 0) || -1; } console.log(n);",
+    // Empty string: zero iterations off `.length`, NaN off direct reads.
+    "const s = ''; let c = 0; for (let i = 0; i < s.length; i++) { c++; } console.log(c, s.charCodeAt(0));",
+    // Monkeypatched String.prototype.charCodeAt: the kernel declines and the
+    // patch is observed, then restored behavior returns.
+    "const orig = String.prototype.charCodeAt; String.prototype.charCodeAt = function (i) { return 7; }; const s = 'abc'; let t = 0; for (let i = 0; i < s.length; i++) { t += s.charCodeAt(i); } String.prototype.charCodeAt = orig; let u = 0; for (let i = 0; i < s.length; i++) { u += s.charCodeAt(i); } console.log(t, u);",
+    // String OBJECT receiver: the slot holds an Object, the guard declines,
+    // the generic wrapper path answers.
+    "const s = new String('abc'); let v = 0; for (let i = 0; i < s.length; i++) { v += s.charCodeAt(i); } console.log(v);",
+    // charCodeAt feeding arithmetic, Math, and array writes in one region.
+    "const s = 'kernelsss'; const a = new Array(9); for (let i = 0; i < s.length; i++) { a[i] = Math.max(s.charCodeAt(i) - 96, 0); } console.log(a.join(','));",
+    // Two distinct string bases in one loop.
+    "const a = 'abcdef', b = 'uvwxyz'; let d = 0; for (let i = 0; i < a.length; i++) { d += b.charCodeAt(i) - a.charCodeAt(i); } console.log(d);",
+    // charAt (string result) keeps the loop generic; results identical.
+    "const s = 'abc'; let r = ''; for (let i = 0; i < s.length; i++) { r += s.charAt(i); } console.log(r);",
+    // Rope-built string (the += builder) scanned afterwards.
+    "let b = ''; for (let i = 0; i < 40; i++) { b += 'ab'; } let q = 0; for (let i = 0; i < b.length; i++) { q += b.charCodeAt(i); } console.log(q, b.length);",
 ];
 
 #[test]
@@ -689,6 +716,40 @@ fn cell_loops_get_kernels() {
     assert!(
         kernels_in("let n = 10; const keep = () => n; const g = (x) => x + 1; let s = 0; for (let i = 0; i < n; i++) { s += g(i); } s;") >= 1,
         "read-only cell + pinned-callee loop must kernelize"
+    );
+}
+
+/// String-scan loops (`s.charCodeAt(i)` under an `s.length` bound) actually
+/// kernelize (pins the string-base tier against silent regressions).
+#[test]
+fn string_scan_loops_get_kernels() {
+    fn kernels_in(src: &str) -> usize {
+        fn count(p: &FuncProto) -> usize {
+            let mut n = p.kernels.len();
+            for c in &p.consts {
+                if let Const::Func(f) = c {
+                    n += count(f);
+                }
+            }
+            n
+        }
+        count(&compile_script(src).expect("compiles"))
+    }
+    // The canonical tokenizer/hash scan.
+    assert!(
+        kernels_in("function f(s) { let h = 0; for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) | 0; } return h; }") >= 1,
+        "charCodeAt scan loop must kernelize"
+    );
+    // charCodeAt + dense-array write in one region.
+    assert!(
+        kernels_in("function f(s, a) { for (let i = 0; i < s.length; i++) { a[i] = s.charCodeAt(i); } }") >= 1,
+        "charCodeAt + array write loop must kernelize"
+    );
+    // charAt returns a STRING — unrepresentable, must stay generic.
+    assert_eq!(
+        kernels_in("function f(s) { let r = 0; for (let i = 0; i < s.length; i++) { r += s.charAt(i) ? 1 : 0; } return r; }"),
+        0,
+        "charAt loop must stay generic"
     );
 }
 

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -500,6 +500,45 @@ const CORPUS: &[&str] = &[
     "function h2(n) { return n <= 0 ? 0 : Math.max(n % 7, h2(n - 1)); } console.log(h2(40));",
     // Captured numeric upvalue inside a recursive const arrow.
     "const LIM = 3; const f2 = (n) => (n <= LIM ? n : f2(n - 2) + 1); console.log(f2(21));",
+    // --- OWN-FRAME CELLS: captured loop bounds and accumulators -----------
+    // Captured loop bound: `n` is a cell (the arrow captures it).
+    "let n = 100; const bound = () => n; let s = 0; for (let i = 0; i < n; i++) { s += i; } console.log(s, bound());",
+    // Captured accumulator: the loop WRITES the cell; the closure reads the
+    // final value after.
+    "let total = 0; const read = () => total; for (let i = 0; i < 50; i++) { total += i * 2; } console.log(total, read());",
+    // Statement-position ++ on a captured binding (IncCellStmt).
+    "let hits = 0; const h = () => hits; for (let i = 0; i < 20; i++) { if (i % 3 === 0) hits++; } console.log(hits, h());",
+    // fib-iteration entirely over captured bindings (cell loads and stores).
+    "let a = 0, b = 1; const keep = () => a + b; for (let i = 0; i < 30; i++) { const t = a + b; a = b; b = t; } console.log(a, b, keep());",
+    // Captured binding warms late: starts undefined (guard declines), then
+    // becomes a number (late entry) — result identical either way.
+    "let t; const g = () => t; let s = 0; for (let i = 0; i < 10; i++) { t = (t || 0) + i; s = t; } console.log(s, t, g());",
+    // A string flows through the captured accumulator: guard declines and the
+    // generic loop concatenates exactly.
+    "let acc = 0; const r = () => acc; for (let i = 0; i < 6; i++) { if (i === 3) acc = '' + acc; acc += i; } console.log(acc, r());",
+    // The captured BOUND is reassigned mid-loop (loop-carried compare operand
+    // through a cell register, written back on every exit).
+    "let n = 10; const f = () => n; let c = 0; for (let i = 0; i < n; i++) { if (i === 5) n = 8; c++; } console.log(c, n, f());",
+    // Cell WRITES + a pinned-closure call in one region: translation must
+    // exclude the combination (a callee upvalue snapshot could go stale) and
+    // the generic path owns it — including when the callee captures the very
+    // accumulator being written.
+    "const dbl = (x) => x * 2; let sum = 0; const peek = () => sum; for (let i = 0; i < 10; i++) { sum += dbl(i); } console.log(sum, peek());",
+    "let sum = 0; const addsum = (x) => x + sum; let s = 0; for (let i = 0; i < 5; i++) { s = addsum(i); sum += 1; } console.log(s, sum);",
+    // Cell READ + pinned-closure call is allowed: bound stays a cell, callee
+    // runs on its window.
+    "let n = 10; const keepn = () => n; const inc = (x) => x + 1; let s = 0; for (let i = 0; i < n; i++) { s += inc(i); } console.log(s, keepn());",
+    // Callee whose upvalue IS the read-only cell: snapshot equals the cell
+    // for the whole activation (no writes anywhere).
+    "let base = 7; const keep = () => base; const addb = (x) => x + base; let s = 0; for (let i = 0; i < 6; i++) { s += addb(i); } console.log(s, keep());",
+    // TDZ: the loop reads a captured `let` before initialization — the guard
+    // declines (Uninitialized) and the generic path throws the ReferenceError.
+    "try { let s = 0; for (let i = 0; i < b; i++) { s += b; } console.log('no'); } catch (e) { console.log(e.constructor.name); } let b = 5; const q = () => b;",
+    // Interleaved kernel and generic iterations must keep the cell coherent:
+    // taint the loop with a bail-y array access while accumulating in a cell.
+    "const a = [1, , 3, 4]; let acc = 0; const look = () => acc; for (let i = 0; i < a.length; i++) { acc += a[i] || 0; } console.log(acc, look());",
+    // -0 / NaN through a captured accumulator.
+    "let z = 5; const zz = () => z; for (let i = 0; i < 3; i++) { z = -0 * i + z * 0; } console.log(Object.is(z, -0), Object.is(zz(), -0));",
 ];
 
 #[test]
@@ -610,6 +649,46 @@ fn v4_loops_get_kernels() {
     assert!(
         kernels_in("function f(t) { let s = 0; for (let i = 0; i < t.length; i++) { s += t[i]; } return s; } f(new Float64Array(4));") >= 1,
         "typed-array loop must kernelize"
+    );
+}
+
+/// Captured-binding (own-frame CELL) loops actually kernelize — and the
+/// cell-write + pinned-closure-call combination never does (a callee's
+/// upvalue snapshot could go stale against the written cell).
+#[test]
+fn cell_loops_get_kernels() {
+    fn kernels_in(src: &str) -> usize {
+        fn count(p: &FuncProto) -> usize {
+            let mut n = p.kernels.len();
+            for c in &p.consts {
+                if let Const::Func(f) = c {
+                    n += count(f);
+                }
+            }
+            n
+        }
+        count(&compile_script(src).expect("compiles"))
+    }
+    // Captured loop bound: the loop reads a cell every test.
+    assert!(
+        kernels_in("let n = 100; const f = () => n; let s = 0; for (let i = 0; i < n; i++) { s += i; } s;") >= 1,
+        "cell-bound loop must kernelize"
+    );
+    // Captured accumulator: the loop WRITES the cell.
+    assert!(
+        kernels_in("let total = 0; const f = () => total; for (let i = 0; i < 50; i++) { total += i; } total;") >= 1,
+        "cell-accumulator loop must kernelize"
+    );
+    // Cell WRITE + pinned closure call: excluded by translation.
+    assert_eq!(
+        kernels_in("const g = (x) => x * 2; let sum = 0; const f = () => sum; for (let i = 0; i < 10; i++) { sum += g(i); } sum;"),
+        0,
+        "cell-write + pinned-callee region must stay generic"
+    );
+    // Cell READ + pinned closure call: allowed.
+    assert!(
+        kernels_in("let n = 10; const keep = () => n; const g = (x) => x + 1; let s = 0; for (let i = 0; i < n; i++) { s += g(i); } s;") >= 1,
+        "read-only cell + pinned-callee loop must kernelize"
     );
 }
 

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -907,11 +907,12 @@ results flowing into property/element stores.
 
 ### 6.5.1 What's next (new baseline)
 
-- Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,
+- ~~Remaining kernel candidates: `String.prototype.charCodeAt`-class reads,
   loop bounds via own-frame CELLS (captured accumulators), typed-array
   element access (a natural fit — elements are statically numeric), and
   argument-typed ARRAY parameters for function kernels (`(a, i) => a[i]`
-  needs arg object slots + a bail-free access story).
+  needs arg object slots + a bail-free access story).~~ **All landed** —
+  typed arrays in §6.8, the other three in §6.10.
 - Kernel-tier extensions with clear shapes: MUTUAL recursion (guard a
   small set of global bindings instead of one), self-calls through local/
   captured bindings (`const f = n => … f(…)`), and boolean-returning
@@ -1076,6 +1077,77 @@ recursion, captured numeric upvalues) and the depth-overflow differential
 now covers the mutual path; structural pins updated (boolean/mutual/
 captured-binding recursion MUST kernelize, parameter-recursion must not);
 full suites + Test262 gate green.
+
+## 6.10 Kernel v10 (landed 2026-07-10): the remaining §6.5.1 candidates —
+cells, string bases, and array-typed function-kernel arguments
+
+Three tiers in three commits, closing out the §6.5.1 candidate list. All
+safe Rust, zero new dependencies; gates green (full suites incl. the
+record→replay byte-identity tests, the kernels differential corpus + fuzz,
+Test262 gate); RESULT lines byte-identical on every measured workload.
+
+1. **Own-frame CELL slots (`KSlot::Cell`)** — a binding captured by a
+   nested closure stays a heap cell after localization, and any loop
+   touching one (the captured bound / accumulator shape: build a total in
+   a `forEach`, then loop to it) lost its kernel entirely. Cells now map
+   into kernel registers like locals: the entry guard requires
+   `Value::Number` (TDZ declines), and every exit/bail/interrupt unwind
+   writes the register back through the `RefCell`. Soundness is the
+   upvalue-snapshot argument — nothing inside a kernel region can CALL the
+   capturing closure — with one carve-out enforced at translation: a
+   region that WRITES a cell and calls a pinned closure (`KOp::CallKernel`)
+   stays generic, because the callee's once-per-activation upvalue snapshot
+   could be the very cell being written. Measured: a 4M-iteration
+   captured-bound/accumulator loop **810 → 145 ms (5.5×)**.
+
+2. **Pinned STRING bases (`Kernel::sslots`)** — the canonical tokenizer
+   scan (`for (i = 0; i < s.length; i++) s.charCodeAt(i)`) never
+   kernelized. String locals now pin into string slots, discovered like
+   array bases (`charCodeAt` consumption is the string-specific evidence
+   and wins the ambiguous `.length` discovery). Both accesses are
+   BAIL-FREE — unlike array elements: the entry guard requires a primitive
+   string (immutable + pinned local) and identity-checks the canonical
+   `String.prototype.charCodeAt` (a primitive receiver's lookup cannot be
+   shadowed anywhere else; pinned in the realm at install like
+   `Array.prototype.push`), after which every `Number` index has a defined
+   result — ToIntegerOrInfinity, code unit in bounds, NaN out — through
+   the same `JsString::code_unit_at` as the builtin. The activation-pinned
+   string also sidesteps a §6.7 gap: the generic path's per-call receiver
+   clone drops the per-instance `Cell` unit-count cache, so a JOIN-built
+   (non-rope) ASCII string still paid an O(n) scan per read — O(n²) per
+   loop. Measured: a 12.8 KB join-built scan ×200 **39.5 s → 0.16 s**;
+   the rope-built `string_scan` benchmark workload **56 → 25 ms (~2.2×)**.
+   (The clone-drops-cache pathology remains for non-kernel access — a
+   shareable unit-count cell is candidate follow-up work.)
+
+3. **Array-typed FUNCTION-kernel arguments (`Kernel::arg_objs`)** — fn
+   kernels rejected element access outright ("a bail needs a frame to
+   resume into"), keeping `(a, i) => a[i]`-class callbacks on the frame
+   path. Argument-typed READ-ONLY array bases now translate — `a[i]`
+   element reads (dense + numeric typed arrays) and dense `a.length` —
+   with a new answer to the bail problem: **`KOp::Abandon`**. A frameless
+   kernel with array bases is read-only pure (element stores reject at
+   translation), so an access missing its dense fast path simply discards
+   the register-only activation and the caller reruns the call
+   generically, which performs the exact spec semantics (holes, prototype
+   reads, OOB, BigInt elements, exotic receivers). The compiler's
+   parameter prologue copies `LoadArg` into locals, so translation binds
+   each discovered obj-local to exactly ONE argument slot at its
+   init-dominated prologue store; accesses resolve through
+   `args[arg_objs[slot]]` at runtime. Excluded wherever an abandon has no
+   caller to rerun from or argument windows carry raw `f64`s: recursive
+   kernels, mutual-recursion family members, `CallKernel` callees, and the
+   all-f64 comparator specialization all decline at their guards.
+   Typed-array `.length` abandons too (a prototype accessor no frameless
+   kernel can guard). Measured: a 4M-call accessor + dot-product workload
+   **1.08 s → 0.64 s (1.7×)**.
+
+Remaining kernel-tier headroom after v10: §6.9's per-outer-call family
+resolution scratch, `charCodeAt` bases via cells/arguments (the tier is
+locals-only), self-calls through parameters, and the shareable string
+unit-count cache above. The structural levers are unchanged: register
+bytecode (§3.5) for non-kernel dispatch, shapes (§3.7) for object
+building.
 
 ## 7. References
 


### PR DESCRIPTION
A binding captured by a nested closure stays a heap cell after
localization, and any loop touching one (the captured bound / accumulator
shape: 'let total = 0; rows.forEach(...); for (i = 0; i < total; i++)')
lost its kernel entirely. KSlot::Cell maps such cells into kernel
registers like locals: the entry guard requires Value::Number (TDZ
declines to the generic path), and every exit/bail/interrupt unwind
writes the register back through the RefCell.

Soundness matches the upvalue-snapshot argument: nothing inside a kernel
region can call the capturing closure, so no observer exists between
entry and write-back. The one exception — pinned-closure calls
(KOp::CallKernel), whose callees snapshot upvalues once per activation —
is excluded at translation: a region that WRITES any cell and calls a
pinned closure stays generic (the callee's snapshot could be the very
cell being written).

Corpus: captured bounds/accumulators, IncCellStmt, late entry, string
taint, mid-loop bound reassignment, TDZ reads, the write+callee
exclusion (both aliased and not), bail interleaving, -0. Structural
pins: cell-bound and cell-accumulator loops MUST kernelize; the
write+callee combination must NOT.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UXTPdiyC5qPFF8Qd678KNj