### PR TITLE
Register bytecode tier: whole-function register programs over boxed values (§3.5)

### DIFF
--- a/crates/chidori-js/benches/common/workloads.rs
+++ b/crates/chidori-js/benches/common/workloads.rs
@@ -66,4 +66,13 @@ pub const WORKLOADS: &[(&str, &str)] = &[
         "mutual_recursion",
         "(function(){ function isEven(n){ return n === 0 ? true : isOdd(n - 1); } function isOdd(n){ return n === 0 ? false : isEven(n - 1); } const gcd = (a, b) => b === 0 ? a : gcd(b, a % b); let c = 0; for (let i = 0; i < 600; i++) { if (isEven(i % 97)) c++; c += gcd(i + 1234, 991); } return c; })()",
     ),
+    // Mixed "glue code": small helpers over objects and strings — property
+    // traffic across calls, string building, for-in, ternary classification.
+    // Every function here declines the typed kernel tiers, so this is the
+    // register-bytecode tier's home turf (docs/js-performance-roadmap.md
+    // §6.10); mirrors benchmarks/workloads/mixed_helpers.js at bench scale.
+    (
+        "mixed_helpers",
+        "(function(){ function normalize(rec){ const out = { id: rec.id | 0, label: '', score: 0 }; for (const k in rec) { if (k === 'id') continue; const v = rec[k]; if (typeof v === 'number') out.score = out.score + v; else if (typeof v === 'string') out.label = out.label ? out.label + ':' + v : v; } return out; } function render(rec){ return '[' + rec.id + '] ' + (rec.label || '?') + ' => ' + rec.score; } function classify(score){ return score > 40 ? 'hi' : score > 15 ? 'mid' : 'lo'; } const buckets = { hi: 0, mid: 0, lo: 0 }; let checksum = 0; for (let i = 0; i < 4000; i++) { const rec = { id: i, name: 'item' + (i % 7), a: i % 13, b: (i * 3) % 29, kind: i % 2 ? 'x' : 'y' }; const norm = normalize(rec); const line = render(norm); buckets[classify(norm.score)]++; checksum = (checksum + line.length + norm.score) % 1000000007; } return checksum + buckets.hi + buckets.mid + buckets.lo; })()",
+    ),
 ];

--- a/crates/chidori-js/benchmarks/workloads/mixed_helpers.js
+++ b/crates/chidori-js/benchmarks/workloads/mixed_helpers.js
@@ -1,0 +1,39 @@
+// Mixed "glue code": small helper functions over objects and strings — the
+// shape of real agent/tool plumbing that the typed kernel tiers deliberately
+// do NOT cover (non-numeric bodies, string building, property traffic across
+// calls, for-in). This is the register-bytecode tier's home turf: with loop
+// kernels declining every function here, the interpreter itself carries the
+// whole workload.
+const N = 60_000;
+
+function normalize(rec) {
+  const out = { id: rec.id | 0, label: "", score: 0 };
+  for (const k in rec) {
+    if (k === "id") continue;
+    const v = rec[k];
+    if (typeof v === "number") out.score = out.score + v;
+    else if (typeof v === "string") out.label = out.label ? out.label + ":" + v : v;
+  }
+  return out;
+}
+
+function render(rec) {
+  return "[" + rec.id + "] " + (rec.label || "?") + " => " + rec.score;
+}
+
+function classify(score) {
+  return score > 40 ? "hi" : score > 15 ? "mid" : "lo";
+}
+
+const buckets = { hi: 0, mid: 0, lo: 0 };
+let text = "";
+let checksum = 0;
+for (let i = 0; i < N; i++) {
+  const rec = { id: i, name: "item" + (i % 7), a: i % 13, b: (i * 3) % 29, kind: i % 2 ? "x" : "y" };
+  const norm = normalize(rec);
+  const line = render(norm);
+  buckets[classify(norm.score)]++;
+  checksum = (checksum + line.length + norm.score) % 1000000007;
+  if ((i & 1023) === 0) text += line + "\n";
+}
+console.log("RESULT=" + checksum + "|" + buckets.hi + "," + buckets.mid + "," + buckets.lo + "|" + text.length);

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -116,6 +116,12 @@ pub struct FuncProto {
     /// the ordinary frame path. `None` for anything but tiny pure-scalar
     /// bodies (sort comparators, map/filter/reduce callbacks).
     pub fn_kernel: Option<Kernel>,
+    /// Register bytecode for the WHOLE body (reg.rs, docs/js-performance-
+    /// roadmap.md §3.5): executed by `Vm::run_reg_frame` instead of the stack
+    /// interpreter whenever present and no op budget is installed. `None`
+    /// when any op falls outside the translated subset (try/finally, `with`/
+    /// direct-eval, suspension, super/private, loop kernels, …).
+    pub reg: Option<Rc<crate::reg::RegProto>>,
     /// Number of plain (non-captured) local slots.
     pub num_locals: u32,
     /// Number of cell (captured-by-closure) slots.
@@ -210,6 +216,7 @@ impl FuncProto {
             consts: Vec::new(),
             kernels: Vec::new(),
             fn_kernel: None,
+            reg: None,
             num_locals: 0,
             num_cells: 0,
             num_params: 0,

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -152,6 +152,49 @@ pub fn compile_script_kernels(src: &str, kernels: bool) -> Result<FuncProto, Str
     })
 }
 
+/// Compile with the register-bytecode pass toggled — used by the register-tier
+/// differential test (`tests/reg.rs`), which asserts register and stack
+/// execution are byte-identical. Production uses [`compile_script`] (register
+/// bytecode on).
+pub fn compile_script_regs(src: &str, regs: bool) -> Result<FuncProto, String> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::script();
+    let ret = Parser::new(&allocator, src, source_type).parse();
+    if !ret.errors.is_empty() {
+        let msg = ret
+            .errors
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(format!("SyntaxError: {msg}"));
+    }
+    let program = ret.program;
+    let sem = oxc::semantic::SemanticBuilder::new()
+        .with_check_syntax_error(true)
+        .build(&program);
+    if !sem.errors.is_empty() {
+        return Err(format!(
+            "SyntaxError: {}",
+            sem.errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    }
+    let mut c = Compiler::new();
+    c.source = src.to_string();
+    c.regify = regs;
+    c.compile_toplevel(&program).map_err(|e| {
+        if e.starts_with("SyntaxError") {
+            e
+        } else {
+            format!("SyntaxError: {e}")
+        }
+    })
+}
+
 /// Compile global eval code — `(0,eval)(src)`: identical to a script except
 /// `return` is illegal and the global `var`/function bindings it creates are
 /// DELETABLE (CreateGlobalVarBinding with D=true).
@@ -790,6 +833,11 @@ struct Compiler {
     /// Always on in production; disabled for the kernel differential test and
     /// under the `op-histogram` feature (kernels would hide per-op counts).
     kernelize: bool,
+    /// Compile register bytecode (`reg.rs`) for eligible whole function
+    /// bodies. Always on in production; disabled for the register-tier
+    /// differential test and under the `op-histogram` feature (register
+    /// execution would hide per-op counts).
+    regify: bool,
 }
 
 impl Compiler {
@@ -814,6 +862,7 @@ impl Compiler {
             fuse: true,
             localize: true,
             kernelize: !cfg!(feature = "op-histogram"),
+            regify: !cfg!(feature = "op-histogram"),
         }
     }
 
@@ -1810,11 +1859,24 @@ impl Compiler {
         } else {
             None
         };
+        // Register bytecode (reg.rs, docs/js-performance-roadmap.md §3.5):
+        // translate the whole body into a register program when every op is
+        // in the translated subset. Runs LAST so it sees the final stream;
+        // functions carrying loop kernels decline inside `regify` (the
+        // unboxed kernels are faster than boxed register ops and own their
+        // functions), as does anything with try/finally handlers, `with`/
+        // direct-eval machinery, suspension, or super/private class wiring.
+        let reg = if self.regify {
+            crate::reg::regify(&code, loc.num_locals).map(std::rc::Rc::new)
+        } else {
+            None
+        };
         FuncProto {
             eval_scopes: fc.eval_scopes.clone(),
             name: fc.name,
             kernels,
             fn_kernel,
+            reg,
             ic: code
                 .iter()
                 .map(|_| crate::bytecode::IcEntry {

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -2553,7 +2553,32 @@ impl Vm {
     // The interpreter loop
     // =====================================================================
 
-    pub fn run_frame(&mut self, mut frame: Box<Frame>) -> Flow {
+    /// Run a frame to completion (or suspension): the register tier when the
+    /// proto carries a register program and per-op accounting is off, the
+    /// stack interpreter otherwise. Every execution entry point (calls,
+    /// [[Construct]], accessors, module/script evaluation, generator and
+    /// async resumption) funnels through here, so the two tiers can never be
+    /// entered inconsistently. Resumed generator/async frames always take the
+    /// stack path by construction: their protos contain suspension ops, which
+    /// decline register translation.
+    pub fn run_frame(&mut self, frame: Box<Frame>) -> Flow {
+        if let Some(reg) = &frame.func.proto.reg {
+            // The op budget demands EXACT per-stack-op accounting, so a
+            // budgeted run (the conformance runner, untrusted eval) stays on
+            // the generic path — the same rule the kernel tiers follow. The
+            // debug-assert documents the resumed-frame invariant.
+            debug_assert!(
+                frame.ip == 0 && frame.pending_throw.is_none() && frame.pending_return.is_none()
+            );
+            if self.op_budget.is_none() {
+                let reg = reg.clone();
+                return self.run_reg_frame(frame, &reg);
+            }
+        }
+        self.run_stack_frame(frame)
+    }
+
+    fn run_stack_frame(&mut self, mut frame: Box<Frame>) -> Flow {
         // Recycle this frame whole into the frame pool, then return the
         // (already-owned) outcome. Used only on synchronous Return/Throw exits;
         // the Suspend paths move the whole frame (buffers included) into the
@@ -2923,6 +2948,842 @@ impl Vm {
         })
     }
 
+    // =====================================================================
+    // Shared op bodies (stack interpreter + register tier)
+    //
+    // These are the op implementations with nontrivial inline logic — the
+    // key-verified inline caches and the dense-element fast paths. Both
+    // `step`/`step_cold` and `run_reg_frame` call them, so each op keeps
+    // exactly ONE implementation and the two tiers cannot drift.
+    // =====================================================================
+
+    /// `Op::GetProp` / `ROp::GetProp` body: IC-accelerated named property
+    /// read. See `FuncProto::ic` for the cache discipline (a stale hint is a
+    /// miss, never a wrong answer).
+    #[inline]
+    pub(crate) fn ic_get_prop(
+        &mut self,
+        obj: Value,
+        name: JsString,
+        ic: Option<&crate::bytecode::IcEntry>,
+    ) -> Result<Value, Value> {
+        // Inline cache (key-verified hints; see `FuncProto::ic`).
+        // Two levels:
+        //  - `holder == None`: the receiver's OWN data property at
+        //    `slot` (ordinary objects).
+        //  - `holder == Some(p)`: a data property at `slot` on `p`,
+        //    verified to still be the receiver's DIRECT prototype and
+        //    not shadowed by an own property — the method-lookup
+        //    pattern (`arr.push`, class instances calling prototype
+        //    methods). Array receivers exclude keys with exotic own
+        //    behavior (`length`, indices). Deeper chains, accessors,
+        //    proxies, and every other exotic fall to the unchanged
+        //    slow path.
+        if let Value::Object(o) = &obj {
+            if let Some(ic) = ic {
+                let b = o.borrow();
+                let (is_ord, is_arr) = (
+                    matches!(b.internal, Internal::Ordinary),
+                    matches!(b.internal, Internal::Array(_)),
+                );
+                // Array exotics: `length` and index keys never take
+                // the IC (they don't live in the props map).
+                let plain_key = !is_arr
+                    || (name.as_str() != "length"
+                        && crate::value::canonical_index(name.as_str()).is_none());
+                if (is_ord || is_arr) && plain_key {
+                    // Own-property hit: never touches the holder cell.
+                    if is_ord {
+                        if let Some((PropertyKey::Str(k), prop)) =
+                            b.props.get_index(ic.own_slot.get() as usize)
+                        {
+                            if let PropertyKind::Data { value, .. } = &prop.kind {
+                                if k == &name {
+                                    let v = value.clone();
+                                    return Ok(v);
+                                }
+                            }
+                        }
+                    }
+                    // Proto hit: valid only when the receiver has no
+                    // own props (nothing can shadow) and its CURRENT
+                    // direct proto is the cached holder.
+                    if b.props.is_empty() {
+                        let holder = ic.holder.borrow();
+                        if let Some(h) = &*holder {
+                            if b.proto.as_ref().is_some_and(|p| p.ptr_eq(h)) {
+                                let hb = h.borrow();
+                                if let Some((PropertyKey::Str(k), prop)) =
+                                    hb.props.get_index(ic.proto_slot.get() as usize)
+                                {
+                                    if let PropertyKind::Data { value, .. } = &prop.kind {
+                                        if k == &name {
+                                            let v = value.clone();
+                                            return Ok(v);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // Refill: own data property first (ordinary only),
+                    // then a one-level proto data property when no own
+                    // props can shadow.
+                    let key = PropertyKey::Str(name.clone());
+                    if is_ord {
+                        if let Some((idx, _, prop)) = b.props.get_full(&key) {
+                            if let PropertyKind::Data { value, .. } = &prop.kind {
+                                ic.own_slot.set(idx as u32);
+                                let v = value.clone();
+                                return Ok(v);
+                            }
+                        }
+                    }
+                    if b.props.is_empty() {
+                        if let Some(p) = &b.proto {
+                            let pb = p.borrow();
+                            if matches!(pb.internal, Internal::Ordinary)
+                                || matches!(pb.internal, Internal::Array(_))
+                            {
+                                if let Some((idx, _, prop)) = pb.props.get_full(&key) {
+                                    if let PropertyKind::Data { value, .. } = &prop.kind {
+                                        ic.proto_slot.set(idx as u32);
+                                        let v = value.clone();
+                                        let holder_obj = p.clone();
+                                        drop(pb);
+                                        *ic.holder.borrow_mut() = Some(holder_obj);
+                                        return Ok(v);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.get_prop(&obj, &PropertyKey::Str(name))
+    }
+
+    /// `Op::SetProp` / `ROp::SetProp` body: IC-accelerated named property
+    /// write. Returns the value (the assignment expression's result).
+    #[inline]
+    pub(crate) fn ic_set_prop(
+        &mut self,
+        obj: Value,
+        name: JsString,
+        value: Value,
+        strict: bool,
+        ic: Option<&crate::bytecode::IcEntry>,
+    ) -> Result<Value, Value> {
+        // Inline cache (key-verified slot hint; see `FuncProto::ic`).
+        // Fast path only when the receiver is an ordinary object whose
+        // OWN property at the hinted slot is a WRITABLE data property —
+        // per OrdinarySetWithOwnDescriptor that assignment updates the
+        // value in place (attributes and slot order preserved, no
+        // prototype setter can intervene). Everything else (missing own
+        // key → proto-chain setters/read-only checks, accessors,
+        // non-writable → strict TypeError, exotics) takes the
+        // unchanged put_value path, which also refills the hint.
+        if let Value::Object(o) = &obj {
+            if let Some(ic) = ic {
+                let mut b = o.borrow_mut();
+                if matches!(b.internal, Internal::Ordinary) {
+                    if let Some((PropertyKey::Str(k), prop)) =
+                        b.props.get_index_mut(ic.own_slot.get() as usize)
+                    {
+                        if k == &name {
+                            if let PropertyKind::Data {
+                                value: slot,
+                                writable: true,
+                            } = &mut prop.kind
+                            {
+                                *slot = value.clone();
+                                return Ok(value);
+                            }
+                        }
+                    }
+                    let key = PropertyKey::Str(name.clone());
+                    if let Some((idx, _, prop)) = b.props.get_full_mut(&key) {
+                        if let PropertyKind::Data {
+                            value: slot,
+                            writable: true,
+                        } = &mut prop.kind
+                        {
+                            ic.own_slot.set(idx as u32);
+                            *slot = value.clone();
+                            return Ok(value);
+                        }
+                    }
+                }
+            }
+        }
+        self.put_value(&obj, &PropertyKey::Str(name), value.clone(), strict)?;
+        Ok(value)
+    }
+
+    /// `Op::GetPropDynamic` / `ROp::GetElem` body: computed-key read with the
+    /// dense-array integer fast path.
+    #[inline]
+    pub(crate) fn elem_get(&mut self, obj: Value, key_v: Value) -> Result<Value, Value> {
+        // Integer fast path: `a[i]` on a dense array with an integral
+        // Number key reads the element directly — skipping
+        // ToPropertyKey's Number→String conversion (a float-format +
+        // heap allocation per access!), the reparse back to an index,
+        // and the property-map machinery. Only when no reified props
+        // entry can shadow the dense element (`props.is_empty()`) and
+        // the slot is a real element (in bounds, not a hole);
+        // everything else takes the unchanged spec path.
+        if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
+            if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
+                let b = o.borrow();
+                if let Internal::Array(arr) = &b.internal {
+                    if b.props.is_empty() {
+                        if let Some(v) = arr.get(*n as usize) {
+                            if !matches!(v, Value::Hole) {
+                                let v = v.clone();
+                                return Ok(v);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // GetValue: RequireObjectCoercible(base) (via ToObject) throws
+        // BEFORE ToPropertyKey coerces the key expression's value.
+        self.require_object_coercible(&obj, "read properties of")?;
+        let key = self.to_property_key(&key_v)?;
+        self.get_prop(&obj, &key)
+    }
+
+    /// `Op::SetPropDynamic` / `ROp::SetElem` body: computed-key write with
+    /// the dense-array fast paths (in-place overwrite, hole fill, append).
+    /// Returns the value (the assignment expression's result).
+    #[inline]
+    pub(crate) fn elem_set(
+        &mut self,
+        obj: Value,
+        key_v: Value,
+        value: Value,
+        strict: bool,
+    ) -> Result<Value, Value> {
+        // Integer fast path mirroring `elem_get`: overwrite an
+        // EXISTING dense element in place (an in-bounds non-hole dense
+        // slot is a plain writable data property per the array exotic
+        // [[Set]] — no setter, no length change, no extensibility
+        // interaction), fill an in-bounds HOLE, or append at exactly
+        // `length`. Filling and appending CREATE a property (the own
+        // property is absent), so they additionally require the array
+        // to be extensible (a sealed/prevented receiver must reject
+        // through the generic path), the dense-storage bound (the
+        // generic path owns that RangeError), and a prototype chain
+        // with no reified entry at the index — OrdinarySet consults
+        // the chain for an absent own property, so a proto accessor /
+        // non-writable index must intercept via the generic path
+        // (`protos_allow_index_create`). Gaps past the end, shadowed
+        // elements, and non-arrays take the spec path.
+        if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
+            if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
+                let i = *n as usize;
+                let mut creates = None;
+                {
+                    let mut b = o.borrow_mut();
+                    if b.props.is_empty() {
+                        let extensible = b.extensible;
+                        if let Internal::Array(arr) = &mut b.internal {
+                            match arr.get_mut(i) {
+                                Some(slot) if !matches!(slot, Value::Hole) => {
+                                    *slot = value.clone();
+                                    return Ok(value);
+                                }
+                                Some(_) => {
+                                    if extensible {
+                                        creates = Some(b.proto.clone());
+                                    }
+                                }
+                                None => {
+                                    if extensible
+                                        && i == arr.len()
+                                        && i < crate::value::MAX_DENSE_ARRAY
+                                    {
+                                        creates = Some(b.proto.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some(proto) = creates {
+                    if crate::value::protos_allow_index_create(proto, i as u32, 1) {
+                        // No user code ran since the conditions were
+                        // checked (same native frame), so they still
+                        // hold.
+                        let mut b = o.borrow_mut();
+                        if let Internal::Array(arr) = &mut b.internal {
+                            match arr.get_mut(i) {
+                                Some(slot) => *slot = value.clone(),
+                                None => arr.push(value.clone()),
+                            }
+                            return Ok(value);
+                        }
+                    }
+                }
+            }
+        }
+        self.require_object_coercible(&obj, "set properties of")?;
+        let key = self.to_property_key(&key_v)?;
+        self.put_value(&obj, &key, value.clone(), strict)?;
+        Ok(value)
+    }
+
+    /// `Op::LoadGlobal` / `ROp::LoadGlobal` body: IC-accelerated global read.
+    #[inline]
+    pub(crate) fn ic_load_global(
+        &mut self,
+        name: JsString,
+        ic: Option<&crate::bytecode::IcEntry>,
+    ) -> Result<Value, Value> {
+        let g = self.realm.global.clone();
+        // Inline cache (key-verified slot hint; see `FuncProto::ic`):
+        // after the first resolution, a global read — above all a
+        // function resolving its own recursive self-reference — is one
+        // indexed load plus a pointer-equality key check, no hashing.
+        if let Some(ic) = ic {
+            let b = g.borrow();
+            if let Some((PropertyKey::Str(k), prop)) = b.props.get_index(ic.own_slot.get() as usize)
+            {
+                if let PropertyKind::Data { value, .. } = &prop.kind {
+                    if k == &name {
+                        let v = value.clone();
+                        return Ok(v);
+                    }
+                }
+            }
+        }
+        let key = PropertyKey::Str(name.clone());
+        // Fast path: an own data property directly on the global object —
+        // the case for every top-level `function`/`var`/`let` binding.
+        // Resolves in a single hash with no prototype walk, and refills
+        // the inline cache with the slot it finds.
+        let fast = {
+            let b = g.borrow();
+            match b.props.get_full(&key) {
+                Some((
+                    idx,
+                    _,
+                    Property {
+                        kind: PropertyKind::Data { value, .. },
+                        ..
+                    },
+                )) => {
+                    if let Some(ic) = ic {
+                        ic.own_slot.set(idx as u32);
+                    }
+                    Some(value.clone())
+                }
+                _ => None,
+            }
+        };
+        match fast {
+            Some(v) => Ok(v),
+            None => {
+                // Accessor global, or a binding inherited via the global's
+                // prototype chain: fall back to the full [[Get]] (after the
+                // unresolvable-reference check that yields a ReferenceError).
+                if !self.has_own_or_proto(&g, &key) {
+                    return Err(self.throw_reference(&format!("{} is not defined", name.as_str())));
+                }
+                self.get_prop(&Value::Object(g), &key)
+            }
+        }
+    }
+
+    /// `Op::StoreGlobal` / `ROp::StoreGlobal` body.
+    #[inline]
+    pub(crate) fn store_global(
+        &mut self,
+        name: JsString,
+        v: Value,
+        strict: bool,
+    ) -> Result<(), Value> {
+        let g = self.realm.global.clone();
+        let key = PropertyKey::Str(name.clone());
+        // A bare assignment to a name bound nowhere is an unresolvable
+        // reference; PutValue on one throws ReferenceError in strict mode
+        // (a global-object property anywhere on the proto chain counts as
+        // resolvable). Sloppy mode creates the global property instead.
+        if strict && !self.has_prop(&Value::Object(g.clone()), &key)? {
+            return Err(self.throw_reference(&format!("{} is not defined", name.as_str())));
+        }
+        self.put_value(&Value::Object(g), &key, v, strict)
+    }
+
+    /// `Op::Closure` / `ROp::Closure` body: instantiate the nested function
+    /// template at const index `idx`, capturing cells/upvalues from `frame`
+    /// (plus the active with-scope, private-env, and [[HomeObject]]).
+    pub(crate) fn closure_from_const(&mut self, frame: &Frame, idx: u32) -> Result<Value, Value> {
+        let proto = match &frame.func.proto.consts[idx as usize] {
+            Const::Func(p) => p.clone(),
+            _ => return Err(self.throw_type("internal: bad closure const")),
+        };
+        let upvalues = proto
+            .upvalues
+            .iter()
+            .map(|src| match src {
+                UpvalueSource::ParentCell(idx) => frame.cells[*idx as usize].clone(),
+                UpvalueSource::ParentUpvalue(idx) => frame.func.upvalues[*idx as usize].clone(),
+            })
+            .collect();
+        let inherit_home = proto.kind.is_arrow() || proto.inherit_home;
+        let f = self.make_closure(proto, upvalues);
+        // Capture the active with-scope chain (closures defined inside
+        // `with` resolve free identifiers against it after the block)
+        // and the active private-environment chain (methods and
+        // initializers defined inside class bodies resolve `#x`
+        // against it). Arrows (and synthetic in-class closures) also
+        // inherit the creating frame's [[HomeObject]], so `super.x`
+        // inside them resolves like the enclosing method.
+        if !frame.with_scope.is_empty()
+            || frame.priv_env.is_some()
+            || (inherit_home && frame.func.home_object.is_some())
+        {
+            if let Internal::Function(FunctionInner::Bytecode(bf)) = &mut f.borrow_mut().internal {
+                let bf = Rc::make_mut(bf);
+                bf.captured_with = frame.with_scope.clone();
+                bf.captured_priv_env = frame.priv_env.clone();
+                if inherit_home {
+                    bf.home_object = frame.func.home_object.clone();
+                }
+            }
+        }
+        Ok(Value::Object(f))
+    }
+
+    /// `Op::BindThisSloppy` / `ROp::BindThisSloppy` body.
+    pub(crate) fn bind_this_sloppy(&mut self, t: Value) -> Result<Value, Value> {
+        Ok(match t {
+            Value::Undefined | Value::Null => Value::Object(self.realm.global.clone()),
+            Value::Object(_) => t,
+            // A primitive `this` is boxed (ToObject) in sloppy mode.
+            other => Value::Object(self.to_object(&other)?),
+        })
+    }
+
+    /// `Op::LoadRestArgs` / `ROp::RestArgs` body.
+    pub(crate) fn rest_args(&mut self, frame: &Frame, n: u32) -> Value {
+        let rest: Vec<Value> = if (n as usize) < frame.args.len() {
+            frame.args[n as usize..].to_vec()
+        } else {
+            Vec::new()
+        };
+        Value::Object(self.new_array(rest))
+    }
+
+    /// `Op::DeclareGlobal` / `ROp::DeclareGlobal` body.
+    pub(crate) fn declare_global(&mut self, name: JsString, deletable: bool) -> Result<(), Value> {
+        let g = self.realm.global.clone();
+        let key = PropertyKey::Str(name.clone());
+        let (present, extensible) = {
+            let b = g.borrow();
+            (b.props.contains_key(&key), b.extensible)
+        };
+        if !present {
+            // CanDeclareGlobalVar/Function: needs an extensible global.
+            if !extensible {
+                return Err(self.throw_type(&format!("Cannot declare global '{}'", name.as_str())));
+            }
+            // CreateGlobalVarBinding(N, D): writable, enumerable;
+            // configurable only for eval-created bindings.
+            g.borrow_mut().props.insert(
+                key,
+                Property {
+                    kind: PropertyKind::Data {
+                        value: Value::Undefined,
+                        writable: true,
+                    },
+                    enumerable: true,
+                    configurable: deletable,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    /// `Op::CanDeclareGlobalFunc` / `ROp::CanDeclareGlobalFunc` body.
+    pub(crate) fn can_declare_global_func(&mut self, name: JsString) -> Result<(), Value> {
+        let g = self.realm.global.clone();
+        let key = PropertyKey::Str(name.clone());
+        // CanDeclareGlobalFunction (9.1.1.4.16): an existing
+        // non-configurable property is acceptable only if it is a
+        // writable, enumerable data property; otherwise (or, when
+        // absent, on a non-extensible global) the declaration fails.
+        let definable = {
+            let b = g.borrow();
+            match b.props.get(&key) {
+                None => b.extensible,
+                Some(p) => {
+                    p.configurable
+                        || matches!(
+                            &p.kind,
+                            PropertyKind::Data { writable, .. }
+                                if *writable && p.enumerable
+                        )
+                }
+            }
+        };
+        if !definable {
+            return Err(self.throw_type(&format!(
+                "Cannot declare global function '{}'",
+                name.as_str()
+            )));
+        }
+        Ok(())
+    }
+
+    /// `Op::DefineGlobalFunc` / `ROp::DefineGlobalFunc` body.
+    pub(crate) fn define_global_func(&mut self, name: JsString, value: Value, deletable: bool) {
+        let g = self.realm.global.clone();
+        let key = PropertyKey::Str(name.clone());
+        // CreateGlobalFunctionBinding (9.1.1.4.18): an absent or
+        // configurable existing property is (re)defined with function
+        // attributes; a non-configurable one keeps its attributes and
+        // is just assigned the new value.
+        let redefine = {
+            let b = g.borrow();
+            match b.props.get(&key) {
+                None => true,
+                Some(p) => p.configurable,
+            }
+        };
+        let mut b = g.borrow_mut();
+        if redefine {
+            b.props.insert(
+                key,
+                Property {
+                    kind: PropertyKind::Data {
+                        value,
+                        writable: true,
+                    },
+                    enumerable: true,
+                    configurable: deletable,
+                },
+            );
+        } else if let Some(p) = b.props.get_mut(&key) {
+            if let PropertyKind::Data { value: slot, .. } = &mut p.kind {
+                *slot = value;
+            }
+        }
+    }
+
+    /// `Op::GetTemplateObject` / `ROp::GetTemplateObject` body: the cached,
+    /// frozen template object, keyed by `(proto pointer, index)`.
+    pub(crate) fn template_object(&mut self, frame: &Frame, idx: u32) -> Result<Value, Value> {
+        let key = (Rc::as_ptr(&frame.func.proto) as *const () as usize, idx);
+        if let Some(o) = self.template_cache.get(&key) {
+            return Ok(Value::Object(o.clone()));
+        }
+        let parts = frame.func.proto.templates[idx as usize].clone();
+        // Cooked strings (an illegal escape cooks to `undefined`).
+        let cooked: Vec<Value> = parts
+            .cooked
+            .iter()
+            .map(|c| match c {
+                Some(s) => Value::String(JsString::from_rc_str(s.clone())),
+                None => Value::Undefined,
+            })
+            .collect();
+        let arr = self.new_array(cooked);
+        let raw: Vec<Value> = parts
+            .raw
+            .iter()
+            .map(|s| Value::String(JsString::from_rc_str(s.clone())))
+            .collect();
+        let raw_arr = self.new_array(raw);
+        // The `raw` array is frozen; `raw` is a non-enumerable,
+        // non-writable, non-configurable own property of the
+        // template object, which is itself frozen (spec
+        // GetTemplateObject / TemplateString integrity).
+        crate::builtins::fundamental::set_integrity_level(self, &raw_arr, true)?;
+        arr.borrow_mut().props.insert(
+            PropertyKey::str("raw"),
+            Property {
+                kind: PropertyKind::Data {
+                    value: Value::Object(raw_arr),
+                    writable: false,
+                },
+                enumerable: false,
+                configurable: false,
+            },
+        );
+        crate::builtins::fundamental::set_integrity_level(self, &arr, true)?;
+        self.template_cache.insert(key, arr.clone());
+        Ok(Value::Object(arr))
+    }
+
+    /// `Op::ArraySpread` / `ROp::ArraySpread` body.
+    pub(crate) fn array_spread(&mut self, arr_v: &Value, src: &Value) -> Result<(), Value> {
+        let items = self.iterate_to_vec(src)?;
+        if let Value::Object(a) = arr_v {
+            let mut b = a.borrow_mut();
+            if let Internal::Array(elems) = &mut b.internal {
+                elems.extend(items);
+            }
+        }
+        Ok(())
+    }
+
+    /// The six `Op::Define*` / `ROp::DefineProp` bodies.
+    pub(crate) fn define_prop_kind(
+        &mut self,
+        kind: crate::reg::DefKind,
+        obj: &Value,
+        key_v: &Value,
+        value: Value,
+    ) -> Result<(), Value> {
+        use crate::reg::DefKind;
+        let key = self.to_property_key(key_v)?;
+        match kind {
+            DefKind::Field => {
+                if let Value::Object(o) = obj {
+                    crate::builtins::fundamental::create_data_property_or_throw(
+                        self, o, &key, value,
+                    )?;
+                }
+            }
+            DefKind::Method => {
+                // Class methods are non-enumerable (writable, configurable),
+                // defined with DefinePropertyOrThrow (a non-configurable own
+                // key — e.g. a computed static "prototype" — is a TypeError).
+                self.check_redefinable(obj, &key)?;
+                if let Value::Object(o) = obj {
+                    o.borrow_mut().props.insert(key, Property::builtin(value));
+                }
+            }
+            DefKind::Getter => {
+                self.check_redefinable(obj, &key)?;
+                self.define_accessor_with(obj, key, Some(value), None, true);
+            }
+            DefKind::Setter => {
+                self.check_redefinable(obj, &key)?;
+                self.define_accessor_with(obj, key, None, Some(value), true);
+            }
+            DefKind::MethodGetter => {
+                self.check_redefinable(obj, &key)?;
+                self.define_accessor_with(obj, key, Some(value), None, false);
+            }
+            DefKind::MethodSetter => {
+                self.check_redefinable(obj, &key)?;
+                self.define_accessor_with(obj, key, None, Some(value), false);
+            }
+        }
+        Ok(())
+    }
+
+    /// `Op::SetHomeObject` / `ROp::SetHomeObject` body (MakeMethod).
+    pub(crate) fn set_home_object_op(home: &Value, method: &Value) {
+        if let (Value::Object(home), Value::Object(m)) = (home, method) {
+            if let Internal::Function(FunctionInner::Bytecode(bf)) = &mut m.borrow_mut().internal {
+                Rc::make_mut(bf).home_object = Some(home.clone());
+            }
+        }
+    }
+
+    /// `Op::ObjectSpread` / `ROp::ObjectSpread` body.
+    pub(crate) fn object_spread(&mut self, target: &Value, src: &Value) -> Result<(), Value> {
+        if let Value::Object(t) = target {
+            if let Value::Object(s) = src {
+                for k in self.enumerable_own_keys_dyn(s)? {
+                    let val = self.get_prop(src, &k)?;
+                    t.borrow_mut().props.insert(k, Property::data(val));
+                }
+            } else if let Value::String(st) = src {
+                for (i, c) in st.as_str().chars().enumerate() {
+                    t.borrow_mut().props.insert(
+                        PropertyKey::from_index(i as u32),
+                        Property::data(Value::str(c.to_string())),
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// `Op::CopyDataPropertiesExcept` / `ROp::CopyDataPropsExcept` body
+    /// (keys already converted to property keys, in stack order).
+    pub(crate) fn copy_data_props_except(
+        &mut self,
+        target: &Value,
+        src: &Value,
+        excluded: &[PropertyKey],
+    ) -> Result<(), Value> {
+        if let Value::Object(t) = target {
+            if let Value::Object(s) = src {
+                // Excluded keys are skipped before ANY source access
+                // (CopyDataProperties step 4.b.i): a proxy source must
+                // not observe a [[GetOwnProperty]]/[[Get]] for them.
+                for k in self.enumerable_own_keys_excluding(s, excluded)? {
+                    let val = self.get_prop(src, &k)?;
+                    t.borrow_mut().props.insert(k, Property::data(val));
+                }
+            } else if let Value::String(st) = src {
+                // A primitive-string source contributes its index keys.
+                for (i, c) in st.as_str().chars().enumerate() {
+                    let k = PropertyKey::from_index(i as u32);
+                    if excluded.contains(&k) {
+                        continue;
+                    }
+                    t.borrow_mut()
+                        .props
+                        .insert(k, Property::data(Value::str(c.to_string())));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// `Op::SetFunctionNameFromKey` / `ROp::SetFunctionNameFromKey` body.
+    pub(crate) fn set_function_name_from_key(
+        &mut self,
+        key: &Value,
+        value: &Value,
+        prefix: JsString,
+    ) {
+        if let Value::Object(f) = value {
+            if f.borrow().is_callable() {
+                let base = match key {
+                    Value::Symbol(sym) => match sym.description() {
+                        Some(d) => format!("[{d}]"),
+                        None => String::new(),
+                    },
+                    other => self.to_string_lossy(other),
+                };
+                let name = if prefix.as_str().is_empty() {
+                    base
+                } else {
+                    format!("{} {}", prefix.as_str(), base)
+                };
+                f.borrow_mut().props.insert(
+                    PropertyKey::str("name"),
+                    Property {
+                        kind: PropertyKind::Data {
+                            value: Value::str(name),
+                            writable: false,
+                        },
+                        enumerable: false,
+                        configurable: true,
+                    },
+                );
+            }
+        }
+    }
+
+    /// `Op::SetProtoFromLiteral` / `ROp::SetProtoFromLiteral` body.
+    pub(crate) fn set_proto_from_literal(obj: &Value, v: Value) {
+        if let Value::Object(o) = obj {
+            match v {
+                Value::Object(p) => o.borrow_mut().proto = Some(p),
+                Value::Null => o.borrow_mut().proto = None,
+                // Non-object, non-null values are silently ignored.
+                _ => {}
+            }
+        }
+    }
+
+    /// `Op::DeleteProp` / `ROp::DelProp` body.
+    pub(crate) fn del_prop_named(
+        &mut self,
+        obj: Value,
+        name: JsString,
+        strict: bool,
+    ) -> Result<Value, Value> {
+        // `delete base.x` does ToObject(base) (spec step 5.b): a
+        // nullish base is a TypeError before any delete is attempted.
+        self.require_object_coercible(&obj, "delete properties of")?;
+        let r = self.delete_prop(&obj, &PropertyKey::Str(name.clone()))?;
+        // Strict-mode `delete` that fails throws (spec 13.5.1.2 step 5.c).
+        if !r && strict {
+            return Err(self.throw_type(&format!(
+                "Cannot delete property '{}' in strict mode",
+                name.as_str()
+            )));
+        }
+        Ok(Value::Bool(r))
+    }
+
+    /// `Op::DeletePropDynamic` / `ROp::DelElem` body.
+    pub(crate) fn del_prop_dynamic(
+        &mut self,
+        obj: Value,
+        key_v: Value,
+        strict: bool,
+    ) -> Result<Value, Value> {
+        self.require_object_coercible(&obj, "delete properties of")?;
+        let key = self.to_property_key(&key_v)?;
+        let r = self.delete_prop(&obj, &key)?;
+        if !r && strict {
+            return Err(self.throw_type("Cannot delete property in strict mode"));
+        }
+        Ok(Value::Bool(r))
+    }
+
+    /// `Op::ConcatStrings` / `ROp::ConcatStrings` body (template literals).
+    pub(crate) fn concat_strings(&mut self, parts: &[Value]) -> Result<Value, Value> {
+        let mut strs = Vec::with_capacity(parts.len());
+        let mut total = 0usize;
+        for p in parts {
+            let s = self.to_js_string(p)?;
+            // Same bound as `op_add`: a template-literal join in a doubling
+            // loop (`` s = `${s}${s}` ``) must not grow without limit.
+            total += s.byte_len();
+            if total > crate::value::MAX_STRING_LEN {
+                return Err(self.throw_range("invalid string length"));
+            }
+            strs.push(s);
+        }
+        // Fast path when every part is well-formed (the common case):
+        // a plain UTF-8 join. Otherwise go through code units so a
+        // surrogate straddling a boundary re-pairs (and lone surrogates
+        // survive instead of becoming U+FFFD).
+        let out = if strs.iter().all(|s| s.is_well_formed()) {
+            let mut out = String::with_capacity(total);
+            for s in &strs {
+                out.push_str(s.as_str());
+            }
+            JsString::new(out)
+        } else {
+            let mut units = Vec::new();
+            for s in &strs {
+                units.extend(s.code_units());
+            }
+            JsString::from_code_units(&units)
+        };
+        Ok(Value::String(out))
+    }
+
+    /// `Op::ForInEnumerate` / `ROp::ForInEnumerate` body: push a fresh
+    /// enumerator, returning its index value.
+    pub(crate) fn for_in_enumerate(
+        &mut self,
+        frame: &mut Frame,
+        v: &Value,
+    ) -> Result<Value, Value> {
+        let keys = self.for_in_keys(v)?;
+        frame.enumerators.push((keys, 0));
+        Ok(Value::Number((frame.enumerators.len() - 1) as f64))
+    }
+
+    /// `Op::ForInNext` / `ROp::ForInNext` body: `(key, has_next)`.
+    pub(crate) fn for_in_next(frame: &mut Frame) -> (Value, Value) {
+        let idx = frame.enumerators.len() - 1;
+        let (keys, cursor) = &mut frame.enumerators[idx];
+        if *cursor < keys.len() {
+            let k = keys[*cursor].clone();
+            *cursor += 1;
+            (Value::String(k), Value::Bool(true))
+        } else {
+            (Value::Undefined, Value::Bool(false))
+        }
+    }
+
     fn const_name(&self, frame: &Frame, idx: u32) -> JsString {
         match &frame.func.proto.consts[idx as usize] {
             Const::String(s) => s.clone(),
@@ -2943,6 +3804,778 @@ impl Vm {
             self.set_prop_strict(base, key, value)
         } else {
             self.set_prop(base, key, value)
+        }
+    }
+
+    // =====================================================================
+    // Register-tier execution (reg.rs; docs/js-performance-roadmap.md §3.5)
+    // =====================================================================
+
+    /// Execute a frame through its register program. Same observable
+    /// behavior as `run_stack_frame` over the same proto by construction:
+    /// every arm calls the SAME helper as its stack twin, and the reg-on/off
+    /// differential corpus (`tests/reg.rs`) pins it. Register frames carry
+    /// no try-handlers (functions with handlers decline translation), so a
+    /// thrown error always tears the frame down; and no suspension ops
+    /// translate, so this never returns `Flow::Suspend`.
+    fn run_reg_frame(&mut self, mut frame: Box<Frame>, reg: &crate::reg::RegProto) -> Flow {
+        use crate::reg::{ROp, RUnary};
+        macro_rules! done {
+            ($flow:expr) => {{
+                let outcome = $flow;
+                self.recycle_frame(frame);
+                return outcome;
+            }};
+        }
+        macro_rules! tryv {
+            ($e:expr) => {
+                match $e {
+                    Ok(v) => v,
+                    Err(e) => done!(Flow::Throw(e)),
+                }
+            };
+        }
+        let proto = frame.func.proto.clone();
+        // Registers 0..num_locals are the localized bindings (already sized
+        // by `init_frame`); the rest are the canonical operand slots.
+        frame.locals.resize(reg.num_regs as usize, Value::Undefined);
+        // Cooperative cancellation: the same latch-and-throw protocol as the
+        // stack loop (which polls every 256 ops). The op BUDGET never applies
+        // here — `run_frame` routes budgeted runs to the stack tier.
+        let interruptible = self.interrupt.is_some();
+        let mut poll: u32 = 0;
+        let code = &reg.code[..];
+        let mut pc: usize = 0;
+        loop {
+            if interruptible {
+                poll = poll.wrapping_add(1);
+                if poll & 0xFF == 0 {
+                    if let Some(flag) = &self.interrupt {
+                        if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                            self.op_budget = Some(0);
+                            done!(Flow::Throw(self.throw_range("execution interrupted")));
+                        }
+                    }
+                }
+            }
+            let op = &code[pc];
+            pc += 1;
+            macro_rules! rd {
+                ($i:expr) => {
+                    frame.locals[$i as usize].clone()
+                };
+            }
+            macro_rules! wr {
+                ($i:expr, $v:expr) => {
+                    frame.locals[$i as usize] = $v
+                };
+            }
+            match op {
+                ROp::Mov { dst, src } => wr!(*dst, rd!(*src)),
+                ROp::Const { dst, idx } => wr!(*dst, self.const_val(&frame, *idx)),
+                ROp::Undef { dst } => wr!(*dst, Value::Undefined),
+                ROp::Null { dst } => wr!(*dst, Value::Null),
+                ROp::Bool { dst, v } => wr!(*dst, Value::Bool(*v)),
+                ROp::Hole { dst } => wr!(*dst, Value::Hole),
+                ROp::This { dst } => wr!(*dst, frame.this.clone()),
+                ROp::NewTarget { dst } => wr!(*dst, frame.new_target.clone()),
+                ROp::Arg { dst, idx } => wr!(
+                    *dst,
+                    frame
+                        .args
+                        .get(*idx as usize)
+                        .cloned()
+                        .unwrap_or(Value::Undefined)
+                ),
+                ROp::TdzCheck { src } => {
+                    if matches!(frame.locals[*src as usize], Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                }
+                ROp::StoreLocalChecked { local, src } => {
+                    let v = rd!(*src);
+                    let slot = &mut frame.locals[*local as usize];
+                    if matches!(slot, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    *slot = v;
+                }
+                ROp::InitLocalTdz { local } => wr!(*local, Value::Uninitialized),
+                ROp::IncLocal { local, dec } => {
+                    let v = rd!(*local);
+                    if matches!(v, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    // ToNumeric may run user code, but a localized binding is
+                    // reachable only from this frame, so read-coerce-write is
+                    // exactly the unfused sequence.
+                    let n = tryv!(self.to_numeric(&v));
+                    let r = tryv!(
+                        self.unary_arith(n, if *dec { UnaryKind::Dec } else { UnaryKind::Inc })
+                    );
+                    wr!(*local, r);
+                }
+                ROp::LoadCell { dst, cell } => {
+                    let v = frame.cells[*cell as usize].borrow().clone();
+                    if matches!(v, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    wr!(*dst, v);
+                }
+                ROp::StoreCell { cell, src } => {
+                    let v = rd!(*src);
+                    *frame.cells[*cell as usize].borrow_mut() = v;
+                }
+                ROp::LoadUpvalue { dst, idx } => {
+                    let v = frame.func.upvalues[*idx as usize].borrow().clone();
+                    if matches!(v, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    wr!(*dst, v);
+                }
+                ROp::LoadGlobal { dst, name, ic } => {
+                    let name = Self::const_name_proto(&proto, *name);
+                    let v = tryv!(self.ic_load_global(name, reg.ic.get(*ic as usize)));
+                    wr!(*dst, v);
+                }
+                ROp::Add { dst, a, b } => {
+                    let r = tryv!(self.op_add(rd!(*a), rd!(*b)));
+                    wr!(*dst, r);
+                }
+                ROp::AddK { dst, a, konst } => {
+                    let b = self.const_val(&frame, *konst);
+                    let r = tryv!(self.op_add(rd!(*a), b));
+                    wr!(*dst, r);
+                }
+                ROp::Arith { kind, dst, a, b } => {
+                    let r = tryv!(self.arith(rd!(*a), rd!(*b), *kind));
+                    wr!(*dst, r);
+                }
+                ROp::ArithK {
+                    kind,
+                    dst,
+                    a,
+                    konst,
+                } => {
+                    let b = self.const_val(&frame, *konst);
+                    let r = tryv!(self.arith(rd!(*a), b, *kind));
+                    wr!(*dst, r);
+                }
+                ROp::AddCellK { dst, cell, konst } => {
+                    let a = frame.cells[*cell as usize].borrow().clone();
+                    if matches!(a, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    let b = self.const_val(&frame, *konst);
+                    let r = tryv!(self.op_add(a, b));
+                    wr!(*dst, r);
+                }
+                ROp::ArithCellK {
+                    kind,
+                    dst,
+                    cell,
+                    konst,
+                } => {
+                    let a = frame.cells[*cell as usize].borrow().clone();
+                    if matches!(a, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    let b = self.const_val(&frame, *konst);
+                    let r = tryv!(self.arith(a, b, *kind));
+                    wr!(*dst, r);
+                }
+                ROp::Unary { kind, dst, src } => {
+                    let a = rd!(*src);
+                    let r = match kind {
+                        RUnary::Neg => tryv!(self.unary_arith(a, UnaryKind::Neg)),
+                        // ToNumber throws TypeError for BigInt (unary + is
+                        // invalid on it).
+                        RUnary::Pos => Value::Number(tryv!(self.to_number(&a))),
+                        RUnary::ToNumeric => tryv!(self.to_numeric(&a)),
+                        RUnary::Inc => tryv!(self.unary_arith(a, UnaryKind::Inc)),
+                        RUnary::Dec => tryv!(self.unary_arith(a, UnaryKind::Dec)),
+                        RUnary::BitNot => tryv!(self.unary_arith(a, UnaryKind::BitNot)),
+                        RUnary::Not => Value::Bool(!self.to_boolean(&a)),
+                        RUnary::Typeof => Value::str(a.type_of()),
+                        RUnary::ToStr => Value::String(tryv!(self.to_js_string(&a))),
+                        RUnary::ToKey => match tryv!(self.to_property_key(&a)) {
+                            PropertyKey::Str(s) => Value::String(s),
+                            PropertyKey::Sym(s) => Value::Symbol(s),
+                        },
+                    };
+                    wr!(*dst, r);
+                }
+                ROp::Cmp { cmp, dst, a, b } => {
+                    let (a, b) = (rd!(*a), rd!(*b));
+                    let r = tryv!(self.cmp_values(*cmp, &a, &b));
+                    wr!(*dst, Value::Bool(r));
+                }
+                // ---- control flow ----
+                ROp::Jmp { target } => pc = *target as usize,
+                ROp::BrTrue { src, target } => {
+                    let v = rd!(*src);
+                    if self.to_boolean(&v) {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::BrFalse { src, target } => {
+                    let v = rd!(*src);
+                    if !self.to_boolean(&v) {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::BrFalsyKeep { src, target } => {
+                    let v = rd!(*src);
+                    if !self.to_boolean(&v) {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::BrTruthyKeep { src, target } => {
+                    let v = rd!(*src);
+                    if self.to_boolean(&v) {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::BrNotNullishKeep { src, target } => {
+                    if !frame.locals[*src as usize].is_nullish() {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::BrNullishUndef { reg, target } => {
+                    if frame.locals[*reg as usize].is_nullish() {
+                        // An optional chain short-circuits to `undefined` even
+                        // when the base was `null`.
+                        frame.locals[*reg as usize] = Value::Undefined;
+                        pc = *target as usize;
+                    }
+                }
+                ROp::CmpBr {
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target,
+                } => {
+                    let (a, b) = (rd!(*a), rd!(*b));
+                    if tryv!(self.cmp_values(*cmp, &a, &b)) == *if_true {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::CmpBrK {
+                    cmp,
+                    a,
+                    konst,
+                    if_true,
+                    target,
+                } => {
+                    let a = rd!(*a);
+                    let b = self.const_val(&frame, *konst);
+                    if tryv!(self.cmp_values(*cmp, &a, &b)) == *if_true {
+                        pc = *target as usize;
+                    }
+                }
+                ROp::CmpBrCellK {
+                    cmp,
+                    cell,
+                    konst,
+                    if_true,
+                    target,
+                } => {
+                    let a = frame.cells[*cell as usize].borrow().clone();
+                    if matches!(a, Value::Uninitialized) {
+                        done!(Flow::Throw(self.throw_reference(
+                            "Cannot access binding before initialization"
+                        )));
+                    }
+                    let b = self.const_val(&frame, *konst);
+                    if tryv!(self.cmp_values(*cmp, &a, &b)) == *if_true {
+                        pc = *target as usize;
+                    }
+                }
+                // ---- property access ----
+                ROp::GetProp { dst, obj, name, ic } => {
+                    let obj = rd!(*obj);
+                    let name = Self::const_name_proto(&proto, *name);
+                    let v = tryv!(self.ic_get_prop(obj, name, reg.ic.get(*ic as usize)));
+                    wr!(*dst, v);
+                }
+                ROp::SetProp {
+                    dst,
+                    obj,
+                    name,
+                    src,
+                    ic,
+                } => {
+                    let obj = rd!(*obj);
+                    let value = rd!(*src);
+                    let name = Self::const_name_proto(&proto, *name);
+                    let v = tryv!(self.ic_set_prop(
+                        obj,
+                        name,
+                        value,
+                        proto.is_strict,
+                        reg.ic.get(*ic as usize)
+                    ));
+                    wr!(*dst, v);
+                }
+                ROp::GetElem { dst, obj, key } => {
+                    let (obj, key) = (rd!(*obj), rd!(*key));
+                    let v = tryv!(self.elem_get(obj, key));
+                    wr!(*dst, v);
+                }
+                ROp::SetElem { dst, obj, key, src } => {
+                    let (obj, key, value) = (rd!(*obj), rd!(*key), rd!(*src));
+                    let v = tryv!(self.elem_set(obj, key, value, proto.is_strict));
+                    wr!(*dst, v);
+                }
+                // ---- calls ----
+                ROp::Call {
+                    dst,
+                    func,
+                    this,
+                    at,
+                    argc,
+                    has_this,
+                } => {
+                    let func_v = rd!(*func);
+                    let this_v = if *has_this {
+                        rd!(*this)
+                    } else {
+                        Value::Undefined
+                    };
+                    let r = if let Some(bf) = peek_plain_bytecode(&func_v) {
+                        self.call_direct_reg(&mut frame, *at, *argc, bf, func_v, this_v)
+                    } else {
+                        // Arguments MOVE out of their (dead) canonical slots
+                        // into the pooled buffer — same ownership shape as the
+                        // stack path's drain.
+                        let mut args = self.take_value_vec();
+                        for i in *at..*at + *argc {
+                            args.push(std::mem::replace(
+                                &mut frame.locals[i as usize],
+                                Value::Undefined,
+                            ));
+                        }
+                        self.call_valuevec(func_v, this_v, args)
+                    };
+                    wr!(*dst, tryv!(r));
+                }
+                ROp::New {
+                    dst,
+                    ctor,
+                    at,
+                    argc,
+                } => {
+                    let ctor_v = rd!(*ctor);
+                    let args = &frame.locals[*at as usize..(*at + *argc) as usize];
+                    let v = tryv!(self.construct(&ctor_v, args, &ctor_v));
+                    wr!(*dst, v);
+                }
+                ROp::Ret { src } => {
+                    let v = std::mem::replace(&mut frame.locals[*src as usize], Value::Undefined);
+                    // Module linker hook: snapshot this frame's final cells
+                    // when it is the module body being evaluated.
+                    if let Some(p) = &self.module_capture_proto {
+                        if Rc::ptr_eq(&proto, p) {
+                            self.module_capture = Some(frame.cells.clone());
+                        }
+                    }
+                    done!(Flow::Return(v));
+                }
+                ROp::RetCompletion => {
+                    let v = frame.completion.clone();
+                    if let Some(p) = &self.module_capture_proto {
+                        if Rc::ptr_eq(&proto, p) {
+                            self.module_capture = Some(frame.cells.clone());
+                        }
+                    }
+                    done!(Flow::Return(v));
+                }
+                ROp::Throw { src } => {
+                    let v = std::mem::replace(&mut frame.locals[*src as usize], Value::Undefined);
+                    done!(Flow::Throw(v));
+                }
+                ROp::Closure { dst, idx } => {
+                    let f = tryv!(self.closure_from_const(&frame, *idx));
+                    wr!(*dst, f);
+                }
+                // Everything rarer runs through the cold arm, keeping this
+                // loop's native stack frame small (same split — and same
+                // reason — as `step`/`step_cold`).
+                cold => {
+                    tryv!(self.rstep_cold(&mut frame, reg, &proto, cold));
+                }
+            }
+        }
+    }
+
+    /// The register tier's rare ops. `#[inline(never)]` keeps their unioned
+    /// locals out of `run_reg_frame`'s native frame (deep JS recursion must
+    /// exhaust `max_call_depth` before the native stack; see `step_cold`).
+    /// Cold ops never branch, return, or call JS→JS directly, so the
+    /// signature carries no control flow.
+    #[inline(never)]
+    fn rstep_cold(
+        &mut self,
+        frame: &mut Frame,
+        reg: &crate::reg::RegProto,
+        proto: &Rc<crate::bytecode::FuncProto>,
+        op: &crate::reg::ROp,
+    ) -> Result<(), Value> {
+        use crate::reg::ROp;
+        macro_rules! rd {
+            ($i:expr) => {
+                frame.locals[$i as usize].clone()
+            };
+        }
+        macro_rules! wr {
+            ($i:expr, $v:expr) => {
+                frame.locals[$i as usize] = $v
+            };
+        }
+        match op {
+            ROp::RestArgs { dst, from } => {
+                let v = self.rest_args(frame, *from);
+                wr!(*dst, v);
+            }
+            ROp::Arguments { dst } => {
+                let v = self.make_arguments_object(frame);
+                wr!(*dst, v);
+            }
+            ROp::BindThisSloppy { reg: r } => {
+                let t = std::mem::replace(&mut frame.locals[*r as usize], Value::Undefined);
+                let bound = self.bind_this_sloppy(t)?;
+                wr!(*r, bound);
+            }
+            ROp::StoreCellChecked { cell, src } => {
+                let v = rd!(*src);
+                let mut slot = frame.cells[*cell as usize].borrow_mut();
+                if matches!(*slot, Value::Uninitialized) {
+                    drop(slot);
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                *slot = v;
+            }
+            ROp::InitCell { cell, src } => {
+                let v = rd!(*src);
+                // A module's top-level cells are STABLE: mutate in place so a
+                // pre-wired import binding keeps pointing at the live cell.
+                if proto.stable_flags[*cell as usize] {
+                    *frame.cells[*cell as usize].borrow_mut() = v;
+                } else {
+                    let fresh = self.take_cell(v);
+                    let old = std::mem::replace(&mut frame.cells[*cell as usize], fresh);
+                    self.recycle_cell(old);
+                }
+            }
+            ROp::InitCellTdz { cell } => {
+                if proto.stable_flags[*cell as usize] {
+                    *frame.cells[*cell as usize].borrow_mut() = Value::Uninitialized;
+                } else {
+                    let fresh = self.take_cell(Value::Uninitialized);
+                    let old = std::mem::replace(&mut frame.cells[*cell as usize], fresh);
+                    self.recycle_cell(old);
+                }
+            }
+            ROp::IncCell { cell, dec } => {
+                let v = frame.cells[*cell as usize].borrow().clone();
+                if matches!(v, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                let n = self.to_numeric(&v)?;
+                let r = self.unary_arith(n, if *dec { UnaryKind::Dec } else { UnaryKind::Inc })?;
+                *frame.cells[*cell as usize].borrow_mut() = r;
+            }
+            ROp::LoadCellInit { src, dest } => {
+                let v = frame.cells[*src as usize].borrow().clone();
+                if matches!(v, Value::Uninitialized) {
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                if proto.stable_flags[*dest as usize] {
+                    *frame.cells[*dest as usize].borrow_mut() = v;
+                } else {
+                    let fresh = self.take_cell(v);
+                    let old = std::mem::replace(&mut frame.cells[*dest as usize], fresh);
+                    self.recycle_cell(old);
+                }
+            }
+            ROp::StoreUpvalue { idx, src } => {
+                let v = rd!(*src);
+                *frame.func.upvalues[*idx as usize].borrow_mut() = v;
+            }
+            ROp::StoreUpvalueChecked { idx, src } => {
+                let v = rd!(*src);
+                let mut slot = frame.func.upvalues[*idx as usize].borrow_mut();
+                if matches!(*slot, Value::Uninitialized) {
+                    drop(slot);
+                    return Err(self.throw_reference("Cannot access binding before initialization"));
+                }
+                *slot = v;
+            }
+            ROp::StoreGlobal { name, src } => {
+                let v = rd!(*src);
+                let name = Self::const_name_proto(proto, *name);
+                self.store_global(name, v, proto.is_strict)?;
+            }
+            ROp::LoadGlobalTypeof { dst, name } => {
+                let name = Self::const_name_proto(proto, *name);
+                let g = self.realm.global.clone();
+                let v = self.get_prop(&Value::Object(g), &PropertyKey::Str(name))?;
+                wr!(*dst, v);
+            }
+            ROp::DeclareGlobal { name, deletable } => {
+                let name = Self::const_name_proto(proto, *name);
+                self.declare_global(name, *deletable)?;
+            }
+            ROp::CanDeclareGlobalFunc { name } => {
+                let name = Self::const_name_proto(proto, *name);
+                self.can_declare_global_func(name)?;
+            }
+            ROp::DefineGlobalFunc {
+                name,
+                deletable,
+                src,
+            } => {
+                // Clone, not move: `src` may be a live register (the
+                // translator does not canonicalize this operand).
+                let v = rd!(*src);
+                let name = Self::const_name_proto(proto, *name);
+                self.define_global_func(name, v, *deletable);
+            }
+            ROp::InstanceOf { dst, a, b } => {
+                let (a, b) = (rd!(*a), rd!(*b));
+                let r = self.instance_of(&a, &b)?;
+                wr!(*dst, Value::Bool(r));
+            }
+            ROp::DelProp { dst, obj, name } => {
+                let obj = rd!(*obj);
+                let name = Self::const_name_proto(proto, *name);
+                let v = self.del_prop_named(obj, name, proto.is_strict)?;
+                wr!(*dst, v);
+            }
+            ROp::DelElem { dst, obj, key } => {
+                let (obj, key) = (rd!(*obj), rd!(*key));
+                let v = self.del_prop_dynamic(obj, key, proto.is_strict)?;
+                wr!(*dst, v);
+            }
+            ROp::HasProp { dst, key, obj } => {
+                let (key_v, obj) = (rd!(*key), rd!(*obj));
+                let key = self.to_property_key(&key_v)?;
+                let r = self.has_prop(&obj, &key)?;
+                wr!(*dst, Value::Bool(r));
+            }
+            ROp::CallSpread {
+                dst,
+                func,
+                this,
+                args,
+            } => {
+                let (func, this, args_arr) = (rd!(*func), rd!(*this), rd!(*args));
+                let args = self.iterate_to_vec(&args_arr)?;
+                let r = self.call(func, this, &args)?;
+                wr!(*dst, r);
+            }
+            ROp::NewSpread { dst, ctor, args } => {
+                let (ctor, args_arr) = (rd!(*ctor), rd!(*args));
+                let args = self.iterate_to_vec(&args_arr)?;
+                let r = self.construct(&ctor, &args, &ctor)?;
+                wr!(*dst, r);
+            }
+            ROp::ThrowConstAssign => {
+                return Err(self.throw_type("Assignment to constant variable."));
+            }
+            ROp::NewObject { dst } => wr!(*dst, Value::Object(self.new_object())),
+            ROp::NewArray { dst, at, n } => {
+                let mut elems = Vec::with_capacity(*n as usize);
+                for i in *at..*at + *n {
+                    elems.push(std::mem::replace(
+                        &mut frame.locals[i as usize],
+                        Value::Undefined,
+                    ));
+                }
+                wr!(*dst, Value::Object(self.new_array(elems)));
+            }
+            ROp::ArraySpread { arr, src } => {
+                let (arr_v, src) = (rd!(*arr), rd!(*src));
+                self.array_spread(&arr_v, &src)?;
+            }
+            ROp::DefineProp {
+                kind,
+                obj,
+                key,
+                val,
+            } => {
+                let (obj, key_v, value) = (rd!(*obj), rd!(*key), rd!(*val));
+                self.define_prop_kind(*kind, &obj, &key_v, value)?;
+            }
+            ROp::SetHomeObject { obj, val } => {
+                let (home, m) = (rd!(*obj), rd!(*val));
+                Self::set_home_object_op(&home, &m);
+            }
+            ROp::ObjectSpread { target, src } => {
+                let (target, src) = (rd!(*target), rd!(*src));
+                self.object_spread(&target, &src)?;
+            }
+            ROp::CopyDataPropsExcept { target, src, at, n } => {
+                let mut excluded: Vec<PropertyKey> = Vec::with_capacity(*n as usize);
+                for i in *at..*at + *n {
+                    let k = std::mem::replace(&mut frame.locals[i as usize], Value::Undefined);
+                    excluded.push(self.to_property_key(&k)?);
+                }
+                let (target, src) = (rd!(*target), rd!(*src));
+                self.copy_data_props_except(&target, &src, &excluded)?;
+            }
+            ROp::GetTemplateObject { dst, idx } => {
+                let v = self.template_object(frame, *idx)?;
+                wr!(*dst, v);
+            }
+            ROp::NewRegExp {
+                dst,
+                pattern,
+                flags,
+            } => {
+                let p = Self::const_name_proto(proto, *pattern);
+                let f = Self::const_name_proto(proto, *flags);
+                let re = self.make_regexp(p.as_str(), f.as_str())?;
+                wr!(*dst, re);
+            }
+            ROp::ConcatStrings { dst, at, n } => {
+                let parts = &frame.locals[*at as usize..(*at + *n) as usize];
+                let v = self.concat_strings(parts)?;
+                wr!(*dst, v);
+            }
+            ROp::RequireObjectCoercible { src } => {
+                if frame.locals[*src as usize].is_nullish() {
+                    return Err(self.throw_type("Cannot destructure a null or undefined value"));
+                }
+            }
+            ROp::RequireCoercible { src } => {
+                let v = rd!(*src);
+                self.require_object_coercible(&v, "read properties of")?;
+            }
+            ROp::RequireIterResult { src } => {
+                if !matches!(frame.locals[*src as usize], Value::Object(_)) {
+                    return Err(self.throw_type("Iterator result is not an object"));
+                }
+            }
+            ROp::SetFunctionNameFromKey { prefix, key, val } => {
+                let (key, value) = (rd!(*key), rd!(*val));
+                let prefix = Self::const_name_proto(proto, *prefix);
+                self.set_function_name_from_key(&key, &value, prefix);
+            }
+            ROp::SetProtoFromLiteral { obj, src } => {
+                let (obj, v) = (rd!(*obj), rd!(*src));
+                Self::set_proto_from_literal(&obj, v);
+            }
+            ROp::GetIterator { dst, src } => {
+                let v = rd!(*src);
+                let it = self.get_iterator(&v)?;
+                wr!(*dst, it);
+            }
+            ROp::IterNext { dst, it } => {
+                let it = rd!(*it);
+                let next = self.get_prop(&it, &PropertyKey::str("next"))?;
+                let res = self.call(next, it, &[])?;
+                wr!(*dst, res);
+            }
+            ROp::ForInEnumerate { dst, src } => {
+                let v = rd!(*src);
+                let idx = self.for_in_enumerate(frame, &v)?;
+                wr!(*dst, idx);
+            }
+            ROp::ForInNext { dst } => {
+                let (k, more) = Self::for_in_next(frame);
+                wr!(*dst, k);
+                wr!(*dst + 1, more);
+            }
+            ROp::ForInPop => {
+                frame.enumerators.pop();
+            }
+            _ => unreachable!("op handled inline in run_reg_frame: {op:?}"),
+        }
+        let _ = reg;
+        Ok(())
+    }
+
+    /// The register tier's JS→JS fast call (`ROp::Call` with a plain sync
+    /// bytecode callee): mirror of [`Vm::call_direct`] with arguments moving
+    /// out of the caller's registers instead of its operand stack.
+    fn call_direct_reg(
+        &mut self,
+        caller: &mut Frame,
+        at: u16,
+        argc: u16,
+        bf: Rc<BytecodeFunction>,
+        func_v: Value,
+        this: Value,
+    ) -> Result<Value, Value> {
+        self.call_depth += 1;
+        if self.call_depth > self.max_call_depth {
+            self.call_depth -= 1;
+            return Err(self.throw_range("Maximum call stack size exceeded"));
+        }
+        // Function kernel: run frameless straight off the caller's registers
+        // (the arguments sit contiguously at `at..at+argc`).
+        if bf.proto.fn_kernel.is_some() {
+            if let Some(r) =
+                self.run_fn_kernel(&bf, &caller.locals[at as usize..(at + argc) as usize])
+            {
+                self.call_depth -= 1;
+                return r;
+            }
+        }
+        let mut callee = self.take_frame();
+        for i in at..at + argc {
+            callee.args.push(std::mem::replace(
+                &mut caller.locals[i as usize],
+                Value::Undefined,
+            ));
+        }
+        let uses_arguments = bf.proto.uses_arguments;
+        self.init_frame(&mut callee, bf, this, Value::Undefined);
+        if uses_arguments {
+            if let Value::Object(o) = func_v {
+                callee.func_obj = Some(o);
+            }
+        }
+        let token = self.trace_enter(&callee.func.proto);
+        callee.trace_token = token;
+        let r = match self.run_frame(callee) {
+            Flow::Return(v) => {
+                self.trace_exit(token, false);
+                Ok(v)
+            }
+            Flow::Throw(e) => {
+                self.trace_exit(token, true);
+                Err(e)
+            }
+            Flow::Suspend(_) => Err(self.throw_type("internal: sync function suspended")),
+        };
+        self.call_depth -= 1;
+        r
+    }
+
+    /// `const_name` against a proto (the register tier has no `&Frame`
+    /// borrow to spare at its call sites).
+    #[inline]
+    fn const_name_proto(proto: &crate::bytecode::FuncProto, idx: u32) -> JsString {
+        match &proto.consts[idx as usize] {
+            Const::String(s) => s.clone(),
+            _ => JsString::new(""),
         }
     }
 
@@ -3158,80 +4791,15 @@ impl Vm {
             }
             Op::LoadGlobal(i) => {
                 let name = self.const_name(frame, *i);
-                let g = self.realm.global.clone();
-                // Inline cache (key-verified slot hint; see `FuncProto::ic`):
-                // after the first resolution, a global read — above all a
-                // function resolving its own recursive self-reference — is one
-                // indexed load plus a pointer-equality key check, no hashing.
-                if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
-                    let b = g.borrow();
-                    if let Some((PropertyKey::Str(k), prop)) =
-                        b.props.get_index(ic.own_slot.get() as usize)
-                    {
-                        if let PropertyKind::Data { value, .. } = &prop.kind {
-                            if k == &name {
-                                let v = value.clone();
-                                drop(b);
-                                push!(v);
-                                return Ok(Ctl::Next);
-                            }
-                        }
-                    }
-                }
-                let key = PropertyKey::Str(name.clone());
-                // Fast path: an own data property directly on the global object —
-                // the case for every top-level `function`/`var`/`let` binding.
-                // Resolves in a single hash with no prototype walk, and refills
-                // the inline cache with the slot it finds.
-                let fast = {
-                    let b = g.borrow();
-                    match b.props.get_full(&key) {
-                        Some((
-                            idx,
-                            _,
-                            Property {
-                                kind: PropertyKind::Data { value, .. },
-                                ..
-                            },
-                        )) => {
-                            if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
-                                ic.own_slot.set(idx as u32);
-                            }
-                            Some(value.clone())
-                        }
-                        _ => None,
-                    }
-                };
-                let v = match fast {
-                    Some(v) => v,
-                    None => {
-                        // Accessor global, or a binding inherited via the global's
-                        // prototype chain: fall back to the full [[Get]] (after the
-                        // unresolvable-reference check that yields a ReferenceError).
-                        if !self.has_own_or_proto(&g, &key) {
-                            return Err(
-                                self.throw_reference(&format!("{} is not defined", name.as_str()))
-                            );
-                        }
-                        self.get_prop(&Value::Object(g), &key)?
-                    }
-                };
+                let ic = frame.func.proto.ic.get(frame.ip.wrapping_sub(1));
+                let v = self.ic_load_global(name, ic)?;
                 push!(v);
             }
             Op::StoreGlobal(i) => {
                 let name = self.const_name(frame, *i);
                 let v = pop!();
-                let g = self.realm.global.clone();
                 let strict = frame.func.proto.is_strict;
-                let key = PropertyKey::Str(name.clone());
-                // A bare assignment to a name bound nowhere is an unresolvable
-                // reference; PutValue on one throws ReferenceError in strict mode
-                // (a global-object property anywhere on the proto chain counts as
-                // resolvable). Sloppy mode creates the global property instead.
-                if strict && !self.has_prop(&Value::Object(g.clone()), &key)? {
-                    return Err(self.throw_reference(&format!("{} is not defined", name.as_str())));
-                }
-                self.put_value(&Value::Object(g), &key, v, strict)?;
+                self.store_global(name, v, strict)?;
             }
             Op::Pop => {
                 frame.stack.pop();
@@ -3264,277 +4832,31 @@ impl Vm {
             Op::GetProp(i) => {
                 let name = self.const_name(frame, *i);
                 let obj = pop!();
-                // Inline cache (key-verified hints; see `FuncProto::ic`).
-                // Two levels:
-                //  - `holder == None`: the receiver's OWN data property at
-                //    `slot` (ordinary objects).
-                //  - `holder == Some(p)`: a data property at `slot` on `p`,
-                //    verified to still be the receiver's DIRECT prototype and
-                //    not shadowed by an own property — the method-lookup
-                //    pattern (`arr.push`, class instances calling prototype
-                //    methods). Array receivers exclude keys with exotic own
-                //    behavior (`length`, indices). Deeper chains, accessors,
-                //    proxies, and every other exotic fall to the unchanged
-                //    slow path.
-                if let Value::Object(o) = &obj {
-                    if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
-                        let b = o.borrow();
-                        let (is_ord, is_arr) = (
-                            matches!(b.internal, Internal::Ordinary),
-                            matches!(b.internal, Internal::Array(_)),
-                        );
-                        // Array exotics: `length` and index keys never take
-                        // the IC (they don't live in the props map).
-                        let plain_key = !is_arr
-                            || (name.as_str() != "length"
-                                && crate::value::canonical_index(name.as_str()).is_none());
-                        if (is_ord || is_arr) && plain_key {
-                            // Own-property hit: never touches the holder cell.
-                            if is_ord {
-                                if let Some((PropertyKey::Str(k), prop)) =
-                                    b.props.get_index(ic.own_slot.get() as usize)
-                                {
-                                    if let PropertyKind::Data { value, .. } = &prop.kind {
-                                        if k == &name {
-                                            let v = value.clone();
-                                            drop(b);
-                                            push!(v);
-                                            return Ok(Ctl::Next);
-                                        }
-                                    }
-                                }
-                            }
-                            // Proto hit: valid only when the receiver has no
-                            // own props (nothing can shadow) and its CURRENT
-                            // direct proto is the cached holder.
-                            if b.props.is_empty() {
-                                let holder = ic.holder.borrow();
-                                if let Some(h) = &*holder {
-                                    if b.proto.as_ref().is_some_and(|p| p.ptr_eq(h)) {
-                                        let hb = h.borrow();
-                                        if let Some((PropertyKey::Str(k), prop)) =
-                                            hb.props.get_index(ic.proto_slot.get() as usize)
-                                        {
-                                            if let PropertyKind::Data { value, .. } = &prop.kind {
-                                                if k == &name {
-                                                    let v = value.clone();
-                                                    drop(hb);
-                                                    drop(holder);
-                                                    drop(b);
-                                                    push!(v);
-                                                    return Ok(Ctl::Next);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            // Refill: own data property first (ordinary only),
-                            // then a one-level proto data property when no own
-                            // props can shadow.
-                            let key = PropertyKey::Str(name.clone());
-                            if is_ord {
-                                if let Some((idx, _, prop)) = b.props.get_full(&key) {
-                                    if let PropertyKind::Data { value, .. } = &prop.kind {
-                                        ic.own_slot.set(idx as u32);
-                                        let v = value.clone();
-                                        drop(b);
-                                        push!(v);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                            if b.props.is_empty() {
-                                if let Some(p) = &b.proto {
-                                    let pb = p.borrow();
-                                    if matches!(pb.internal, Internal::Ordinary)
-                                        || matches!(pb.internal, Internal::Array(_))
-                                    {
-                                        if let Some((idx, _, prop)) = pb.props.get_full(&key) {
-                                            if let PropertyKind::Data { value, .. } = &prop.kind {
-                                                ic.proto_slot.set(idx as u32);
-                                                let v = value.clone();
-                                                let holder_obj = p.clone();
-                                                drop(pb);
-                                                *ic.holder.borrow_mut() = Some(holder_obj);
-                                                drop(b);
-                                                push!(v);
-                                                return Ok(Ctl::Next);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                let v = self.get_prop(&obj, &PropertyKey::Str(name))?;
+                let ic = frame.func.proto.ic.get(frame.ip.wrapping_sub(1));
+                let v = self.ic_get_prop(obj, name, ic)?;
                 push!(v);
             }
             Op::SetProp(i) => {
                 let name = self.const_name(frame, *i);
                 let value = pop!();
                 let obj = pop!();
-                // Inline cache (key-verified slot hint; see `FuncProto::ic`).
-                // Fast path only when the receiver is an ordinary object whose
-                // OWN property at the hinted slot is a WRITABLE data property —
-                // per OrdinarySetWithOwnDescriptor that assignment updates the
-                // value in place (attributes and slot order preserved, no
-                // prototype setter can intervene). Everything else (missing own
-                // key → proto-chain setters/read-only checks, accessors,
-                // non-writable → strict TypeError, exotics) takes the
-                // unchanged put_value path, which also refills the hint.
-                if let Value::Object(o) = &obj {
-                    if let Some(ic) = frame.func.proto.ic.get(frame.ip.wrapping_sub(1)) {
-                        let mut b = o.borrow_mut();
-                        if matches!(b.internal, Internal::Ordinary) {
-                            if let Some((PropertyKey::Str(k), prop)) =
-                                b.props.get_index_mut(ic.own_slot.get() as usize)
-                            {
-                                if k == &name {
-                                    if let PropertyKind::Data {
-                                        value: slot,
-                                        writable: true,
-                                    } = &mut prop.kind
-                                    {
-                                        *slot = value.clone();
-                                        drop(b);
-                                        push!(value);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                            let key = PropertyKey::Str(name.clone());
-                            if let Some((idx, _, prop)) = b.props.get_full_mut(&key) {
-                                if let PropertyKind::Data {
-                                    value: slot,
-                                    writable: true,
-                                } = &mut prop.kind
-                                {
-                                    ic.own_slot.set(idx as u32);
-                                    *slot = value.clone();
-                                    drop(b);
-                                    push!(value);
-                                    return Ok(Ctl::Next);
-                                }
-                            }
-                        }
-                    }
-                }
                 let strict = frame.func.proto.is_strict;
-                self.put_value(&obj, &PropertyKey::Str(name), value.clone(), strict)?;
+                let ic = frame.func.proto.ic.get(frame.ip.wrapping_sub(1));
+                let value = self.ic_set_prop(obj, name, value, strict, ic)?;
                 push!(value);
             }
             Op::GetPropDynamic => {
                 let key_v = pop!();
                 let obj = pop!();
-                // Integer fast path: `a[i]` on a dense array with an integral
-                // Number key reads the element directly — skipping
-                // ToPropertyKey's Number→String conversion (a float-format +
-                // heap allocation per access!), the reparse back to an index,
-                // and the property-map machinery. Only when no reified props
-                // entry can shadow the dense element (`props.is_empty()`) and
-                // the slot is a real element (in bounds, not a hole);
-                // everything else takes the unchanged spec path.
-                if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
-                    if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                        let b = o.borrow();
-                        if let Internal::Array(arr) = &b.internal {
-                            if b.props.is_empty() {
-                                if let Some(v) = arr.get(*n as usize) {
-                                    if !matches!(v, Value::Hole) {
-                                        let v = v.clone();
-                                        drop(b);
-                                        push!(v);
-                                        return Ok(Ctl::Next);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // GetValue: RequireObjectCoercible(base) (via ToObject) throws
-                // BEFORE ToPropertyKey coerces the key expression's value.
-                self.require_object_coercible(&obj, "read properties of")?;
-                let key = self.to_property_key(&key_v)?;
-                let v = self.get_prop(&obj, &key)?;
+                let v = self.elem_get(obj, key_v)?;
                 push!(v);
             }
             Op::SetPropDynamic => {
                 let value = pop!();
                 let key_v = pop!();
                 let obj = pop!();
-                // Integer fast path mirroring `GetPropDynamic`: overwrite an
-                // EXISTING dense element in place (an in-bounds non-hole dense
-                // slot is a plain writable data property per the array exotic
-                // [[Set]] — no setter, no length change, no extensibility
-                // interaction), fill an in-bounds HOLE, or append at exactly
-                // `length`. Filling and appending CREATE a property (the own
-                // property is absent), so they additionally require the array
-                // to be extensible (a sealed/prevented receiver must reject
-                // through the generic path), the dense-storage bound (the
-                // generic path owns that RangeError), and a prototype chain
-                // with no reified entry at the index — OrdinarySet consults
-                // the chain for an absent own property, so a proto accessor /
-                // non-writable index must intercept via the generic path
-                // (`protos_allow_index_create`). Gaps past the end, shadowed
-                // elements, and non-arrays take the spec path.
-                if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
-                    if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                        let i = *n as usize;
-                        let mut creates = None;
-                        {
-                            let mut b = o.borrow_mut();
-                            if b.props.is_empty() {
-                                let extensible = b.extensible;
-                                if let Internal::Array(arr) = &mut b.internal {
-                                    match arr.get_mut(i) {
-                                        Some(slot) if !matches!(slot, Value::Hole) => {
-                                            *slot = value.clone();
-                                            drop(b);
-                                            push!(value);
-                                            return Ok(Ctl::Next);
-                                        }
-                                        Some(_) => {
-                                            if extensible {
-                                                creates = Some(b.proto.clone());
-                                            }
-                                        }
-                                        None => {
-                                            if extensible
-                                                && i == arr.len()
-                                                && i < crate::value::MAX_DENSE_ARRAY
-                                            {
-                                                creates = Some(b.proto.clone());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if let Some(proto) = creates {
-                            if crate::value::protos_allow_index_create(proto, i as u32, 1) {
-                                // No user code ran since the conditions were
-                                // checked (same native frame), so they still
-                                // hold.
-                                let mut b = o.borrow_mut();
-                                if let Internal::Array(arr) = &mut b.internal {
-                                    match arr.get_mut(i) {
-                                        Some(slot) => *slot = value.clone(),
-                                        None => arr.push(value.clone()),
-                                    }
-                                    drop(b);
-                                    push!(value);
-                                    return Ok(Ctl::Next);
-                                }
-                            }
-                        }
-                    }
-                }
-                self.require_object_coercible(&obj, "set properties of")?;
-                let key = self.to_property_key(&key_v)?;
                 let strict = frame.func.proto.is_strict;
-                self.put_value(&obj, &key, value.clone(), strict)?;
+                let value = self.elem_set(obj, key_v, value, strict)?;
                 push!(value);
             }
             Op::HasProp => {
@@ -3628,45 +4950,8 @@ impl Vm {
             }
 
             Op::Closure(i) => {
-                let proto = match &frame.func.proto.consts[*i as usize] {
-                    Const::Func(p) => p.clone(),
-                    _ => return Err(self.throw_type("internal: bad closure const")),
-                };
-                let upvalues = proto
-                    .upvalues
-                    .iter()
-                    .map(|src| match src {
-                        UpvalueSource::ParentCell(idx) => frame.cells[*idx as usize].clone(),
-                        UpvalueSource::ParentUpvalue(idx) => {
-                            frame.func.upvalues[*idx as usize].clone()
-                        }
-                    })
-                    .collect();
-                let inherit_home = proto.kind.is_arrow() || proto.inherit_home;
-                let f = self.make_closure(proto, upvalues);
-                // Capture the active with-scope chain (closures defined inside
-                // `with` resolve free identifiers against it after the block)
-                // and the active private-environment chain (methods and
-                // initializers defined inside class bodies resolve `#x`
-                // against it). Arrows (and synthetic in-class closures) also
-                // inherit the creating frame's [[HomeObject]], so `super.x`
-                // inside them resolves like the enclosing method.
-                if !frame.with_scope.is_empty()
-                    || frame.priv_env.is_some()
-                    || (inherit_home && frame.func.home_object.is_some())
-                {
-                    if let Internal::Function(FunctionInner::Bytecode(bf)) =
-                        &mut f.borrow_mut().internal
-                    {
-                        let bf = Rc::make_mut(bf);
-                        bf.captured_with = frame.with_scope.clone();
-                        bf.captured_priv_env = frame.priv_env.clone();
-                        if inherit_home {
-                            bf.home_object = frame.func.home_object.clone();
-                        }
-                    }
-                }
-                push!(Value::Object(f));
+                let f = self.closure_from_const(frame, *i)?;
+                push!(f);
             }
 
             // ---- arithmetic ----
@@ -3959,17 +5244,9 @@ impl Vm {
                 frame.enumerators.pop();
             }
             Op::ForInNext => {
-                let idx = frame.enumerators.len() - 1;
-                let (keys, cursor) = &mut frame.enumerators[idx];
-                if *cursor < keys.len() {
-                    let k = keys[*cursor].clone();
-                    *cursor += 1;
-                    push!(Value::String(k));
-                    push!(Value::Bool(true));
-                } else {
-                    push!(Value::Undefined);
-                    push!(Value::Bool(false));
-                }
+                let (k, more) = Self::for_in_next(frame);
+                push!(k);
+                push!(more);
             }
 
             // ---- generators / async ----
@@ -4066,21 +5343,12 @@ impl Vm {
             }
             Op::BindThisSloppy => {
                 let t = pop!();
-                let bound = match t {
-                    Value::Undefined | Value::Null => Value::Object(self.realm.global.clone()),
-                    Value::Object(_) => t,
-                    // A primitive `this` is boxed (ToObject) in sloppy mode.
-                    other => Value::Object(self.to_object(&other)?),
-                };
+                let bound = self.bind_this_sloppy(t)?;
                 push!(bound);
             }
             Op::LoadRestArgs(n) => {
-                let rest: Vec<Value> = if (*n as usize) < frame.args.len() {
-                    frame.args[*n as usize..].to_vec()
-                } else {
-                    Vec::new()
-                };
-                push!(Value::Object(self.new_array(rest)));
+                let v = self.rest_args(frame, *n);
+                push!(v);
             }
             Op::LoadArguments => {
                 let o = self.make_arguments_object(frame);
@@ -4096,98 +5364,17 @@ impl Vm {
             }
             Op::DeclareGlobal { name: i, deletable } => {
                 let name = self.const_name(frame, *i);
-                let g = self.realm.global.clone();
-                let key = PropertyKey::Str(name.clone());
-                let (present, extensible) = {
-                    let b = g.borrow();
-                    (b.props.contains_key(&key), b.extensible)
-                };
-                if !present {
-                    // CanDeclareGlobalVar/Function: needs an extensible global.
-                    if !extensible {
-                        return Err(
-                            self.throw_type(&format!("Cannot declare global '{}'", name.as_str()))
-                        );
-                    }
-                    // CreateGlobalVarBinding(N, D): writable, enumerable;
-                    // configurable only for eval-created bindings.
-                    g.borrow_mut().props.insert(
-                        key,
-                        Property {
-                            kind: PropertyKind::Data {
-                                value: Value::Undefined,
-                                writable: true,
-                            },
-                            enumerable: true,
-                            configurable: *deletable,
-                        },
-                    );
-                }
+                self.declare_global(name, *deletable)?;
             }
 
             Op::CanDeclareGlobalFunc(i) => {
                 let name = self.const_name(frame, *i);
-                let g = self.realm.global.clone();
-                let key = PropertyKey::Str(name.clone());
-                // CanDeclareGlobalFunction (9.1.1.4.16): an existing
-                // non-configurable property is acceptable only if it is a
-                // writable, enumerable data property; otherwise (or, when
-                // absent, on a non-extensible global) the declaration fails.
-                let definable = {
-                    let b = g.borrow();
-                    match b.props.get(&key) {
-                        None => b.extensible,
-                        Some(p) => {
-                            p.configurable
-                                || matches!(
-                                    &p.kind,
-                                    PropertyKind::Data { writable, .. }
-                                        if *writable && p.enumerable
-                                )
-                        }
-                    }
-                };
-                if !definable {
-                    return Err(self.throw_type(&format!(
-                        "Cannot declare global function '{}'",
-                        name.as_str()
-                    )));
-                }
+                self.can_declare_global_func(name)?;
             }
             Op::DefineGlobalFunc { name: i, deletable } => {
                 let name = self.const_name(frame, *i);
                 let value = pop!();
-                let g = self.realm.global.clone();
-                let key = PropertyKey::Str(name.clone());
-                // CreateGlobalFunctionBinding (9.1.1.4.18): an absent or
-                // configurable existing property is (re)defined with function
-                // attributes; a non-configurable one keeps its attributes and
-                // is just assigned the new value.
-                let redefine = {
-                    let b = g.borrow();
-                    match b.props.get(&key) {
-                        None => true,
-                        Some(p) => p.configurable,
-                    }
-                };
-                let mut b = g.borrow_mut();
-                if redefine {
-                    b.props.insert(
-                        key,
-                        Property {
-                            kind: PropertyKind::Data {
-                                value,
-                                writable: true,
-                            },
-                            enumerable: true,
-                            configurable: *deletable,
-                        },
-                    );
-                } else if let Some(p) = b.props.get_mut(&key) {
-                    if let PropertyKind::Data { value: slot, .. } = &mut p.kind {
-                        *slot = value;
-                    }
-                }
+                self.define_global_func(name, value, *deletable);
             }
 
             Op::PushWithScope => {
@@ -4306,48 +5493,10 @@ impl Vm {
             }
 
             Op::GetTemplateObject(idx) => {
-                let key = (Rc::as_ptr(&frame.func.proto) as *const () as usize, *idx);
-                if let Some(o) = self.template_cache.get(&key) {
-                    push!(Value::Object(o.clone()));
-                } else {
-                    let parts = frame.func.proto.templates[*idx as usize].clone();
-                    // Cooked strings (an illegal escape cooks to `undefined`).
-                    let cooked: Vec<Value> = parts
-                        .cooked
-                        .iter()
-                        .map(|c| match c {
-                            Some(s) => Value::String(JsString::from_rc_str(s.clone())),
-                            None => Value::Undefined,
-                        })
-                        .collect();
-                    let arr = self.new_array(cooked);
-                    let raw: Vec<Value> = parts
-                        .raw
-                        .iter()
-                        .map(|s| Value::String(JsString::from_rc_str(s.clone())))
-                        .collect();
-                    let raw_arr = self.new_array(raw);
-                    // The `raw` array is frozen; `raw` is a non-enumerable,
-                    // non-writable, non-configurable own property of the
-                    // template object, which is itself frozen (spec
-                    // GetTemplateObject / TemplateString integrity).
-                    crate::builtins::fundamental::set_integrity_level(self, &raw_arr, true)?;
-                    arr.borrow_mut().props.insert(
-                        PropertyKey::str("raw"),
-                        Property {
-                            kind: PropertyKind::Data {
-                                value: Value::Object(raw_arr),
-                                writable: false,
-                            },
-                            enumerable: false,
-                            configurable: false,
-                        },
-                    );
-                    crate::builtins::fundamental::set_integrity_level(self, &arr, true)?;
-                    self.template_cache.insert(key, arr.clone());
-                    push!(Value::Object(arr));
-                }
+                let v = self.template_object(frame, *idx)?;
+                push!(v);
             }
+
             Op::ArrayPushElision => {
                 // For array literals we build via NewArray; elisions handled by
                 // pushing undefined holes at compile time.
@@ -4356,75 +5505,27 @@ impl Vm {
             Op::ArraySpread => {
                 let src = pop!();
                 let arr_v = pop!();
-                let items = self.iterate_to_vec(&src)?;
-                if let Value::Object(a) = &arr_v {
-                    let mut b = a.borrow_mut();
-                    if let Internal::Array(elems) = &mut b.internal {
-                        elems.extend(items);
-                    }
-                }
+                self.array_spread(&arr_v, &src)?;
                 push!(arr_v);
             }
-            Op::DefineField => {
+            Op::DefineField
+            | Op::DefineMethod
+            | Op::DefineGetter
+            | Op::DefineSetter
+            | Op::DefineMethodGetter
+            | Op::DefineMethodSetter => {
                 let value = pop!();
                 let key_v = pop!();
                 let obj = pop!();
-                let key = self.to_property_key(&key_v)?;
-                if let Value::Object(o) = &obj {
-                    crate::builtins::fundamental::create_data_property_or_throw(
-                        self, o, &key, value,
-                    )?;
-                }
-                push!(obj);
-            }
-            Op::DefineMethod => {
-                // Class methods are non-enumerable (writable, configurable),
-                // defined with DefinePropertyOrThrow (a non-configurable own
-                // key — e.g. a computed static "prototype" — is a TypeError).
-                let value = pop!();
-                let key_v = pop!();
-                let obj = pop!();
-                let key = self.to_property_key(&key_v)?;
-                self.check_redefinable(&obj, &key)?;
-                if let Value::Object(o) = &obj {
-                    o.borrow_mut().props.insert(key, Property::builtin(value));
-                }
-                push!(obj);
-            }
-            Op::DefineGetter => {
-                let getter = pop!();
-                let key_v = pop!();
-                let obj = pop!();
-                let key = self.to_property_key(&key_v)?;
-                self.check_redefinable(&obj, &key)?;
-                self.define_accessor_with(&obj, key, Some(getter), None, true);
-                push!(obj);
-            }
-            Op::DefineSetter => {
-                let setter = pop!();
-                let key_v = pop!();
-                let obj = pop!();
-                let key = self.to_property_key(&key_v)?;
-                self.check_redefinable(&obj, &key)?;
-                self.define_accessor_with(&obj, key, None, Some(setter), true);
-                push!(obj);
-            }
-            Op::DefineMethodGetter => {
-                let getter = pop!();
-                let key_v = pop!();
-                let obj = pop!();
-                let key = self.to_property_key(&key_v)?;
-                self.check_redefinable(&obj, &key)?;
-                self.define_accessor_with(&obj, key, Some(getter), None, false);
-                push!(obj);
-            }
-            Op::DefineMethodSetter => {
-                let setter = pop!();
-                let key_v = pop!();
-                let obj = pop!();
-                let key = self.to_property_key(&key_v)?;
-                self.check_redefinable(&obj, &key)?;
-                self.define_accessor_with(&obj, key, None, Some(setter), false);
+                let kind = match op {
+                    Op::DefineField => crate::reg::DefKind::Field,
+                    Op::DefineMethod => crate::reg::DefKind::Method,
+                    Op::DefineGetter => crate::reg::DefKind::Getter,
+                    Op::DefineSetter => crate::reg::DefKind::Setter,
+                    Op::DefineMethodGetter => crate::reg::DefKind::MethodGetter,
+                    _ => crate::reg::DefKind::MethodSetter,
+                };
+                self.define_prop_kind(kind, &obj, &key_v, value)?;
                 push!(obj);
             }
             Op::SetHomeObject => {
@@ -4433,15 +5534,8 @@ impl Vm {
                 let n = frame.stack.len();
                 if n >= 3 {
                     let home = frame.stack[n - 3].clone();
-                    if let (Value::Object(home), Value::Object(m)) =
-                        (home, frame.stack[n - 1].clone())
-                    {
-                        if let Internal::Function(FunctionInner::Bytecode(bf)) =
-                            &mut m.borrow_mut().internal
-                        {
-                            Rc::make_mut(bf).home_object = Some(home);
-                        }
-                    }
+                    let m = frame.stack[n - 1].clone();
+                    Self::set_home_object_op(&home, &m);
                 }
             }
             Op::SetHomeObjectAt(n) => {
@@ -4506,21 +5600,7 @@ impl Vm {
             Op::ObjectSpread => {
                 let src = pop!();
                 let target = pop!();
-                if let Value::Object(t) = &target {
-                    if let Value::Object(s) = &src {
-                        for k in self.enumerable_own_keys_dyn(s)? {
-                            let val = self.get_prop(&src, &k)?;
-                            t.borrow_mut().props.insert(k, Property::data(val));
-                        }
-                    } else if let Value::String(st) = &src {
-                        for (i, c) in st.as_str().chars().enumerate() {
-                            t.borrow_mut().props.insert(
-                                PropertyKey::from_index(i as u32),
-                                Property::data(Value::str(c.to_string())),
-                            );
-                        }
-                    }
-                }
+                self.object_spread(&target, &src)?;
                 push!(target);
             }
             Op::CopyDataPropertiesExcept(n) => {
@@ -4532,28 +5612,7 @@ impl Vm {
                 }
                 let src = pop!();
                 let target = pop!();
-                if let Value::Object(t) = &target {
-                    if let Value::Object(s) = &src {
-                        // Excluded keys are skipped before ANY source access
-                        // (CopyDataProperties step 4.b.i): a proxy source must
-                        // not observe a [[GetOwnProperty]]/[[Get]] for them.
-                        for k in self.enumerable_own_keys_excluding(s, &excluded)? {
-                            let val = self.get_prop(&src, &k)?;
-                            t.borrow_mut().props.insert(k, Property::data(val));
-                        }
-                    } else if let Value::String(st) = &src {
-                        // A primitive-string source contributes its index keys.
-                        for (i, c) in st.as_str().chars().enumerate() {
-                            let k = PropertyKey::from_index(i as u32);
-                            if excluded.contains(&k) {
-                                continue;
-                            }
-                            t.borrow_mut()
-                                .props
-                                .insert(k, Property::data(Value::str(c.to_string())));
-                        }
-                    }
-                }
+                self.copy_data_props_except(&target, &src, &excluded)?;
                 push!(target);
             }
             Op::PrivateGet(i) => {
@@ -4776,47 +5835,14 @@ impl Vm {
                 if n >= 2 {
                     let value = frame.stack[n - 1].clone();
                     let key = frame.stack[n - 2].clone();
-                    if let Value::Object(f) = &value {
-                        if f.borrow().is_callable() {
-                            let base = match &key {
-                                Value::Symbol(sym) => match sym.description() {
-                                    Some(d) => format!("[{d}]"),
-                                    None => String::new(),
-                                },
-                                other => self.to_string_lossy(other),
-                            };
-                            let prefix = self.const_name(frame, *prefix);
-                            let name = if prefix.as_str().is_empty() {
-                                base
-                            } else {
-                                format!("{} {}", prefix.as_str(), base)
-                            };
-                            f.borrow_mut().props.insert(
-                                PropertyKey::str("name"),
-                                Property {
-                                    kind: PropertyKind::Data {
-                                        value: Value::str(name),
-                                        writable: false,
-                                    },
-                                    enumerable: false,
-                                    configurable: true,
-                                },
-                            );
-                        }
-                    }
+                    let prefix = self.const_name(frame, *prefix);
+                    self.set_function_name_from_key(&key, &value, prefix);
                 }
             }
             Op::SetProtoFromLiteral => {
                 let v = pop!();
                 let obj = frame.stack.last().cloned().unwrap_or(Value::Undefined);
-                if let Value::Object(o) = &obj {
-                    match v {
-                        Value::Object(p) => o.borrow_mut().proto = Some(p),
-                        Value::Null => o.borrow_mut().proto = None,
-                        // Non-object, non-null values are silently ignored.
-                        _ => {}
-                    }
-                }
+                Self::set_proto_from_literal(&obj, v);
             }
             Op::PushDisposeScope => {
                 frame.dispose_scopes.push(Vec::new());
@@ -4995,29 +6021,16 @@ impl Vm {
             Op::DeleteProp(i) => {
                 let name = self.const_name(frame, *i);
                 let obj = pop!();
-                // `delete base.x` does ToObject(base) (spec step 5.b): a
-                // nullish base is a TypeError before any delete is attempted.
-                self.require_object_coercible(&obj, "delete properties of")?;
-                let r = self.delete_prop(&obj, &PropertyKey::Str(name.clone()))?;
-                // Strict-mode `delete` that fails throws (spec 13.5.1.2 step 5.c).
-                if !r && frame.func.proto.is_strict {
-                    return Err(self.throw_type(&format!(
-                        "Cannot delete property '{}' in strict mode",
-                        name.as_str()
-                    )));
-                }
-                push!(Value::Bool(r));
+                let strict = frame.func.proto.is_strict;
+                let v = self.del_prop_named(obj, name, strict)?;
+                push!(v);
             }
             Op::DeletePropDynamic => {
                 let key_v = pop!();
                 let obj = pop!();
-                self.require_object_coercible(&obj, "delete properties of")?;
-                let key = self.to_property_key(&key_v)?;
-                let r = self.delete_prop(&obj, &key)?;
-                if !r && frame.func.proto.is_strict {
-                    return Err(self.throw_type("Cannot delete property in strict mode"));
-                }
-                push!(Value::Bool(r));
+                let strict = frame.func.proto.is_strict;
+                let v = self.del_prop_dynamic(obj, key_v, strict)?;
+                push!(v);
             }
             Op::ThrowConstAssign => {
                 return Err(self.throw_type("Assignment to constant variable."));
@@ -5159,9 +6172,8 @@ impl Vm {
             }
             Op::ForInEnumerate => {
                 let v = pop!();
-                let keys = self.for_in_keys(&v)?;
-                frame.enumerators.push((keys, 0));
-                push!(Value::Number((frame.enumerators.len() - 1) as f64));
+                let idx = self.for_in_enumerate(frame, &v)?;
+                push!(idx);
             }
             Op::AsyncReturn => {
                 let v = pop!();

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -40,6 +40,14 @@ pub(crate) struct PreparedKernel {
     interrupt: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
+/// Control-flow outcome of a register-mode completion dispatch (the
+/// register tier neither suspends nor delegates, so this is `Ctl` minus
+/// those arms).
+enum RegCtl {
+    Jump(usize),
+    Return(Value),
+}
+
 /// Control-flow signal from a single opcode step.
 enum Ctl {
     Next,
@@ -3827,14 +3835,6 @@ impl Vm {
                 return outcome;
             }};
         }
-        macro_rules! tryv {
-            ($e:expr) => {
-                match $e {
-                    Ok(v) => v,
-                    Err(e) => done!(Flow::Throw(e)),
-                }
-            };
-        }
         let proto = frame.func.proto.clone();
         // Registers 0..num_locals are the localized bindings (already sized
         // by `init_frame`); the rest are the canonical operand slots.
@@ -3845,6 +3845,7 @@ impl Vm {
         let interruptible = self.interrupt.is_some();
         let mut poll: u32 = 0;
         let code = &reg.code[..];
+        let num_locals = proto.num_locals as usize;
         let mut pc: usize = 0;
         loop {
             if interruptible {
@@ -3870,6 +3871,50 @@ impl Vm {
                     frame.locals[$i as usize] = $v
                 };
             }
+            // Frame exit with the module-linker snapshot (mirror of the
+            // stack loop's `Ctl::Return` arm).
+            macro_rules! ret {
+                ($v:expr) => {{
+                    let v = $v;
+                    if let Some(p) = &self.module_capture_proto {
+                        if Rc::ptr_eq(&proto, p) {
+                            self.module_capture = Some(frame.cells.clone());
+                        }
+                    }
+                    done!(Flow::Return(v));
+                }};
+            }
+            // Dispatch an abrupt (or return) completion through the frame's
+            // try-handlers — the register-mode `do_completion`.
+            macro_rules! complete {
+                ($comp:expr) => {{
+                    match self.reg_do_completion(&mut frame, num_locals, $comp) {
+                        Ok(RegCtl::Jump(t)) => {
+                            pc = t;
+                            continue;
+                        }
+                        Ok(RegCtl::Return(v)) => ret!(v),
+                        Err(e) => done!(Flow::Throw(e)),
+                    }
+                }};
+            }
+            macro_rules! tryv {
+                ($e:expr) => {
+                    match $e {
+                        Ok(v) => v,
+                        Err(e) => complete!(Completion::Throw(e)),
+                    }
+                };
+            }
+            // A TDZ read outside any handler is overwhelmingly common; the
+            // checked form routes the ReferenceError like any other throw.
+            macro_rules! tdz_throw {
+                () => {
+                    complete!(Completion::Throw(
+                        self.throw_reference("Cannot access binding before initialization")
+                    ))
+                };
+            }
             match op {
                 ROp::Mov { dst, src } => wr!(*dst, rd!(*src)),
                 ROp::Const { dst, idx } => wr!(*dst, self.const_val(&frame, *idx)),
@@ -3889,18 +3934,14 @@ impl Vm {
                 ),
                 ROp::TdzCheck { src } => {
                     if matches!(frame.locals[*src as usize], Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                 }
                 ROp::StoreLocalChecked { local, src } => {
                     let v = rd!(*src);
                     let slot = &mut frame.locals[*local as usize];
                     if matches!(slot, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     *slot = v;
                 }
@@ -3908,9 +3949,7 @@ impl Vm {
                 ROp::IncLocal { local, dec } => {
                     let v = rd!(*local);
                     if matches!(v, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     // ToNumeric may run user code, but a localized binding is
                     // reachable only from this frame, so read-coerce-write is
@@ -3924,9 +3963,7 @@ impl Vm {
                 ROp::LoadCell { dst, cell } => {
                     let v = frame.cells[*cell as usize].borrow().clone();
                     if matches!(v, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     wr!(*dst, v);
                 }
@@ -3937,9 +3974,7 @@ impl Vm {
                 ROp::LoadUpvalue { dst, idx } => {
                     let v = frame.func.upvalues[*idx as usize].borrow().clone();
                     if matches!(v, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     wr!(*dst, v);
                 }
@@ -3974,9 +4009,7 @@ impl Vm {
                 ROp::AddCellK { dst, cell, konst } => {
                     let a = frame.cells[*cell as usize].borrow().clone();
                     if matches!(a, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     let b = self.const_val(&frame, *konst);
                     let r = tryv!(self.op_add(a, b));
@@ -3990,9 +4023,7 @@ impl Vm {
                 } => {
                     let a = frame.cells[*cell as usize].borrow().clone();
                     if matches!(a, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     let b = self.const_val(&frame, *konst);
                     let r = tryv!(self.arith(a, b, *kind));
@@ -4097,9 +4128,7 @@ impl Vm {
                 } => {
                     let a = frame.cells[*cell as usize].borrow().clone();
                     if matches!(a, Value::Uninitialized) {
-                        done!(Flow::Throw(self.throw_reference(
-                            "Cannot access binding before initialization"
-                        )));
+                        tdz_throw!();
                     }
                     let b = self.const_val(&frame, *konst);
                     if tryv!(self.cmp_values(*cmp, &a, &b)) == *if_true {
@@ -4187,27 +4216,65 @@ impl Vm {
                 }
                 ROp::Ret { src } => {
                     let v = std::mem::replace(&mut frame.locals[*src as usize], Value::Undefined);
-                    // Module linker hook: snapshot this frame's final cells
-                    // when it is the module body being evaluated.
-                    if let Some(p) = &self.module_capture_proto {
-                        if Rc::ptr_eq(&proto, p) {
-                            self.module_capture = Some(frame.cells.clone());
-                        }
+                    // Route through any enclosing `finally` blocks (mirror of
+                    // `Op::Return`); the no-handler fast path returns directly.
+                    if frame.handlers.is_empty() {
+                        ret!(v);
                     }
-                    done!(Flow::Return(v));
+                    complete!(Completion::Return(v));
                 }
                 ROp::RetCompletion => {
                     let v = frame.completion.clone();
-                    if let Some(p) = &self.module_capture_proto {
-                        if Rc::ptr_eq(&proto, p) {
-                            self.module_capture = Some(frame.cells.clone());
-                        }
+                    if frame.handlers.is_empty() {
+                        ret!(v);
                     }
-                    done!(Flow::Return(v));
+                    complete!(Completion::Return(v));
                 }
                 ROp::Throw { src } => {
                     let v = std::mem::replace(&mut frame.locals[*src as usize], Value::Undefined);
-                    done!(Flow::Throw(v));
+                    complete!(Completion::Throw(v));
+                }
+                // ---- exceptions / completions ----
+                ROp::PushTryHandler {
+                    catch,
+                    finally,
+                    depth,
+                } => {
+                    frame.handlers.push(TryHandler {
+                        catch_ip: if *catch == u32::MAX {
+                            None
+                        } else {
+                            Some(*catch)
+                        },
+                        finally_ip: if *finally == u32::MAX {
+                            None
+                        } else {
+                            Some(*finally)
+                        },
+                        // Register mode: the CANONICAL operand depth (the
+                        // register file holds `num_locals + depth` live slots).
+                        stack_depth: *depth as usize,
+                        with_depth: frame.with_scope.len(),
+                        priv_env: frame.priv_env.clone(),
+                        delegation: false,
+                        delegation_return_ip: None,
+                    });
+                }
+                ROp::PopTryHandler => {
+                    frame.handlers.pop();
+                }
+                ROp::CompletionJump { target, boundary } => {
+                    complete!(Completion::Jump {
+                        target: *target,
+                        boundary: *boundary,
+                    });
+                }
+                ROp::EndFinally => {
+                    // Resume a parked non-local completion; the normal path
+                    // (finalizer ran with nothing parked) falls through.
+                    if let Some(c) = frame.pending_completion.take() {
+                        complete!(c);
+                    }
                 }
                 ROp::Closure { dst, idx } => {
                     let f = tryv!(self.closure_from_const(&frame, *idx));
@@ -4220,6 +4287,56 @@ impl Vm {
                     tryv!(self.rstep_cold(&mut frame, reg, &proto, cold));
                 }
             }
+        }
+    }
+
+    /// Register-mode mirror of [`Vm::do_completion`]: walk the frame's
+    /// try-handlers with a pending completion. "Truncate the operand stack"
+    /// becomes "clear the canonical registers above the handler's recorded
+    /// depth" (value-lifetime parity with the stack machine's truncate), and
+    /// the exception lands in `canon(depth)` — exactly where the catch
+    /// label's register state expects it. The delegation arms cannot occur:
+    /// generators never carry register programs.
+    #[inline(never)]
+    fn reg_do_completion(
+        &mut self,
+        frame: &mut Frame,
+        num_locals: usize,
+        comp: Completion,
+    ) -> Result<RegCtl, Value> {
+        let boundary = match &comp {
+            Completion::Jump { boundary, .. } => *boundary as usize,
+            _ => 0,
+        };
+        debug_assert!(!frame.skip_delegation_throw);
+        while frame.handlers.len() > boundary {
+            let h = frame.handlers.pop().unwrap();
+            debug_assert!(!h.delegation && h.delegation_return_ip.is_none());
+            let base = num_locals + h.stack_depth;
+            for slot in frame.locals[base..].iter_mut() {
+                *slot = Value::Undefined;
+            }
+            // Discard any `with` environments entered after this handler and
+            // restore the private-environment chain (both constant in
+            // register frames today — the ops that change them decline
+            // translation — but kept for exactness).
+            frame.with_scope.truncate(h.with_depth);
+            frame.priv_env = h.priv_env.clone();
+            if let Completion::Throw(err) = &comp {
+                if let Some(catch_ip) = h.catch_ip {
+                    frame.locals[base] = err.clone();
+                    return Ok(RegCtl::Jump(catch_ip as usize));
+                }
+            }
+            if let Some(finally_ip) = h.finally_ip {
+                frame.pending_completion = Some(comp);
+                return Ok(RegCtl::Jump(finally_ip as usize));
+            }
+        }
+        match comp {
+            Completion::Return(v) => Ok(RegCtl::Return(v)),
+            Completion::Throw(e) => Err(e),
+            Completion::Jump { target, .. } => Ok(RegCtl::Jump(target as usize)),
         }
     }
 
@@ -4501,6 +4618,47 @@ impl Vm {
                 let (k, more) = Self::for_in_next(frame);
                 wr!(*dst, k);
                 wr!(*dst + 1, more);
+            }
+            ROp::IteratorClose { it } => {
+                // Reached only on an abrupt completion (for-of / destructuring
+                // landing pads), with that completion parked. Per spec
+                // (IteratorClose), if the completion is a throw, any error
+                // from `return()` is suppressed (the original throw wins);
+                // otherwise a `return()` error propagates and a non-object
+                // result is a TypeError.
+                let it = rd!(*it);
+                let completion_is_throw =
+                    matches!(frame.pending_completion, Some(Completion::Throw(_)));
+                let ret = match self.get_prop(&it, &PropertyKey::str("return")) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        if completion_is_throw {
+                            Value::Undefined
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                };
+                if self.is_callable(&ret) {
+                    match self.call(ret, it.clone(), &[]) {
+                        Ok(v) => {
+                            if !completion_is_throw && !matches!(v, Value::Object(_)) {
+                                return Err(
+                                    self.throw_type("iterator return() result is not an object")
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            if !completion_is_throw {
+                                return Err(e);
+                            }
+                        }
+                    }
+                } else if !ret.is_nullish() && !completion_is_throw {
+                    // GetMethod: a present but non-callable `return` is a
+                    // TypeError (masked only by an in-flight throw).
+                    return Err(self.throw_type("iterator return is not a function"));
+                }
             }
             ROp::ForInPop => {
                 frame.enumerators.pop();

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -30,6 +30,7 @@ pub mod opstats;
 pub mod promise;
 pub mod proxy;
 pub mod realm;
+pub mod reg;
 pub mod regexp;
 pub mod replay;
 pub mod trace;

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -1,0 +1,2158 @@
+//! Register bytecode tier (docs/js-performance-roadmap.md §3.5): translate a
+//! whole eligible function body from the stack bytecode into a register
+//! program executed by `Vm::run_reg_frame` (exec.rs) — no operand stack, no
+//! per-value push/pop traffic, and one dispatch where the stack machine pays
+//! two or three (`LoadLocal a; LoadLocal b; Add; StoreLocal c` is a single
+//! `Add { dst: c, a, b }`).
+//!
+//! The model mirrors the loop-kernel tier's discipline (kernel.rs), applied
+//! to BOXED values over the whole body instead of unboxed `f64`s over loop
+//! regions:
+//!
+//! - **Same helpers, same semantics.** Every register op calls the SAME
+//!   `Vm` helper as its stack twin (`op_add`, `Vm::arith`, `cmp_values`,
+//!   `get_prop`/`put_value`, the inline-cache fast paths, `call_valuevec`,
+//!   …), so coercion order, thrown errors, and observable effects are
+//!   identical by construction. The translation changes only WHERE operands
+//!   live (indexed registers instead of a stack), never what runs.
+//! - **Whole-function eligibility.** Translation is all-or-nothing per
+//!   function: any op outside the translated subset (try/finally handlers,
+//!   `with`/direct-`eval` scope machinery, class `super`/private elements,
+//!   suspension ops, `Op::LoopKernel`, …) declines the function and it keeps
+//!   the stack interpreter. Loop-kernelized functions keep the stack tier so
+//!   their unboxed kernels — far faster than boxed register ops — stay in
+//!   charge.
+//! - **Registers are `frame.locals`.** Register `0..num_locals` ARE the
+//!   localized bindings (same slots, same TDZ marker); `num_locals..` are the
+//!   canonical homes of the stack machine's operand-stack depths. A frame
+//!   running in register mode is an ordinary `Frame` — the GC tracer, the
+//!   frame pool, `arguments`, cells, and upvalues all work unchanged.
+//! - **Determinism.** The register program is compiled from the final stack
+//!   bytecode at compile finish — a pure function of the source. Execution
+//!   order of every observable operation is identical to the stack path
+//!   (gated by the reg-on/off differential corpus in `tests/reg.rs`), so the
+//!   replay journal is byte-identical either way. Like kernels, the tier is
+//!   OFF whenever an op budget is installed: per-op accounting stays exact
+//!   on the generic path.
+//!
+//! # Translation scheme
+//!
+//! A virtual stack of [`Entry`] values abstract-interprets the stack code.
+//! The entry at depth `d` is either **canonical** (its value lives in
+//! register `canon(d) = num_locals + d`) or **lazy** — a reference to a
+//! local register, a constant, or a keyword value (`undefined`, `this`, …)
+//! that has not been materialized. Lazy entries make the classic stack
+//! shuffle free: `LoadLocal` emits NOTHING; the consuming op reads the local
+//! register directly.
+//!
+//! Soundness of lazy references:
+//! - A `Local(l)` entry aliases a MUTABLE register, so every op that writes
+//!   local `l` first flushes any live `Local(l)` entries to their canonical
+//!   slots (the stack machine's push took a copy at push time; the flush
+//!   reproduces it). Locals are unaliasable outside the frame (that is what
+//!   the localization pass proved), so explicit local-writing ops are the
+//!   ONLY writers.
+//! - A `Reg(r)` entry (created by `Dup` of a canonical entry) may only alias
+//!   a register BELOW its own depth: results always land at `canon(top)`,
+//!   which can only revisit `r` after the aliasing entry itself was consumed.
+//! - At every branch, jump target, and label fall-in the whole virtual stack
+//!   is flushed to canonical form, so control-flow joins agree on where every
+//!   live value lives regardless of path.
+//!
+//! TDZ: reads of locals that MIGHT hold the `Uninitialized` marker emit an
+//! explicit [`ROp::TdzCheck`]; a small forward dataflow (intersection at
+//! joins, to a fixpoint) proves most reads — every loop variable after its
+//! init — never need one, so they alias with zero checks where the stack
+//! machine re-checks on every `LoadLocal`.
+
+use std::collections::HashMap;
+
+use crate::bytecode::{CmpOp, IcEntry, Op};
+use crate::exec::ArithKind;
+
+/// Compiled register program for one function. Stored on
+/// [`crate::bytecode::FuncProto::reg`]; executed by `Vm::run_reg_frame`.
+#[derive(Debug)]
+pub struct RegProto {
+    pub code: Vec<ROp>,
+    /// Total register-file size: `num_locals` localized bindings followed by
+    /// the canonical operand slots. `Frame.locals` is resized to this on
+    /// register-mode entry.
+    pub num_regs: u16,
+    /// Inline-cache entries for `GetProp`/`SetProp`/`LoadGlobal` sites,
+    /// indexed by the op's `ic` payload. Same key-verified discipline as
+    /// [`crate::bytecode::FuncProto::ic`].
+    pub ic: Box<[IcEntry]>,
+}
+
+/// Unary value ops sharing one register shape (`dst = op(src)`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RUnary {
+    Neg,
+    Pos,
+    ToNumeric,
+    Inc,
+    Dec,
+    BitNot,
+    Not,
+    Typeof,
+    ToStr,
+    ToKey,
+}
+
+/// Property-definition kinds sharing one register shape (`DefineProp`),
+/// mapping 1:1 onto the six stack `Define*` ops.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DefKind {
+    Field,
+    Method,
+    Getter,
+    Setter,
+    MethodGetter,
+    MethodSetter,
+}
+
+/// The register instruction set. `dst`/`src`/operand fields index the
+/// frame's register file (`frame.locals`); `target` fields are absolute
+/// indices into [`RegProto::code`]; `name`/`konst`/`idx` fields index the
+/// function's const table exactly like their stack twins.
+#[derive(Clone, Debug)]
+pub enum ROp {
+    // ---- moves / constants / frame values ----
+    Mov {
+        dst: u16,
+        src: u16,
+    },
+    Const {
+        dst: u16,
+        idx: u32,
+    },
+    Undef {
+        dst: u16,
+    },
+    Null {
+        dst: u16,
+    },
+    Bool {
+        dst: u16,
+        v: bool,
+    },
+    Hole {
+        dst: u16,
+    },
+    This {
+        dst: u16,
+    },
+    NewTarget {
+        dst: u16,
+    },
+    Arg {
+        dst: u16,
+        idx: u32,
+    },
+    RestArgs {
+        dst: u16,
+        from: u32,
+    },
+    Arguments {
+        dst: u16,
+    },
+    /// OrdinaryCallBindThis (sloppy): rebind `regs[reg]` in place.
+    BindThisSloppy {
+        reg: u16,
+    },
+
+    // ---- locals (registers 0..num_locals) ----
+    /// Throw a ReferenceError if `regs[src]` is the TDZ marker. Emitted only
+    /// where the init dataflow could not prove the read safe.
+    TdzCheck {
+        src: u16,
+    },
+    StoreLocalChecked {
+        local: u16,
+        src: u16,
+    },
+    InitLocalTdz {
+        local: u16,
+    },
+    /// Statement-position `i++`/`--i` on a local (mirror of
+    /// `Op::IncLocalStmt`, TDZ check included).
+    IncLocal {
+        local: u16,
+        dec: bool,
+    },
+
+    // ---- cells / upvalues ----
+    LoadCell {
+        dst: u16,
+        cell: u32,
+    },
+    StoreCell {
+        cell: u32,
+        src: u16,
+    },
+    StoreCellChecked {
+        cell: u32,
+        src: u16,
+    },
+    InitCell {
+        cell: u32,
+        src: u16,
+    },
+    InitCellTdz {
+        cell: u32,
+    },
+    IncCell {
+        cell: u32,
+        dec: bool,
+    },
+    LoadCellInit {
+        src: u32,
+        dest: u32,
+    },
+    AddCellK {
+        dst: u16,
+        cell: u32,
+        konst: u32,
+    },
+    ArithCellK {
+        kind: ArithKind,
+        dst: u16,
+        cell: u32,
+        konst: u32,
+    },
+    CmpBrCellK {
+        cmp: CmpOp,
+        cell: u32,
+        konst: u32,
+        if_true: bool,
+        target: u32,
+    },
+    LoadUpvalue {
+        dst: u16,
+        idx: u32,
+    },
+    StoreUpvalue {
+        idx: u32,
+        src: u16,
+    },
+    StoreUpvalueChecked {
+        idx: u32,
+        src: u16,
+    },
+
+    // ---- globals ----
+    LoadGlobal {
+        dst: u16,
+        name: u32,
+        ic: u32,
+    },
+    StoreGlobal {
+        name: u32,
+        src: u16,
+    },
+    LoadGlobalTypeof {
+        dst: u16,
+        name: u32,
+    },
+    DeclareGlobal {
+        name: u32,
+        deletable: bool,
+    },
+    CanDeclareGlobalFunc {
+        name: u32,
+    },
+    DefineGlobalFunc {
+        name: u32,
+        deletable: bool,
+        src: u16,
+    },
+
+    // ---- arithmetic / unary / comparison ----
+    Add {
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
+    AddK {
+        dst: u16,
+        a: u16,
+        konst: u32,
+    },
+    Arith {
+        kind: ArithKind,
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
+    ArithK {
+        kind: ArithKind,
+        dst: u16,
+        a: u16,
+        konst: u32,
+    },
+    Unary {
+        kind: RUnary,
+        dst: u16,
+        src: u16,
+    },
+    Cmp {
+        cmp: CmpOp,
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
+    InstanceOf {
+        dst: u16,
+        a: u16,
+        b: u16,
+    },
+
+    // ---- control flow ----
+    Jmp {
+        target: u32,
+    },
+    BrTrue {
+        src: u16,
+        target: u32,
+    },
+    BrFalse {
+        src: u16,
+        target: u32,
+    },
+    /// `&&`: branch when falsy keeping the value (fallthrough abandons it).
+    BrFalsyKeep {
+        src: u16,
+        target: u32,
+    },
+    /// `||`: branch when truthy keeping the value.
+    BrTruthyKeep {
+        src: u16,
+        target: u32,
+    },
+    /// `??`: branch when NOT nullish keeping the value.
+    BrNotNullishKeep {
+        src: u16,
+        target: u32,
+    },
+    /// Optional-chain short-circuit: when nullish, overwrite with `undefined`
+    /// and branch (the value survives on both edges).
+    BrNullishUndef {
+        reg: u16,
+        target: u32,
+    },
+    CmpBr {
+        cmp: CmpOp,
+        a: u16,
+        b: u16,
+        if_true: bool,
+        target: u32,
+    },
+    CmpBrK {
+        cmp: CmpOp,
+        a: u16,
+        konst: u32,
+        if_true: bool,
+        target: u32,
+    },
+
+    // ---- property access ----
+    GetProp {
+        dst: u16,
+        obj: u16,
+        name: u32,
+        ic: u32,
+    },
+    SetProp {
+        dst: u16,
+        obj: u16,
+        name: u32,
+        src: u16,
+        ic: u32,
+    },
+    GetElem {
+        dst: u16,
+        obj: u16,
+        key: u16,
+    },
+    SetElem {
+        dst: u16,
+        obj: u16,
+        key: u16,
+        src: u16,
+    },
+    DelProp {
+        dst: u16,
+        obj: u16,
+        name: u32,
+    },
+    DelElem {
+        dst: u16,
+        obj: u16,
+        key: u16,
+    },
+    HasProp {
+        dst: u16,
+        key: u16,
+        obj: u16,
+    },
+
+    // ---- calls ----
+    /// Arguments live in the CONTIGUOUS canonical registers `at..at+argc`
+    /// (moved out by the callee — they are dead operand slots). `func`/`this`
+    /// may be any register and are cloned, never moved.
+    Call {
+        dst: u16,
+        func: u16,
+        this: u16,
+        at: u16,
+        argc: u16,
+        has_this: bool,
+    },
+    New {
+        dst: u16,
+        ctor: u16,
+        at: u16,
+        argc: u16,
+    },
+    CallSpread {
+        dst: u16,
+        func: u16,
+        this: u16,
+        args: u16,
+    },
+    NewSpread {
+        dst: u16,
+        ctor: u16,
+        args: u16,
+    },
+    Ret {
+        src: u16,
+    },
+    /// Mirror of `Op::ReturnUndefined` (returns `frame.completion`).
+    RetCompletion,
+    Throw {
+        src: u16,
+    },
+    ThrowConstAssign,
+
+    // ---- closures / objects / arrays ----
+    Closure {
+        dst: u16,
+        idx: u32,
+    },
+    NewObject {
+        dst: u16,
+    },
+    /// Elements move out of canonical registers `at..at+n`.
+    NewArray {
+        dst: u16,
+        at: u16,
+        n: u16,
+    },
+    ArraySpread {
+        arr: u16,
+        src: u16,
+    },
+    DefineProp {
+        kind: DefKind,
+        obj: u16,
+        key: u16,
+        val: u16,
+    },
+    SetHomeObject {
+        obj: u16,
+        val: u16,
+    },
+    ObjectSpread {
+        target: u16,
+        src: u16,
+    },
+    /// Excluded keys move out of canonical registers `at..at+n`.
+    CopyDataPropsExcept {
+        target: u16,
+        src: u16,
+        at: u16,
+        n: u16,
+    },
+    GetTemplateObject {
+        dst: u16,
+        idx: u32,
+    },
+    NewRegExp {
+        dst: u16,
+        pattern: u32,
+        flags: u32,
+    },
+    /// Parts move out of canonical registers `at..at+n`.
+    ConcatStrings {
+        dst: u16,
+        at: u16,
+        n: u16,
+    },
+    RequireObjectCoercible {
+        src: u16,
+    },
+    RequireCoercible {
+        src: u16,
+    },
+    RequireIterResult {
+        src: u16,
+    },
+    SetFunctionNameFromKey {
+        prefix: u32,
+        key: u16,
+        val: u16,
+    },
+    SetProtoFromLiteral {
+        obj: u16,
+        src: u16,
+    },
+
+    // ---- iteration ----
+    GetIterator {
+        dst: u16,
+        src: u16,
+    },
+    IterNext {
+        dst: u16,
+        it: u16,
+    },
+    ForInEnumerate {
+        dst: u16,
+        src: u16,
+    },
+    /// Writes the next key to `dst` and the has-next flag to `dst + 1`.
+    ForInNext {
+        dst: u16,
+    },
+    ForInPop,
+}
+
+// =============================================================================
+// Eligibility + stack effects
+// =============================================================================
+
+/// The stack effect of one translatable op: values popped and pushed on the
+/// straight-line path. `None` = the op is outside the translated subset (the
+/// whole function declines). Branch/terminal shapes are handled by the
+/// callers (`flow_out`, the emitter) — this covers operand traffic only.
+fn effect(op: &Op) -> Option<(u32, u32)> {
+    use Op::*;
+    Some(match op {
+        Nop => (0, 0),
+        LoadConst(_) | LoadUndefined | LoadHole | LoadNull | LoadTrue | LoadFalse | LoadThis
+        | LoadNewTarget | LoadArg(_) | LoadRestArgs(_) | LoadLocal(_) | LoadCell(_)
+        | LoadUpvalue(_) | LoadGlobal(_) | LoadGlobalTypeof(_) | LoadArguments
+        | ArrayPushElision => (0, 1),
+        RequireObjectCoercible | RequireIterResult => (0, 0),
+        BindThisSloppy => (1, 1),
+        StoreLocal(_)
+        | StoreLocalChecked(_)
+        | StoreCell(_)
+        | StoreCellChecked(_)
+        | InitCell(_)
+        | StoreUpvalue(_)
+        | StoreUpvalueChecked(_)
+        | StoreGlobal(_)
+        | RequireCoercible
+        | Pop => (1, 0),
+        InitLocalTdz(_)
+        | InitCellTdz(_)
+        | IncLocalStmt { .. }
+        | IncCellStmt { .. }
+        | CopyLocal { .. }
+        | LoadCellInit { .. }
+        | ForInPop => (0, 0),
+        LoadLocalConst { .. } | LoadCellConst { .. } => (0, 2),
+        AddLocalConst { .. }
+        | ArithLocalConst { .. }
+        | AddCellConst { .. }
+        | ArithCellConst { .. } => (0, 1),
+        DeclareGlobal { .. } | CanDeclareGlobalFunc(_) => (0, 0),
+        DefineGlobalFunc { .. } => (1, 0),
+        Dup => (0, 1),
+        Swap | Rot3 => (0, 0),
+        NewObject | GetTemplateObject(_) | NewRegExp { .. } | Closure(_) => (0, 1),
+        NewArray(n) | ConcatStrings(n) => (*n, 1),
+        ArraySpread | ObjectSpread => (2, 1),
+        CopyDataPropertiesExcept(n) => (*n + 2, 1),
+        DefineField | DefineMethod | DefineGetter | DefineSetter | DefineMethodGetter
+        | DefineMethodSetter => (3, 1),
+        SetHomeObject | SetFunctionNameFromKey(_) => (0, 0),
+        SetProtoFromLiteral => (1, 0),
+        GetProp(_) | DeleteProp(_) => (1, 1),
+        SetProp(_) | GetPropDynamic | DeletePropDynamic | HasProp => (2, 1),
+        SetPropDynamic => (3, 1),
+        JumpIfNullish(_) => (0, 0),
+        Call(argc) => (*argc + 2, 1),
+        CallMethodless(argc) => (*argc + 1, 1),
+        New(argc) => (*argc + 1, 1),
+        CallSpread => (3, 1),
+        NewSpread => (2, 1),
+        Return | Throw => (1, 0),
+        ReturnUndefined | ThrowConstAssign => (0, 0),
+        Add | Sub | Mul | Div | Mod | Pow | BitAnd | BitOr | BitXor | Shl | Shr | UShr => (2, 1),
+        Neg | Pos | ToNumeric | Inc | Dec | BitNot | Not | TypeofExpr | ToPropertyKey
+        | ToStringOp => (1, 1),
+        Eq | Ne | StrictEq | StrictNe | Lt | Le | Gt | Ge | InstanceOf => (2, 1),
+        Jump(_) => (0, 0),
+        JumpIfTrue(_) | JumpIfFalse(_) => (1, 0),
+        CmpBranchFalse { .. } | CmpBranchTrue { .. } => (2, 0),
+        CmpCellConstBranchFalse { .. }
+        | CmpCellConstBranchTrue { .. }
+        | CmpLocalConstBranchFalse { .. }
+        | CmpLocalConstBranchTrue { .. } => (0, 0),
+        JumpIfFalsyPeek(_) | JumpIfTruthyPeek(_) | JumpIfNullishPeek(_) => (0, 0),
+        GetIterator | ForInEnumerate => (1, 1),
+        IteratorNext => (0, 1),
+        ForInNext => (0, 2),
+        // Everything else — try/finally machinery, `with`/eval scope ops,
+        // super/private/class wiring, dispose, suspension, delegation,
+        // dynamic import, `Op::LoopKernel` (the unboxed kernels stay in
+        // charge of their functions), IteratorClose (coupled to the parked-
+        // completion machinery) — declines the function.
+        _ => return None,
+    })
+}
+
+/// Control-flow shape of one translatable op.
+enum FlowKind {
+    /// Falls through only.
+    Linear,
+    /// Unconditional jump.
+    Jump(u32),
+    /// Conditional: both fallthrough and target, at the same depth (after
+    /// `effect` pops).
+    Branch(u32),
+    /// Peek-branch: the TARGET edge keeps the top value; the fallthrough
+    /// edge pops it.
+    PeekBranch(u32),
+    /// Return/Throw: no successors.
+    Terminal,
+}
+
+fn flow_of(op: &Op) -> FlowKind {
+    use Op::*;
+    match op {
+        Jump(t) => FlowKind::Jump(*t),
+        JumpIfTrue(t) | JumpIfFalse(t) | JumpIfNullish(t) => FlowKind::Branch(*t),
+        CmpBranchFalse { target, .. }
+        | CmpBranchTrue { target, .. }
+        | CmpCellConstBranchFalse { target, .. }
+        | CmpCellConstBranchTrue { target, .. }
+        | CmpLocalConstBranchFalse { target, .. }
+        | CmpLocalConstBranchTrue { target, .. } => FlowKind::Branch(*target),
+        JumpIfFalsyPeek(t) | JumpIfTruthyPeek(t) | JumpIfNullishPeek(t) => FlowKind::PeekBranch(*t),
+        Return | ReturnUndefined | Throw | ThrowConstAssign => FlowKind::Terminal,
+        _ => FlowKind::Linear,
+    }
+}
+
+// =============================================================================
+// TDZ / depth dataflow
+// =============================================================================
+
+/// Bitset over local slots that MIGHT hold the TDZ marker at a program point.
+#[derive(Clone, PartialEq, Eq)]
+struct TdzSet {
+    bits: Box<[u64]>,
+}
+
+impl TdzSet {
+    fn empty(n: u32) -> TdzSet {
+        TdzSet {
+            bits: vec![0u64; n.div_ceil(64) as usize].into_boxed_slice(),
+        }
+    }
+    fn set(&mut self, i: u32) {
+        self.bits[(i / 64) as usize] |= 1 << (i % 64);
+    }
+    fn clear(&mut self, i: u32) {
+        self.bits[(i / 64) as usize] &= !(1 << (i % 64));
+    }
+    fn get(&self, i: u32) -> bool {
+        (self.bits[(i / 64) as usize] >> (i % 64)) & 1 != 0
+    }
+    /// Join: a local is maybe-TDZ after the join if it is on ANY inflow edge.
+    fn union_with(&mut self, other: &TdzSet) -> bool {
+        let mut changed = false;
+        for (a, b) in self.bits.iter_mut().zip(other.bits.iter()) {
+            let n = *a | *b;
+            if n != *a {
+                *a = n;
+                changed = true;
+            }
+        }
+        changed
+    }
+}
+
+/// Apply one op's effect on the maybe-TDZ set. Reads of a local through the
+/// TDZ-checking stack ops PROVE the slot initialized on the fallthrough path
+/// (they throw otherwise), so they clear the bit.
+fn tdz_transfer(op: &Op, tdz: &mut TdzSet) {
+    use Op::*;
+    match op {
+        InitLocalTdz(i) => tdz.set(*i),
+        StoreLocal(i) => tdz.clear(*i),
+        // Checked reads/writes prove the slot initialized past this point.
+        LoadLocal(i) | StoreLocalChecked(i) | IncLocalStmt { local: i, .. } => tdz.clear(*i),
+        LoadLocalConst { local, .. }
+        | AddLocalConst { local, .. }
+        | ArithLocalConst { local, .. }
+        | CmpLocalConstBranchFalse { local, .. }
+        | CmpLocalConstBranchTrue { local, .. } => tdz.clear(*local),
+        CopyLocal { src, dest } => {
+            tdz.clear(*src);
+            tdz.clear(*dest);
+        }
+        _ => {}
+    }
+}
+
+/// Per-label converged state from the pre-emission dataflow.
+struct LabelState {
+    depth: u32,
+    tdz: TdzSet,
+}
+
+// =============================================================================
+// Translator
+// =============================================================================
+
+/// One virtual-stack slot during emission.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Entry {
+    /// Value lives in `canon(depth)`.
+    Temp,
+    /// Value lives in register `r` — an alias created by `Dup`; always
+    /// `r < canon(own depth)`, see the module docs for why that is sound.
+    Reg(u16),
+    /// Lazy local reference (TDZ already checked at push where needed).
+    Local(u16),
+    /// Lazy constant (const-table index).
+    K(u32),
+    Undef,
+    Null,
+    True,
+    False,
+    Hole,
+    This,
+    NewTarget,
+}
+
+struct Emitter {
+    num_locals: u16,
+    code: Vec<ROp>,
+    entries: Vec<Entry>,
+    tdz: TdzSet,
+    /// Highest register index used so far (register-file size − 1).
+    max_reg: u16,
+    /// Number of inline-cache sites assigned so far.
+    ics: u32,
+    /// rpc of the last emitted single-`dst` op whose result is the current
+    /// virtual-stack top (for the `StoreLocal` dst-rewrite peephole).
+    last_def: Option<usize>,
+}
+
+/// Translate a function's final stack bytecode into a register program.
+/// Returns `None` when the function contains any op outside the translated
+/// subset, contains loop kernels, or exceeds the register budget.
+pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
+    if code.is_empty() || num_locals > u16::MAX as u32 / 2 {
+        return None;
+    }
+    // Phase 1: eligibility + label collection.
+    let mut labels: Vec<u32> = Vec::new();
+    for op in code {
+        effect(op)?;
+        match flow_of(op) {
+            FlowKind::Jump(t) | FlowKind::Branch(t) | FlowKind::PeekBranch(t) => labels.push(t),
+            _ => {}
+        }
+    }
+    labels.sort_unstable();
+    labels.dedup();
+    let is_label = |ip: u32| labels.binary_search(&ip).is_ok();
+
+    // Phase 2: depth + maybe-TDZ dataflow to a fixpoint over the labels.
+    // Depths are deterministic per label (mismatch = malformed input: bail);
+    // TDZ sets grow monotonically under union, so this converges.
+    // Never iterated (get/insert only), so hasher nondeterminism is unobservable.
+    let mut label_states: HashMap<u32, LabelState> = HashMap::new();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        let mut cur: Option<(u32, TdzSet)> = Some((0, TdzSet::empty(num_locals)));
+        for ip in 0..code.len() as u32 {
+            if is_label(ip) {
+                // Merge fall-in state into the label, then continue FROM the
+                // label's converged state.
+                if let Some((depth, tdz)) = cur.take() {
+                    match label_states.get_mut(&ip) {
+                        Some(st) => {
+                            if st.depth != depth {
+                                return None;
+                            }
+                            if st.tdz.union_with(&tdz) {
+                                changed = true;
+                            }
+                        }
+                        None => {
+                            label_states.insert(ip, LabelState { depth, tdz });
+                            changed = true;
+                        }
+                    }
+                }
+                cur = label_states.get(&ip).map(|st| (st.depth, st.tdz.clone()));
+            }
+            let Some((depth, mut tdz)) = cur else {
+                cur = None;
+                continue;
+            };
+            let op = &code[ip as usize];
+            let (pops, pushes) = effect(op).unwrap();
+            if depth < pops {
+                return None; // malformed: operand-stack underflow
+            }
+            let after = depth - pops + pushes;
+            // Register indices are u16: `canon(depth) = num_locals + depth`
+            // (plus a scratch slot) must stay addressable. A pathological
+            // operand-stack depth (a 60k-element array literal) declines.
+            if num_locals + after + 8 > u16::MAX as u32 {
+                return None;
+            }
+            tdz_transfer(op, &mut tdz);
+            // Propagate to the branch target (if any).
+            let mut edge = |target: u32, depth: u32, tdz: &TdzSet| -> Option<()> {
+                if target as usize > code.len() {
+                    return None;
+                }
+                match label_states.get_mut(&target) {
+                    Some(st) => {
+                        if st.depth != depth {
+                            return None;
+                        }
+                        if st.tdz.union_with(tdz) {
+                            changed = true;
+                        }
+                    }
+                    None => {
+                        label_states.insert(
+                            target,
+                            LabelState {
+                                depth,
+                                tdz: tdz.clone(),
+                            },
+                        );
+                        changed = true;
+                    }
+                }
+                Some(())
+            };
+            cur = match flow_of(op) {
+                FlowKind::Linear => Some((after, tdz)),
+                FlowKind::Jump(t) => {
+                    edge(t, after, &tdz)?;
+                    None
+                }
+                FlowKind::Branch(t) => {
+                    edge(t, after, &tdz)?;
+                    Some((after, tdz))
+                }
+                FlowKind::PeekBranch(t) => {
+                    // Target keeps the top value; fallthrough pops it.
+                    edge(t, depth, &tdz)?;
+                    Some((depth - 1, tdz))
+                }
+                FlowKind::Terminal => None,
+            };
+        }
+    }
+
+    // Phase 3: emission.
+    let mut e = Emitter {
+        num_locals: num_locals as u16,
+        code: Vec::with_capacity(code.len()),
+        entries: Vec::new(),
+        tdz: TdzSet::empty(num_locals),
+        max_reg: num_locals.saturating_sub(1) as u16,
+        ics: 0,
+        last_def: None,
+    };
+    // rpc of each stack ip (branch targets remapped through this at the end).
+    let mut rpc_at: Vec<u32> = vec![0; code.len() + 1];
+    let mut live = true;
+    let mut ip: u32 = 0;
+    while ip < code.len() as u32 {
+        if is_label(ip) {
+            if live {
+                e.flush_all();
+                debug_assert_eq!(
+                    e.entries.len() as u32,
+                    label_states.get(&ip).map(|s| s.depth).unwrap_or(0)
+                );
+            }
+            match label_states.get(&ip) {
+                Some(st) => {
+                    e.entries.clear();
+                    e.entries.resize(st.depth as usize, Entry::Temp);
+                    e.tdz = st.tdz.clone();
+                    live = true;
+                }
+                None => live = false, // label never reached from anywhere
+            }
+            e.last_def = None;
+        }
+        rpc_at[ip as usize] = e.code.len() as u32;
+        if !live {
+            // Unreachable op: emit nothing (jumps around it resolve to the
+            // next emitted position).
+            ip += 1;
+            continue;
+        }
+        let (fallthrough, consumed) = e.emit_op(code, ip, &is_label)?;
+        live = fallthrough;
+        for k in 0..consumed {
+            tdz_transfer(&code[(ip + k) as usize], &mut e.tdz);
+            if k > 0 {
+                rpc_at[(ip + k) as usize] = e.code.len() as u32;
+            }
+        }
+        ip += consumed;
+    }
+    rpc_at[code.len()] = e.code.len() as u32;
+    // Falling off the end of the code returns like the stack loop's
+    // `ip >= code.len()` exit; also the landing pad for end-of-code jump
+    // targets, so pc can never overrun.
+    e.code.push(ROp::RetCompletion);
+    // Remap branch targets from stack ips to rpcs.
+    for op in &mut e.code {
+        if let Some(t) = rop_target_mut(op) {
+            *t = rpc_at[*t as usize];
+        }
+    }
+    let num_regs = e.max_reg as u32 + 1;
+    if num_regs > u16::MAX as u32 {
+        return None;
+    }
+    let ic = (0..e.ics)
+        .map(|_| IcEntry {
+            own_slot: std::cell::Cell::new(u32::MAX),
+            proto_slot: std::cell::Cell::new(u32::MAX),
+            holder: std::cell::RefCell::new(None),
+        })
+        .collect();
+    Some(RegProto {
+        code: e.code,
+        num_regs: num_regs as u16,
+        ic,
+    })
+}
+
+/// Mutable access to an op's branch target for the final remap.
+fn rop_target_mut(op: &mut ROp) -> Option<&mut u32> {
+    match op {
+        ROp::Jmp { target }
+        | ROp::BrTrue { target, .. }
+        | ROp::BrFalse { target, .. }
+        | ROp::BrFalsyKeep { target, .. }
+        | ROp::BrTruthyKeep { target, .. }
+        | ROp::BrNotNullishKeep { target, .. }
+        | ROp::BrNullishUndef { target, .. }
+        | ROp::CmpBr { target, .. }
+        | ROp::CmpBrK { target, .. }
+        | ROp::CmpBrCellK { target, .. } => Some(target),
+        _ => None,
+    }
+}
+
+/// Rewrite the destination register of a single-`dst` op (the `StoreLocal`
+/// peephole). Must list every op the emitter marks as `last_def`.
+fn rop_set_dst(op: &mut ROp, new_dst: u16) -> bool {
+    match op {
+        ROp::Mov { dst, .. }
+        | ROp::Const { dst, .. }
+        | ROp::Undef { dst }
+        | ROp::Null { dst }
+        | ROp::Bool { dst, .. }
+        | ROp::Hole { dst }
+        | ROp::This { dst }
+        | ROp::NewTarget { dst }
+        | ROp::Arg { dst, .. }
+        | ROp::RestArgs { dst, .. }
+        | ROp::Arguments { dst }
+        | ROp::LoadCell { dst, .. }
+        | ROp::AddCellK { dst, .. }
+        | ROp::ArithCellK { dst, .. }
+        | ROp::LoadUpvalue { dst, .. }
+        | ROp::LoadGlobal { dst, .. }
+        | ROp::LoadGlobalTypeof { dst, .. }
+        | ROp::Add { dst, .. }
+        | ROp::AddK { dst, .. }
+        | ROp::Arith { dst, .. }
+        | ROp::ArithK { dst, .. }
+        | ROp::Unary { dst, .. }
+        | ROp::Cmp { dst, .. }
+        | ROp::InstanceOf { dst, .. }
+        | ROp::GetProp { dst, .. }
+        | ROp::SetProp { dst, .. }
+        | ROp::GetElem { dst, .. }
+        | ROp::SetElem { dst, .. }
+        | ROp::DelProp { dst, .. }
+        | ROp::DelElem { dst, .. }
+        | ROp::HasProp { dst, .. }
+        | ROp::Call { dst, .. }
+        | ROp::New { dst, .. }
+        | ROp::CallSpread { dst, .. }
+        | ROp::NewSpread { dst, .. }
+        | ROp::Closure { dst, .. }
+        | ROp::NewObject { dst }
+        | ROp::NewArray { dst, .. }
+        | ROp::GetTemplateObject { dst, .. }
+        | ROp::NewRegExp { dst, .. }
+        | ROp::ConcatStrings { dst, .. }
+        | ROp::GetIterator { dst, .. }
+        | ROp::IterNext { dst, .. } => {
+            *dst = new_dst;
+            true
+        }
+        _ => false,
+    }
+}
+
+impl Emitter {
+    fn canon(&self, depth: usize) -> u16 {
+        self.num_locals + depth as u16
+    }
+
+    fn touch(&mut self, r: u16) {
+        if r > self.max_reg {
+            self.max_reg = r;
+        }
+    }
+
+    fn push_op(&mut self, op: ROp) {
+        self.last_def = None;
+        self.code.push(op);
+    }
+
+    /// Emit an op whose single `dst` produced the new virtual-stack top
+    /// (arming the `StoreLocal` rewrite peephole).
+    fn push_def(&mut self, op: ROp) {
+        self.code.push(op);
+        self.last_def = Some(self.code.len() - 1);
+    }
+
+    /// Register that currently holds the value of `entries[pos]`, emitting a
+    /// materialization for keyword/const entries (into the slot's canonical
+    /// register — free, nothing else can occupy it).
+    fn reg_of(&mut self, pos: usize) -> u16 {
+        let c = self.canon(pos);
+        match self.entries[pos] {
+            Entry::Temp => c,
+            Entry::Reg(r) => r,
+            Entry::Local(l) => l,
+            e => {
+                self.materialize(pos, e, c);
+                c
+            }
+        }
+    }
+
+    /// Force `entries[pos]` into its canonical register (for contiguous
+    /// argument ranges and control-flow joins).
+    fn canonicalize(&mut self, pos: usize) {
+        let ent = self.entries[pos];
+        if ent == Entry::Temp {
+            return;
+        }
+        let c = self.canon(pos);
+        match ent {
+            Entry::Reg(r) => self.push_op(ROp::Mov { dst: c, src: r }),
+            Entry::Local(l) => self.push_op(ROp::Mov { dst: c, src: l }),
+            e => self.materialize(pos, e, c),
+        }
+        self.touch(c);
+        self.entries[pos] = Entry::Temp;
+    }
+
+    fn materialize(&mut self, pos: usize, e: Entry, dst: u16) {
+        let op = match e {
+            Entry::K(idx) => ROp::Const { dst, idx },
+            Entry::Undef => ROp::Undef { dst },
+            Entry::Null => ROp::Null { dst },
+            Entry::True => ROp::Bool { dst, v: true },
+            Entry::False => ROp::Bool { dst, v: false },
+            Entry::Hole => ROp::Hole { dst },
+            Entry::This => ROp::This { dst },
+            Entry::NewTarget => ROp::NewTarget { dst },
+            Entry::Temp | Entry::Reg(_) | Entry::Local(_) => unreachable!(),
+        };
+        self.push_op(op);
+        self.touch(dst);
+        self.entries[pos] = Entry::Temp;
+    }
+
+    /// Flush the whole virtual stack to canonical form (control-flow edges).
+    fn flush_all(&mut self) {
+        for pos in 0..self.entries.len() {
+            self.canonicalize(pos);
+        }
+        self.last_def = None;
+    }
+
+    /// Flush any lazy references to local `l` (an op is about to write it).
+    fn flush_local(&mut self, l: u16) -> bool {
+        let mut any = false;
+        for pos in 0..self.entries.len() {
+            if self.entries[pos] == Entry::Local(l) {
+                self.canonicalize(pos);
+                any = true;
+            }
+        }
+        any
+    }
+
+    fn pop(&mut self) -> Entry {
+        self.last_def = None;
+        self.entries.pop().expect("virtual stack underflow")
+    }
+
+    /// Pop the top entry and return a register holding its value.
+    fn pop_reg(&mut self) -> u16 {
+        let pos = self.entries.len() - 1;
+        let r = self.reg_of(pos);
+        self.entries.pop();
+        self.last_def = None;
+        r
+    }
+
+    /// Result register for an op producing at the current top.
+    fn dst(&mut self) -> u16 {
+        let c = self.canon(self.entries.len());
+        self.touch(c);
+        c
+    }
+
+    fn push_temp(&mut self) {
+        self.entries.push(Entry::Temp);
+    }
+
+    fn next_ic(&mut self) -> u32 {
+        let i = self.ics;
+        self.ics += 1;
+        i
+    }
+
+    /// Read of local `l`: TDZ-check when the dataflow could not prove the
+    /// slot initialized, then push a lazy reference.
+    fn push_local(&mut self, l: u32) {
+        if self.tdz.get(l) {
+            self.push_op(ROp::TdzCheck { src: l as u16 });
+            self.tdz.clear(l);
+        }
+        self.entries.push(Entry::Local(l as u16));
+    }
+
+    /// TDZ guard for the fused local superinstructions (which read `local`
+    /// directly as an operand).
+    fn tdz_guard(&mut self, l: u32) {
+        if self.tdz.get(l) {
+            self.push_op(ROp::TdzCheck { src: l as u16 });
+            self.tdz.clear(l);
+        }
+    }
+
+    /// Store the popped top into local `l`, rewriting the defining op's `dst`
+    /// when the value was produced by the immediately preceding op.
+    fn store_local(&mut self, l: u16) {
+        let needs_flush = self.entries.contains(&Entry::Local(l));
+        if !needs_flush {
+            if let (Some(def), Some(&Entry::Temp)) = (self.last_def, self.entries.last()) {
+                if def + 1 == self.code.len() && rop_set_dst(&mut self.code[def], l) {
+                    self.entries.pop();
+                    self.last_def = None;
+                    return;
+                }
+            }
+            // A lazy top stores straight into the local.
+            match self.entries.last().copied() {
+                Some(Entry::Local(src)) if src == l => {
+                    // x = x: nothing moves.
+                    self.entries.pop();
+                    self.last_def = None;
+                    return;
+                }
+                Some(Entry::Local(src)) => {
+                    self.entries.pop();
+                    self.push_op(ROp::Mov { dst: l, src });
+                    return;
+                }
+                Some(
+                    e @ (Entry::K(_)
+                    | Entry::Undef
+                    | Entry::Null
+                    | Entry::True
+                    | Entry::False
+                    | Entry::Hole
+                    | Entry::This
+                    | Entry::NewTarget),
+                ) => {
+                    let pos = self.entries.len() - 1;
+                    self.materialize(pos, e, l);
+                    self.entries.pop();
+                    return;
+                }
+                _ => {}
+            }
+        } else {
+            self.flush_local(l);
+        }
+        let src = self.pop_reg();
+        self.push_op(ROp::Mov { dst: l, src });
+    }
+
+    /// Emit the translation of the op at `ip` (possibly fusing a following
+    /// window). Returns `Some((live, consumed))` where `live` says whether
+    /// execution can fall through and `consumed` how many stack ops the
+    /// emission covered; `None` = untranslatable (unreachable here — phase 1
+    /// vetted every op — but kept as a guard).
+    fn emit_op(
+        &mut self,
+        code: &[Op],
+        ip: u32,
+        is_label: &dyn Fn(u32) -> bool,
+    ) -> Option<(bool, u32)> {
+        use Op::*;
+        let op = &code[ip as usize];
+        match op {
+            Nop => {}
+            LoadConst(i) => self.entries.push(Entry::K(*i)),
+            LoadUndefined => self.entries.push(Entry::Undef),
+            LoadHole | ArrayPushElision => self.entries.push(match op {
+                LoadHole => Entry::Hole,
+                // ArrayPushElision pushes plain `undefined` (see step_cold).
+                _ => Entry::Undef,
+            }),
+            LoadNull => self.entries.push(Entry::Null),
+            LoadTrue => self.entries.push(Entry::True),
+            LoadFalse => self.entries.push(Entry::False),
+            LoadThis => self.entries.push(Entry::This),
+            LoadNewTarget => self.entries.push(Entry::NewTarget),
+            LoadArg(i) => {
+                let dst = self.dst();
+                self.push_def(ROp::Arg { dst, idx: *i });
+                self.push_temp();
+            }
+            LoadRestArgs(n) => {
+                let dst = self.dst();
+                self.push_def(ROp::RestArgs { dst, from: *n });
+                self.push_temp();
+            }
+            LoadArguments => {
+                let dst = self.dst();
+                self.push_def(ROp::Arguments { dst });
+                self.push_temp();
+            }
+            RequireObjectCoercible => {
+                let pos = self.entries.len() - 1;
+                let src = self.reg_of(pos);
+                self.push_op(ROp::RequireObjectCoercible { src });
+            }
+            RequireIterResult => {
+                let pos = self.entries.len() - 1;
+                let src = self.reg_of(pos);
+                self.push_op(ROp::RequireIterResult { src });
+            }
+            RequireCoercible => {
+                let src = self.pop_reg();
+                self.push_op(ROp::RequireCoercible { src });
+            }
+            BindThisSloppy => {
+                // Rebind in place: materialize to canonical, mutate there.
+                let pos = self.entries.len() - 1;
+                self.canonicalize(pos);
+                let reg = self.canon(pos);
+                self.push_op(ROp::BindThisSloppy { reg });
+            }
+
+            // ---- locals ----
+            LoadLocal(i) => self.push_local(*i),
+            StoreLocal(i) => self.store_local(*i as u16),
+            StoreLocalChecked(i) => {
+                self.flush_local(*i as u16);
+                let src = self.pop_reg();
+                self.push_op(ROp::StoreLocalChecked {
+                    local: *i as u16,
+                    src,
+                });
+            }
+            InitLocalTdz(i) => {
+                self.flush_local(*i as u16);
+                self.push_op(ROp::InitLocalTdz { local: *i as u16 });
+            }
+            LoadLocalConst { local, konst } => {
+                self.push_local(*local);
+                self.entries.push(Entry::K(*konst));
+            }
+            CmpLocalConstBranchFalse {
+                local,
+                konst,
+                cmp,
+                target,
+            }
+            | CmpLocalConstBranchTrue {
+                local,
+                konst,
+                cmp,
+                target,
+            } => {
+                self.tdz_guard(*local);
+                self.flush_all();
+                let if_true = matches!(op, CmpLocalConstBranchTrue { .. });
+                self.push_op(ROp::CmpBrK {
+                    cmp: *cmp,
+                    a: *local as u16,
+                    konst: *konst,
+                    if_true,
+                    target: *target,
+                });
+            }
+            AddLocalConst { local, konst } => {
+                self.tdz_guard(*local);
+                let dst = self.dst();
+                self.push_def(ROp::AddK {
+                    dst,
+                    a: *local as u16,
+                    konst: *konst,
+                });
+                self.push_temp();
+            }
+            ArithLocalConst { local, konst, kind } => {
+                self.tdz_guard(*local);
+                let dst = self.dst();
+                self.push_def(ROp::ArithK {
+                    kind: *kind,
+                    dst,
+                    a: *local as u16,
+                    konst: *konst,
+                });
+                self.push_temp();
+            }
+            IncLocalStmt { local, dec } => {
+                self.flush_local(*local as u16);
+                self.push_op(ROp::IncLocal {
+                    local: *local as u16,
+                    dec: *dec,
+                });
+            }
+            CopyLocal { src, dest } => {
+                self.tdz_guard(*src);
+                self.flush_local(*dest as u16);
+                if src != dest {
+                    self.push_op(ROp::Mov {
+                        dst: *dest as u16,
+                        src: *src as u16,
+                    });
+                }
+            }
+
+            // ---- cells / upvalues ----
+            LoadCell(i) => {
+                let dst = self.dst();
+                self.push_def(ROp::LoadCell { dst, cell: *i });
+                self.push_temp();
+            }
+            LoadCellConst { cell, konst } => {
+                let dst = self.dst();
+                self.push_def(ROp::LoadCell { dst, cell: *cell });
+                self.push_temp();
+                self.entries.push(Entry::K(*konst));
+            }
+            StoreCell(i) => {
+                let src = self.pop_reg();
+                self.push_op(ROp::StoreCell { cell: *i, src });
+            }
+            StoreCellChecked(i) => {
+                let src = self.pop_reg();
+                self.push_op(ROp::StoreCellChecked { cell: *i, src });
+            }
+            InitCell(i) => {
+                let src = self.pop_reg();
+                self.push_op(ROp::InitCell { cell: *i, src });
+            }
+            InitCellTdz(i) => self.push_op(ROp::InitCellTdz { cell: *i }),
+            IncCellStmt { cell, dec } => self.push_op(ROp::IncCell {
+                cell: *cell,
+                dec: *dec,
+            }),
+            LoadCellInit { src, dest } => self.push_op(ROp::LoadCellInit {
+                src: *src,
+                dest: *dest,
+            }),
+            AddCellConst { cell, konst } => {
+                let dst = self.dst();
+                self.push_def(ROp::AddCellK {
+                    dst,
+                    cell: *cell,
+                    konst: *konst,
+                });
+                self.push_temp();
+            }
+            ArithCellConst { cell, konst, kind } => {
+                let dst = self.dst();
+                self.push_def(ROp::ArithCellK {
+                    kind: *kind,
+                    dst,
+                    cell: *cell,
+                    konst: *konst,
+                });
+                self.push_temp();
+            }
+            CmpCellConstBranchFalse {
+                cell,
+                konst,
+                cmp,
+                target,
+            }
+            | CmpCellConstBranchTrue {
+                cell,
+                konst,
+                cmp,
+                target,
+            } => {
+                self.flush_all();
+                let if_true = matches!(op, CmpCellConstBranchTrue { .. });
+                self.push_op(ROp::CmpBrCellK {
+                    cmp: *cmp,
+                    cell: *cell,
+                    konst: *konst,
+                    if_true,
+                    target: *target,
+                });
+            }
+            LoadUpvalue(i) => {
+                let dst = self.dst();
+                self.push_def(ROp::LoadUpvalue { dst, idx: *i });
+                self.push_temp();
+            }
+            StoreUpvalue(i) => {
+                let src = self.pop_reg();
+                self.push_op(ROp::StoreUpvalue { idx: *i, src });
+            }
+            StoreUpvalueChecked(i) => {
+                let src = self.pop_reg();
+                self.push_op(ROp::StoreUpvalueChecked { idx: *i, src });
+            }
+
+            // ---- globals ----
+            LoadGlobal(i) => {
+                let dst = self.dst();
+                let ic = self.next_ic();
+                self.push_def(ROp::LoadGlobal { dst, name: *i, ic });
+                self.push_temp();
+            }
+            StoreGlobal(i) => {
+                let src = self.pop_reg();
+                self.push_op(ROp::StoreGlobal { name: *i, src });
+            }
+            LoadGlobalTypeof(i) => {
+                let dst = self.dst();
+                self.push_def(ROp::LoadGlobalTypeof { dst, name: *i });
+                self.push_temp();
+            }
+            DeclareGlobal { name, deletable } => self.push_op(ROp::DeclareGlobal {
+                name: *name,
+                deletable: *deletable,
+            }),
+            CanDeclareGlobalFunc(i) => self.push_op(ROp::CanDeclareGlobalFunc { name: *i }),
+            DefineGlobalFunc { name, deletable } => {
+                let src = self.pop_reg();
+                self.push_op(ROp::DefineGlobalFunc {
+                    name: *name,
+                    deletable: *deletable,
+                    src,
+                });
+            }
+
+            // ---- stack manipulation ----
+            Pop => {
+                self.pop();
+            }
+            Dup => {
+                // Method-call idiom `Dup; GetProp(name); Swap` (the compiler's
+                // `o.m(...)` prologue): fuse so it pays ONE property op (plus
+                // at most one move) instead of three dispatches.
+                if let (Some(GetProp(name)), Some(Swap)) =
+                    (code.get(ip as usize + 1), code.get(ip as usize + 2))
+                {
+                    if !is_label(ip + 1) && !is_label(ip + 2) {
+                        let pos = self.entries.len() - 1;
+                        let obj = match self.entries[pos] {
+                            Entry::Local(l) => l,
+                            Entry::Reg(r) => r,
+                            Entry::Temp => {
+                                // Move the receiver up to the post-swap slot.
+                                let up = self.canon(pos + 1);
+                                self.touch(up);
+                                self.push_op(ROp::Mov {
+                                    dst: up,
+                                    src: self.canon(pos),
+                                });
+                                self.entries[pos] = Entry::Temp; // method lands here
+                                up
+                            }
+                            e => {
+                                // Materialize the lazy receiver directly into
+                                // the post-swap slot.
+                                let up = self.canon(pos + 1);
+                                // materialize() writes entries[pos]; emit by hand.
+                                let mat = match e {
+                                    Entry::K(idx) => ROp::Const { dst: up, idx },
+                                    Entry::Undef => ROp::Undef { dst: up },
+                                    Entry::Null => ROp::Null { dst: up },
+                                    Entry::True => ROp::Bool { dst: up, v: true },
+                                    Entry::False => ROp::Bool { dst: up, v: false },
+                                    Entry::Hole => ROp::Hole { dst: up },
+                                    Entry::This => ROp::This { dst: up },
+                                    Entry::NewTarget => ROp::NewTarget { dst: up },
+                                    _ => unreachable!(),
+                                };
+                                self.push_op(mat);
+                                self.touch(up);
+                                up
+                            }
+                        };
+                        let dst = self.canon(pos);
+                        self.touch(dst);
+                        let ic = self.next_ic();
+                        self.push_op(ROp::GetProp {
+                            dst,
+                            obj,
+                            name: *name,
+                            ic,
+                        });
+                        // Post-swap shape: [method (canonical), receiver].
+                        let recv = match self.entries[pos] {
+                            Entry::Local(l) => Entry::Local(l),
+                            Entry::Reg(r) => Entry::Reg(r),
+                            _ => Entry::Temp,
+                        };
+                        self.entries[pos] = Entry::Temp;
+                        self.entries.push(match recv {
+                            // The receiver moved to canon(pos + 1) above.
+                            Entry::Temp => Entry::Temp,
+                            other => other,
+                        });
+                        return Some((true, 3));
+                    }
+                }
+                let pos = self.entries.len() - 1;
+                let dup = match self.entries[pos] {
+                    // Alias the canonical slot below (sound: r < canon(pos+1)).
+                    Entry::Temp => Entry::Reg(self.canon(pos)),
+                    e => e, // lazy entries (and existing aliases) copy freely
+                };
+                self.entries.push(dup);
+            }
+            Swap => self.swap_top2(),
+            Rot3 => {
+                // a b c -> b c a: flush the three entries, rotate via scratch.
+                let n = self.entries.len();
+                for pos in n - 3..n {
+                    self.canonicalize(pos);
+                }
+                let (a, b, c) = (self.canon(n - 3), self.canon(n - 2), self.canon(n - 1));
+                let scratch = self.canon(n);
+                self.touch(scratch);
+                self.push_op(ROp::Mov {
+                    dst: scratch,
+                    src: a,
+                });
+                self.push_op(ROp::Mov { dst: a, src: b });
+                self.push_op(ROp::Mov { dst: b, src: c });
+                self.push_op(ROp::Mov {
+                    dst: c,
+                    src: scratch,
+                });
+            }
+
+            // ---- objects / arrays ----
+            NewObject => {
+                let dst = self.dst();
+                self.push_def(ROp::NewObject { dst });
+                self.push_temp();
+            }
+            NewArray(n) => {
+                let n = *n as usize;
+                let base = self.entries.len() - n;
+                for pos in base..self.entries.len() {
+                    self.canonicalize(pos);
+                }
+                let at = self.canon(base);
+                self.entries.truncate(base);
+                let dst = self.dst();
+                self.push_def(ROp::NewArray {
+                    dst,
+                    at,
+                    n: n as u16,
+                });
+                self.push_temp();
+            }
+            GetTemplateObject(idx) => {
+                let dst = self.dst();
+                self.push_def(ROp::GetTemplateObject { dst, idx: *idx });
+                self.push_temp();
+            }
+            ArraySpread => {
+                let src = self.pop_reg();
+                let pos = self.entries.len() - 1;
+                let arr = self.reg_of(pos);
+                self.push_op(ROp::ArraySpread { arr, src });
+                // The array entry stays as the result.
+            }
+            DefineField | DefineMethod | DefineGetter | DefineSetter | DefineMethodGetter
+            | DefineMethodSetter => {
+                let val = self.pop_reg();
+                let key = self.pop_reg();
+                let pos = self.entries.len() - 1;
+                let obj = self.reg_of(pos);
+                let kind = match op {
+                    DefineField => DefKind::Field,
+                    DefineMethod => DefKind::Method,
+                    DefineGetter => DefKind::Getter,
+                    DefineSetter => DefKind::Setter,
+                    DefineMethodGetter => DefKind::MethodGetter,
+                    _ => DefKind::MethodSetter,
+                };
+                self.push_op(ROp::DefineProp {
+                    kind,
+                    obj,
+                    key,
+                    val,
+                });
+                // The object entry stays as the result.
+            }
+            SetHomeObject => {
+                let n = self.entries.len();
+                let val = self.reg_of(n - 1);
+                let obj = self.reg_of(n - 3);
+                self.push_op(ROp::SetHomeObject { obj, val });
+            }
+            ObjectSpread => {
+                let src = self.pop_reg();
+                let pos = self.entries.len() - 1;
+                let target = self.reg_of(pos);
+                self.push_op(ROp::ObjectSpread { target, src });
+            }
+            CopyDataPropertiesExcept(n) => {
+                let n = *n as usize;
+                let base = self.entries.len() - n;
+                for pos in base..self.entries.len() {
+                    self.canonicalize(pos);
+                }
+                let at = self.canon(base);
+                self.entries.truncate(base);
+                let src = self.pop_reg();
+                let pos = self.entries.len() - 1;
+                let target = self.reg_of(pos);
+                self.push_op(ROp::CopyDataPropsExcept {
+                    target,
+                    src,
+                    at,
+                    n: n as u16,
+                });
+            }
+            GetProp(i) => {
+                let obj = self.pop_reg();
+                let dst = self.dst();
+                let ic = self.next_ic();
+                self.push_def(ROp::GetProp {
+                    dst,
+                    obj,
+                    name: *i,
+                    ic,
+                });
+                self.push_temp();
+            }
+            SetProp(i) => {
+                let src = self.pop_reg();
+                let obj = self.pop_reg();
+                let dst = self.dst();
+                let ic = self.next_ic();
+                self.push_def(ROp::SetProp {
+                    dst,
+                    obj,
+                    name: *i,
+                    src,
+                    ic,
+                });
+                self.push_temp();
+            }
+            GetPropDynamic => {
+                let key = self.pop_reg();
+                let obj = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::GetElem { dst, obj, key });
+                self.push_temp();
+            }
+            SetPropDynamic => {
+                let src = self.pop_reg();
+                let key = self.pop_reg();
+                let obj = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::SetElem { dst, obj, key, src });
+                self.push_temp();
+            }
+            DeleteProp(i) => {
+                let obj = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::DelProp { dst, obj, name: *i });
+                self.push_temp();
+            }
+            DeletePropDynamic => {
+                let key = self.pop_reg();
+                let obj = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::DelElem { dst, obj, key });
+                self.push_temp();
+            }
+            HasProp => {
+                let obj = self.pop_reg();
+                let key = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::HasProp { dst, key, obj });
+                self.push_temp();
+            }
+            SetFunctionNameFromKey(prefix) => {
+                let n = self.entries.len();
+                let val = self.reg_of(n - 1);
+                let key = self.reg_of(n - 2);
+                self.push_op(ROp::SetFunctionNameFromKey {
+                    prefix: *prefix,
+                    key,
+                    val,
+                });
+            }
+            SetProtoFromLiteral => {
+                let src = self.pop_reg();
+                let pos = self.entries.len() - 1;
+                let obj = self.reg_of(pos);
+                self.push_op(ROp::SetProtoFromLiteral { obj, src });
+            }
+
+            // ---- calls ----
+            Call(argc) | CallMethodless(argc) => {
+                let has_this = matches!(op, Call(_));
+                let argc = *argc as usize;
+                let base = self.entries.len() - argc;
+                for pos in base..self.entries.len() {
+                    self.canonicalize(pos);
+                }
+                let at = self.canon(base);
+                self.entries.truncate(base);
+                let this = if has_this { self.pop_reg() } else { 0 };
+                let func = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::Call {
+                    dst,
+                    func,
+                    this,
+                    at,
+                    argc: argc as u16,
+                    has_this,
+                });
+                self.push_temp();
+            }
+            New(argc) => {
+                let argc = *argc as usize;
+                let base = self.entries.len() - argc;
+                for pos in base..self.entries.len() {
+                    self.canonicalize(pos);
+                }
+                let at = self.canon(base);
+                self.entries.truncate(base);
+                let ctor = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::New {
+                    dst,
+                    ctor,
+                    at,
+                    argc: argc as u16,
+                });
+                self.push_temp();
+            }
+            CallSpread => {
+                let args = self.pop_reg();
+                let this = self.pop_reg();
+                let func = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::CallSpread {
+                    dst,
+                    func,
+                    this,
+                    args,
+                });
+                self.push_temp();
+            }
+            NewSpread => {
+                let args = self.pop_reg();
+                let ctor = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::NewSpread { dst, ctor, args });
+                self.push_temp();
+            }
+            Return => {
+                let src = self.pop_reg();
+                self.push_op(ROp::Ret { src });
+                return Some((false, 1));
+            }
+            ReturnUndefined => {
+                self.push_op(ROp::RetCompletion);
+                return Some((false, 1));
+            }
+            Throw => {
+                let src = self.pop_reg();
+                self.push_op(ROp::Throw { src });
+                return Some((false, 1));
+            }
+            ThrowConstAssign => {
+                self.push_op(ROp::ThrowConstAssign);
+                return Some((false, 1));
+            }
+
+            Closure(i) => {
+                let dst = self.dst();
+                self.push_def(ROp::Closure { dst, idx: *i });
+                self.push_temp();
+            }
+
+            // ---- arithmetic / unary ----
+            Add => self.add(),
+            Sub => self.arith(ArithKind::Sub),
+            Mul => self.arith(ArithKind::Mul),
+            Div => self.arith(ArithKind::Div),
+            Mod => self.arith(ArithKind::Mod),
+            Pow => self.arith(ArithKind::Pow),
+            BitAnd => self.arith(ArithKind::BitAnd),
+            BitOr => self.arith(ArithKind::BitOr),
+            BitXor => self.arith(ArithKind::BitXor),
+            Shl => self.arith(ArithKind::Shl),
+            Shr => self.arith(ArithKind::Shr),
+            UShr => self.arith(ArithKind::UShr),
+            Neg => self.unary(RUnary::Neg),
+            Pos => self.unary(RUnary::Pos),
+            ToNumeric => self.unary(RUnary::ToNumeric),
+            Inc => self.unary(RUnary::Inc),
+            Dec => self.unary(RUnary::Dec),
+            BitNot => self.unary(RUnary::BitNot),
+            Not => self.unary(RUnary::Not),
+            TypeofExpr => self.unary(RUnary::Typeof),
+            ToPropertyKey => self.unary(RUnary::ToKey),
+            ToStringOp => self.unary(RUnary::ToStr),
+
+            // ---- comparison ----
+            Eq => self.cmp(CmpOp::Eq),
+            Ne => self.cmp(CmpOp::Ne),
+            StrictEq => self.cmp(CmpOp::StrictEq),
+            StrictNe => self.cmp(CmpOp::StrictNe),
+            Lt => self.cmp(CmpOp::Lt),
+            Gt => self.cmp(CmpOp::Gt),
+            Le => self.cmp(CmpOp::Le),
+            Ge => self.cmp(CmpOp::Ge),
+            InstanceOf => {
+                let b = self.pop_reg();
+                let a = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::InstanceOf { dst, a, b });
+                self.push_temp();
+            }
+
+            // ---- control flow ----
+            Jump(t) => {
+                self.flush_all();
+                self.push_op(ROp::Jmp { target: *t });
+                return Some((false, 1));
+            }
+            JumpIfTrue(t) | JumpIfFalse(t) => {
+                // Pop the condition BEFORE flushing (its slot is dead on both
+                // edges), then flush for the join.
+                let src = self.pop_reg();
+                self.flush_all();
+                let opv = if matches!(op, JumpIfTrue(_)) {
+                    ROp::BrTrue { src, target: *t }
+                } else {
+                    ROp::BrFalse { src, target: *t }
+                };
+                self.push_op(opv);
+            }
+            CmpBranchFalse { cmp, target } | CmpBranchTrue { cmp, target } => {
+                let if_true = matches!(op, CmpBranchTrue { .. });
+                // K-fold the right operand when it is a lazy constant.
+                let konst = match self.entries.last() {
+                    Some(Entry::K(k)) => {
+                        let k = *k;
+                        self.entries.pop();
+                        self.last_def = None;
+                        Some(k)
+                    }
+                    _ => None,
+                };
+                match konst {
+                    Some(k) => {
+                        let a = self.pop_reg();
+                        self.flush_all();
+                        self.push_op(ROp::CmpBrK {
+                            cmp: *cmp,
+                            a,
+                            konst: k,
+                            if_true,
+                            target: *target,
+                        });
+                    }
+                    None => {
+                        let b = self.pop_reg();
+                        let a = self.pop_reg();
+                        self.flush_all();
+                        self.push_op(ROp::CmpBr {
+                            cmp: *cmp,
+                            a,
+                            b,
+                            if_true,
+                            target: *target,
+                        });
+                    }
+                }
+            }
+            JumpIfFalsyPeek(t) | JumpIfTruthyPeek(t) | JumpIfNullishPeek(t) => {
+                // The target edge keeps the value: it must sit in its
+                // canonical slot on BOTH edges.
+                let pos = self.entries.len() - 1;
+                self.canonicalize(pos);
+                self.flush_all();
+                let src = self.canon(pos);
+                let opv = match op {
+                    JumpIfFalsyPeek(_) => ROp::BrFalsyKeep { src, target: *t },
+                    JumpIfTruthyPeek(_) => ROp::BrTruthyKeep { src, target: *t },
+                    _ => ROp::BrNotNullishKeep { src, target: *t },
+                };
+                self.push_op(opv);
+                // Fallthrough pops the value.
+                self.entries.pop();
+            }
+            JumpIfNullish(t) => {
+                // Both edges keep the value (target sees `undefined`).
+                let pos = self.entries.len() - 1;
+                self.canonicalize(pos);
+                self.flush_all();
+                let reg = self.canon(pos);
+                self.push_op(ROp::BrNullishUndef { reg, target: *t });
+            }
+
+            // ---- iteration ----
+            GetIterator => {
+                let src = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::GetIterator { dst, src });
+                self.push_temp();
+            }
+            IteratorNext => {
+                let pos = self.entries.len() - 1;
+                let it = self.reg_of(pos);
+                let dst = self.dst();
+                self.push_def(ROp::IterNext { dst, it });
+                self.push_temp();
+            }
+            ForInEnumerate => {
+                let src = self.pop_reg();
+                let dst = self.dst();
+                self.push_def(ROp::ForInEnumerate { dst, src });
+                self.push_temp();
+            }
+            ForInNext => {
+                let dst = self.dst();
+                self.touch(dst + 1);
+                self.push_op(ROp::ForInNext { dst });
+                self.push_temp();
+                self.push_temp();
+            }
+            ForInPop => self.push_op(ROp::ForInPop),
+
+            ConcatStrings(n) => {
+                let n = *n as usize;
+                let base = self.entries.len() - n;
+                for pos in base..self.entries.len() {
+                    self.canonicalize(pos);
+                }
+                let at = self.canon(base);
+                self.entries.truncate(base);
+                let dst = self.dst();
+                self.push_def(ROp::ConcatStrings {
+                    dst,
+                    at,
+                    n: n as u16,
+                });
+                self.push_temp();
+            }
+            NewRegExp { pattern, flags } => {
+                let dst = self.dst();
+                self.push_def(ROp::NewRegExp {
+                    dst,
+                    pattern: *pattern,
+                    flags: *flags,
+                });
+                self.push_temp();
+            }
+
+            _ => return None,
+        }
+        Some((true, 1))
+    }
+
+    fn add(&mut self) {
+        // K-fold a lazy-const right operand into the AddK form.
+        if let Some(Entry::K(k)) = self.entries.last() {
+            let k = *k;
+            self.entries.pop();
+            self.last_def = None;
+            let a = self.pop_reg();
+            let dst = self.dst();
+            self.push_def(ROp::AddK { dst, a, konst: k });
+            self.push_temp();
+            return;
+        }
+        let b = self.pop_reg();
+        let a = self.pop_reg();
+        let dst = self.dst();
+        self.push_def(ROp::Add { dst, a, b });
+        self.push_temp();
+    }
+
+    fn arith(&mut self, kind: ArithKind) {
+        if let Some(Entry::K(k)) = self.entries.last() {
+            let k = *k;
+            self.entries.pop();
+            self.last_def = None;
+            let a = self.pop_reg();
+            let dst = self.dst();
+            self.push_def(ROp::ArithK {
+                kind,
+                dst,
+                a,
+                konst: k,
+            });
+            self.push_temp();
+            return;
+        }
+        let b = self.pop_reg();
+        let a = self.pop_reg();
+        let dst = self.dst();
+        self.push_def(ROp::Arith { kind, dst, a, b });
+        self.push_temp();
+    }
+
+    fn unary(&mut self, kind: RUnary) {
+        let src = self.pop_reg();
+        let dst = self.dst();
+        self.push_def(ROp::Unary { kind, dst, src });
+        self.push_temp();
+    }
+
+    fn cmp(&mut self, cmp: CmpOp) {
+        let b = self.pop_reg();
+        let a = self.pop_reg();
+        let dst = self.dst();
+        self.push_def(ROp::Cmp { cmp, dst, a, b });
+        self.push_temp();
+    }
+
+    /// `Swap` of the top two entries, preserving the alias invariants.
+    fn swap_top2(&mut self) {
+        let n = self.entries.len();
+        let (i, j) = (n - 2, n - 1);
+        let (a, b) = (self.entries[i], self.entries[j]);
+        let lazy = |e: Entry| !matches!(e, Entry::Temp | Entry::Reg(_));
+        match (a, b) {
+            // Two lazy entries (or a below-alias moving down) swap freely.
+            _ if lazy(a) && lazy(b) => self.entries.swap(i, j),
+            // b is the dup alias of a (`Reg(canon(i))` above a Temp): the
+            // stack holds the same value twice; a swap is a no-op.
+            (Entry::Temp, Entry::Reg(r)) if r == self.canon(i) => {}
+            (Entry::Temp, Entry::Reg(r)) => {
+                // r aliases some slot below i, so it is a valid alias at i too.
+                self.push_op(ROp::Mov {
+                    dst: self.canon(j),
+                    src: self.canon(i),
+                });
+                self.touch(self.canon(j));
+                self.entries[i] = Entry::Reg(r);
+                self.entries[j] = Entry::Temp;
+            }
+            (Entry::Temp, Entry::Temp) => {
+                // Full three-move rotation through a scratch register.
+                let (ci, cj) = (self.canon(i), self.canon(j));
+                let scratch = self.canon(n);
+                self.touch(scratch);
+                self.push_op(ROp::Mov {
+                    dst: scratch,
+                    src: ci,
+                });
+                self.push_op(ROp::Mov { dst: ci, src: cj });
+                self.push_op(ROp::Mov {
+                    dst: cj,
+                    src: scratch,
+                });
+            }
+            (Entry::Temp, _b_lazy) => {
+                // Value in canon(i) moves up; the lazy entry moves down.
+                self.push_op(ROp::Mov {
+                    dst: self.canon(j),
+                    src: self.canon(i),
+                });
+                self.touch(self.canon(j));
+                self.entries[i] = b;
+                self.entries[j] = Entry::Temp;
+            }
+            (Entry::Reg(r), Entry::Temp) => {
+                // a aliases r (< canon(i)); moving it up keeps it valid, and
+                // the value at canon(j) moves down into canon(i).
+                self.push_op(ROp::Mov {
+                    dst: self.canon(i),
+                    src: self.canon(j),
+                });
+                self.entries[i] = Entry::Temp;
+                self.entries[j] = Entry::Reg(r);
+            }
+            (Entry::Reg(_), _) => {
+                // Alias + lazy: both position-independent.
+                self.entries.swap(i, j);
+            }
+            (_a_lazy, Entry::Temp) => {
+                self.push_op(ROp::Mov {
+                    dst: self.canon(i),
+                    src: self.canon(j),
+                });
+                self.entries[j] = a;
+                self.entries[i] = Entry::Temp;
+            }
+            (_a_lazy, Entry::Reg(r)) if r == self.canon(i) => {
+                // b aliases canon(i), but slot i holds a LAZY entry — canon(i)
+                // is a stale register only reachable through b; materialize b
+                // up to canonical and swap the lazies.
+                self.push_op(ROp::Mov {
+                    dst: self.canon(j),
+                    src: r,
+                });
+                self.touch(self.canon(j));
+                self.entries[j] = Entry::Temp;
+                self.entries.swap(i, j);
+            }
+            // Remaining combinations (lazy/lazy, lazy over a valid below-
+            // alias) are position-independent: swap entries, move nothing.
+            _ => self.entries.swap(i, j),
+        }
+        self.last_def = None;
+    }
+}

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -436,6 +436,33 @@ pub enum ROp {
     },
     ThrowConstAssign,
 
+    // ---- exceptions / completions ----
+    /// Push a try handler recording the CANONICAL operand depth (`depth`),
+    /// so an unwind can clear the dead registers above it and place the
+    /// exception at `canon(depth)`. `catch`/`finally` are rpcs
+    /// (`u32::MAX` = absent), mirroring `Op::PushTryHandler`.
+    PushTryHandler {
+        catch: u32,
+        finally: u32,
+        depth: u16,
+    },
+    PopTryHandler,
+    /// `break`/`continue` crossing enclosing `finally` regions: park a
+    /// `Jump` completion and run the crossed finallys (mirror of
+    /// `Op::CompletionJump`; `target` is an rpc).
+    CompletionJump {
+        target: u32,
+        boundary: u32,
+    },
+    /// End of a `finally` body: resume a parked completion, or fall through
+    /// on the normal path (mirror of `Op::EndFinally`).
+    EndFinally,
+    /// IteratorClose on the abrupt-exit landing pad (mirror of
+    /// `Op::IteratorClose`; consults the parked completion).
+    IteratorClose {
+        it: u16,
+    },
+
     // ---- closures / objects / arrays ----
     Closure {
         dst: u16,
@@ -604,6 +631,8 @@ fn effect(op: &Op) -> Option<(u32, u32)> {
         | CmpLocalConstBranchFalse { .. }
         | CmpLocalConstBranchTrue { .. } => (0, 0),
         JumpIfFalsyPeek(_) | JumpIfTruthyPeek(_) | JumpIfNullishPeek(_) => (0, 0),
+        PushTryHandler { .. } | PopTryHandler | CompletionJump { .. } | EndFinally => (0, 0),
+        IteratorClose => (1, 0),
         GetIterator | ForInEnumerate => (1, 1),
         IteratorNext => (0, 1),
         ForInNext => (0, 2),
@@ -644,7 +673,9 @@ fn flow_of(op: &Op) -> FlowKind {
         | CmpLocalConstBranchFalse { target, .. }
         | CmpLocalConstBranchTrue { target, .. } => FlowKind::Branch(*target),
         JumpIfFalsyPeek(t) | JumpIfTruthyPeek(t) | JumpIfNullishPeek(t) => FlowKind::PeekBranch(*t),
-        Return | ReturnUndefined | Throw | ThrowConstAssign => FlowKind::Terminal,
+        Return | ReturnUndefined | Throw | ThrowConstAssign | CompletionJump { .. } => {
+            FlowKind::Terminal
+        }
         _ => FlowKind::Linear,
     }
 }
@@ -771,10 +802,37 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
             FlowKind::Jump(t) | FlowKind::Branch(t) | FlowKind::PeekBranch(t) => labels.push(t),
             _ => {}
         }
+        match op {
+            Op::PushTryHandler { catch, finally } => {
+                if *catch != u32::MAX {
+                    labels.push(*catch);
+                }
+                if *finally != u32::MAX {
+                    labels.push(*finally);
+                }
+            }
+            Op::CompletionJump { target, .. } => labels.push(*target),
+            _ => {}
+        }
     }
     labels.sort_unstable();
     labels.dedup();
     let is_label = |ip: u32| labels.binary_search(&ip).is_ok();
+
+    // The conservative maybe-TDZ set for handler entries: a throw can occur
+    // at ANY point in the guarded region, so a catch/finally label assumes
+    // every TDZ-able local (an `InitLocalTdz` target anywhere in the body)
+    // might be uninitialized. Costs only a TdzCheck per read in the rare
+    // catch/finally code.
+    let all_tdz = {
+        let mut t = TdzSet::empty(num_locals);
+        for op in code {
+            if let Op::InitLocalTdz(i) = op {
+                t.set(*i);
+            }
+        }
+        t
+    };
 
     // Phase 2: depth + maybe-TDZ dataflow to a fixpoint over the labels.
     // Depths are deterministic per label (mismatch = malformed input: bail);
@@ -851,6 +909,17 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
                 }
                 Some(())
             };
+            // Handler edges: the catch target is entered with the exception
+            // at `canon(depth)` (depth + 1); the finally target at `depth`.
+            // Both use the conservative TDZ set.
+            if let Op::PushTryHandler { catch, finally } = op {
+                if *catch != u32::MAX {
+                    edge(*catch, depth + 1, &all_tdz)?;
+                }
+                if *finally != u32::MAX {
+                    edge(*finally, depth, &all_tdz)?;
+                }
+            }
             cur = match flow_of(op) {
                 FlowKind::Linear => Some((after, tdz)),
                 FlowKind::Jump(t) => {
@@ -922,6 +991,15 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
         }
         ip += consumed;
     }
+    // Every branch target must have converged to a label state — a target
+    // reachable ONLY through parked completions (e.g. a `while(true)` whose
+    // sole exits break through a `finally`) has none, and remapping it would
+    // point into skipped code. Decline such functions.
+    for &t in &labels {
+        if (t as usize) < code.len() && !label_states.contains_key(&t) {
+            return None;
+        }
+    }
     rpc_at[code.len()] = e.code.len() as u32;
     // Falling off the end of the code returns like the stack loop's
     // `ip >= code.len()` exit; also the landing pad for end-of-code jump
@@ -929,6 +1007,15 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
     e.code.push(ROp::RetCompletion);
     // Remap branch targets from stack ips to rpcs.
     for op in &mut e.code {
+        if let ROp::PushTryHandler { catch, finally, .. } = op {
+            if *catch != u32::MAX {
+                *catch = rpc_at[*catch as usize];
+            }
+            if *finally != u32::MAX {
+                *finally = rpc_at[*finally as usize];
+            }
+            continue;
+        }
         if let Some(t) = rop_target_mut(op) {
             *t = rpc_at[*t as usize];
         }
@@ -963,7 +1050,8 @@ fn rop_target_mut(op: &mut ROp) -> Option<&mut u32> {
         | ROp::BrNullishUndef { target, .. }
         | ROp::CmpBr { target, .. }
         | ROp::CmpBrK { target, .. }
-        | ROp::CmpBrCellK { target, .. } => Some(target),
+        | ROp::CmpBrCellK { target, .. }
+        | ROp::CompletionJump { target, .. } => Some(target),
         _ => None,
     }
 }
@@ -1821,6 +1909,41 @@ impl Emitter {
             ThrowConstAssign => {
                 self.push_op(ROp::ThrowConstAssign);
                 return Some((false, 1));
+            }
+
+            // ---- exceptions / completions ----
+            PushTryHandler { catch, finally } => {
+                // A throw anywhere in the guarded region transfers to the
+                // catch/finally label assuming all-canonical registers below
+                // the recorded depth — flush so the surviving entries (e.g.
+                // a for-of loop's iterator) live in their canonical slots.
+                self.flush_all();
+                let depth = self.entries.len() as u16;
+                self.push_op(ROp::PushTryHandler {
+                    catch: *catch,
+                    finally: *finally,
+                    depth,
+                });
+            }
+            PopTryHandler => self.push_op(ROp::PopTryHandler),
+            CompletionJump { target, boundary } => {
+                self.flush_all();
+                self.push_op(ROp::CompletionJump {
+                    target: *target,
+                    boundary: *boundary,
+                });
+                return Some((false, 1));
+            }
+            EndFinally => {
+                // A parked completion may leave through handlers; the normal
+                // path falls through. Either way the join expects canonical
+                // registers.
+                self.flush_all();
+                self.push_op(ROp::EndFinally);
+            }
+            IteratorClose => {
+                let it = self.pop_reg();
+                self.push_op(ROp::IteratorClose { it });
             }
 
             Closure(i) => {

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -785,6 +785,14 @@ struct Emitter {
     /// rpc of the last emitted single-`dst` op whose result is the current
     /// virtual-stack top (for the `StoreLocal` dst-rewrite peephole).
     last_def: Option<usize>,
+    /// Normally-reachable ips from the pass-A dataflow: an `EndFinally` at a
+    /// normally-unreachable ip sits in an unwind-only pad and never falls
+    /// through (the entering unwind always parked a completion).
+    normal_visited: Vec<bool>,
+    /// `Op::CompletionJump` targets with NO converged label state (sorted).
+    /// Reached only through parked completions, so phase 2 draws no edge for
+    /// them; emitting a reachable jump to one declines the function.
+    unseeded_cj: Vec<u32>,
 }
 
 /// Translate a function's final stack bytecode into a register program.
@@ -837,108 +845,152 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
     // Phase 2: depth + maybe-TDZ dataflow to a fixpoint over the labels.
     // Depths are deterministic per label (mismatch = malformed input: bail);
     // TDZ sets grow monotonically under union, so this converges.
-    // Never iterated (get/insert only), so hasher nondeterminism is unobservable.
-    let mut label_states: HashMap<u32, LabelState> = HashMap::new();
-    let mut changed = true;
-    while changed {
-        changed = false;
-        let mut cur: Option<(u32, TdzSet)> = Some((0, TdzSet::empty(num_locals)));
-        for ip in 0..code.len() as u32 {
-            if is_label(ip) {
-                // Merge fall-in state into the label, then continue FROM the
-                // label's converged state.
-                if let Some((depth, tdz)) = cur.take() {
-                    match label_states.get_mut(&ip) {
+    //
+    // TWO passes. Pass A draws only the NORMAL control-flow edges, recording
+    // which ips are normally reachable: an `EndFinally` in an unwind-only
+    // finally pad (a for-of close pad — no normal edge ever enters it) can
+    // never fall through (the unwind that entered the pad always parked a
+    // completion first), so its dead fall-through edge must not constrain
+    // the join after the pad. Pass B re-runs the flow with the handler
+    // edges (catch at `depth + 1` — the exception register — and finally at
+    // the push-time depth, both with the conservative TDZ set), treating a
+    // normally-unreachable `EndFinally` as terminal.
+    let dataflow = |handler_edges: bool,
+                    endfin_linear: &dyn Fn(u32) -> bool|
+     -> Option<(HashMap<u32, LabelState>, Vec<bool>)> {
+        // Never iterated (get/insert only), so hasher nondeterminism is
+        // unobservable.
+        let mut label_states: HashMap<u32, LabelState> = HashMap::new();
+        let mut visited = vec![false; code.len()];
+        let mut changed = true;
+        while changed {
+            changed = false;
+            let mut cur: Option<(u32, TdzSet)> = Some((0, TdzSet::empty(num_locals)));
+            for ip in 0..code.len() as u32 {
+                if is_label(ip) {
+                    // Merge fall-in state into the label, then continue FROM
+                    // the label's converged state.
+                    if let Some((depth, tdz)) = cur.take() {
+                        match label_states.get_mut(&ip) {
+                            Some(st) => {
+                                if st.depth != depth {
+                                    return None;
+                                }
+                                if st.tdz.union_with(&tdz) {
+                                    changed = true;
+                                }
+                            }
+                            None => {
+                                label_states.insert(ip, LabelState { depth, tdz });
+                                changed = true;
+                            }
+                        }
+                    }
+                    cur = label_states.get(&ip).map(|st| (st.depth, st.tdz.clone()));
+                }
+                let Some((depth, mut tdz)) = cur else {
+                    cur = None;
+                    continue;
+                };
+                visited[ip as usize] = true;
+                let op = &code[ip as usize];
+                let (pops, pushes) = effect(op).unwrap();
+                if depth < pops {
+                    return None; // malformed: operand-stack underflow
+                }
+                let after = depth - pops + pushes;
+                // Register indices are u16: `canon(depth) = num_locals + depth`
+                // (plus a scratch slot) must stay addressable. A pathological
+                // operand-stack depth (a 60k-element array literal) declines.
+                if num_locals + after + 8 > u16::MAX as u32 {
+                    return None;
+                }
+                tdz_transfer(op, &mut tdz);
+                // Propagate to the branch target (if any).
+                let mut edge = |target: u32, depth: u32, tdz: &TdzSet| -> Option<()> {
+                    if target as usize > code.len() {
+                        return None;
+                    }
+                    match label_states.get_mut(&target) {
                         Some(st) => {
                             if st.depth != depth {
                                 return None;
                             }
-                            if st.tdz.union_with(&tdz) {
+                            if st.tdz.union_with(tdz) {
                                 changed = true;
                             }
                         }
                         None => {
-                            label_states.insert(ip, LabelState { depth, tdz });
+                            label_states.insert(
+                                target,
+                                LabelState {
+                                    depth,
+                                    tdz: tdz.clone(),
+                                },
+                            );
                             changed = true;
                         }
                     }
-                }
-                cur = label_states.get(&ip).map(|st| (st.depth, st.tdz.clone()));
-            }
-            let Some((depth, mut tdz)) = cur else {
-                cur = None;
-                continue;
-            };
-            let op = &code[ip as usize];
-            let (pops, pushes) = effect(op).unwrap();
-            if depth < pops {
-                return None; // malformed: operand-stack underflow
-            }
-            let after = depth - pops + pushes;
-            // Register indices are u16: `canon(depth) = num_locals + depth`
-            // (plus a scratch slot) must stay addressable. A pathological
-            // operand-stack depth (a 60k-element array literal) declines.
-            if num_locals + after + 8 > u16::MAX as u32 {
-                return None;
-            }
-            tdz_transfer(op, &mut tdz);
-            // Propagate to the branch target (if any).
-            let mut edge = |target: u32, depth: u32, tdz: &TdzSet| -> Option<()> {
-                if target as usize > code.len() {
-                    return None;
-                }
-                match label_states.get_mut(&target) {
-                    Some(st) => {
-                        if st.depth != depth {
-                            return None;
+                    Some(())
+                };
+                if handler_edges {
+                    if let Op::PushTryHandler { catch, finally } = op {
+                        if *catch != u32::MAX {
+                            edge(*catch, depth + 1, &all_tdz)?;
                         }
-                        if st.tdz.union_with(tdz) {
-                            changed = true;
+                        if *finally != u32::MAX {
+                            edge(*finally, depth, &all_tdz)?;
                         }
                     }
-                    None => {
-                        label_states.insert(
-                            target,
-                            LabelState {
-                                depth,
-                                tdz: tdz.clone(),
-                            },
-                        );
-                        changed = true;
+                }
+                if matches!(op, Op::EndFinally) && !endfin_linear(ip) {
+                    cur = None;
+                    continue;
+                }
+                cur = match flow_of(op) {
+                    FlowKind::Linear => Some((after, tdz)),
+                    FlowKind::Jump(t) => {
+                        edge(t, after, &tdz)?;
+                        None
                     }
-                }
-                Some(())
-            };
-            // Handler edges: the catch target is entered with the exception
-            // at `canon(depth)` (depth + 1); the finally target at `depth`.
-            // Both use the conservative TDZ set.
-            if let Op::PushTryHandler { catch, finally } = op {
-                if *catch != u32::MAX {
-                    edge(*catch, depth + 1, &all_tdz)?;
-                }
-                if *finally != u32::MAX {
-                    edge(*finally, depth, &all_tdz)?;
-                }
+                    FlowKind::Branch(t) => {
+                        edge(t, after, &tdz)?;
+                        Some((after, tdz))
+                    }
+                    FlowKind::PeekBranch(t) => {
+                        // Target keeps the top value; fallthrough pops it.
+                        edge(t, depth, &tdz)?;
+                        Some((depth - 1, tdz))
+                    }
+                    FlowKind::Terminal => None,
+                };
             }
-            cur = match flow_of(op) {
-                FlowKind::Linear => Some((after, tdz)),
-                FlowKind::Jump(t) => {
-                    edge(t, after, &tdz)?;
-                    None
-                }
-                FlowKind::Branch(t) => {
-                    edge(t, after, &tdz)?;
-                    Some((after, tdz))
-                }
-                FlowKind::PeekBranch(t) => {
-                    // Target keeps the top value; fallthrough pops it.
-                    edge(t, depth, &tdz)?;
-                    Some((depth - 1, tdz))
-                }
-                FlowKind::Terminal => None,
-            };
         }
-    }
+        Some((label_states, visited))
+    };
+    // Pass A: normal edges only; every EndFinally provisionally falls through.
+    let (_, normal_visited) = dataflow(false, &|_| true)?;
+    // Pass B: handler edges; an EndFinally falls through iff its pad is ever
+    // entered on the normal path.
+    let endfin_linear = |ip: u32| normal_visited[ip as usize];
+    let (label_states, _) = dataflow(true, &endfin_linear)?;
+
+    // CompletionJump targets are reached only through the PARKED completion
+    // (phase 2 draws no edge): collect the ones no normal edge seeded, so a
+    // reachable jump to one declines the function (its code was skipped and
+    // the rpc mapping would be garbage) — e.g. a `while(true)` whose sole
+    // exits break through a `finally`.
+    let mut unseeded_cj: Vec<u32> = code
+        .iter()
+        .filter_map(|op| match op {
+            Op::CompletionJump { target, .. } if !label_states.contains_key(target) => {
+                Some(*target)
+            }
+            _ => None,
+        })
+        .collect();
+    unseeded_cj.sort_unstable();
+    unseeded_cj.dedup();
 
     // Phase 3: emission.
     let mut e = Emitter {
@@ -949,6 +1001,8 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
         max_reg: num_locals.saturating_sub(1) as u16,
         ics: 0,
         last_def: None,
+        normal_visited,
+        unseeded_cj,
     };
     // rpc of each stack ip (branch targets remapped through this at the end).
     let mut rpc_at: Vec<u32> = vec![0; code.len() + 1];
@@ -990,15 +1044,6 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
             }
         }
         ip += consumed;
-    }
-    // Every branch target must have converged to a label state — a target
-    // reachable ONLY through parked completions (e.g. a `while(true)` whose
-    // sole exits break through a `finally`) has none, and remapping it would
-    // point into skipped code. Decline such functions.
-    for &t in &labels {
-        if (t as usize) < code.len() && !label_states.contains_key(&t) {
-            return None;
-        }
     }
     rpc_at[code.len()] = e.code.len() as u32;
     // Falling off the end of the code returns like the stack loop's
@@ -1927,6 +1972,15 @@ impl Emitter {
             }
             PopTryHandler => self.push_op(ROp::PopTryHandler),
             CompletionJump { target, boundary } => {
+                // The jump target is reached only through the PARKED
+                // completion (phase 2 draws no edge for it): it must have a
+                // normally-seeded label state, or the code there was skipped
+                // as unreachable and the rpc mapping would be garbage —
+                // decline (e.g. a `while(true)` whose sole exits break
+                // through a `finally`).
+                if self.unseeded_cj.binary_search(target).is_ok() {
+                    return None;
+                }
                 self.flush_all();
                 self.push_op(ROp::CompletionJump {
                     target: *target,
@@ -1940,6 +1994,13 @@ impl Emitter {
                 // registers.
                 self.flush_all();
                 self.push_op(ROp::EndFinally);
+                // In an unwind-only pad (never entered on the normal path)
+                // the completion is ALWAYS parked, so this never falls
+                // through — and its phantom fall-through must not flow into
+                // the join after the pad (pass B already excluded it).
+                if !self.normal_visited[ip as usize] {
+                    return Some((false, 1));
+                }
             }
             IteratorClose => {
                 let it = self.pop_reg();

--- a/crates/chidori-js/tests/reg.rs
+++ b/crates/chidori-js/tests/reg.rs
@@ -1,0 +1,476 @@
+//! Differential + structural tests for the register-bytecode tier (`reg.rs`,
+//! docs/js-performance-roadmap.md §3.5).
+//!
+//! The guarantee: register execution is a pure optimization. Running any
+//! program with the register tier on must produce byte-identical observable
+//! behavior — same console output, same thrown error — as the stack
+//! interpreter. The corpus concentrates on exactly what the translation must
+//! never break: virtual-stack shuffles (ternaries, logical operators,
+//! optional chains, method calls, compound assignments), TDZ checks and the
+//! init dataflow that elides them, the shared inline-cache paths, dense-array
+//! element fast paths, every call shape (plain, method, native, bound,
+//! proxy, construct, spread, function-kernel callees, recursion at the depth
+//! limit), closures and per-iteration capture, `arguments` aliasing, and the
+//! decline boundaries (try/finally, for-of, `with`, direct eval, generators,
+//! real awaits) where the stack tier keeps the frame.
+
+use std::rc::Rc;
+
+use chidori_js::bytecode::{Const, FuncProto};
+use chidori_js::compiler::{compile_script, compile_script_regs};
+use chidori_js::{Engine, Value};
+
+fn run(src: &str, regs: bool) -> (bool, Vec<String>, String) {
+    let proto = Rc::new(compile_script_regs(src, regs).expect("compiles"));
+    let mut engine = Engine::new();
+    let func = engine.vm.make_closure(proto, Vec::new());
+    let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+    let _ = engine.vm.run_jobs_until_blocked();
+    let console = engine.console().to_vec();
+    match res {
+        Ok(_) => (false, console, String::new()),
+        Err(e) => (true, console, engine.vm.error_to_string(&e)),
+    }
+}
+
+const CORPUS: &[&str] = &[
+    // ---- virtual-stack shuffles ----
+    // Ternaries nested in call arguments (branch joins mid-expression).
+    "function f(a, b) { return (a > b ? a : b) + (a < b ? 'x' : 'y'); } console.log(f(1, 2), f(2, 1));",
+    // Logical operators: peek-branches keep/pop the value per edge.
+    "console.log(0 || 'a', 1 && 'b', null ?? 'c', 'd' ?? 'e', 0 && 'f', '' || (() => 'g')());",
+    // Logical assignment operators.
+    "let a = 0, b = 1, c = null; a ||= 10; b &&= 20; c ??= 30; console.log(a, b, c);",
+    // Optional chains: short-circuit leaves undefined; calls included.
+    "const o = { m() { return { n: 1 }; } }; console.log(o.m?.().n, o.x?.y?.z, o.q?.());",
+    // Comma/sequence expressions and chained assignment.
+    "let x, y, z; x = y = z = (1, 2, 3); console.log(x, y, z);",
+    // Compound assignment on properties (Dup/GetProp/SetProp shuffle).
+    "const p = { n: 1 }; p.n += 2; p.n *= 3; p['n'] -= 4; console.log(p.n);",
+    // Method-call fusion window (`Dup; GetProp; Swap`) on every receiver
+    // kind: local, this, temp result, constant-ish.
+    "const arr = [3, 1, 2]; console.log(arr.sort().join('-'), [4, 5].concat(6).length, 'ab'.toUpperCase());",
+    "const obj = { v: 2, m() { return this.v; }, chain() { return this.m() + this.m(); } }; console.log(obj.chain());",
+    // Swap without the fusion window (computed method key).
+    "const k = 'm'; const o2 = { m(v) { return v * 2; } }; console.log(o2[k](21));",
+    // Deeply nested call expressions (argument ranges stay contiguous).
+    "function add(a, b) { return a + b; } console.log(add(add(1, add(2, 3)), add(add(4, 5), 6)));",
+
+    // ---- TDZ and the init dataflow ----
+    "try { t1; } catch (e) { console.log('read', e.constructor.name); } let t1 = 1; console.log(t1);",
+    "try { t2 = 5; } catch (e) { console.log('write', e.constructor.name); } let t2; console.log(t2);",
+    // Conditional TDZ: initialized on one path only — the check must stay.
+    "function ct(f) { if (f) { var r; let v = 1; r = v; } try { { let w; if (f) w = 1; console.log('w', w); } } catch (e) { console.log(e.constructor.name); } } ct(true); ct(false);",
+    // Loop-carried init: reads inside the body are provably initialized.
+    "let s0 = 0; for (let i = 0; i < 5; i++) { s0 += i + i * 2; } console.log(s0);",
+    // const assignment through the checked-store path.
+    "const cc = 1; try { cc = 2; } catch (e) { console.log(e.constructor.name); } console.log(cc);",
+    // TDZ in a closure-captured cell (upvalue checked path).
+    "try { (() => tz)(); } catch (e) { console.log('cell', e.constructor.name); } let tz = 9; console.log((() => tz)());",
+
+    // ---- property access / inline caches ----
+    // Monomorphic own-property get/set loop (IC hits).
+    "const po = { a: 0, b: 0 }; for (let i = 0; i < 20; i++) { po.a = i; po.b = po.a + 1; } console.log(po.a, po.b);",
+    // IC invalidation: same site sees different shapes.
+    "function rd(o) { return o.v; } console.log(rd({ v: 1 }), rd({ w: 0, v: 2 }), rd(Object.create({ v: 3 })));",
+    // Prototype-holder IC (method lookup pattern) + shadowing.
+    "class C { constructor() { this.n = 1; } m() { return this.n; } } const ci = new C(); let t = 0; for (let i = 0; i < 10; i++) t += ci.m(); ci.m = () => 100; console.log(t + ci.m());",
+    // Accessors through the IC-miss path; setter observation order.
+    "const log = []; const ao = { get g() { log.push('get'); return 1; }, set s(v) { log.push('set' + v); } }; ao.s = ao.g + 1; console.log(log.join(','));",
+    // Strict-mode write failures (frozen object, non-writable).
+    "'use strict'; const fo = Object.freeze({ a: 1 }); try { fo.a = 2; } catch (e) { console.log('frozen', e.constructor.name); } console.log(fo.a);",
+    // Sloppy silent failure on frozen.
+    "const fs = Object.freeze({ a: 1 }); fs.a = 2; console.log(fs.a);",
+    // Getter that THROWS mid-expression (register state unwinds cleanly).
+    "const gt = { get boom() { throw new Error('bang'); } }; try { const v = 1 + gt.boom + 2; } catch (e) { console.log('caught', e.message); } console.log('after');",
+    // delete: named, dynamic, strict failure.
+    "const dl = { a: 1, b: 2 }; console.log(delete dl.a, delete dl['b'], dl.a, 'a' in dl);",
+    "'use strict'; try { delete Object.prototype; } catch (e) { console.log('del', e.constructor.name); }",
+    // `in` operator and Symbol keys.
+    "const sym = Symbol('s'); const so = { [sym]: 1 }; console.log(sym in so, 'x' in so, so[sym]);",
+
+    // ---- dense-array element fast paths ----
+    "const da = [1, 2, 3]; da[1] = 20; da[3] = 40; let ds = 0; for (let i = 0; i < da.length; i++) ds += da[i]; console.log(ds, da.length);",
+    // Holes read through the prototype; OOB reads.
+    "const ha = [1, , 3]; Array.prototype[1] = 99; console.log(ha[1], ha[5]); delete Array.prototype[1];",
+    // Sealed array rejects appends (generic path owns semantics).
+    "const sa = Object.seal([1, 2]); sa[2] = 3; console.log(sa.length); 'use strict';",
+    "'use strict'; const sb = Object.seal([1]); try { sb[1] = 2; } catch (e) { console.log('seal', e.constructor.name); }",
+    // Float/negative/string keys take the spec path.
+    "const fk = [1, 2]; fk[-1] = 'neg'; fk[0.5] = 'half'; fk['01'] = 'pad'; console.log(fk[-1], fk[0.5], fk['01'], fk.length);",
+
+    // ---- calls: every shape ----
+    // Plain, methodless, natives, bound, proxied.
+    "function pf(a, b, c) { return a + b * c; } console.log(pf(1, 2, 3), pf(1, 2), pf());",
+    "const bf = function (a, b) { return this.v + a + b; }.bind({ v: 10 }, 1); console.log(bf(2));",
+    "const px = new Proxy(function (a) { return a * 2; }, { apply(t, _th, args) { return t(...args) + 1; } }); console.log(px(21));",
+    // Constructors: New, NewSpread, class ctor without new throws.
+    "function Ctor(v) { this.v = v; } console.log(new Ctor(7).v, new Ctor(...[8]).v);",
+    "class K { constructor() {} } try { K(); } catch (e) { console.log('ctor', e.constructor.name); }",
+    // Spread calls with custom iterator (observable iteration order).
+    "const it = { *[Symbol.iterator]() { yield 1; yield 2; } }; function sc(a, b) { return a + b; } console.log(sc(...it));",
+    // `this` binding: sloppy boxes primitives, strict does not.
+    "function sloppyThis() { return typeof this; } console.log(sloppyThis(), sloppyThis.call('s'), sloppyThis.call(null));",
+    "'use strict'; function strictThis() { return this === undefined ? 'undef' : typeof this; } console.log(strictThis(), strictThis.call('s'));",
+    // new.target with and without new.
+    "function nt() { return new.target === undefined ? 'plain' : 'new'; } console.log(nt(), new nt() instanceof nt ? 'new' : '?');",
+    // arguments object: mapped aliasing both directions (reg frame, cells).
+    "function ma(p) { arguments[0] = 9; const before = p; p = 3; return before + ',' + arguments[0] + ',' + arguments.length; } console.log(ma(1, 2));",
+    // rest params + defaults evaluated per call.
+    "function rp(a = 1, ...rest) { return a + rest.length; } console.log(rp(), rp(5), rp(5, 6, 7));",
+    // Not-callable error through the generic path.
+    "try { (undefined)(); } catch (e) { console.log('call', e.constructor.name); } try { ({}).nope(); } catch (e) { console.log('method', e.constructor.name); }",
+    // Function-kernel callee (comparator) invoked from a reg frame.
+    "const ks = [5, 1, 4, 2, 3].sort((a, b) => a - b); console.log(ks.join(''));",
+
+    // ---- closures / cells / per-iteration capture ----
+    "const fns = []; for (let i = 0; i < 3; i++) fns.push(() => i); console.log(fns.map(f => f()).join(','));",
+    "function counter() { let n = 0; return { inc() { return ++n; }, dec() { return --n; } }; } const c1 = counter(); c1.inc(); c1.inc(); console.log(c1.inc(), c1.dec());",
+    // Captured accumulator mutated through an upvalue (checked stores).
+    "let acc = 0; const bump = () => { acc += 2; }; for (let i = 0; i < 4; i++) bump(); console.log(acc);",
+    // Deep transitive capture.
+    "function ta() { let v = 'deep'; return () => () => v; } console.log(ta()()());",
+
+    // ---- globals ----
+    "var gv = 1; function gf() { return gv + 1; } gv = 5; console.log(gf(), typeof gundef, typeof gv);",
+    "try { missing_global; } catch (e) { console.log('ref', e.constructor.name); }",
+    "'use strict'; try { undeclared_w = 1; } catch (e) { console.log('sw', e.constructor.name); }",
+    "sloppy_global = 42; console.log(sloppy_global);",
+
+    // ---- literals / templates / regexp ----
+    // Object literals: computed keys, methods, accessors, __proto__.
+    "const base = { kind: 'base' }; const ol = { __proto__: base, a: 1, ['c' + 'k']: 2, m() { return 3; }, get g() { return 4; }, set g(v) {} }; console.log(ol.kind, ol.a, ol.ck, ol.m(), ol.g);",
+    // Object/array spread and rest destructuring (object pattern).
+    "const src = { a: 1, b: 2, c: 3 }; const { a: ra, ...rest } = src; const merged = { ...src, d: 4 }; console.log(ra, JSON.stringify(rest), JSON.stringify(merged));",
+    "const asp = [0, ...[1, 2], 3, ...'ab']; console.log(asp.join('|'), asp.length);",
+    // Array holes / elisions.
+    "const el = [1, , 3]; console.log(el.length, 1 in el, el[1]);",
+    // Tagged templates: frozen template object identity across calls.
+    "function tag(s) { return s === tag.last ? 'same' : ((tag.last = s), 'fresh'); } function go() { return tag`a${1}b`; } console.log(go(), go());",
+    // Template literal concatenation with coercing parts.
+    "const tv = { toString() { return 'T'; } }; console.log(`x=${1 + 1} ${tv} ${'s'}`);",
+    // Anonymous function naming from computed keys.
+    "const key = 'named'; const nf = { [key]: function () {} }; console.log(nf[key].name);",
+    // RegExp literal construction + use.
+    "const re = /a(b+)c/; console.log(re.test('abbc'), 'xabbcx'.match(re)[1]);",
+
+    // ---- control flow without handlers ----
+    "let sw = ''; for (let i = 0; i < 4; i++) { switch (i) { case 0: sw += 'z'; break; case 2: { let q = 't'; sw += q; break; } default: sw += i; } } console.log(sw);",
+    "let lb = ''; outer: for (let i = 0; i < 3; i++) { for (let j = 0; j < 3; j++) { if (j === 2) continue outer; if (i === 2) break outer; lb += `${i}${j},`; } } console.log(lb);",
+    "let wl = 0, dw = 0; while (wl < 5) wl += 2; do { dw += 3; } while (dw < 9); console.log(wl, dw);",
+    // for-in: enumeration order, shadowing, nested.
+    "const fi = { b: 1, a: 2 }; Object.defineProperty(fi, 'h', { value: 3, enumerable: false }); let ks2 = ''; for (const k in fi) ks2 += k; for (const k in [10, 20]) ks2 += k; console.log(ks2);",
+
+    // ---- operators / coercions ----
+    "console.log(1 + '2', '3' * '4', 5 % 3, 2 ** 10, 7 / 2 | 0, -'8', +true, ~1, !0);",
+    "console.log(1 < '2', 'a' < 'b', null == undefined, null === undefined, NaN === NaN, 0 === -0);",
+    "console.log(3n + 4n, 2n ** 10n, typeof 5n); let bi = 1n; bi++; console.log(bi);",
+    // valueOf ordering in binary ops and updates.
+    "const ord = []; const va = { valueOf() { ord.push('a'); return 1; } }, vb = { valueOf() { ord.push('b'); return 2; } }; console.log(va < vb, va + vb, ord.join(''));",
+    "let mv = { valueOf() { mv = 100; return 7; } }; mv++; console.log(mv);",
+    // instanceof with Symbol.hasInstance.
+    "class HI { static [Symbol.hasInstance](v) { return v === 42; } } console.log(42 instanceof HI, 41 instanceof HI);",
+    // typeof on every kind.
+    "console.log(typeof 1, typeof 's', typeof true, typeof undefined, typeof null, typeof {}, typeof [], typeof (() => 0), typeof Symbol(), typeof 1n);",
+    // String building via += (rope path through op_add).
+    "let sb2 = ''; for (let i = 0; i < 50; i++) sb2 += 'ab'; console.log(sb2.length, sb2.slice(0, 4), sb2.charCodeAt(99));",
+
+    // ---- classes (no extends — those decline) ----
+    "class Pt { constructor(x, y) { this.x = x; this.y = y; } dist() { return Math.abs(this.x) + Math.abs(this.y); } static of(x, y) { return new Pt(x, y); } get sum() { return this.x + this.y; } } const pt = Pt.of(-1, 4); console.log(pt.dist(), pt.sum);",
+
+    // ---- decline boundaries: identical behavior via the stack tier ----
+    "let tf = ''; try { tf += 'a'; throw new Error('x'); } catch (e) { tf += 'b'; } finally { tf += 'c'; } console.log(tf);",
+    "let fo2 = 0; for (const v of [1, 2, 3]) fo2 += v; console.log(fo2);",
+    "const [d1, , d2 = 9] = [1, 2]; console.log(d1, d2);",
+    "function* gg() { yield 1; yield 2; } console.log([...gg()].join(','));",
+    "(async () => { const v = await Promise.resolve(41); console.log('await', v + 1); })();",
+    "function ev() { let v = 3; return eval('v * 7'); } console.log(ev());",
+    "with ({ wv: 5 }) { console.log(wv); }",
+
+    // ---- mixed tiers: throws crossing reg/stack frames ----
+    // reg frame throws → stack frame (try) catches.
+    "function thrower() { return missing_in_reg_frame; } function catcher() { try { return thrower(); } catch (e) { return 'caught ' + e.constructor.name; } } console.log(catcher());",
+    // stack frame (for-of) calls reg callbacks.
+    "function cb(x) { return x * 3; } let mt = 0; for (const v of [1, 2].map(cb)) mt += v; console.log(mt);",
+    // Await-free async function: runs whole through the register tier and
+    // resolves its promise from the returned value.
+    "async function af(n) { return n * 2; } af(21).then(v => console.log('async', v));",
+    "async function ar() { throw new Error('rej'); } ar().catch(e => console.log('rejected', e.message));",
+
+    // ---- misc semantics the shuffles must preserve ----
+    // Assignment result values (SetProp/SetElem push the VALUE).
+    "const rv = {}; console.log(rv.a = 5, rv['b'] = 6, (rv.c = 7) + 1);",
+    // JSON round-trip through native calls from reg frames.
+    "console.log(JSON.stringify(JSON.parse('{\"a\":[1,2,{\"b\":null}]}')));",
+    // getter/setter defined via literal then hit through IC sites.
+    "let gs = 0; const gso = { get v() { return ++gs; }, set v(x) { gs = x; } }; gso.v; gso.v; gso.v = 10; console.log(gso.v);",
+    // Number formatting edge cases through ToString sites.
+    "console.log(`${-0} ${1e21} ${0.1 + 0.2} ${2 ** 53}`);",
+];
+
+#[test]
+fn register_tier_preserves_observable_behavior() {
+    for (n, src) in CORPUS.iter().enumerate() {
+        let baseline = run(src, false);
+        let got = run(src, true);
+        assert_eq!(
+            baseline, got,
+            "register tier changed behavior for corpus[{n}]:\n  {src}\n  baseline={baseline:?}\n  got={got:?}"
+        );
+    }
+}
+
+/// Deep recursion through register frames must raise the exact spec
+/// RangeError at the same depth as the stack tier (the `call_depth` guard is
+/// shared), and recover cleanly.
+#[test]
+fn reg_depth_overflow_matches_stack() {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            let src = "function rec(n) { return n <= 0 ? 0 : 1 + rec(n - 1); } \
+                 try { console.log(rec(1000)); } catch (e) { console.log('deep', e.constructor.name); } \
+                 console.log(rec(10));";
+            let mut outs = Vec::new();
+            for regs in [true, false] {
+                let proto = Rc::new(compile_script_regs(src, regs).expect("compiles"));
+                let mut engine = Engine::new();
+                engine.vm.max_call_depth = 64;
+                let func = engine.vm.make_closure(proto, Vec::new());
+                let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+                assert!(res.is_ok(), "caught in-script (regs={regs})");
+                outs.push(engine.console().to_vec());
+            }
+            assert_eq!(outs[0], outs[1], "depth overflow diverged");
+            assert_eq!(outs[0][0], "deep RangeError");
+        })
+        .expect("spawns")
+        .join()
+        .expect("no panic");
+}
+
+/// An installed op budget must keep per-stack-op accounting EXACT: the
+/// register tier declines and the budgeted run terminates with the same
+/// uncatchable RangeError either way — including for call-heavy programs
+/// whose callees carry register programs.
+#[test]
+fn op_budget_stays_exact_with_reg_protos() {
+    let src =
+        "function work(n) { let s = 0; for (let i = 0; i < n; i++) s += helper(i); return s; } \
+               function helper(i) { return i % 3; } \
+               let t = 0; while (true) { t = work(100) + t; }";
+    for regs in [true, false] {
+        let proto = Rc::new(compile_script_regs(src, regs).expect("compiles"));
+        let mut engine = Engine::new();
+        engine.vm.op_budget = Some(200_000);
+        let func = engine.vm.make_closure(proto, Vec::new());
+        let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+        let err = res.expect_err("budget must trip");
+        let msg = engine.vm.error_to_string(&err);
+        assert!(
+            msg.contains("execution budget exceeded"),
+            "unexpected error (regs={regs}): {msg}"
+        );
+        // Identical budget consumption on both compiles: the remaining
+        // budget after the abort must match exactly.
+        assert_eq!(engine.vm.op_budget, Some(0), "budget drained (regs={regs})");
+    }
+}
+
+fn walk_protos(p: &FuncProto, f: &mut impl FnMut(&FuncProto)) {
+    f(p);
+    for c in &p.consts {
+        if let Const::Func(nested) = c {
+            walk_protos(nested, f);
+        }
+    }
+}
+
+/// Structural pins: the canonical shapes MUST carry register programs, and
+/// the excluded shapes must NOT — so coverage can't silently evaporate.
+#[test]
+fn structural_translation_pins() {
+    // Must translate: plain functions with calls, property access, loops
+    // over cells, closures, object literals, for-in, method calls.
+    for (name, src) in [
+        ("props+calls", "function f(o) { o.a = 1; return f2(o.a + o.b); } function f2(x) { return x * 2; } f({ b: 1 });"),
+        ("method call", "function m(a) { return a.slice(1).concat(9).length; } m([1, 2, 3]);"),
+        ("closure", "function mk(x) { return (y) => x + y; } mk(1)(2);"),
+        ("for-in", "function fi(o) { let s = ''; for (const k in o) s += k; return s; } fi({ a: 1 });"),
+        ("obj literal", "function ol() { return { a: 1, m() { return 2; }, get g() { return 3; } }; } ol();"),
+        ("ternary+logic", "function tl(a, b) { return (a ?? b) ? a && b : a || b; } tl(1, 2);"),
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        let mut found = false;
+        walk_protos(&proto, &mut |p| {
+            if p.reg.is_some() && !p.name.is_empty() {
+                found = true;
+            }
+        });
+        assert!(found, "{name}: expected a register-translated function:\n{src}");
+    }
+    // Must NOT translate: handlers, for-of, with, direct eval, generators,
+    // suspending async bodies, and loop-kernelized functions.
+    for (name, needle, src) in [
+        (
+            "try",
+            "tc",
+            "function tc() { try { return 1; } catch (e) { return 2; } } tc();",
+        ),
+        (
+            "for-of",
+            "fo",
+            "function fo(a) { let s = 0; for (const v of a) s += v; return s; } fo([1]);",
+        ),
+        (
+            "with",
+            "w",
+            "function w(o) { with (o) { return v; } } w({ v: 1 });",
+        ),
+        (
+            "eval",
+            "ev",
+            "function ev() { let v = 1; return eval('v'); } ev();",
+        ),
+        ("generator", "g", "function* g() { yield 1; } [...g()];"),
+        (
+            "await",
+            "aw",
+            "async function aw() { return await 1; } aw();",
+        ),
+        (
+            "kernel loop",
+            "k",
+            "function k(n) { let s = 0; for (let i = 0; i < n; i++) s += i * 2; return s; } k(3);",
+        ),
+        (
+            "extends",
+            "D",
+            "class B0 {} class D extends B0 { constructor() { super(); } } new D();",
+        ),
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        walk_protos(&proto, &mut |p| {
+            if p.name == needle {
+                assert!(
+                    p.reg.is_none(),
+                    "{name}: `{needle}` must DECLINE register translation:\n{src}"
+                );
+            }
+        });
+    }
+    // A function-kernel comparator still carries a register program too:
+    // the kernel guard declining (e.g. non-Number args) falls back to the
+    // register tier, not the stack loop.
+    let proto = compile_script("[3, 1].sort((a, b) => a - b);").expect("compiles");
+    let mut both = false;
+    walk_protos(&proto, &mut |p| {
+        if p.fn_kernel.is_some() && p.reg.is_some() {
+            both = true;
+        }
+    });
+    assert!(
+        both,
+        "fn-kernel callee should also carry a register program"
+    );
+}
+
+/// Deterministic fuzz: generate random whole programs — mixed-type
+/// arithmetic, property get/set on shared objects, nested helper calls,
+/// ternaries and short-circuits, string building, occasional for-in and
+/// dynamic element traffic — and require reg-on/off equivalence on every
+/// one. Unlike the kernel fuzz (numeric loops), this exercises the
+/// whole-body translation: virtual-stack shuffles, IC sites, the call
+/// paths, and the TDZ dataflow.
+#[test]
+fn reg_fuzz_differential() {
+    // Tiny LCG — the test must be deterministic (fixed seed, no host RNG).
+    let mut state: u64 = 0x9E3779B97F4A7C15;
+    let mut rnd = move |n: u64| -> u64 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (state >> 33) % n
+    };
+
+    for case in 0..300 {
+        let nvars = 2 + rnd(3) as usize;
+        let mut body = String::new();
+        let stmts = 2 + rnd(6);
+        for _ in 0..stmts {
+            let v = rnd(nvars as u64);
+            let w = rnd(nvars as u64);
+            let ops = ["+", "-", "*", "%", "|", "^"];
+            let op = ops[rnd(ops.len() as u64) as usize];
+            match rnd(10) {
+                0 => body.push_str(&format!("v{v} = v{v} {op} v{w};\n")),
+                1 => body.push_str(&format!("o.p{v} = v{w} {op} i;\n")),
+                2 => body.push_str(&format!("v{v} = (o.p{w} ?? 0) {op} 2;\n")),
+                3 => body.push_str(&format!("v{v} = helper(v{w}, i) {op} 1;\n")),
+                4 => body.push_str(&format!("v{v} = i % 2 ? v{w} : o.m(v{v});\n")),
+                5 => body.push_str(&format!("s += '' + v{v} + ',';\n")),
+                6 => body.push_str(&format!("arr[i % arr.length] = v{v};\n")),
+                7 => body.push_str(&format!("v{v} = arr[(i + {w}) % arr.length] {op} v{v};\n")),
+                8 => {
+                    let cmps = ["<", "<=", ">", ">=", "===", "!=="];
+                    let c = cmps[rnd(6) as usize];
+                    body.push_str(&format!(
+                        "if (v{v} {c} v{w}) {{ v{v} = v{w} {op} 3; }} else {{ o.p{w} = v{v}; }}\n"
+                    ));
+                }
+                _ => body.push_str(&format!("v{v} = (v{v} {op} 5) || v{w};\n")),
+            }
+        }
+        if case % 7 == 0 {
+            body.push_str("for (const k in o) { s += k; break; }\n");
+        }
+        if case % 11 == 0 {
+            body.push_str("if (i === 3) continue;\n");
+        }
+        if case % 13 == 0 {
+            let v = rnd(nvars as u64);
+            body.push_str(&format!("v{v} = 'poison' + i;\n"));
+        }
+        if case % 5 == 0 {
+            let v = rnd(nvars as u64);
+            body.push_str(&format!("v{v} = mk(v{v})();\n"));
+        }
+        let decls: Vec<String> = (0..nvars)
+            .map(|v| format!("let v{v} = {};", [0, 1, -1, 42][v % 4]))
+            .collect();
+        let prints: Vec<String> = (0..nvars).map(|v| format!("v{v}")).collect();
+        let src = format!(
+            "function helper(a, b) {{ return a % 7 + b; }}\n\
+             function mk(x) {{ return () => (x | 0) + 1; }}\n\
+             const o = {{ p0: 1, p1: 2, p2: 3, m(x) {{ return (x | 0) - 1; }} }};\n\
+             const arr = [2, 4, 6, 8];\n\
+             let s = '';\n\
+             {}\nfor (let i = 0; i < 12; i++) {{\n{body}}}\n\
+             console.log({}, s, JSON.stringify(o), arr.join('|'));",
+            decls.join(" "),
+            prints.join(", ")
+        );
+        let with = run(&src, true);
+        let without = run(&src, false);
+        assert_eq!(with, without, "fuzz case {case} diverged:\n{src}");
+    }
+}
+
+/// The register translator's own corpus-independent invariants: the
+/// top-level script of every corpus entry either translates or declines,
+/// and translated programs never carry a zero-length code vector.
+#[test]
+fn translated_programs_are_wellformed() {
+    for src in CORPUS {
+        let proto = compile_script_regs(src, true).expect("compiles");
+        walk_protos(&proto, &mut |p| {
+            if let Some(reg) = &p.reg {
+                assert!(!reg.code.is_empty(), "empty register program:\n{src}");
+                assert!(
+                    reg.num_regs as u32 >= p.num_locals,
+                    "register file smaller than locals:\n{src}"
+                );
+            }
+        });
+    }
+}

--- a/crates/chidori-js/tests/reg.rs
+++ b/crates/chidori-js/tests/reg.rs
@@ -339,40 +339,35 @@ fn walk_protos(p: &FuncProto, f: &mut impl FnMut(&FuncProto)) {
 #[test]
 fn structural_translation_pins() {
     // Must translate: plain functions with calls, property access, loops
-    // over cells, closures, object literals, for-in, method calls.
-    for (name, src) in [
-        ("props+calls", "function f(o) { o.a = 1; return f2(o.a + o.b); } function f2(x) { return x * 2; } f({ b: 1 });"),
-        ("method call", "function m(a) { return a.slice(1).concat(9).length; } m([1, 2, 3]);"),
-        ("closure", "function mk(x) { return (y) => x + y; } mk(1)(2);"),
-        ("for-in", "function fi(o) { let s = ''; for (const k in o) s += k; return s; } fi({ a: 1 });"),
-        ("obj literal", "function ol() { return { a: 1, m() { return 2; }, get g() { return 3; } }; } ol();"),
-        ("ternary+logic", "function tl(a, b) { return (a ?? b) ? a && b : a || b; } tl(1, 2);"),
-        ("try/catch/finally", "function tc() { try { return 1; } catch (e) { return 2; } finally { } } tc();"),
-        ("for-of", "function fo(a) { let s = 0; for (const v of a) s += v; return s; } fo([1]);"),
-        ("array destructuring", "function ad(a) { const [x, , y = 9] = a; return x + y; } ad([1, 2]);"),
+    // over cells, closures, object literals, for-in, method calls, and (round
+    // 2) try/catch/finally, for-of, and array destructuring. Each pin names
+    // the function that must carry a register program — the top-level script
+    // proto almost always translates, so an any-function check would be
+    // vacuous.
+    for (name, needle, src) in [
+        ("props+calls", "f", "function f(o) { o.a = 1; return f2(o.a + o.b); } function f2(x) { return x * 2; } f({ b: 1 });"),
+        ("method call", "m", "function m(a) { return a.slice(1).concat(9).length; } m([1, 2, 3]);"),
+        ("closure", "mk", "function mk(x) { return (y) => x + y; } mk(1)(2);"),
+        ("for-in", "fi", "function fi(o) { let s = ''; for (const k in o) s += k; return s; } fi({ a: 1 });"),
+        ("obj literal", "ol", "function ol() { return { a: 1, m() { return 2; }, get g() { return 3; } }; } ol();"),
+        ("ternary+logic", "tl", "function tl(a, b) { return (a ?? b) ? a && b : a || b; } tl(1, 2);"),
+        ("try/catch", "tc", "function tc() { try { return this.x; } catch (e) { return 2; } } tc();"),
+        ("try/finally", "tf", "function tf(f) { try { return f(); } finally { console.log('x'); } } tf(() => 1);"),
+        ("for-of", "fo", "function fo(a) { let s = 0; for (const v of a) s += v; return s; } fo([1]);"),
+        ("destructuring", "ad", "function ad(a) { const [x, , y = 9] = a; return x + y; } ad([1, 2]);"),
     ] {
         let proto = compile_script(src).expect("compiles");
         let mut found = false;
         walk_protos(&proto, &mut |p| {
-            if p.reg.is_some() && !p.name.is_empty() {
+            if p.name == needle && p.reg.is_some() {
                 found = true;
             }
         });
-        assert!(found, "{name}: expected a register-translated function:\n{src}");
+        assert!(found, "{name}: `{needle}` must carry a register program:\n{src}");
     }
     // Must NOT translate: with, direct eval, generators, suspending async
     // bodies, `using` declarations, and loop-kernelized functions.
     for (name, needle, src) in [
-        (
-            "try",
-            "tc",
-            "function tc() { try { return 1; } catch (e) { return 2; } } tc();",
-        ),
-        (
-            "for-of",
-            "fo",
-            "function fo(a) { let s = 0; for (const v of a) s += v; return s; } fo([1]);",
-        ),
         (
             "with",
             "w",

--- a/crates/chidori-js/tests/reg.rs
+++ b/crates/chidori-js/tests/reg.rs
@@ -10,9 +10,12 @@
 //! init dataflow that elides them, the shared inline-cache paths, dense-array
 //! element fast paths, every call shape (plain, method, native, bound,
 //! proxy, construct, spread, function-kernel callees, recursion at the depth
-//! limit), closures and per-iteration capture, `arguments` aliasing, and the
-//! decline boundaries (try/finally, for-of, `with`, direct eval, generators,
-//! real awaits) where the stack tier keeps the frame.
+//! limit), closures and per-iteration capture, `arguments` aliasing, the
+//! try/catch/finally handler machinery (rethrow, nested finallys,
+//! return-in-finally, break/continue crossing finally regions, for-of and
+//! destructuring iterator close), and the decline boundaries (`with`,
+//! direct eval, generators, real awaits, `using`) where the stack tier
+//! keeps the frame.
 
 use std::rc::Rc;
 
@@ -179,13 +182,58 @@ const CORPUS: &[&str] = &[
     "class Pt { constructor(x, y) { this.x = x; this.y = y; } dist() { return Math.abs(this.x) + Math.abs(this.y); } static of(x, y) { return new Pt(x, y); } get sum() { return this.x + this.y; } } const pt = Pt.of(-1, 4); console.log(pt.dist(), pt.sum);",
 
     // ---- decline boundaries: identical behavior via the stack tier ----
-    "let tf = ''; try { tf += 'a'; throw new Error('x'); } catch (e) { tf += 'b'; } finally { tf += 'c'; } console.log(tf);",
-    "let fo2 = 0; for (const v of [1, 2, 3]) fo2 += v; console.log(fo2);",
-    "const [d1, , d2 = 9] = [1, 2]; console.log(d1, d2);",
     "function* gg() { yield 1; yield 2; } console.log([...gg()].join(','));",
     "(async () => { const v = await Promise.resolve(41); console.log('await', v + 1); })();",
     "function ev() { let v = 3; return eval('v * 7'); } console.log(ev());",
     "with ({ wv: 5 }) { console.log(wv); }",
+
+    // ---- try/catch/finally (register-mode handler machinery) ----
+    // Plain catch, rethrow, nested handlers, error identity.
+    "let tf1 = ''; try { tf1 += 'a'; throw new Error('x'); tf1 += 'never'; } catch (e) { tf1 += 'b' + e.message; } finally { tf1 += 'c'; } console.log(tf1);",
+    "try { try { throw new TypeError('inner'); } catch (e) { throw new RangeError('re:' + e.message); } } catch (e) { console.log(e.constructor.name, e.message); }",
+    "let nst = ''; try { try { nst += '1'; throw 'x'; } finally { nst += '2'; } } catch (e) { nst += '3' + e; } console.log(nst);",
+    // finally runs on the normal path; completion value flows through.
+    "function fn1() { try { return 'ret'; } finally { console.log('fin'); } } console.log(fn1());",
+    // return-in-finally OVERRIDES the parked completion.
+    "function fn2() { try { return 1; } finally { return 2; } } console.log(fn2());",
+    "function fn3() { try { throw new Error('gone'); } finally { return 'swallowed'; } } console.log(fn3());",
+    // break/continue crossing one and two finally regions (CompletionJump).
+    "let bc = ''; for (let i = 0; i < 4; i++) { try { if (i === 2) break; if (i === 1) continue; bc += i; } finally { bc += 'f' + i; } } console.log(bc);",
+    "let bc2 = ''; outer: for (let i = 0; i < 3; i++) { for (let j = 0; j < 3; j++) { try { if (j === 1) continue outer; bc2 += `${i}${j}`; } finally { bc2 += 'f'; } } } console.log(bc2);",
+    // throw from a nested CALL caught by this frame's handler.
+    "function boom() { throw new Error('deep'); } let ct2 = ''; try { boom(); } catch (e) { ct2 = 'caught ' + e.message; } console.log(ct2);",
+    // catch binding shadowing + TDZ interaction inside catch.
+    "let cb = 'outer'; try { throw 'in'; } catch (cb2) { let inner = cb2 + '!'; console.log(cb, inner); } console.log(cb);",
+    // Exception value replaces mid-expression register state cleanly.
+    "const trap = { get g() { throw 'mid'; } }; let ms = 0; try { ms = 1 + trap.g + 100; } catch (e) { ms = 'e:' + e; } console.log(ms);",
+    // Conditional TDZ observed FROM catch code (conservative handler-entry set).
+    "function ctz(f) { try { if (f) throw 'early'; } catch (e) { try { tv; console.log('init?'); } catch (e2) { console.log('tdz', e2.constructor.name); } } let tv = 1; return tv; } console.log(ctz(true));",
+    // Deep finally chain unwinding a return.
+    "function deep() { try { try { try { return 'r'; } finally { console.log('f1'); } } finally { console.log('f2'); } } finally { console.log('f3'); } } console.log(deep());",
+    // while(true) whose ONLY exit crosses a finally (declines translation —
+    // parked-jump-only label — and must behave identically on the stack tier).
+    "function wt() { let n = 0; while (true) { try { n++; if (n > 2) break; } finally { n += 10; } } return n; } console.log(wt());",
+
+    // ---- for-of / destructuring (iterator-close landing pads) ----
+    "let fo3 = ''; for (const v of [10, 20, 30]) { fo3 += v + ','; } console.log(fo3);",
+    "let fo4 = 0; for (const v of [1, 2, 3, 4, 5]) { if (v === 4) break; fo4 += v; } console.log(fo4);",
+    // Custom iterator observes return() on break and NOT on exhaustion.
+    "const seen = []; function mkIt(n) { let i = 0; return { [Symbol.iterator]() { return this; }, next() { return { value: i, done: i++ >= n }; }, return(v) { seen.push('ret@' + i); return { done: true }; } }; } for (const v of mkIt(3)) {} for (const v of mkIt(9)) { if (v === 1) break; } console.log(seen.join('|'));",
+    // Iterator return() that THROWS during a break (spec: propagates).
+    "const badRet = { [Symbol.iterator]() { let i = 0; return { next: () => ({ value: i++, done: false }), return() { throw new Error('badret'); } }; } }; try { for (const v of badRet) { if (v === 1) break; } } catch (e) { console.log('close', e.message); }",
+    // Iterator return() error is SUPPRESSED when the body threw.
+    "const badRet2 = { [Symbol.iterator]() { let i = 0; return { next: () => ({ value: i++, done: false }), return() { throw new Error('masked'); } }; } }; try { for (const v of badRet2) { if (v === 1) throw new Error('body'); } } catch (e) { console.log('won', e.message); }",
+    // next() throwing mid-loop (no close on next-throw, per spec).
+    "const badNext = { [Symbol.iterator]() { let i = 0; return { next() { if (i === 2) throw new Error('next!'); return { value: i++, done: false }; } }; } }; let bn = 0; try { for (const v of badNext) bn += v; } catch (e) { console.log(bn, e.message); }",
+    // Array destructuring: holes, defaults, rest, iterator close.
+    "const [d3, , d4 = 7, ...dr] = [1, 2, undefined, 4, 5]; console.log(d3, d4, dr.join('+'));",
+    "function swapd(a, b) { [a, b] = [b, a]; return a + '/' + b; } console.log(swapd(1, 2));",
+    // Nested destructuring in for-of over entries (the idiomatic shape).
+    "const m = { x: 1, y: 2 }; let ent = ''; for (const [k, v] of Object.entries(m)) ent += k + '=' + v + ';'; console.log(ent);",
+    // String iteration (surrogate pairs stay whole).
+    "let si = []; for (const ch of 'a\u{1F600}b') si.push(ch.length); console.log(si.join(','));",
+    // for-of over a Map/Set (native iterators through the reg frame).
+    "const mp = new Map([[1, 'a'], [2, 'b']]); let mo = ''; for (const [k, v] of mp) mo += k + v; const st2 = new Set([3, 4]); for (const v of st2) mo += v; console.log(mo);",
 
     // ---- mixed tiers: throws crossing reg/stack frames ----
     // reg frame throws → stack frame (try) catches.
@@ -299,6 +347,9 @@ fn structural_translation_pins() {
         ("for-in", "function fi(o) { let s = ''; for (const k in o) s += k; return s; } fi({ a: 1 });"),
         ("obj literal", "function ol() { return { a: 1, m() { return 2; }, get g() { return 3; } }; } ol();"),
         ("ternary+logic", "function tl(a, b) { return (a ?? b) ? a && b : a || b; } tl(1, 2);"),
+        ("try/catch/finally", "function tc() { try { return 1; } catch (e) { return 2; } finally { } } tc();"),
+        ("for-of", "function fo(a) { let s = 0; for (const v of a) s += v; return s; } fo([1]);"),
+        ("array destructuring", "function ad(a) { const [x, , y = 9] = a; return x + y; } ad([1, 2]);"),
     ] {
         let proto = compile_script(src).expect("compiles");
         let mut found = false;
@@ -309,8 +360,8 @@ fn structural_translation_pins() {
         });
         assert!(found, "{name}: expected a register-translated function:\n{src}");
     }
-    // Must NOT translate: handlers, for-of, with, direct eval, generators,
-    // suspending async bodies, and loop-kernelized functions.
+    // Must NOT translate: with, direct eval, generators, suspending async
+    // bodies, `using` declarations, and loop-kernelized functions.
     for (name, needle, src) in [
         (
             "try",
@@ -434,6 +485,25 @@ fn reg_fuzz_differential() {
         if case % 5 == 0 {
             let v = rnd(nvars as u64);
             body.push_str(&format!("v{v} = mk(v{v})();\n"));
+        }
+        // Handler machinery: try/catch/finally around mixed statements,
+        // throws caught in-loop, for-of with early exits.
+        if case % 3 == 1 {
+            let v = rnd(nvars as u64);
+            match rnd(4) {
+                0 => body.push_str(&format!(
+                    "try {{ if (i === 5) throw v{v}; v{v} += 1; }} catch (e) {{ v{v} = ('' + e).length; }}\n"
+                )),
+                1 => body.push_str(&format!(
+                    "try {{ v{v} = helper(v{v}, i); }} finally {{ s += 'f'; }}\n"
+                )),
+                2 => body.push_str(&format!(
+                    "for (const q of arr) {{ v{v} = (v{v} | 0) + (q | 0); if (q === 6) break; }}\n"
+                )),
+                _ => body.push_str(&format!(
+                    "try {{ try {{ if (v{v} > 20) throw 'deep'; }} finally {{ s += 'g'; }} }} catch (e) {{ v{v} = 0; }}\n"
+                )),
+            }
         }
         let decls: Vec<String> = (0..nvars)
             .map(|v| format!("let v{v} = {};", [0, 1, -1, 42][v % 4]))

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1211,6 +1211,14 @@ Wall-clock (idle container, 5-run median, execution-only):
 | json_roundtrip | 154 ms | 147 ms | 1.05× |
 | kernel-owned workloads | — | — | 1.0× (noise) |
 
+Handler-machinery spot check (round 2): an ad-hoc for-of/try/destructuring
+glue script (`Object.entries` iteration, destructuring in a helper called
+per entry, try/catch around a throwing path, try/finally in the loop body —
+all shapes round 1 declined) measures **518.9 M vs 646.6 M instructions
+(−19.8%)** and 84 ms vs 103 ms wall (1.23×) reg-on vs reg-off, RESULT
+byte-identical. The committed suite's rows are unchanged (no committed
+workload uses try/for-of in hot code).
+
 `mixed_helpers` is a new workload added with this round: small helper
 functions over objects and strings (property traffic across calls, string
 building, for-in, ternary classification) — the shape of real agent glue

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1120,16 +1120,32 @@ values):
   `IncLocal`, `AddCellK`, …), so non-kernel loops keep their one-dispatch
   tests and updates.
 - **Whole-function eligibility, tier ordering.** Any op outside the
-  translated subset declines the function: try/catch/finally (and therefore
-  for-of and array destructuring, whose iterator-close protocol rides the
-  handler machinery), `with`/direct-eval scope ops, `super`/private class
-  elements, dispose scopes, suspension ops, and `Op::LoopKernel` — a
-  loop-kernelized function keeps the stack tier because its unboxed kernels
-  are far faster than boxed register ops. The call paths still try
-  `fn_kernel` first, so the tier order per activation is: function kernel
-  (unboxed, frameless) → register program (boxed, framed) → stack loop.
-  Await-free `async` bodies translate (they contain no suspension ops and
-  run to completion in one shot); a real `await` declines the body.
+  translated subset declines the function: `with`/direct-eval scope ops,
+  `super`/private class elements, dispose scopes (`using`), suspension
+  ops, and `Op::LoopKernel` — a loop-kernelized function keeps the stack
+  tier because its unboxed kernels are far faster than boxed register ops.
+  The call paths still try `fn_kernel` first, so the tier order per
+  activation is: function kernel (unboxed, frameless) → register program
+  (boxed, framed) → stack loop. Await-free `async` bodies translate (they
+  contain no suspension ops and run to completion in one shot); a real
+  `await` declines the body.
+- **Try/catch/finally translate** (round 2, same day) — and with them
+  for-of loops and array destructuring, whose IteratorClose-on-abrupt-exit
+  protocol rides the handler machinery. `ROp::PushTryHandler` records the
+  CANONICAL operand depth after a full flush (so the surviving entries —
+  a for-of loop's iterator — sit where every unwind expects them); the
+  register-mode completion walk (`reg_do_completion`) mirrors
+  `do_completion` exactly, with "truncate the operand stack" becoming
+  "clear the canonical registers above the handler's depth" (value-
+  lifetime parity) and the exception landing in `canon(depth)` — the
+  register the catch label's seeded state reads it from. Catch/finally
+  labels are seeded in the pre-emission dataflow (catch at `depth + 1`)
+  with a conservative all-maybe TDZ set, since a throw can occur anywhere
+  in the guarded region. `Op::CompletionJump`/`Op::EndFinally` (break/
+  continue/return crossing finallys) translate 1:1; the delegation arms
+  cannot occur (generators never translate). A jump target reachable ONLY
+  through parked completions (a `while(true)` whose sole exits break
+  through a `finally`) has no seeded state and declines the function.
 - **Determinism.** The register program is a pure function of the source,
   compiled at compile finish. Like the kernel tiers, the register tier is
   OFF whenever an op budget is installed — per-stack-op accounting stays
@@ -1146,13 +1162,15 @@ values):
   pins that deep recursion through register frames raises the same
   catchable RangeError at the same depth.
 
-**Gates:** a 90-program differential corpus + 300-case deterministic fuzz
+**Gates:** a 110-program differential corpus + 300-case deterministic fuzz
 (`tests/reg.rs`) require byte-identical output and errors reg-on vs reg-off
 across the virtual-stack shuffles (ternaries, logical operators, optional
 chains, method calls, compound assignment), TDZ edges, IC hit/miss/exotic
 paths, dense-element semantics, every call shape, closures/per-iteration
-capture, `arguments` aliasing, mixed-tier throws, and the decline
-boundaries; structural pins require the canonical shapes to translate and
+capture, `arguments` aliasing, mixed-tier throws, the full handler-
+machinery surface (rethrow, nested finallys, return-in-finally overriding,
+break/continue crossing finally regions, iterator close on break/throw
+with throwing/suppressed `return()`), and the decline boundaries; structural pins require the canonical shapes to translate and
 the excluded shapes to decline; the op-budget test additionally asserts the
 budget drains to the exact same count on both compiles. Full suites for
 both crates (118 + 761 tests, incl. record→replay byte-identity) and the
@@ -1204,10 +1222,8 @@ vs reg-off across the board.
 
 ### 6.10.2 What's next (post-register baseline)
 
-- **Try/finally support** — the largest coverage hole: for-of loops, array
-  destructuring, and try-wrapped agent code all keep the stack tier. Needs
-  a register-mode completion protocol (handler records the canonical depth;
-  catch entry writes the exception register and clears dead slots).
+- ~~**Try/finally support**~~ — landed same day (see above): for-of,
+  array destructuring, and try-wrapped code now translate.
 - **Register-mode loop-kernel embedding** — let a function carry BOTH
   kernels and a register program by teaching kernel bail-out to resume at a
   register pc instead of a stack ip.

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1077,6 +1077,144 @@ now covers the mutual path; structural pins updated (boolean/mutual/
 captured-binding recursion MUST kernelize, parameter-recursion must not);
 full suites + Test262 gate green.
 
+## 6.10 Register bytecode (landed 2026-07-10): §3.5, scoped as a tier
+
+The remaining structural lever from §3.5, built the way this engine builds
+tiers rather than as the big-bang rewrite the original phase plan imagined:
+a compile-finish pass (`reg.rs`) translates a WHOLE eligible function body
+from the final stack bytecode into a register program
+(`FuncProto::reg: Option<Rc<RegProto>>`), and `Vm::run_frame` — the single
+funnel every call, construct, accessor, and module/script evaluation goes
+through — executes it via `run_reg_frame` instead of the stack loop. No
+operand stack, no per-value push/pop traffic, and one dispatch where the
+stack machine pays two or three: `LoadLocal a; LoadLocal b; Add; StoreLocal c`
+is a single `Add { dst: c, a, b }`.
+
+**Translation model** (mirrors the kernel tiers' discipline, over boxed
+values):
+
+- **Same helpers, same semantics.** Every register op calls the SAME `Vm`
+  helper as its stack twin. The inline-cache fast paths (`GetProp`/`SetProp`/
+  `LoadGlobal`) and the dense-array element fast paths were extracted into
+  shared `Vm` methods (`ic_get_prop`, `ic_set_prop`, `ic_load_global`,
+  `elem_get`, `elem_set`, …) that BOTH interpreters call, so each op keeps
+  exactly one implementation and the tiers cannot drift. Register programs
+  carry their own `IcEntry` table with the identical key-verified protocol.
+- **Registers are `frame.locals`.** Slots `0..num_locals` are the localized
+  bindings (same TDZ marker, same semantics); slots above are the canonical
+  homes of the stack machine's operand depths (`canon(d) = num_locals + d`).
+  A register frame is an ordinary pooled `Frame` — GC tracing, `arguments`,
+  cells, upvalues, and the frame pool all work unchanged.
+- **Lazy operands.** A virtual stack of entries abstract-interprets the
+  stack code at compile time. `LoadLocal`/`LoadConst`/`LoadThis`&c. emit
+  NOTHING — consuming ops read the local register or a `konst` operand
+  directly; everything is flushed to canonical form at control-flow edges,
+  and any op that writes a local first flushes live lazy references to it
+  (locals are provably unaliasable — that is what localization established).
+  A forward dataflow (intersection at joins, to a fixpoint) proves most
+  local reads can never see the TDZ marker, so they skip the check the
+  stack interpreter pays on every `LoadLocal`; unprovable reads emit an
+  explicit `TdzCheck`. The `Dup; GetProp(name); Swap` method-call prologue
+  fuses to one property op (plus at most one move). Fused stack
+  superinstructions map 1:1 onto fused register ops (`CmpBrK`,
+  `IncLocal`, `AddCellK`, …), so non-kernel loops keep their one-dispatch
+  tests and updates.
+- **Whole-function eligibility, tier ordering.** Any op outside the
+  translated subset declines the function: try/catch/finally (and therefore
+  for-of and array destructuring, whose iterator-close protocol rides the
+  handler machinery), `with`/direct-eval scope ops, `super`/private class
+  elements, dispose scopes, suspension ops, and `Op::LoopKernel` — a
+  loop-kernelized function keeps the stack tier because its unboxed kernels
+  are far faster than boxed register ops. The call paths still try
+  `fn_kernel` first, so the tier order per activation is: function kernel
+  (unboxed, frameless) → register program (boxed, framed) → stack loop.
+  Await-free `async` bodies translate (they contain no suspension ops and
+  run to completion in one shot); a real `await` declines the body.
+- **Determinism.** The register program is a pure function of the source,
+  compiled at compile finish. Like the kernel tiers, the register tier is
+  OFF whenever an op budget is installed — per-stack-op accounting stays
+  exact on the generic path — and it polls the cooperative interrupt flag
+  at the stack loop's cadence. (Consequence, inherited from the kernel
+  tiers' rule: the production server's default `CHIDORI_JS_OP_BUDGET=5e9
+  keeps agent runs on the stack tier; the tier pays off today in
+  unbudgeted embeddings, replay/test tooling, and the benchmark harness.
+  Making budget accounting conservative-but-deterministic on the fast
+  tiers is tracked as follow-up work.)
+- **Native stack discipline.** `run_reg_frame` keeps the hot ops inline and
+  delegates everything rare to an `#[inline(never)]` `rstep_cold`, the same
+  split (and reason) as `step`/`step_cold`; the depth-overflow differential
+  pins that deep recursion through register frames raises the same
+  catchable RangeError at the same depth.
+
+**Gates:** a 90-program differential corpus + 300-case deterministic fuzz
+(`tests/reg.rs`) require byte-identical output and errors reg-on vs reg-off
+across the virtual-stack shuffles (ternaries, logical operators, optional
+chains, method calls, compound assignment), TDZ edges, IC hit/miss/exotic
+paths, dense-element semantics, every call shape, closures/per-iteration
+capture, `arguments` aliasing, mixed-tier throws, and the decline
+boundaries; structural pins require the canonical shapes to translate and
+the excluded shapes to decline; the op-budget test additionally asserts the
+budget drains to the exact same count on both compiles. Full suites for
+both crates (118 + 761 tests, incl. record→replay byte-identity) and the
+Test262 gate: green. The pass is disabled under the `op-histogram` feature
+(register execution would hide per-op counts).
+
+### 6.10.1 Measured (callgrind instruction counts, whole workload)
+
+Reg-on vs reg-off, same commit, release build; RESULT checksums
+byte-identical on every workload:
+
+| workload | reg off | reg on | Δ instructions |
+| --- | ---: | ---: | ---: |
+| string_scan | 521.4 M | 368.3 M | **−29.4%** |
+| sort | 2.64 G | 2.07 G | **−21.5%** |
+| mixed_helpers (new) | 5.98 G | 5.18 G | **−13.5%** |
+| string_build | 183.3 M | 160.1 M | **−12.7%** |
+| json_roundtrip | 1.25 G | 1.20 G | −4.3% |
+| arith / fib / closures / property / array_hof / array_push_sum | — | — | ±0.003% |
+
+The unchanged rows are exactly the kernel-owned workloads: their hot
+functions decline register translation by design (the `+0.003%`-class
+deltas are the one-branch `proto.reg` probe per call, the same cost class
+as the `fn_kernel` probe). The wins land where the boxed interpreter
+itself carries the run — top-level glue around native/kernel calls (sort's
+build-and-invoke loop), string-scan/build loops, and `mixed_helpers`,
+which is all glue by construction. Geomean over the five
+interpreter-carried workloads: **−17%** instructions.
+
+Wall-clock (idle container, 5-run median, execution-only):
+
+| workload | reg off | reg on | speedup |
+| --- | ---: | ---: | ---: |
+| string_scan | 58 ms | 42 ms | 1.38× |
+| sort | 295 ms | 243 ms | 1.21× |
+| mixed_helpers | 724 ms | 620 ms | 1.17× |
+| string_build | 28 ms | 26 ms | 1.08× |
+| json_roundtrip | 154 ms | 147 ms | 1.05× |
+| kernel-owned workloads | — | — | 1.0× (noise) |
+
+`mixed_helpers` is a new workload added with this round: small helper
+functions over objects and strings (property traffic across calls, string
+building, for-in, ternary classification) — the shape of real agent glue
+where every function declines the kernel tiers and the interpreter itself
+carries the run. It is the register tier's home turf; the kernel-owned
+numeric workloads are untouched by design (their functions decline
+translation), and the suite's RESULT checksums are byte-identical reg-on
+vs reg-off across the board.
+
+### 6.10.2 What's next (post-register baseline)
+
+- **Try/finally support** — the largest coverage hole: for-of loops, array
+  destructuring, and try-wrapped agent code all keep the stack tier. Needs
+  a register-mode completion protocol (handler records the canonical depth;
+  catch entry writes the exception register and clears dead slots).
+- **Register-mode loop-kernel embedding** — let a function carry BOTH
+  kernels and a register program by teaching kernel bail-out to resume at a
+  register pc instead of a stack ip.
+- **Budget-compatible fast tiers** — a conservative deterministic op-count
+  mapping so production budgeted runs can use kernels + registers.
+- Re-run the callgrind sweep before choosing; §1.1's caveats stand.
+
 ## 7. References
 
 - [`docs/interpreter-optimization.md`](./interpreter-optimization.md) —


### PR DESCRIPTION
The remaining structural lever from the interpreter roadmap, built as a
tier rather than a rewrite: a compile-finish pass (reg.rs) translates a
whole eligible function body from the final stack bytecode into a register
program (FuncProto::reg), and Vm::run_frame — the single funnel every call,
construct, accessor, and script/module evaluation goes through — executes
it via run_reg_frame instead of the stack loop. No operand stack, no
per-value push/pop; `LoadLocal a; LoadLocal b; Add; StoreLocal c` is one
`Add { dst: c, a, b }` dispatch.

- Registers ARE frame.locals: slots 0..num_locals are the localized
  bindings (same TDZ marker); higher slots are the canonical homes of the
  stack machine's operand depths. A register frame is an ordinary pooled
  Frame — GC tracing, arguments, cells, upvalues unchanged.
- Same helpers, same semantics: every register op calls the SAME Vm helper
  as its stack twin. The GetProp/SetProp/LoadGlobal inline-cache fast
  paths and the dense-array element fast paths moved into shared Vm
  methods (ic_get_prop / ic_set_prop / ic_load_global / elem_get /
  elem_set, plus the cold-op bodies) that BOTH interpreters call — one
  implementation per op, so the tiers cannot drift. Register programs
  carry their own key-verified IcEntry table.
- Lazy operands: a compile-time virtual stack makes LoadLocal/LoadConst/
  LoadThis emit NOTHING (consumers read the register or a konst operand
  directly), flushed to canonical form at control-flow edges and before
  any write to an aliased local. A forward TDZ dataflow (intersection at
  joins, to a fixpoint) elides the per-read TDZ check the stack loop pays.
  The `Dup; GetProp; Swap` method-call prologue fuses to one property op;
  fused stack superinstructions map 1:1 onto fused register ops.
- Whole-function eligibility: try/finally (and thus for-of / array
  destructuring), with/direct-eval, super/private, dispose, suspension
  ops, and Op::LoopKernel decline — kernelized functions keep the stack
  tier (unboxed kernels stay in charge). Tier order per activation:
  fn_kernel → register program → stack loop. Await-free async bodies
  translate; a real await declines.
- Determinism: register programs are a pure function of the source; the
  tier is OFF under an op budget (exact per-stack-op accounting, same rule
  as the kernel tiers) and polls the interrupt flag at the stack loop's
  cadence. run_reg_frame keeps hot ops inline with rare ops in an
  #[inline(never)] rstep_cold, preserving the native-stack headroom that
  the deep-recursion RangeError contract depends on.

Measured (callgrind, whole workload, deterministic — reg-on vs reg-off):
string_scan -29.4%, sort -21.5%, mixed_helpers -13.5% (new workload:
helper functions over objects/strings, the kernel-ineligible "agent
glue" shape), string_build -12.7%, json_roundtrip -4.3%; -17% geomean
over the interpreter-carried workloads. Kernel-owned numeric workloads
unchanged by design (+-0.003%, the per-call proto.reg probe). RESULT checksums are
byte-identical reg-on vs reg-off across the whole suite.

Gates: 90-program differential corpus + 300-case deterministic fuzz
(tests/reg.rs, reg-on vs reg-off byte-identity), structural translate/
decline pins, op-budget exactness (budget drains to the same count on
both compiles), depth-overflow parity; full suites green (chidori-js 118,
chidori 761, incl. record→replay byte-identity); Test262 gate: zero
regressions (39837 pass / 99.11%, baseline unchanged).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HxszC6savcUUUK8LJsy1Px