### PR TITLE
Add Rust style guide and enforce clippy across the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: Test workspace
         run: cargo test --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,6 @@ dependencies = [
  "clap",
  "criterion",
  "cron",
- "derive_more",
  "flate2",
  "futures",
  "hex",
@@ -568,7 +567,6 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower 0.5.3",
@@ -916,27 +914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,22 @@ members = [
 ]
 resolver = "2"
 
+# Workspace-wide lint levels, inherited by every crate via `[lints]
+# workspace = true`. CI and the pre-commit hook run
+# `cargo clippy --workspace --all-targets -- -D warnings`, so anything not
+# allowed here must be fixed (or suppressed narrowly with
+# `#[expect(..., reason = "...")]`). This table is the only place for blanket
+# allows — see docs/rust-style-guide.md.
+[workspace.lints.clippy]
+# The interpreter and runtime traffic in genuinely wide types (nested
+# generics over handles, callbacks, and journal entries); factoring every one
+# into a named alias hurts more than it helps. Reviewed case-by-case instead.
+type_complexity = "allow"
+# A few VM/runtime entry points thread many distinct parameters by design;
+# collapsing them into structs is a refactor to take deliberately, not to
+# satisfy a lint.
+too_many_arguments = "allow"
+
 # Shared metadata for the published crates. Inherited with `field.workspace =
 # true`; paths (like `readme`) resolve relative to this workspace root.
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ deterministic, replayable, and testable for free.
 | [Detached agents](./docs/detached-agents.md) | Durable, addressable, hibernating agent processes; `chidori.alarm`; the `/agents/detached` HTTP surface |
 | [Durable storage](./docs/durable-storage.md) | The run store: append-only journal, SQLite / Durable Object mirrors, hydration, strict durability, leases, `--until-seq` |
 | [Deployment](./docs/deployment.md) | Running in production: config, durability tiers, recipes for a plain VM / Fly.io / Kubernetes, failure & recovery |
+| [Rust style guide](./docs/rust-style-guide.md) | Conventions for contributing Rust: error handling, panics, tracing, async, `unsafe` policy, testing |
 | [Python SDK](./sdk/python/README.md) · [TypeScript SDK](./sdk/typescript/README.md) | HTTP clients with no native bindings |
 | [`llm.txt`](./llm.txt) | Complete API reference, optimized for LLMs generating agents |
 

--- a/crates/chidori-js/Cargo.toml
+++ b/crates/chidori-js/Cargo.toml
@@ -81,3 +81,7 @@ harness = false
 [[bench]]
 name = "memory"
 harness = false
+
+# Workspace-wide lint levels (see [workspace.lints] in the root Cargo.toml).
+[lints]
+workspace = true

--- a/crates/chidori-js/benches/execution.rs
+++ b/crates/chidori-js/benches/execution.rs
@@ -4,11 +4,14 @@
 //! property access, arrays, strings, closures).
 //!
 //! Three angles per workload:
-//!   * `compile`  — parse + lower to bytecode only (front-end cost).
-//!   * `eval`     — full `Engine::new()` + parse + compile + run (end-to-end,
-//!                  what a real `eval()` call pays, realm setup included).
-//!   * `interp`   — compile ONCE, then time only the VM running the bytecode
-//!                  (isolates the interpreter dispatch loop from the front end).
+//!
+//! ```text
+//! compile  — parse + lower to bytecode only (front-end cost).
+//! eval     — full `Engine::new()` + parse + compile + run (end-to-end,
+//!            what a real `eval()` call pays, realm setup included).
+//! interp   — compile ONCE, then time only the VM running the bytecode
+//!            (isolates the interpreter dispatch loop from the front end).
+//! ```
 //!
 //! Run with: `cargo bench -p chidori-js`
 //!

--- a/crates/chidori-js/examples/agent_replay.rs
+++ b/crates/chidori-js/examples/agent_replay.rs
@@ -11,10 +11,14 @@
 //! It builds a representative agent — real glue compute (prompt building, string
 //! scanning, modular arithmetic) interleaved with recorded host effects (an
 //! `llm` call per step) — then measures three things on the SAME workload:
-//!   * `compute_only`  — the JS compute with no host boundary (pure interpreter).
-//!   * `record`        — a live run building the journal (host returns instantly).
-//!   * `replay`        — re-running from the journal (no host calls at all).
-//! and models the live wall-clock under representative LLM latencies.
+//!
+//! ```text
+//! compute_only  — the JS compute with no host boundary (pure interpreter).
+//! record        — a live run building the journal (host returns instantly).
+//! replay        — re-running from the journal (no host calls at all).
+//! ```
+//!
+//! It also models the live wall-clock under representative LLM latencies.
 //!
 //! Run: `cargo run -q --release --example agent_replay -p chidori-js`
 

--- a/crates/chidori-js/examples/react_branch_converge.rs
+++ b/crates/chidori-js/examples/react_branch_converge.rs
@@ -38,8 +38,7 @@ struct Card {
     chosen: bool,
 }
 
-#[derive(Serialize)]
-#[derive(Default)]
+#[derive(Serialize, Default)]
 struct Frame {
     kind: String, // "branches" | "feedback" | "converged" | "replay"
     caption: String,
@@ -53,7 +52,6 @@ struct Frame {
     inputs: usize,
     replayed: usize,
 }
-
 
 /// The agent + its durable journal. Both `prompt` (model) and `input` (human)
 /// answers are recorded; on replay they are served for free — so a converged

--- a/crates/chidori-js/examples/react_branch_converge.rs
+++ b/crates/chidori-js/examples/react_branch_converge.rs
@@ -39,6 +39,7 @@ struct Card {
 }
 
 #[derive(Serialize)]
+#[derive(Default)]
 struct Frame {
     kind: String, // "branches" | "feedback" | "converged" | "replay"
     caption: String,
@@ -53,23 +54,6 @@ struct Frame {
     replayed: usize,
 }
 
-impl Default for Frame {
-    fn default() -> Self {
-        Frame {
-            kind: String::new(),
-            caption: String::new(),
-            note: String::new(),
-            cards: Vec::new(),
-            html: String::new(),
-            tests: Vec::new(),
-            question: String::new(),
-            answer: String::new(),
-            model_calls: 0,
-            inputs: 0,
-            replayed: 0,
-        }
-    }
-}
 
 /// The agent + its durable journal. Both `prompt` (model) and `input` (human)
 /// answers are recorded; on replay they are served for free — so a converged

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -1315,7 +1315,7 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         defined.retain(|v| !v.is_undefined());
         let undef_count = item_count - defined.len();
         merge_sort(vm, &mut defined, &cmp, has_cmp)?;
-        defined.extend(std::iter::repeat(Value::Undefined).take(undef_count));
+        defined.extend(std::iter::repeat_n(Value::Undefined, undef_count));
         Ok(Value::Object(vm.new_array(defined)))
     });
     vm.define_method(proto, "toReversed", 0, |vm, this, _args| {

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -1540,12 +1540,7 @@ fn flatten_into(
     Ok(target_index)
 }
 
-fn merge_sort(
-    vm: &mut Vm,
-    items: &mut Vec<Value>,
-    cmp: &Value,
-    has_cmp: bool,
-) -> Result<(), Value> {
+fn merge_sort(vm: &mut Vm, items: &mut [Value], cmp: &Value, has_cmp: bool) -> Result<(), Value> {
     if items.len() <= 1 {
         return Ok(());
     }

--- a/crates/chidori-js/src/builtins/async_builtins.rs
+++ b/crates/chidori-js/src/builtins/async_builtins.rs
@@ -229,11 +229,6 @@ fn install_promise(vm: &mut Vm) {
     });
 }
 
-/// Test-and-set an element's `alreadyCalled` flag. Returns `true` if the element
-/// has already settled (so the caller must bail out), `false` on the first call
-/// (and marks it settled). Mirrors the spec's per-element resolve/reject guard so
-/// a misbehaving thenable cannot double-count the combinator's pending counter.
-
 /// `IfAbruptCloseIterator`: on an abrupt completion mid-combinator, close the
 /// iterator (suppressing any close error — the original abrupt wins) and
 /// propagate.
@@ -611,6 +606,7 @@ fn make_aggregate_error(vm: &mut Vm, errors: Vec<Value>) -> Value {
     agg
 }
 
+#[allow(dead_code)] // Left from the pre-refactor combinator settle path; deletion candidate.
 fn settle_one(
     vm: &mut Vm,
     remaining: &Rc<RefCell<usize>>,

--- a/crates/chidori-js/src/builtins/bigint.rs
+++ b/crates/chidori-js/src/builtins/bigint.rs
@@ -119,7 +119,7 @@ fn number_to_bigint(vm: &mut Vm, n: f64) -> Result<BigInt, Value> {
 fn to_index(vm: &mut Vm, v: &Value) -> Result<u64, Value> {
     let n = vm.to_number(v)?;
     let i = if n.is_nan() { 0.0 } else { n.trunc() };
-    if i < 0.0 || i > 9007199254740991.0 {
+    if !(0.0..=9007199254740991.0).contains(&i) {
         return Err(vm.throw_range("Index out of range"));
     }
     let bits = i as u64;

--- a/crates/chidori-js/src/builtins/collections.rs
+++ b/crates/chidori-js/src/builtins/collections.rs
@@ -874,7 +874,7 @@ struct SetRecord {
 impl SetRecord {
     /// Invoke `this.[[Has]](key)` and coerce the result to a boolean.
     fn has(&self, vm: &mut Vm, key: &Value) -> Result<bool, Value> {
-        let r = vm.call(self.has.clone(), self.obj.clone(), &[key.clone()])?;
+        let r = vm.call(self.has.clone(), self.obj.clone(), std::slice::from_ref(key))?;
         Ok(vm.to_boolean(&r))
     }
 

--- a/crates/chidori-js/src/builtins/collections.rs
+++ b/crates/chidori-js/src/builtins/collections.rs
@@ -874,7 +874,11 @@ struct SetRecord {
 impl SetRecord {
     /// Invoke `this.[[Has]](key)` and coerce the result to a boolean.
     fn has(&self, vm: &mut Vm, key: &Value) -> Result<bool, Value> {
-        let r = vm.call(self.has.clone(), self.obj.clone(), std::slice::from_ref(key))?;
+        let r = vm.call(
+            self.has.clone(),
+            self.obj.clone(),
+            std::slice::from_ref(key),
+        )?;
         Ok(vm.to_boolean(&r))
     }
 

--- a/crates/chidori-js/src/builtins/date.rs
+++ b/crates/chidori-js/src/builtins/date.rs
@@ -51,7 +51,7 @@ fn time_clip(t: f64) -> f64 {
 fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
     let y = if m <= 2 { y - 1 } else { y };
     let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = (y - era * 400) as i64; // [0, 399]
+    let yoe = y - era * 400; // [0, 399]
     let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1; // [0, 365]
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
     era * 146097 + doe - 719468
@@ -432,10 +432,9 @@ fn find_zone_sign(s: &str) -> Option<usize> {
 fn parse_zone_offset(s: &str) -> Option<f64> {
     let (sign, rest) = if let Some(r) = s.strip_prefix('+') {
         (1.0, r)
-    } else if let Some(r) = s.strip_prefix('-') {
-        (-1.0, r)
     } else {
-        return None;
+        let r = s.strip_prefix('-')?;
+        (-1.0, r)
     };
     let (h, m) = if let Some((a, b)) = rest.split_once(':') {
         (a, b)

--- a/crates/chidori-js/src/builtins/date.rs
+++ b/crates/chidori-js/src/builtins/date.rs
@@ -467,6 +467,7 @@ fn parse_uint(s: &str) -> Option<u64> {
 /// Accept the two human-readable forms this engine itself emits:
 ///   - `Www, DD Mmm YYYY HH:mm:ss GMT`            (toUTCString)
 ///   - `Www Mmm DD YYYY HH:mm:ss ...`             (toString / toDateString)
+///
 /// Both are interpreted as UTC. Returns None if neither matches.
 fn parse_legacy(s: &str) -> Option<f64> {
     // Tokenize on whitespace and commas.

--- a/crates/chidori-js/src/builtins/disposable.rs
+++ b/crates/chidori-js/src/builtins/disposable.rs
@@ -148,7 +148,7 @@ fn install_one(vm: &mut Vm, is_async: bool) {
         }
         let v = value.clone();
         let disposer = vm.new_native("", 0, move |vm, _t, _a| {
-            vm.call(on_dispose.clone(), Value::Undefined, &[v.clone()])
+            vm.call(on_dispose.clone(), Value::Undefined, std::slice::from_ref(&v))
         });
         push_disposer(&arr, Value::Object(disposer));
         Ok(value)

--- a/crates/chidori-js/src/builtins/disposable.rs
+++ b/crates/chidori-js/src/builtins/disposable.rs
@@ -148,7 +148,11 @@ fn install_one(vm: &mut Vm, is_async: bool) {
         }
         let v = value.clone();
         let disposer = vm.new_native("", 0, move |vm, _t, _a| {
-            vm.call(on_dispose.clone(), Value::Undefined, std::slice::from_ref(&v))
+            vm.call(
+                on_dispose.clone(),
+                Value::Undefined,
+                std::slice::from_ref(&v),
+            )
         });
         push_disposer(&arr, Value::Object(disposer));
         Ok(value)

--- a/crates/chidori-js/src/builtins/fundamental.rs
+++ b/crates/chidori-js/src/builtins/fundamental.rs
@@ -2326,7 +2326,8 @@ fn install_errors(vm: &mut Vm) {
     // EvalError lacks a realm-resident prototype (nothing throws it internally);
     // create an ordinary prototype chaining to Error.prototype.
     let error_proto = vm.realm.error_proto.clone();
-    for name in ["EvalError"] {
+    {
+        let name = "EvalError";
         let proto = vm.alloc_ordinary(Some(error_proto.clone()));
         let ctor = install_error_kind(vm, &proto, name);
         // Subtype ctor inherits from the Error constructor.

--- a/crates/chidori-js/src/builtins/fundamental.rs
+++ b/crates/chidori-js/src/builtins/fundamental.rs
@@ -259,8 +259,11 @@ fn define_own_property_inner(
     // `current` afterwards so post-valueOf state is what gets validated.
     let obj_is_array = matches!(obj.borrow().internal, Internal::Array(_));
     let mut coerced_desc;
-    let d: &PropDesc = if obj_is_array && key.as_str() == Some("length") && d.value.is_some() {
-        let v = d.value.as_ref().unwrap();
+    let d: &PropDesc = if let Some(v) = d
+        .value
+        .as_ref()
+        .filter(|_| obj_is_array && key.as_str() == Some("length"))
+    {
         let new_len = vm.to_uint32(v)?;
         let number_len = vm.to_number(v)?;
         if (new_len as f64) != number_len {
@@ -1805,31 +1808,6 @@ pub(crate) fn own_property_descriptor(o: &JsObject, key: &PropertyKey) -> Option
                         kind: PropertyKind::Data {
                             value: Value::String(JsString::from_code_units(&[u])),
                             writable: false,
-                        },
-                        enumerable: true,
-                        configurable: false,
-                    });
-                }
-            }
-            None
-        }
-        // Module Namespace exotic [[GetOwnProperty]] for an export name:
-        // a live {writable:true, enumerable:true, configurable:false} data
-        // property (an uninitialized binding reads as undefined here — the
-        // throwing TDZ check lives on the [[Get]] path).
-        Internal::ModuleNamespace(ns) => {
-            if let PropertyKey::Str(s) = key {
-                if let Some(cell) = ns.exports.get(s) {
-                    let v = cell.borrow().clone();
-                    let v = if matches!(v, Value::Uninitialized) {
-                        Value::Undefined
-                    } else {
-                        v
-                    };
-                    return Some(Property {
-                        kind: PropertyKind::Data {
-                            value: v,
-                            writable: true,
                         },
                         enumerable: true,
                         configurable: false,

--- a/crates/chidori-js/src/builtins/intl.rs
+++ b/crates/chidori-js/src/builtins/intl.rs
@@ -17,8 +17,8 @@ use std::str::FromStr;
 
 thread_local! {
     static CANONICALIZER: icu_locale::LocaleCanonicalizer =
-        icu_locale::LocaleCanonicalizer::new_extended();
-    static EXPANDER: icu_locale::LocaleExpander = icu_locale::LocaleExpander::new_extended();
+        const { icu_locale::LocaleCanonicalizer::new_extended() };
+    static EXPANDER: icu_locale::LocaleExpander = const { icu_locale::LocaleExpander::new_extended() };
 }
 
 pub fn install(vm: &mut Vm) {
@@ -1096,7 +1096,7 @@ fn nf_formatter(rec: &JsObject) -> DecimalFormatter {
         _ => GroupingStrategy::Auto,
     });
     // The full locale (not just its id) so the `-u-nu` numbering system applies.
-    DecimalFormatter::try_new((&loc).into(), opts.clone())
+    DecimalFormatter::try_new((&loc).into(), opts)
         .or_else(|_| DecimalFormatter::try_new(Default::default(), opts))
         .unwrap()
 }

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -799,7 +799,7 @@ pub(crate) fn math_round(n: f64) -> f64 {
     if n > 0.0 && n < 0.5 {
         return 0.0;
     }
-    if n < 0.0 && n >= -0.5 {
+    if (-0.5..0.0).contains(&n) {
         // -0 result, preserving sign.
         return -0.0;
     }

--- a/crates/chidori-js/src/builtins/string.rs
+++ b/crates/chidori-js/src/builtins/string.rs
@@ -508,20 +508,15 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
         Ok(Value::str(str_this(vm, &this)?.to_lowercase()))
     });
     vm.define_method(proto, "trim", 0, |vm, this, _a| {
-        Ok(Value::str(
-            str_this(vm, &this)?.trim_matches(is_js_ws),
-        ))
+        Ok(Value::str(str_this(vm, &this)?.trim_matches(is_js_ws)))
     });
     vm.define_method(proto, "trimStart", 0, |vm, this, _a| {
         Ok(Value::str(
-            str_this(vm, &this)?
-                .trim_start_matches(is_js_ws),
+            str_this(vm, &this)?.trim_start_matches(is_js_ws),
         ))
     });
     vm.define_method(proto, "trimEnd", 0, |vm, this, _a| {
-        Ok(Value::str(
-            str_this(vm, &this)?.trim_end_matches(is_js_ws),
-        ))
+        Ok(Value::str(str_this(vm, &this)?.trim_end_matches(is_js_ws)))
     });
     vm.define_method(proto, "repeat", 1, |vm, this, args| {
         let s = str_this(vm, &this)?;

--- a/crates/chidori-js/src/builtins/string.rs
+++ b/crates/chidori-js/src/builtins/string.rs
@@ -509,19 +509,18 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
     });
     vm.define_method(proto, "trim", 0, |vm, this, _a| {
         Ok(Value::str(
-            str_this(vm, &this)?.trim_matches(is_js_ws).to_string(),
+            str_this(vm, &this)?.trim_matches(is_js_ws),
         ))
     });
     vm.define_method(proto, "trimStart", 0, |vm, this, _a| {
         Ok(Value::str(
             str_this(vm, &this)?
-                .trim_start_matches(is_js_ws)
-                .to_string(),
+                .trim_start_matches(is_js_ws),
         ))
     });
     vm.define_method(proto, "trimEnd", 0, |vm, this, _a| {
         Ok(Value::str(
-            str_this(vm, &this)?.trim_end_matches(is_js_ws).to_string(),
+            str_this(vm, &this)?.trim_end_matches(is_js_ws),
         ))
     });
     vm.define_method(proto, "repeat", 1, |vm, this, args| {
@@ -736,7 +735,7 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
         if matches!(regexp, Value::Object(_)) {
             let key = PropertyKey::Sym(vm.realm.symbol_search.clone());
             if let Some(m) = get_method(vm, &regexp, &key)? {
-                return vm.call(m, regexp.clone(), &[this.clone()]);
+                return vm.call(m, regexp.clone(), std::slice::from_ref(&this));
             }
         }
         // Fall back: RegExpCreate then Invoke(rx, @@search, «S»).
@@ -757,7 +756,7 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
         if matches!(regexp, Value::Object(_)) {
             let key = PropertyKey::Sym(vm.realm.symbol_match.clone());
             if let Some(m) = get_method(vm, &regexp, &key)? {
-                return vm.call(m, regexp.clone(), &[this.clone()]);
+                return vm.call(m, regexp.clone(), std::slice::from_ref(&this));
             }
         }
         let s = str_this(vm, &this)?;
@@ -788,7 +787,7 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
             }
             let key = PropertyKey::Sym(vm.realm.symbol_match_all.clone());
             if let Some(m) = get_method(vm, &regexp, &key)? {
-                return vm.call(m, regexp.clone(), &[this.clone()]);
+                return vm.call(m, regexp.clone(), std::slice::from_ref(&this));
             }
         }
         // Fall back: S = ToString(this), then RegExpCreate(regexp, "g") and

--- a/crates/chidori-js/src/builtins/temporal.rs
+++ b/crates/chidori-js/src/builtins/temporal.rs
@@ -53,7 +53,7 @@ fn get_increment(vm: &mut Vm, obj: &Value) -> Result<Option<RoundingIncrement>, 
         return Ok(None);
     }
     let n = vm.to_number(&v)?;
-    if !n.is_finite() || n.fract() != 0.0 || n < 1.0 || n > 1.0e9 {
+    if !n.is_finite() || n.fract() != 0.0 || !(1.0..=1.0e9).contains(&n) {
         return Err(vm.throw_range("invalid roundingIncrement"));
     }
     RoundingIncrement::try_new(n as u32)
@@ -227,7 +227,7 @@ fn this_duration(vm: &mut Vm, this: &Value) -> Result<Duration, Value> {
     if let Value::Object(o) = this {
         if let Internal::Temporal(slot) = &o.borrow().internal {
             if let TemporalSlot::Duration(d) = slot.as_ref() {
-                return Ok(d.clone());
+                return Ok(*d);
             }
         }
     }
@@ -289,7 +289,7 @@ fn to_temporal_duration(vm: &mut Vm, v: &Value) -> Result<Duration, Value> {
     if let Value::Object(o) = v {
         if let Internal::Temporal(slot) = &o.borrow().internal {
             if let TemporalSlot::Duration(d) = slot.as_ref() {
-                return Ok(d.clone());
+                return Ok(*d);
             }
         }
     }

--- a/crates/chidori-js/src/builtins/temporal.rs
+++ b/crates/chidori-js/src/builtins/temporal.rs
@@ -2651,7 +2651,7 @@ fn define_zdt_getter(
 /// A fresh system-clock `Now` (the bare conformance context reads real time,
 /// like `Date`; the durable runtime captures this as an effect at a higher layer).
 fn now_clock() -> temporal_rs::now::Now<temporal_rs::sys::LocalHostSystem> {
-    temporal_rs::Temporal::now()
+    temporal_rs::Temporal::local_now()
 }
 
 /// The optional `temporalTimeZoneLike` argument of the `Now` methods.

--- a/crates/chidori-js/src/builtins/typedarray.rs
+++ b/crates/chidori-js/src/builtins/typedarray.rs
@@ -333,7 +333,7 @@ fn install_array_buffer(vm: &mut Vm, species: &JsSymbol) {
                 vm.throw_type("ArrayBuffer.prototype.slice: species returned the same buffer")
             );
         }
-        if (buffer_byte_length(&new_buf) as usize) < new_len {
+        if buffer_byte_length(&new_buf) < new_len {
             return Err(vm.throw_type(
                 "ArrayBuffer.prototype.slice: species returned a buffer that is too small",
             ));
@@ -2010,7 +2010,7 @@ fn construct_typed_array(vm: &mut Vm, kind: TAKind, args: &[Value]) -> Result<Va
                 // A RESIZABLE buffer's auto-length view is length-tracking:
                 // its element count floors freely, with no alignment demand
                 // (the requirement applies to fixed buffers only).
-                if remaining % elem != 0 && ab_max_byte_length(&buffer).is_none() {
+                if !remaining.is_multiple_of(elem) && ab_max_byte_length(&buffer).is_none() {
                     return Err(vm.throw_range("Byte length is not aligned to element size"));
                 }
                 remaining / elem
@@ -2723,7 +2723,7 @@ enum AtomicOp {
 /// `ToIndex`: a non-negative integer ≤ 2^53−1, else a RangeError.
 fn to_index(vm: &mut Vm, v: &Value) -> Result<usize, Value> {
     let n = to_integer_or_infinity(vm, v)?;
-    if n < 0.0 || n > 9007199254740991.0 {
+    if !(0.0..=9007199254740991.0).contains(&n) {
         return Err(vm.throw_range("Atomics: index out of range"));
     }
     Ok(n as usize)

--- a/crates/chidori-js/src/builtins/typedarray.rs
+++ b/crates/chidori-js/src/builtins/typedarray.rs
@@ -1685,7 +1685,7 @@ fn ta_snapshot_array(vm: &mut Vm, o: &JsObject) -> JsObject {
 /// In-place sort of typed-array element values. Elements are all one kind
 /// (Number or BigInt). Default compare is ascending numeric (NaN sorts to the
 /// end); an optional comparator is honored. Stable merge sort.
-fn ta_sort(vm: &mut Vm, items: &mut Vec<Value>, cmp: &Value, has_cmp: bool) -> Result<(), Value> {
+fn ta_sort(vm: &mut Vm, items: &mut [Value], cmp: &Value, has_cmp: bool) -> Result<(), Value> {
     // The comparator's function kernel, prepared ONCE for the whole sort
     // (see `Vm::prepare_kernel_callback`).
     let mut prep = if has_cmp {

--- a/crates/chidori-js/src/builtins/typedarray.rs
+++ b/crates/chidori-js/src/builtins/typedarray.rs
@@ -1672,6 +1672,7 @@ fn install_ta_methods(vm: &mut Vm, proto: &JsObject) {
 
 /// Snapshot a typed array's elements into a fresh dense JS array (used to back
 /// the keys/values/entries iterators).
+#[allow(dead_code)] // Superseded by the index-based iterators; kept as the snapshot fallback.
 fn ta_snapshot_array(vm: &mut Vm, o: &JsObject) -> JsObject {
     let len = vm.ta_length(o).unwrap_or(0);
     let mut elems = Vec::with_capacity(len);
@@ -1721,7 +1722,7 @@ fn ta_sort(vm: &mut Vm, items: &mut Vec<Value>, cmp: &Value, has_cmp: bool) -> R
 
 fn ta_sort_range(
     vm: &mut Vm,
-    items: &mut Vec<Value>,
+    items: &mut [Value],
     cmp: &Value,
     has_cmp: bool,
     prep: &mut Option<crate::exec::PreparedKernel>,

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -659,7 +659,7 @@ struct FnCtx {
     script_global: bool,
     /// Nesting depth of enclosing `with` statements within this function. When
     /// > 0, unqualified identifier reads/writes compile to dynamic name ops that
-    /// consult the runtime with-scope stack before the static binding.
+    /// > consult the runtime with-scope stack before the static binding.
     with_depth: u32,
     /// True when this function is textually nested inside a `with` block of an
     /// enclosing function: its free identifiers must also resolve dynamically
@@ -871,7 +871,7 @@ impl Compiler {
     fn region_has_arguments(&self, start: u32, end: u32) -> bool {
         self.source
             .get(start as usize..end as usize)
-            .map_or(true, |s| s.contains("arguments"))
+            .is_none_or(|s| s.contains("arguments"))
     }
 
     /// Whether the source region mentions `eval` — the conservative trigger
@@ -880,7 +880,7 @@ impl Compiler {
     fn region_has_eval(&self, start: u32, end: u32) -> bool {
         self.source
             .get(start as usize..end as usize)
-            .map_or(true, |s| s.contains("eval"))
+            .is_none_or(|s| s.contains("eval"))
     }
 }
 
@@ -1040,7 +1040,7 @@ impl Compiler {
     /// True while compiling directly in the top-level script body, where
     /// `var`/`function` declarations create global-object properties.
     fn in_global_scope(&self) -> bool {
-        self.fns.last().map_or(false, |f| f.script_global)
+        self.fns.last().is_some_and(|f| f.script_global)
     }
 
     /// Hoist one `var` binding pattern: a top-level simple identifier becomes a
@@ -4143,14 +4143,11 @@ impl Compiler {
                         self.emit(Op::TypeofExpr);
                         return Ok(());
                     }
-                    match self.resolve(name) {
-                        Resolved::Global => {
-                            let n = self.str_const(name);
-                            self.emit(Op::LoadGlobalTypeof(n));
-                            self.emit(Op::TypeofExpr);
-                            return Ok(());
-                        }
-                        _ => {}
+                    if let Resolved::Global = self.resolve(name) {
+                        let n = self.str_const(name);
+                        self.emit(Op::LoadGlobalTypeof(n));
+                        self.emit(Op::TypeofExpr);
+                        return Ok(());
                     }
                 }
                 self.compile_expr(&u.argument)?;

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -638,7 +638,9 @@ struct FnCtx {
     uses_arguments: bool,
     /// Cell index of the implicit `this` binding (for non-arrow functions).
     this_cell: Option<u32>,
+    #[allow(dead_code)] // Reserved for new.target support; written but not yet read.
     new_target_cell: Option<u32>,
+    #[allow(dead_code)] // Reserved for mapped-arguments support; written but not yet read.
     arguments_cell: Option<u32>,
     /// Names captured by nested functions (conservative): such bindings become
     /// cells (always true here since all bindings are cells, but retained for
@@ -2638,6 +2640,7 @@ impl Compiler {
         self.patch_jump(jhave2, have);
     }
 
+    #[allow(dead_code)] // Not referenced by the current iteration lowering; kept for the Op sequence it documents.
     fn emit_iter_step(&mut self, itc: u32) {
         self.emit(Op::LoadCell(itc)); // [iter]
         self.emit(Op::IteratorNext); // [iter, result]
@@ -3235,6 +3238,7 @@ impl Compiler {
     ///   `finally`) is taken by `do_completion`;
     /// - throw/return/break/continue in `body` or `catch`: `do_completion` runs
     ///   the finalizer with the completion parked, and `EndFinally` resumes it.
+    ///
     /// This single-copy model (vs. duplicating the finalizer per path) is what
     /// makes non-local exits run `finally`.
     fn compile_try_with_finally(&mut self, t: &TryStatement, finalizer: &BlockStatement) -> R {
@@ -7083,6 +7087,5 @@ fn collect_pattern_names(pat: &BindingPattern, out: &mut Vec<String>) {
             }
         }
         BindingPattern::AssignmentPattern(a) => collect_pattern_names(&a.left, out),
-        _ => {}
     }
 }

--- a/crates/chidori-js/src/dom.rs
+++ b/crates/chidori-js/src/dom.rs
@@ -918,7 +918,6 @@ impl Dom {
                 (AttrOp::Prefix, Some(v)) => v.starts_with(&a.value),
                 (AttrOp::Suffix, Some(v)) => v.ends_with(&a.value),
                 (AttrOp::Substring, Some(v)) => v.contains(&a.value),
-                (AttrOp::Exists, None) => false,
             };
             if !ok {
                 return false;
@@ -1026,6 +1025,10 @@ struct AttrSel {
 }
 
 #[derive(Clone)]
+#[expect(
+    clippy::enum_variant_names,
+    reason = "variants mirror the CSS pseudo-class names verbatim"
+)]
 enum Pseudo {
     FirstChild,
     LastChild,

--- a/crates/chidori-js/src/dom.rs
+++ b/crates/chidori-js/src/dom.rs
@@ -1400,7 +1400,7 @@ impl DomHandle {
                 if once {
                     remove_listener(&self.0, node, ty, &handler, capture);
                 }
-                if let Err(e) = vm.call(handler, ct.clone(), &[event.clone()]) {
+                if let Err(e) = vm.call(handler, ct.clone(), std::slice::from_ref(&event)) {
                     let msg = vm.error_to_string(&e);
                     return Err(format!("event handler threw: {msg}"));
                 }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -2750,6 +2750,7 @@ impl Vm {
     ///   finalizer (whose `EndFinally` resumes this dispatch);
     /// - once no more crossing handlers remain, the action is performed
     ///   (`Ctl::Return` / re-`throw` as `Err` / `Ctl::Jump` to the loop target).
+    ///
     /// PerformEval (spec 19.2.1.1) for a direct call to %eval%: compile the
     /// source against the call site's scope snapshot, run the spec's
     /// EvalDeclarationInstantiation checks (the sloppy `var arguments`
@@ -6978,9 +6979,7 @@ impl Vm {
 fn js_mod(a: f64, b: f64) -> f64 {
     if b == 0.0 || a.is_nan() || b.is_nan() || a.is_infinite() {
         f64::NAN
-    } else if b.is_infinite() {
-        a
-    } else if a == 0.0 {
+    } else if b.is_infinite() || a == 0.0 {
         a
     } else {
         // Fast path: both operands integral and exactly representable (|x| <=

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -5698,7 +5698,7 @@ impl Vm {
             }
             Op::SetHomeObjectAt(n) => {
                 let len = frame.stack.len();
-                if len >= *n as usize + 1 {
+                if len > *n as usize {
                     let home = frame.stack[len - 1 - *n as usize].clone();
                     if let (Value::Object(home), Value::Object(m)) =
                         (home, frame.stack[len - 1].clone())
@@ -6943,7 +6943,7 @@ impl Vm {
         let has_inst = self.realm.symbol_has_instance.clone();
         let method = self.get_prop(ctor, &PropertyKey::Sym(has_inst))?;
         if self.is_callable(&method) {
-            let r = self.call(method, ctor.clone(), &[obj.clone()])?;
+            let r = self.call(method, ctor.clone(), std::slice::from_ref(obj))?;
             return Ok(self.to_boolean(&r));
         }
         if !cobj.borrow().is_callable() {

--- a/crates/chidori-js/src/fuse.rs
+++ b/crates/chidori-js/src/fuse.rs
@@ -69,11 +69,10 @@ fn for_each_ip(op: &mut Op, mut f: impl FnMut(&mut u32)) {
         }
         // `target` is an ip; `boundary` is a handler-stack depth — do NOT remap.
         Op::CompletionJump { target, .. } => f(target),
-        Op::MarkDelegationHandler(t) => {
-            if *t != u32::MAX {
+        Op::MarkDelegationHandler(t)
+            if *t != u32::MAX => {
                 f(t);
             }
-        }
         _ => {}
     }
 }

--- a/crates/chidori-js/src/fuse.rs
+++ b/crates/chidori-js/src/fuse.rs
@@ -69,10 +69,9 @@ fn for_each_ip(op: &mut Op, mut f: impl FnMut(&mut u32)) {
         }
         // `target` is an ip; `boundary` is a handler-stack depth — do NOT remap.
         Op::CompletionJump { target, .. } => f(target),
-        Op::MarkDelegationHandler(t)
-            if *t != u32::MAX => {
-                f(t);
-            }
+        Op::MarkDelegationHandler(t) if *t != u32::MAX => {
+            f(t);
+        }
         _ => {}
     }
 }

--- a/crates/chidori-js/src/generator.rs
+++ b/crates/chidori-js/src/generator.rs
@@ -312,7 +312,7 @@ impl Vm {
                     let cell_f = cell.clone();
                     let on_f = self.new_native("", 1, move |vm, _t, args| {
                         if let Some(fr) = cell_f.borrow_mut().take() {
-                            let awaited = args.get(0).cloned().unwrap_or(Value::Undefined);
+                            let awaited = args.first().cloned().unwrap_or(Value::Undefined);
                             vm.set_gen_state(&gen_f, GeneratorState::SuspendedYield(fr));
                             let r = vm.make_iter_result(awaited, false);
                             vm.resolve_promise(&res_f, r);
@@ -328,7 +328,7 @@ impl Vm {
                         if let Some(mut fr) = cell.borrow_mut().take() {
                             let token = fr.trace_token;
                             vm.trace_resume(token);
-                            let e = args.get(0).cloned().unwrap_or(Value::Undefined);
+                            let e = args.first().cloned().unwrap_or(Value::Undefined);
                             // Internal await-of-yielded-value rejection: it
                             // propagates out of a `yield*` rather than being
                             // delegated to the inner iterator's `throw`.
@@ -353,7 +353,7 @@ impl Vm {
                         if let Some(fr) = cell_f.borrow_mut().take() {
                             let token = fr.trace_token;
                             vm.trace_resume(token);
-                            let v = args.get(0).cloned().unwrap_or(Value::Undefined);
+                            let v = args.first().cloned().unwrap_or(Value::Undefined);
                             let flow = vm.resume_frame(fr, v);
                             vm.agen_drive(&gen_f, flow, &res_f, token);
                         }
@@ -365,7 +365,7 @@ impl Vm {
                         if let Some(fr) = cell.borrow_mut().take() {
                             let token = fr.trace_token;
                             vm.trace_resume(token);
-                            let e = args.get(0).cloned().unwrap_or(Value::Undefined);
+                            let e = args.first().cloned().unwrap_or(Value::Undefined);
                             let flow = vm.resume_frame_throw(fr, e);
                             vm.agen_drive(&gen_r, flow, &res_r, token);
                         }

--- a/crates/chidori-js/src/iter.rs
+++ b/crates/chidori-js/src/iter.rs
@@ -92,11 +92,8 @@ impl Vm {
         }
         let it = self.get_iterator(v)?;
         let mut out = Vec::new();
-        loop {
-            match self.iterator_step(&it)? {
-                Some(val) => out.push(val),
-                None => break,
-            }
+        while let Some(val) = self.iterator_step(&it)? {
+            out.push(val);
         }
         Ok(out)
     }
@@ -208,14 +205,13 @@ impl Vm {
         let ta_oob = {
             let b = it.borrow();
             match &b.internal {
-                Internal::Iterator(st) if !st.done => {
-                    st.target
-                        .as_ref()
-                        .is_some_and(|t| match &t.borrow().internal {
-                            Internal::TypedArray(td) => crate::typed_array::ta_out_of_bounds(td),
-                            _ => false,
-                        })
-                }
+                Internal::Iterator(st) if !st.done => st.target.as_ref().is_some_and(|t| match &t
+                    .borrow()
+                    .internal
+                {
+                    Internal::TypedArray(td) => crate::typed_array::ta_out_of_bounds(td),
+                    _ => false,
+                }),
                 _ => false,
             }
         };

--- a/crates/chidori-js/src/iter.rs
+++ b/crates/chidori-js/src/iter.rs
@@ -211,7 +211,7 @@ impl Vm {
                 Internal::Iterator(st) if !st.done => {
                     st.target
                         .as_ref()
-                        .map_or(false, |t| match &t.borrow().internal {
+                        .is_some_and(|t| match &t.borrow().internal {
                             Internal::TypedArray(td) => crate::typed_array::ta_out_of_bounds(td),
                             _ => false,
                         })

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -72,7 +72,7 @@ impl Engine {
     /// Compile and run a script to completion (draining microtasks), returning
     /// the completion value. Errors are returned as their string form.
     pub fn eval(&mut self, src: &str) -> Result<Value, String> {
-        let proto = compiler::compile_script(src).map_err(|e| e)?;
+        let proto = compiler::compile_script(src)?;
         let func = self.vm.make_closure(std::rc::Rc::new(proto), Vec::new());
         let result = self
             .vm

--- a/crates/chidori-js/src/promise.rs
+++ b/crates/chidori-js/src/promise.rs
@@ -125,12 +125,12 @@ impl Vm {
         let p1 = promise.clone();
         let p2 = promise.clone();
         let resolve = self.new_native("", 1, move |vm, _this, args| {
-            let v = args.get(0).cloned().unwrap_or(Value::Undefined);
+            let v = args.first().cloned().unwrap_or(Value::Undefined);
             vm.resolve_promise(&p1, v);
             Ok(Value::Undefined)
         });
         let reject = self.new_native("", 1, move |vm, _this, args| {
-            let v = args.get(0).cloned().unwrap_or(Value::Undefined);
+            let v = args.first().cloned().unwrap_or(Value::Undefined);
             vm.reject_promise(&p2, v);
             Ok(Value::Undefined)
         });

--- a/crates/chidori-js/src/proxy.rs
+++ b/crates/chidori-js/src/proxy.rs
@@ -100,12 +100,13 @@ impl Vm {
                                     ));
                                 }
                             }
-                            PropertyKind::Accessor { get, .. } if get.is_none()
-                                && !result.is_undefined() => {
-                                    return Err(self.throw_type(
+                            PropertyKind::Accessor { get, .. }
+                                if get.is_none() && !result.is_undefined() =>
+                            {
+                                return Err(self.throw_type(
                                         "proxy get trap must report undefined for a non-configurable accessor with no getter",
                                     ));
-                                }
+                            }
                             _ => {}
                         }
                     }
@@ -740,6 +741,7 @@ impl Vm {
     /// Ordinary `[[Set]]` returning the boolean success flag, used when a Proxy
     /// `set` trap is absent and the operation forwards to the target. If the
     /// target is itself a Proxy, dispatch its `[[Set]]` (trap or recursion).
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     fn ordinary_set(
         &mut self,
         target: &JsObject,
@@ -902,15 +904,17 @@ impl Vm {
                         // Step 16.c: a non-configurable, writable target data
                         // property cannot be redefined as non-writable.
                         if let PropertyKind::Data { writable, .. } = &p.kind {
-                            if !p.configurable && *writable
-                                && self.has_prop(&desc, &PropertyKey::str("writable"))? {
-                                    let w = self.get_prop(&desc, &PropertyKey::str("writable"))?;
-                                    if !self.to_boolean(&w) {
-                                        return Err(self.throw_type(
+                            if !p.configurable
+                                && *writable
+                                && self.has_prop(&desc, &PropertyKey::str("writable"))?
+                            {
+                                let w = self.get_prop(&desc, &PropertyKey::str("writable"))?;
+                                if !self.to_boolean(&w) {
+                                    return Err(self.throw_type(
                                             "proxy [[DefineOwnProperty]]: cannot redefine a non-configurable writable property as non-writable",
                                         ));
-                                    }
                                 }
+                            }
                         }
                     }
                 }

--- a/crates/chidori-js/src/proxy.rs
+++ b/crates/chidori-js/src/proxy.rs
@@ -100,13 +100,12 @@ impl Vm {
                                     ));
                                 }
                             }
-                            PropertyKind::Accessor { get, .. } if get.is_none() => {
-                                if !result.is_undefined() {
+                            PropertyKind::Accessor { get, .. } if get.is_none()
+                                && !result.is_undefined() => {
                                     return Err(self.throw_type(
                                         "proxy get trap must report undefined for a non-configurable accessor with no getter",
                                     ));
                                 }
-                            }
                             _ => {}
                         }
                     }
@@ -903,8 +902,8 @@ impl Vm {
                         // Step 16.c: a non-configurable, writable target data
                         // property cannot be redefined as non-writable.
                         if let PropertyKind::Data { writable, .. } = &p.kind {
-                            if !p.configurable && *writable {
-                                if self.has_prop(&desc, &PropertyKey::str("writable"))? {
+                            if !p.configurable && *writable
+                                && self.has_prop(&desc, &PropertyKey::str("writable"))? {
                                     let w = self.get_prop(&desc, &PropertyKey::str("writable"))?;
                                     if !self.to_boolean(&w) {
                                         return Err(self.throw_type(
@@ -912,7 +911,6 @@ impl Vm {
                                         ));
                                     }
                                 }
-                            }
                         }
                     }
                 }

--- a/crates/chidori-js/src/replay.rs
+++ b/crates/chidori-js/src/replay.rs
@@ -232,7 +232,7 @@ impl ReplayRuntime {
         let state = self.state.clone();
         self.vm
             .define_method(&global, "durableStep", 1, move |vm, _this, args| {
-                let f = args.get(0).cloned().unwrap_or(Value::Undefined);
+                let f = args.first().cloned().unwrap_or(Value::Undefined);
                 let site = "durableStep".to_string();
                 let seq = {
                     let mut s = state.borrow_mut();

--- a/crates/chidori-js/src/replay.rs
+++ b/crates/chidori-js/src/replay.rs
@@ -41,6 +41,7 @@ struct PendingOp {
 
 struct JournalState {
     journal: Journal,
+    #[allow(dead_code)] // Recorded at construction; not yet read back.
     mode: Mode,
     counters: HashMap<String, u64>,
     pending: HashMap<u64, PendingOp>,

--- a/crates/chidori-js/src/typed_array.rs
+++ b/crates/chidori-js/src/typed_array.rs
@@ -21,8 +21,9 @@ pub fn decode(bytes: &[u8], off: usize, kind: TAKind) -> f64 {
     macro_rules! rd {
         ($t:ty, $n:expr) => {{
             let mut a = [0u8; $n];
-            if off + $n <= bytes.len() {
-                a.copy_from_slice(&bytes[off..off + $n]);
+            let end = off + $n;
+            if end <= bytes.len() {
+                a.copy_from_slice(&bytes[off..end]);
             }
             <$t>::from_le_bytes(a)
         }};
@@ -91,8 +92,9 @@ pub fn encode(bytes: &mut [u8], off: usize, kind: TAKind, v: f64) {
     macro_rules! wr {
         ($e:expr, $n:expr) => {{
             let b = ($e).to_le_bytes();
-            if off + $n <= bytes.len() {
-                bytes[off..off + $n].copy_from_slice(&b);
+            let end = off + $n;
+            if end <= bytes.len() {
+                bytes[off..end].copy_from_slice(&b);
             }
         }};
     }
@@ -130,9 +132,7 @@ fn to_int(v: f64) -> i64 {
 }
 
 fn to_uint8_clamp(v: f64) -> u8 {
-    if v.is_nan() {
-        0
-    } else if v <= 0.0 {
+    if v.is_nan() || v <= 0.0 {
         0
     } else if v >= 255.0 {
         255

--- a/crates/chidori-js/src/unicode_tables.rs
+++ b/crates/chidori-js/src/unicode_tables.rs
@@ -3,7 +3,12 @@
 //     python3 crates/chidori-js/scripts/gen_unicode_tables.py
 //
 // Range slices are sorted, disjoint, and inclusive on both ends.
+//
+// The generator emits the complete UCD property set; builtins consume only a
+// subset, so unused tables are expected (dead_code allow below), and keeping
+// the full set beats special-casing the generator per consumer.
 #![allow(clippy::all)]
+#![allow(dead_code)]
 
 static GC_C: &[(u32, u32)] = &[
     (0x0, 0x1F),

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -357,6 +357,12 @@ pub struct Vm {
     pub(crate) kernel_callees: Vec<(std::rc::Rc<crate::value::BytecodeFunction>, u32)>,
 }
 
+impl Default for Vm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Vm {
     pub fn new() -> Vm {
         let mut vm = Vm {
@@ -427,7 +433,7 @@ impl Vm {
         let id = self.symbol_counter;
         self.symbol_counter += 1;
         JsSymbol(Rc::new(SymbolData {
-            description: description.map(|d| Rc::from(d)),
+            description: description.map(Rc::from),
             id,
         }))
     }
@@ -640,7 +646,7 @@ impl Vm {
         );
         obj.borrow_mut().props.insert(
             PropertyKey::str("stack"),
-            Property::builtin(Value::str(&format!("{}: {}", kind.name(), message))),
+            Property::builtin(Value::str(format!("{}: {}", kind.name(), message))),
         );
         Value::Object(obj)
     }
@@ -935,7 +941,7 @@ impl Vm {
         // Fast paths for primitives without boxing.
         match base {
             Value::Undefined | Value::Uninitialized | Value::Hole | Value::Null => {
-                return Err(self.throw_type(&format!(
+                Err(self.throw_type(&format!(
                     "Cannot read properties of {} (reading '{}')",
                     if base.is_null() { "null" } else { "undefined" },
                     key_display(key)
@@ -947,23 +953,23 @@ impl Vm {
                 }
                 // fall through to String.prototype
                 let proto = self.realm.string_proto.clone();
-                return self.get_from_object(&proto, key, base.clone());
+                self.get_from_object(&proto, key, base.clone())
             }
             Value::Number(_) => {
                 let proto = self.realm.number_proto.clone();
-                return self.get_from_object(&proto, key, base.clone());
+                self.get_from_object(&proto, key, base.clone())
             }
             Value::Bool(_) => {
                 let proto = self.realm.boolean_proto.clone();
-                return self.get_from_object(&proto, key, base.clone());
+                self.get_from_object(&proto, key, base.clone())
             }
             Value::Symbol(_) => {
                 let proto = self.realm.symbol_proto.clone();
-                return self.get_from_object(&proto, key, base.clone());
+                self.get_from_object(&proto, key, base.clone())
             }
             Value::BigInt(_) => {
                 let proto = self.realm.bigint_proto.clone();
-                return self.get_from_object(&proto, key, base.clone());
+                self.get_from_object(&proto, key, base.clone())
             }
             Value::Object(o) => self.get_from_object(o, key, base.clone()),
         }
@@ -1313,7 +1319,7 @@ impl Vm {
                         let dense_own = match &b.internal {
                             Internal::Array(arr) => match key.as_str() {
                                 Some("length") => true,
-                                _ => key.array_index().map_or(false, |i| {
+                                _ => key.array_index().is_some_and(|i| {
                                     (i as usize) < arr.len()
                                         && !matches!(arr[i as usize], Value::Hole)
                                 }),
@@ -2179,7 +2185,7 @@ fn format_decimal(s: &str, k: i32, n: i32) -> String {
         // Integer: all digits followed by n-k zeros.
         let mut out = String::with_capacity(n as usize);
         out.push_str(s);
-        out.extend(std::iter::repeat('0').take((n - k) as usize));
+        out.extend(std::iter::repeat_n('0', (n - k) as usize));
         out
     } else if 0 < n && n <= 21 {
         // Decimal point inside the digits.

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -940,13 +940,12 @@ impl Vm {
     pub fn get_prop(&mut self, base: &Value, key: &PropertyKey) -> Result<Value, Value> {
         // Fast paths for primitives without boxing.
         match base {
-            Value::Undefined | Value::Uninitialized | Value::Hole | Value::Null => {
-                Err(self.throw_type(&format!(
+            Value::Undefined | Value::Uninitialized | Value::Hole | Value::Null => Err(self
+                .throw_type(&format!(
                     "Cannot read properties of {} (reading '{}')",
                     if base.is_null() { "null" } else { "undefined" },
                     key_display(key)
-                )))
-            }
+                ))),
             Value::String(s) => {
                 if let Some(v) = self.string_own_prop(s, key) {
                     return Ok(v);

--- a/crates/chidori-js/tests/replay.rs
+++ b/crates/chidori-js/tests/replay.rs
@@ -59,7 +59,7 @@ fn suspend_persist_restore_resume() {
     let mut rt = ReplayRuntime::record(BUNDLE, &["fetchValue", "report"]);
     let mut calls = 0;
     let mut handler =
-        |name: &str, args: &serde_json::Value| -> Option<Result<serde_json::Value, String>> {
+        |name: &str, _args: &serde_json::Value| -> Option<Result<serde_json::Value, String>> {
             if name == "fetchValue" {
                 calls += 1;
                 if calls == 1 {

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -122,3 +122,7 @@ criterion = "0.5"
 [[bench]]
 name = "runtime"
 harness = false
+
+# Workspace-wide lint levels (see [workspace.lints] in the root Cargo.toml).
+[lints]
+workspace = true

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -58,7 +58,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Utilities
 anyhow = "1"
-thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
@@ -74,7 +73,6 @@ rand = "0.8"
 # Pure-Rust JS engine + deterministic-replay durable runtime. The only JS engine.
 chidori-js = { path = "../chidori-js", version = "0.3.2" }
 async-trait = "0.1"
-derive_more = { version = "1", features = ["display"] }
 
 # SQLite session store
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/chidori/benches/runtime.rs
+++ b/crates/chidori/benches/runtime.rs
@@ -5,29 +5,31 @@
 //! the same footing for the paths a live agent actually pays per host call,
 //! per state transition, and per run:
 //!
-//!   * `replay_lookup`      — `RuntimeContext::try_replay` over a growing
-//!                            journal. A resume calls this once per recorded
-//!                            effect; the lookup is a linear scan today
-//!                            (`runtime/context.rs`), so a full resume sweep
-//!                            is O(N²) in journal length.
-//!   * `record_call`        — the live-path cost of recording one host call
-//!                            as payloads grow (deep `CallRecord` clones).
-//!   * `session_store_put`  — `SqliteStore::put` as the session's call log
-//!                            grows. Every pause/resume/approval state
-//!                            transition re-serializes the WHOLE session blob
-//!                            and pays a full fsync (no WAL) today
-//!                            (`storage.rs`).
-//!   * `run_store_append`   — `SqliteRunStore::append_record` against a run
-//!                            that already holds K records. The append's
-//!                            `MAX(pos)` subquery scans the run's rows, so
-//!                            appending the K-th record is O(K) today
-//!                            (`runtime/store.rs`) despite the trait's O(1)
-//!                            contract.
-//!   * `per_run_setup`      — fixed construction costs paid per agent run /
-//!                            per fetch: `new_tokio_runtime()` (built per run
-//!                            in `server.rs`/`scheduler.rs`) and a
-//!                            `reqwest::Client` (built per `fetch()` host
-//!                            call in `runtime/host_core.rs`).
+//! ```text
+//! replay_lookup      — RuntimeContext::try_replay over a growing
+//!                      journal. A resume calls this once per recorded
+//!                      effect; the lookup is a linear scan today
+//!                      (runtime/context.rs), so a full resume sweep
+//!                      is O(N²) in journal length.
+//! record_call        — the live-path cost of recording one host call
+//!                      as payloads grow (deep CallRecord clones).
+//! session_store_put  — SqliteStore::put as the session's call log
+//!                      grows. Every pause/resume/approval state
+//!                      transition re-serializes the WHOLE session blob
+//!                      and pays a full fsync (no WAL) today
+//!                      (storage.rs).
+//! run_store_append   — SqliteRunStore::append_record against a run
+//!                      that already holds K records. The append's
+//!                      MAX(pos) subquery scans the run's rows, so
+//!                      appending the K-th record is O(K) today
+//!                      (runtime/store.rs) despite the trait's O(1)
+//!                      contract.
+//! per_run_setup      — fixed construction costs paid per agent run /
+//!                      per fetch: new_tokio_runtime() (built per run
+//!                      in server.rs/scheduler.rs) and a
+//!                      reqwest::Client (built per fetch() host
+//!                      call in runtime/host_core.rs).
+//! ```
 //!
 //! Run with: `cargo bench -p chidori --bench runtime`
 //! Smoke-check (each bench once, no statistics): append `-- --test`.

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -1574,7 +1574,7 @@ fn cmd_serve(file: &Path, port: u16, verbose: bool, untrusted: bool, trusted: bo
     tokio_rt.block_on(server::serve(
         providers,
         template_engine,
-        file.clone(),
+        file.to_path_buf(),
         port,
         policy,
         policy_posture,

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -12,7 +12,7 @@ mod server;
 mod storage;
 mod tools;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -759,6 +759,7 @@ fn cli_policy(untrusted: bool) -> Arc<policy::PolicyConfig> {
 ///   3. Explicit, valid CHIDORI_POLICY* configuration — as configured.
 ///   4. Nothing configured (or only malformed configuration, which fails
 ///      closed) — the deny-by-default serve profile.
+///
 /// Returns the policy plus a posture label for the startup banner.
 fn serve_policy(untrusted: bool, trusted: bool) -> (Arc<policy::PolicyConfig>, String) {
     if untrusted {
@@ -798,7 +799,7 @@ fn abs_dir(dir: &std::path::Path) -> PathBuf {
 }
 
 fn cmd_run(
-    file: &PathBuf,
+    file: &Path,
     inputs: &[String],
     trace: bool,
     verbose: bool,
@@ -899,7 +900,7 @@ fn cmd_run(
 /// event to stdout as the agent executes, then a final `done` event. Used by
 /// the builder server's SSE streaming bridge.
 fn cmd_run_stream(
-    file: &PathBuf,
+    file: &Path,
     inputs: &[String],
     verbose: bool,
     extra_tool_dirs: &[PathBuf],
@@ -1181,7 +1182,7 @@ fn cmd_chat(
     Ok(())
 }
 
-fn cmd_check(file: &PathBuf) -> Result<()> {
+fn cmd_check(file: &Path) -> Result<()> {
     let providers = Arc::new(ProviderRegistry::new());
     let template_engine = Arc::new(TemplateEngine::new("."));
     let tokio_rt =
@@ -1232,7 +1233,7 @@ fn cmd_tools(dirs: &[PathBuf]) -> Result<()> {
 }
 
 fn cmd_resume(
-    file: &PathBuf,
+    file: &Path,
     run_id: &str,
     dir: Option<&std::path::Path>,
     until_seq: Option<u64>,
@@ -1536,13 +1537,7 @@ fn cmd_stats(dir: Option<&std::path::Path>) -> Result<()> {
     Ok(())
 }
 
-fn cmd_serve(
-    file: &PathBuf,
-    port: u16,
-    verbose: bool,
-    untrusted: bool,
-    trusted: bool,
-) -> Result<()> {
+fn cmd_serve(file: &Path, port: u16, verbose: bool, untrusted: bool, trusted: bool) -> Result<()> {
     if verbose {
         tracing_subscriber::fmt()
             .with_env_filter("info")

--- a/crates/chidori/src/mem_guard.rs
+++ b/crates/chidori/src/mem_guard.rs
@@ -155,6 +155,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
 
 /// Current live bytes tracked by [`CountingAllocator`]. Returns 0 when the
 /// allocator is not installed.
+#[allow(dead_code)] // Diagnostic accessor; no production call sites yet.
 pub fn current_allocated_bytes() -> usize {
     ALLOCATED.load(Ordering::Relaxed)
 }

--- a/crates/chidori/src/policy.rs
+++ b/crates/chidori/src/policy.rs
@@ -29,7 +29,6 @@ pub enum Decision {
     NeverAllow,
 }
 
-
 impl Decision {
     /// Total order by restrictiveness: AlwaysAllow < AskBefore < NeverAllow.
     fn strictness(self) -> u8 {

--- a/crates/chidori/src/policy.rs
+++ b/crates/chidori/src/policy.rs
@@ -21,17 +21,14 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum Decision {
+    #[default]
     AlwaysAllow,
     AskBefore,
     NeverAllow,
 }
 
-impl Default for Decision {
-    fn default() -> Self {
-        Decision::AlwaysAllow
-    }
-}
 
 impl Decision {
     /// Total order by restrictiveness: AlwaysAllow < AskBefore < NeverAllow.

--- a/crates/chidori/src/providers/anthropic.rs
+++ b/crates/chidori/src/providers/anthropic.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use std::sync::Arc;
@@ -544,6 +544,39 @@ fn retry_after_duration(headers: &reqwest::header::HeaderMap, attempt: u32) -> D
     Duration::from_secs(1u64 << attempt.min(6))
 }
 
+fn content_block_to_anthropic_json(block: &ContentBlock) -> Value {
+    match block {
+        ContentBlock::Text { text } => json!({ "type": "text", "text": text }),
+        ContentBlock::ToolUse { id, name, input } => {
+            // Anthropic requires `input` to be an object. Defense in depth
+            // against any already-stored history (or non-streaming producer)
+            // that left a null / non-object here; see the parse-time guard
+            // in the stream handler for the original failure mode.
+            let input_obj = if input.is_object() {
+                input.clone()
+            } else {
+                json!({})
+            };
+            json!({
+                "type": "tool_use",
+                "id": id,
+                "name": name,
+                "input": input_obj,
+            })
+        }
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => json!({
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": content,
+            "is_error": is_error,
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -651,38 +684,5 @@ mod tests {
             serde_json::from_str(r#"{ "input_tokens": 10, "output_tokens": 5 }"#).unwrap();
         assert_eq!(without.cache_creation_input_tokens, 0);
         assert_eq!(without.cache_read_input_tokens, 0);
-    }
-}
-
-fn content_block_to_anthropic_json(block: &ContentBlock) -> Value {
-    match block {
-        ContentBlock::Text { text } => json!({ "type": "text", "text": text }),
-        ContentBlock::ToolUse { id, name, input } => {
-            // Anthropic requires `input` to be an object. Defense in depth
-            // against any already-stored history (or non-streaming producer)
-            // that left a null / non-object here; see the parse-time guard
-            // in the stream handler for the original failure mode.
-            let input_obj = if input.is_object() {
-                input.clone()
-            } else {
-                json!({})
-            };
-            json!({
-                "type": "tool_use",
-                "id": id,
-                "name": name,
-                "input": input_obj,
-            })
-        }
-        ContentBlock::ToolResult {
-            tool_use_id,
-            content,
-            is_error,
-        } => json!({
-            "type": "tool_result",
-            "tool_use_id": tool_use_id,
-            "content": content,
-            "is_error": is_error,
-        }),
     }
 }

--- a/crates/chidori/src/providers/mod.rs
+++ b/crates/chidori/src/providers/mod.rs
@@ -255,67 +255,9 @@ fn request_has_tool_result(request: &LlmRequest) -> bool {
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn static_provider_returns_configured_response() {
-        let provider = StaticProvider {
-            response: "fixed response".to_string(),
-            tool_call: None,
-            calls: AtomicUsize::new(0),
-        };
-        let request = LlmRequest {
-            model: "any-model".to_string(),
-            messages: vec![Message::user_text("hello")],
-            system: None,
-            temperature: 0.0,
-            max_tokens: 10,
-            tools: Vec::new(),
-            cache: CacheLayout::default(),
-        };
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let response = rt.block_on(provider.send(&request)).unwrap();
-
-        assert_eq!(response.content, "fixed response");
-        assert_eq!(response.stop_reason, "end_turn");
-    }
-
-    #[test]
-    fn static_provider_returns_configured_tool_call_once() {
-        let provider = StaticProvider {
-            response: "done".to_string(),
-            tool_call: Some(serde_json::json!({
-                "id": "call_1",
-                "name": "read",
-                "input": { "path": "notes.txt" }
-            })),
-            calls: AtomicUsize::new(0),
-        };
-        let request = LlmRequest {
-            model: "any-model".to_string(),
-            messages: vec![Message::user_text("hello")],
-            system: None,
-            temperature: 0.0,
-            max_tokens: 10,
-            tools: Vec::new(),
-            cache: CacheLayout::default(),
-        };
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        let first = rt.block_on(provider.send(&request)).unwrap();
-        assert_eq!(first.content, "");
-        assert_eq!(first.stop_reason, "tool_use");
-        assert_eq!(first.tool_calls.len(), 1);
-        assert_eq!(first.tool_calls[0].id, "call_1");
-        assert_eq!(first.tool_calls[0].name, "read");
-        assert_eq!(first.tool_calls[0].input["path"], "notes.txt");
-
-        let second = rt.block_on(provider.send(&request)).unwrap();
-        assert_eq!(second.content, "done");
-        assert_eq!(second.stop_reason, "end_turn");
-        assert!(second.tool_calls.is_empty());
+impl Default for ProviderRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -426,5 +368,69 @@ impl ProviderRegistry {
             "No provider found for model '{}'. Set ANTHROPIC_API_KEY or OPENAI_API_KEY, or run `chidori model-login` to sign in with OpenRouter.",
             request.model
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_provider_returns_configured_response() {
+        let provider = StaticProvider {
+            response: "fixed response".to_string(),
+            tool_call: None,
+            calls: AtomicUsize::new(0),
+        };
+        let request = LlmRequest {
+            model: "any-model".to_string(),
+            messages: vec![Message::user_text("hello")],
+            system: None,
+            temperature: 0.0,
+            max_tokens: 10,
+            tools: Vec::new(),
+            cache: CacheLayout::default(),
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let response = rt.block_on(provider.send(&request)).unwrap();
+
+        assert_eq!(response.content, "fixed response");
+        assert_eq!(response.stop_reason, "end_turn");
+    }
+
+    #[test]
+    fn static_provider_returns_configured_tool_call_once() {
+        let provider = StaticProvider {
+            response: "done".to_string(),
+            tool_call: Some(serde_json::json!({
+                "id": "call_1",
+                "name": "read",
+                "input": { "path": "notes.txt" }
+            })),
+            calls: AtomicUsize::new(0),
+        };
+        let request = LlmRequest {
+            model: "any-model".to_string(),
+            messages: vec![Message::user_text("hello")],
+            system: None,
+            temperature: 0.0,
+            max_tokens: 10,
+            tools: Vec::new(),
+            cache: CacheLayout::default(),
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let first = rt.block_on(provider.send(&request)).unwrap();
+        assert_eq!(first.content, "");
+        assert_eq!(first.stop_reason, "tool_use");
+        assert_eq!(first.tool_calls.len(), 1);
+        assert_eq!(first.tool_calls[0].id, "call_1");
+        assert_eq!(first.tool_calls[0].name, "read");
+        assert_eq!(first.tool_calls[0].input["path"], "notes.txt");
+
+        let second = rt.block_on(provider.send(&request)).unwrap();
+        assert_eq!(second.content, "done");
+        assert_eq!(second.stop_reason, "end_turn");
+        assert!(second.tool_calls.is_empty());
     }
 }

--- a/crates/chidori/src/providers/openai.rs
+++ b/crates/chidori/src/providers/openai.rs
@@ -422,7 +422,7 @@ impl LlmProvider for OpenAiProvider {
         }
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         for (_idx, (id, name, args)) in tool_acc {
-            let input: Value = serde_json::from_str(&args).unwrap_or_else(|_| Value::String(args));
+            let input: Value = serde_json::from_str(&args).unwrap_or(Value::String(args));
             tool_calls.push(ToolCall {
                 id: id.clone(),
                 name: name.clone(),

--- a/crates/chidori/src/runtime/call_log.rs
+++ b/crates/chidori/src/runtime/call_log.rs
@@ -67,6 +67,12 @@ pub struct CallLog {
     records: Vec<CallRecord>,
 }
 
+impl Default for CallLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CallLog {
     pub fn new() -> Self {
         Self {

--- a/crates/chidori/src/runtime/capability.rs
+++ b/crates/chidori/src/runtime/capability.rs
@@ -59,8 +59,10 @@ impl Capability {
 
     /// Parse the JS-side flag string emitted by the prelude host shims back
     /// into a `Capability`. Returns `None` for unknown strings so a forward-
-    /// compatible prelude can't crash an older runtime.
-    pub fn from_str(value: &str) -> Option<Self> {
+    /// compatible prelude can't crash an older runtime. (Named `parse`, not
+    /// `from_str`, because the fallible-by-`Option` shape doesn't fit the
+    /// `FromStr` trait contract.)
+    pub fn parse(value: &str) -> Option<Self> {
         match value {
             "fs_read" => Some(Capability::FsRead),
             "fs_write" => Some(Capability::FsWrite),

--- a/crates/chidori/src/runtime/capability.rs
+++ b/crates/chidori/src/runtime/capability.rs
@@ -147,9 +147,9 @@ mod tests {
             Capability::Timer,
             Capability::Microtask,
         ] {
-            assert_eq!(Capability::from_str(cap.as_str()), Some(cap));
+            assert_eq!(Capability::parse(cap.as_str()), Some(cap));
         }
-        assert_eq!(Capability::from_str("nope"), None);
+        assert_eq!(Capability::parse("nope"), None);
     }
 
     #[test]

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -360,6 +360,7 @@ impl std::fmt::Debug for ModelOverride {
 }
 
 impl ModelOverride {
+    #[allow(dead_code)] // Exercised only by tests today; the lib target sees it as dead.
     pub fn new(callback: impl Fn() -> Option<String> + Send + Sync + 'static) -> Self {
         Self(Arc::new(callback))
     }
@@ -879,6 +880,7 @@ impl RuntimeContext {
     /// the full `checkpoint.json` is rewritten only at compaction points (run
     /// start, pause, settle) or when the log is checkpoint-dirty. Returns the
     /// run directory path.
+    #[allow(dead_code)] // Exercised only by tests today; the lib target sees it as dead.
     pub fn enable_persistence(&self, base_dir: PathBuf) -> PathBuf {
         let run_dir = base_dir.join(self.run_id());
         let _ = std::fs::create_dir_all(&run_dir);
@@ -1323,6 +1325,7 @@ impl RuntimeContext {
     /// Install a model-override hook consulted before every prompt host call,
     /// so a mid-run model change refreshes the model on the next provider
     /// request across all execution paths.
+    #[allow(dead_code)] // Exercised only by tests today; the lib target sees it as dead.
     pub fn set_model_override(&self, model_override: ModelOverride) {
         self.inner.lock().unwrap().model_override = Some(model_override);
     }
@@ -1861,9 +1864,7 @@ fn vfs_from_seed_env() -> Vfs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::snapshot::{
-        HostPromiseState, PENDING_HOST_OPERATION_FILE,
-    };
+    use crate::runtime::snapshot::{HostPromiseState, PENDING_HOST_OPERATION_FILE};
 
     #[test]
     fn runtime_context_tracks_host_promise_lifecycle() {

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -472,6 +472,12 @@ impl Default for AgentConfig {
     }
 }
 
+impl Default for RuntimeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RuntimeContext {
     pub fn new() -> Self {
         Self {
@@ -1856,7 +1862,7 @@ fn vfs_from_seed_env() -> Vfs {
 mod tests {
     use super::*;
     use crate::runtime::snapshot::{
-        HostPromiseState, HOST_PROMISE_TABLE_FILE, PENDING_HOST_OPERATION_FILE,
+        HostPromiseState, PENDING_HOST_OPERATION_FILE,
     };
 
     #[test]

--- a/crates/chidori/src/runtime/engine.rs
+++ b/crates/chidori/src/runtime/engine.rs
@@ -441,6 +441,7 @@ impl Engine {
         self.run_with_context(path, inputs, ctx)
     }
 
+    #[allow(dead_code)] // Lib-facade entry point; the bin target compiles the module tree separately and never calls it.
     pub fn run_with_replay_and_host_promises(
         &self,
         path: &Path,
@@ -560,6 +561,7 @@ impl Engine {
         self.run_with_context(path, inputs, ctx)
     }
 
+    #[allow(dead_code)] // Lib-facade entry point; the bin target compiles the module tree separately and never calls it.
     pub fn run_replay_pausable_with_host_promises(
         &self,
         path: &Path,
@@ -578,6 +580,7 @@ impl Engine {
 
     /// As `run_replay_pausable_with_host_promises`, restoring a snapshot
     /// manifest's virtual filesystem for the resumed run.
+    #[allow(dead_code)] // Lib-facade entry point; the bin target compiles the module tree separately and never calls it.
     pub fn run_replay_pausable_with_host_promises_and_vfs(
         &self,
         path: &Path,

--- a/crates/chidori/src/runtime/engine.rs
+++ b/crates/chidori/src/runtime/engine.rs
@@ -337,6 +337,7 @@ impl Engine {
     /// Persist runs through a pre-built [`RunStoreFactory`] — the server path,
     /// which constructs the factory once at startup (a durable mirror holds
     /// shared state like a SQLite connection) instead of once per engine.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn with_run_store(mut self, factory: crate::runtime::store::RunStoreFactory) -> Self {
         self.persist_base = Some(factory.run_base().to_path_buf());
         self.run_store = Some(factory);
@@ -505,6 +506,7 @@ impl Engine {
     /// approval requests. This is the in-process equivalent of the session
     /// server's interactive execution path for embedders that already own
     /// their UI/event loop.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn run_streaming_pausable(
         &self,
         path: &Path,
@@ -517,6 +519,7 @@ impl Engine {
     /// As `run_streaming_pausable`, but installs an optional model-override hook
     /// (Pi-style save point) so a mid-run model change refreshes the model on
     /// the next provider request inside this run's tool loop.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn run_streaming_pausable_with_model_override(
         &self,
         path: &Path,
@@ -593,6 +596,7 @@ impl Engine {
     /// replay resume uses this so a resumed run keeps its original id (and its
     /// persisted run directory), matching the live-VM resume path — a resumed
     /// run is the same durable run, not a new one.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn run_replay_pausable_with_host_promises_and_vfs_preserving_run_id(
         &self,
         path: &Path,
@@ -675,6 +679,7 @@ impl Engine {
     /// Resume/replay an interactive streaming run with persisted host-promise
     /// state. Used by embedders that mirror the server session interaction
     /// without routing through HTTP.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn run_streaming_replay_pausable_with_host_promises(
         &self,
         path: &Path,

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -376,8 +376,10 @@ pub fn signal_timeout_sentinel(names: &[String]) -> Value {
 ///      WITHOUT pausing, recording the `{name,payload,from}` result;
 ///   4. otherwise PAUSE: set `PendingSignal` and bail with `PAUSE_MARKER` (the
 ///      pause *type* is distinguished from `input` by which pending slot is set).
+///
 /// The durable match key is `{ "name": name }` only — the payload is unknown at
 /// pause time and rides in the result.
+///
 /// Resolve a signal-family listen point in place: mark the host op resolved,
 /// append the journal record (the same shape a queued drain, a server-side
 /// synthetic resolution, or a timeout sentinel produces), and run the
@@ -697,6 +699,7 @@ pub fn execute_poll_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> 
 ///      `{cached: false}` — the binding runs the callback and reports its
 ///      result through [`execute_step_end`], which writes the record at this
 ///      same `seq`.
+///
 /// While the step is live, every other host effect is refused (the dispatchers
 /// check `active_step_name`), so the callback is guaranteed pure compute and
 /// skipping it on replay cannot desynchronize the journal. Steps never pause

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -1641,7 +1641,7 @@ fn execute_http_with_secrets(
             }
         };
         let text = secrets.redact(&String::from_utf8_lossy(&bytes));
-        let body = serde_json::from_str::<Value>(&text).unwrap_or_else(|_| Value::String(text));
+        let body = serde_json::from_str::<Value>(&text).unwrap_or(Value::String(text));
 
         Ok(json!({
             "status": status,
@@ -2150,7 +2150,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(result["status"], json!(0));
-        assert!(result["error"].as_str().unwrap_or_default().len() > 0);
+        assert!(!result["error"].as_str().unwrap_or_default().is_empty());
         assert!(result["headers"].as_object().unwrap().is_empty());
         assert!(result["body"].is_null());
     }

--- a/crates/chidori/src/runtime/isolate/worker.rs
+++ b/crates/chidori/src/runtime/isolate/worker.rs
@@ -83,6 +83,7 @@ pub fn run() -> io::Result<()> {
 /// applying any per-process resource limits. Factored out of [`run`] so tests
 /// can drive the worker over an in-process socket without a subprocess — and
 /// without the worker's `setrlimit` floor leaking onto the test process.
+#[allow(dead_code)] // Exercised only by tests today; the lib target sees it as dead.
 pub fn serve<R: Read + 'static, W: Write + 'static>(reader: R, writer: W) -> io::Result<()> {
     serve_inner(reader, writer, false)
 }

--- a/crates/chidori/src/runtime/native.rs
+++ b/crates/chidori/src/runtime/native.rs
@@ -105,6 +105,11 @@ pub struct PendingBatch {
     pub pending_index: usize,
 }
 
+#[expect(
+    clippy::large_enum_variant,
+    reason = "transient control-flow result, never stored in bulk; boxing the \
+              pause payload buys nothing"
+)]
 enum BatchOutcome {
     Completed,
     Paused {

--- a/crates/chidori/src/runtime/otel.rs
+++ b/crates/chidori/src/runtime/otel.rs
@@ -226,7 +226,7 @@ impl RunSpan {
         while let Some(pos) = state
             .pending
             .iter()
-            .position(|r| r.parent_seq.map_or(true, |p| state.emitted.contains(&p)))
+            .position(|r| r.parent_seq.is_none_or(|p| state.emitted.contains(&p)))
         {
             let record = state.pending.remove(pos);
             self.emit_one(state, &record);
@@ -242,7 +242,7 @@ impl RunSpan {
             let pos = state
                 .pending
                 .iter()
-                .position(|r| r.parent_seq.map_or(true, |p| state.emitted.contains(&p)))
+                .position(|r| r.parent_seq.is_none_or(|p| state.emitted.contains(&p)))
                 .unwrap_or(0);
             let record = state.pending.remove(pos);
             self.emit_one(state, &record);

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -35,6 +35,7 @@ pub struct RustReplayEngine {
     effects: Vec<String>,
 }
 
+#[allow(dead_code)] // Embedding surface for the replay engine; only trait-side entry points are wired today.
 impl RustReplayEngine {
     /// Begin a fresh durable execution of `bundle`, exposing the named host
     /// effects as global async functions.
@@ -91,7 +92,7 @@ const JS_TRACE_MAX_DEPTH: usize = 64;
 /// [`HostBindingBackend`], with policy enforcement and MCP. Relative and `node:`
 /// multi-file imports are resolved and linked by the engine; nested TypeScript
 /// tools and sub-agents run natively on this same engine.
-pub fn run_agent(
+pub(crate) fn run_agent(
     path: &Path,
     source: &str,
     inputs: &Value,

--- a/crates/chidori/src/runtime/secret_env.rs
+++ b/crates/chidori/src/runtime/secret_env.rs
@@ -141,6 +141,7 @@ impl SecretStore {
     }
 
     /// Recursively redact secret values from every string inside `value`.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn redact_value(&self, value: &mut Value) {
         match value {
             Value::String(text) => {

--- a/crates/chidori/src/runtime/snapshot.rs
+++ b/crates/chidori/src/runtime/snapshot.rs
@@ -759,9 +759,11 @@ pub struct SnapshotBranchMetadata {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum SnapshotBlobKind {
     /// Current scaffold: a serialized set of TypeScript context roots after
     /// initial module evaluation, not a suspended VM continuation.
+    #[default]
     InitialTypeScriptStateScaffold,
     /// Legacy blob kind for a live VM-image snapshot (async continuations, job
     /// queues, module records, and heap roots). VM-image snapshots are descoped
@@ -770,11 +772,6 @@ pub enum SnapshotBlobKind {
     LiveQuickJsVm,
 }
 
-impl Default for SnapshotBlobKind {
-    fn default() -> Self {
-        Self::InitialTypeScriptStateScaffold
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotManifest {

--- a/crates/chidori/src/runtime/snapshot.rs
+++ b/crates/chidori/src/runtime/snapshot.rs
@@ -772,7 +772,6 @@ pub enum SnapshotBlobKind {
     LiveQuickJsVm,
 }
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotManifest {
     pub run_id: String,

--- a/crates/chidori/src/runtime/store.rs
+++ b/crates/chidori/src/runtime/store.rs
@@ -110,6 +110,7 @@ impl FsRunStore {
         }
     }
 
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn run_dir(&self) -> &Path {
         &self.run_dir
     }
@@ -359,6 +360,7 @@ impl SqliteRunStoreShared {
         }))
     }
 
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     fn list_runs(&self) -> Result<Vec<String>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
@@ -848,6 +850,7 @@ impl HttpRelay {
         }
     }
 
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     fn list_runs(&self) -> Result<Vec<String>> {
         let (status, bytes) = self.request("GET", format!("{}/runs", self.base_url), None)?;
         if !(200..300).contains(&status) {
@@ -1158,6 +1161,7 @@ pub struct RunStoreFactory {
 }
 
 impl RunStoreFactory {
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn fs(run_base: impl Into<PathBuf>) -> Self {
         Self {
             run_base: run_base.into(),
@@ -1241,6 +1245,7 @@ impl RunStoreFactory {
     }
 
     /// Whether a durable mirror is configured (vs filesystem only).
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn has_durable_mirror(&self) -> bool {
         !matches!(self.backend, RunStoreBackend::Fs)
     }
@@ -1287,6 +1292,7 @@ impl RunStoreFactory {
 
     /// Every run id the backend knows: local run directories, unioned with the
     /// durable mirror's runs (which may include runs from a lost machine).
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn list_runs(&self) -> Result<Vec<String>> {
         let mut ids = BTreeSet::new();
         match std::fs::read_dir(&self.run_base) {

--- a/crates/chidori/src/runtime/store.rs
+++ b/crates/chidori/src/runtime/store.rs
@@ -1745,7 +1745,7 @@ mod tests {
     fn spawn_protocol_server() -> String {
         use axum::extract::{Path as AxPath, State};
         use axum::http::StatusCode;
-        use axum::routing::{get, post, put};
+        use axum::routing::get;
         use std::collections::HashMap;
 
         #[derive(Clone, Default)]

--- a/crates/chidori/src/runtime/store_blob.rs
+++ b/crates/chidori/src/runtime/store_blob.rs
@@ -247,6 +247,7 @@ impl S3BlobStore {
 
     /// The configured key prefix (empty or `…/`-terminated), so the factory
     /// can address `runs/…` / `agents/…` keyspaces.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn key_prefix(&self) -> &str {
         &self.prefix
     }
@@ -565,6 +566,7 @@ impl RunStore for BlobRunStore {
 }
 
 /// Run ids known to the bucket (`runs/<id>/…` common prefixes).
+#[allow(dead_code)] // Not yet wired into a call path; staged API.
 pub fn list_runs(store: &S3BlobStore) -> Result<Vec<String>> {
     let prefix = format!("{}runs/", store.prefix);
     let (_, common) = store.list(&prefix, Some("/"))?;

--- a/crates/chidori/src/runtime/typescript/bindings.rs
+++ b/crates/chidori/src/runtime/typescript/bindings.rs
@@ -838,6 +838,7 @@ impl HostBindingBackend {
     /// durable runtime policy — for sub-runs that are their OWN durable runs
     /// (detached agents), whose policy is derived from their own run id so a
     /// wake on a fresh process reconstructs the identical policy.
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub(crate) fn with_runtime_ctx_and_policy(
         &self,
         runtime_ctx: RuntimeContext,

--- a/crates/chidori/src/runtime/typescript/bindings.rs
+++ b/crates/chidori/src/runtime/typescript/bindings.rs
@@ -684,7 +684,7 @@ impl HostBindingBackend {
                         server_id,
                         remote_name,
                     } => tokio_rt.block_on(async {
-                        mcp.call_tool(&server_id, &remote_name, &serde_json::Value::Object(kwargs))
+                        mcp.call_tool(server_id, remote_name, &serde_json::Value::Object(kwargs))
                             .await
                     }),
                     ToolBackend::TypeScript => {

--- a/crates/chidori/src/runtime/typescript/builtins.rs
+++ b/crates/chidori/src/runtime/typescript/builtins.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 /// Allowlisted builtin names. Kept in sync with `NODE_BUILTIN_ALLOWLIST` in
 /// `transpile.rs`.
+#[allow(dead_code)] // Reference copy of the allowlist; transpile.rs owns the enforced one.
 pub const BUILTIN_NAMES: &[&str] = &[
     "process",
     "buffer",

--- a/crates/chidori/src/runtime/typescript/builtins.rs
+++ b/crates/chidori/src/runtime/typescript/builtins.rs
@@ -1500,6 +1500,67 @@ pub fn builtin_name_from_path(path: &Path) -> Option<String> {
     Some(name.to_string())
 }
 
+// ---------------------------------------------------------------------------
+// Vendored packages: self-contained UMD bundles served as synthetic ES modules.
+//
+// npm `react` / `react-dom` are CommonJS (internal `require`), which the
+// ESM-only engine can't link. The official UMD builds are self-contained, so we
+// wrap them in an ESM shim that runs the bundle (which populates `globalThis`)
+// and re-exports — making `import React from 'react'` and
+// `import { renderToStaticMarkup } from 'react-dom/server'` resolve and link.
+// This is analogous to the `node:` builtin shims above.
+// ---------------------------------------------------------------------------
+
+const REACT_UMD: &str = include_str!("../vendor/react/react.js");
+const REACT_DOM_SERVER_UMD: &str = include_str!("../vendor/react/react-dom-server.js");
+
+/// True for bare specifiers served from the vendored-package registry.
+pub fn is_vendored_package(specifier: &str) -> bool {
+    matches!(
+        specifier,
+        "react" | "react-dom" | "react-dom/server" | "react-dom/server.browser"
+    )
+}
+
+/// Resolve a vendored bare specifier to `(module_key, esm_source)`, or `None`.
+/// The key is stable so the module graph evaluates each bundle exactly once.
+pub fn vendored_module(specifier: &str) -> Option<(String, String)> {
+    match specifier {
+        "react" | "react-dom" => Some((
+            "vendor:react".to_string(),
+            format!(
+                "globalThis.self = globalThis; globalThis.global = globalThis;\n\
+                 {REACT_UMD}\n\
+                 const __R = globalThis.React;\n\
+                 export default __R;\n\
+                 export const createElement = __R.createElement,\n\
+                   cloneElement = __R.cloneElement, createContext = __R.createContext,\n\
+                   Fragment = __R.Fragment, Children = __R.Children,\n\
+                   Component = __R.Component, PureComponent = __R.PureComponent,\n\
+                   memo = __R.memo, forwardRef = __R.forwardRef,\n\
+                   isValidElement = __R.isValidElement, version = __R.version,\n\
+                   useState = __R.useState, useEffect = __R.useEffect,\n\
+                   useLayoutEffect = __R.useLayoutEffect, useMemo = __R.useMemo,\n\
+                   useRef = __R.useRef, useCallback = __R.useCallback,\n\
+                   useContext = __R.useContext, useReducer = __R.useReducer,\n\
+                   useId = __R.useId;\n"
+            ),
+        )),
+        "react-dom/server" | "react-dom/server.browser" => Some((
+            "vendor:react-dom/server".to_string(),
+            format!(
+                "import 'react';\n\
+                 {REACT_DOM_SERVER_UMD}\n\
+                 const __S = globalThis.ReactDOMServer;\n\
+                 export default __S;\n\
+                 export const renderToString = __S.renderToString,\n\
+                   renderToStaticMarkup = __S.renderToStaticMarkup;\n"
+            ),
+        )),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1598,66 +1659,5 @@ mod tests {
         let path = PathBuf::from("/some/workspace/src/index.ts");
         assert_eq!(builtin_name_from_path(&path), None);
         assert_eq!(source_for(&path), None);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Vendored packages: self-contained UMD bundles served as synthetic ES modules.
-//
-// npm `react` / `react-dom` are CommonJS (internal `require`), which the
-// ESM-only engine can't link. The official UMD builds are self-contained, so we
-// wrap them in an ESM shim that runs the bundle (which populates `globalThis`)
-// and re-exports — making `import React from 'react'` and
-// `import { renderToStaticMarkup } from 'react-dom/server'` resolve and link.
-// This is analogous to the `node:` builtin shims above.
-// ---------------------------------------------------------------------------
-
-const REACT_UMD: &str = include_str!("../vendor/react/react.js");
-const REACT_DOM_SERVER_UMD: &str = include_str!("../vendor/react/react-dom-server.js");
-
-/// True for bare specifiers served from the vendored-package registry.
-pub fn is_vendored_package(specifier: &str) -> bool {
-    matches!(
-        specifier,
-        "react" | "react-dom" | "react-dom/server" | "react-dom/server.browser"
-    )
-}
-
-/// Resolve a vendored bare specifier to `(module_key, esm_source)`, or `None`.
-/// The key is stable so the module graph evaluates each bundle exactly once.
-pub fn vendored_module(specifier: &str) -> Option<(String, String)> {
-    match specifier {
-        "react" | "react-dom" => Some((
-            "vendor:react".to_string(),
-            format!(
-                "globalThis.self = globalThis; globalThis.global = globalThis;\n\
-                 {REACT_UMD}\n\
-                 const __R = globalThis.React;\n\
-                 export default __R;\n\
-                 export const createElement = __R.createElement,\n\
-                   cloneElement = __R.cloneElement, createContext = __R.createContext,\n\
-                   Fragment = __R.Fragment, Children = __R.Children,\n\
-                   Component = __R.Component, PureComponent = __R.PureComponent,\n\
-                   memo = __R.memo, forwardRef = __R.forwardRef,\n\
-                   isValidElement = __R.isValidElement, version = __R.version,\n\
-                   useState = __R.useState, useEffect = __R.useEffect,\n\
-                   useLayoutEffect = __R.useLayoutEffect, useMemo = __R.useMemo,\n\
-                   useRef = __R.useRef, useCallback = __R.useCallback,\n\
-                   useContext = __R.useContext, useReducer = __R.useReducer,\n\
-                   useId = __R.useId;\n"
-            ),
-        )),
-        "react-dom/server" | "react-dom/server.browser" => Some((
-            "vendor:react-dom/server".to_string(),
-            format!(
-                "import 'react';\n\
-                 {REACT_DOM_SERVER_UMD}\n\
-                 const __S = globalThis.ReactDOMServer;\n\
-                 export default __S;\n\
-                 export const renderToString = __S.renderToString,\n\
-                   renderToStaticMarkup = __S.renderToStaticMarkup;\n"
-            ),
-        )),
-        _ => None,
     }
 }

--- a/crates/chidori/src/runtime/typescript/check.rs
+++ b/crates/chidori/src/runtime/typescript/check.rs
@@ -47,7 +47,7 @@ fn check_agent_source(
 ) -> Result<TypeScriptCheck> {
     let javascript = transpile_module(
         path,
-        &source,
+        source,
         &TranspileOptions {
             import_policy: policy.typescript_imports,
         },

--- a/crates/chidori/src/runtime/typescript/module_graph.rs
+++ b/crates/chidori/src/runtime/typescript/module_graph.rs
@@ -19,6 +19,7 @@ use crate::runtime::typescript::transpile::validate_imports;
 
 /// Module fingerprints for every dependency of `path` (excluding the entry
 /// itself), used to detect source drift on resume.
+#[allow(dead_code)] // Not yet wired into a call path; staged API.
 pub fn snapshot_module_fingerprints(
     path: &Path,
     source: &str,
@@ -28,6 +29,7 @@ pub fn snapshot_module_fingerprints(
 }
 
 /// The full module import graph (entry + dependencies) for the manifest.
+#[allow(dead_code)] // Not yet wired into a call path; staged API.
 pub fn snapshot_module_graph(
     path: &Path,
     source: &str,

--- a/crates/chidori/src/runtime/typescript/resolver.rs
+++ b/crates/chidori/src/runtime/typescript/resolver.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_CONDITIONS: &[&str] = &["chidori", "import", "module", "defaul
 
 /// Same as DEFAULT_CONDITIONS but with `types` prepended, for the tsc-facing
 /// resolution pass.
+#[allow(dead_code)] // Staged for the tsc-facing resolution pass.
 pub const TYPES_CONDITIONS: &[&str] = &["types", "chidori", "import", "module", "default"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,6 +86,7 @@ struct PackageJson {
     name: Option<String>,
     main: Option<String>,
     module: Option<String>,
+    #[allow(dead_code)] // Parsed for the tsc-facing pass; not yet read.
     types: Option<String>,
     exports: Option<Value>,
 }
@@ -103,6 +105,7 @@ impl Resolver {
         }
     }
 
+    #[allow(dead_code)] // Not yet wired into a call path; staged API.
     pub fn project_root(&self) -> &Path {
         &self.project_root
     }

--- a/crates/chidori/src/runtime/vfs.rs
+++ b/crates/chidori/src/runtime/vfs.rs
@@ -184,9 +184,9 @@ impl Vfs {
                 if force {
                     return Ok(());
                 }
-                return Err(format!(
+                Err(format!(
                     "ENOENT: no such file or directory, unlink '{path}'"
-                ));
+                ))
             }
             Some(VfsNode::File { .. }) => {
                 self.nodes.remove(&path);

--- a/crates/chidori/src/runtime/workspace.rs
+++ b/crates/chidori/src/runtime/workspace.rs
@@ -1,3 +1,10 @@
+//! Workspace file store scaffolding: manifest, file/deleted entries, and the
+//! path-sanitized read/write/list/delete surface. Not yet wired into the
+//! runtime — hence the module-wide `dead_code` allow, same as the other
+//! staged runtime modules (`native.rs`, `snapshot.rs`, `capability.rs`,
+//! `vfs.rs`). Remove the allow when the first call site lands.
+#![allow(dead_code)]
+
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 

--- a/crates/chidori/src/scheduler.rs
+++ b/crates/chidori/src/scheduler.rs
@@ -135,7 +135,7 @@ pub async fn run_once(recipe: &Recipe, deps: &SchedulerDeps) -> Result<String> {
 
         // Build the tool registry: recipe-local dirs + default `<agent>/tools`
         // + any MCP tools the server handed us.
-        let mut dirs: Vec<PathBuf> = recipe.tools.iter().cloned().collect();
+        let mut dirs: Vec<PathBuf> = recipe.tools.to_vec();
         dirs.push(
             agent_path
                 .parent()

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -215,8 +215,6 @@ impl AppState {
     }
 }
 
-const PROMPT_TOOL_PAUSE_FILE: &str = "prompt_tool_pause.json";
-
 #[derive(Clone)]
 struct ActiveSession {
     cancelled: Arc<AtomicBool>,
@@ -422,6 +420,10 @@ fn complete_persisted_pending_host_operation(
     Ok(Some(pending))
 }
 
+// Not yet wired: the reject/timeout side of persisted host-promise completion.
+// `resolve_persisted_pending_host_operation` covers today's resolve path; this
+// generalizes it to arbitrary completions by operation id.
+#[allow(dead_code)]
 fn complete_persisted_host_promise_record(
     run_base: &FsPath,
     run_id: Option<&str>,
@@ -3078,150 +3080,6 @@ mod tests {
         assert_eq!(stored.error.as_deref(), Some("rewind"));
     }
 
-    struct ServerStaticProvider {
-        content: String,
-        input_tokens: u64,
-        output_tokens: u64,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::providers::LlmProvider for ServerStaticProvider {
-        fn supports_model(&self, _model: &str) -> bool {
-            true
-        }
-
-        async fn send(
-            &self,
-            _request: &crate::providers::LlmRequest,
-        ) -> anyhow::Result<crate::providers::LlmResponse> {
-            Ok(crate::providers::LlmResponse {
-                content: self.content.clone(),
-                blocks: vec![crate::providers::ContentBlock::Text {
-                    text: self.content.clone(),
-                }],
-                tool_calls: Vec::new(),
-                stop_reason: "end_turn".to_string(),
-                input_tokens: self.input_tokens,
-                output_tokens: self.output_tokens,
-                ..Default::default()
-            })
-        }
-    }
-
-    struct ServerToolUseProvider {
-        calls: std::sync::atomic::AtomicUsize,
-        tool_name: String,
-        tool_input: Value,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::providers::LlmProvider for ServerToolUseProvider {
-        fn supports_model(&self, _model: &str) -> bool {
-            true
-        }
-
-        async fn send(
-            &self,
-            _request: &crate::providers::LlmRequest,
-        ) -> anyhow::Result<crate::providers::LlmResponse> {
-            if self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
-                Ok(crate::providers::LlmResponse {
-                    content: String::new(),
-                    blocks: vec![crate::providers::ContentBlock::ToolUse {
-                        id: "toolu_1".to_string(),
-                        name: self.tool_name.clone(),
-                        input: self.tool_input.clone(),
-                    }],
-                    tool_calls: vec![crate::providers::ToolCall {
-                        id: "toolu_1".to_string(),
-                        name: self.tool_name.clone(),
-                        input: self.tool_input.clone(),
-                    }],
-                    stop_reason: "tool_use".to_string(),
-                    input_tokens: 2,
-                    output_tokens: 3,
-                    ..Default::default()
-                })
-            } else {
-                Ok(crate::providers::LlmResponse {
-                    content: "final answer".to_string(),
-                    blocks: vec![crate::providers::ContentBlock::Text {
-                        text: "final answer".to_string(),
-                    }],
-                    tool_calls: Vec::new(),
-                    stop_reason: "end_turn".to_string(),
-                    input_tokens: 5,
-                    output_tokens: 7,
-                    ..Default::default()
-                })
-            }
-        }
-    }
-
-    struct ServerRepeatedToolUseProvider {
-        calls: std::sync::atomic::AtomicUsize,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::providers::LlmProvider for ServerRepeatedToolUseProvider {
-        fn supports_model(&self, _model: &str) -> bool {
-            true
-        }
-
-        async fn send(
-            &self,
-            _request: &crate::providers::LlmRequest,
-        ) -> anyhow::Result<crate::providers::LlmResponse> {
-            match self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) {
-                0 => Ok(crate::providers::LlmResponse {
-                    content: String::new(),
-                    blocks: vec![crate::providers::ContentBlock::ToolUse {
-                        id: "toolu_1".to_string(),
-                        name: "ask".to_string(),
-                        input: json!({ "prompt": "first tool?" }),
-                    }],
-                    tool_calls: vec![crate::providers::ToolCall {
-                        id: "toolu_1".to_string(),
-                        name: "ask".to_string(),
-                        input: json!({ "prompt": "first tool?" }),
-                    }],
-                    stop_reason: "tool_use".to_string(),
-                    input_tokens: 2,
-                    output_tokens: 3,
-                    ..Default::default()
-                }),
-                1 => Ok(crate::providers::LlmResponse {
-                    content: String::new(),
-                    blocks: vec![crate::providers::ContentBlock::ToolUse {
-                        id: "toolu_2".to_string(),
-                        name: "ask".to_string(),
-                        input: json!({ "prompt": "second tool?" }),
-                    }],
-                    tool_calls: vec![crate::providers::ToolCall {
-                        id: "toolu_2".to_string(),
-                        name: "ask".to_string(),
-                        input: json!({ "prompt": "second tool?" }),
-                    }],
-                    stop_reason: "tool_use".to_string(),
-                    input_tokens: 4,
-                    output_tokens: 5,
-                    ..Default::default()
-                }),
-                _ => Ok(crate::providers::LlmResponse {
-                    content: "final repeated answer".to_string(),
-                    blocks: vec![crate::providers::ContentBlock::Text {
-                        text: "final repeated answer".to_string(),
-                    }],
-                    tool_calls: Vec::new(),
-                    stop_reason: "end_turn".to_string(),
-                    input_tokens: 6,
-                    output_tokens: 7,
-                    ..Default::default()
-                }),
-            }
-        }
-    }
-
     fn write_completed_host_promises(
         run_base: &FsPath,
         run_id: &str,
@@ -3986,6 +3844,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[test]
     fn resume_resolves_persisted_pending_input_host_operation() {
         let temp_dir = std::env::temp_dir().join(format!(
             "chidori-server-resume-host-promise-test-{}",

--- a/crates/chidori/src/tools/mod.rs
+++ b/crates/chidori/src/tools/mod.rs
@@ -23,9 +23,11 @@ pub struct ToolParam {
 /// How a tool is executed. File-backed tools are local `.ts` files; MCP-backed
 /// tools are dispatched to a running MCP server child process via `McpManager`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default)]
 pub enum ToolBackend {
     /// The tool's body lives in a local .ts file with `export const tool` and
     /// `export async function run(args, chidori)`.
+    #[default]
     TypeScript,
     /// The tool is remote-hosted by an MCP server.
     Mcp {
@@ -37,11 +39,6 @@ pub enum ToolBackend {
     Native,
 }
 
-impl Default for ToolBackend {
-    fn default() -> Self {
-        ToolBackend::TypeScript
-    }
-}
 
 /// A registered tool with its metadata and execution backend.
 #[derive(Debug, Clone)]
@@ -97,6 +94,12 @@ pub struct ToolRegistry {
     /// a later "Unknown tool" error can explain *why* an expected tool isn't
     /// available, instead of the failure being a silent stderr warn.
     load_errors: Vec<(PathBuf, String)>,
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ToolRegistry {
@@ -376,7 +379,7 @@ mod tests {
         )
         .unwrap();
 
-        let registry = ToolRegistry::load_from_dirs(&[dir.clone()]).unwrap();
+        let registry = ToolRegistry::load_from_dirs(std::slice::from_ref(&dir)).unwrap();
         let tool = registry.get("web_search").unwrap();
 
         assert_eq!(tool.backend, ToolBackend::TypeScript);
@@ -416,7 +419,7 @@ mod tests {
         )
         .unwrap();
 
-        let registry = ToolRegistry::load_from_dirs(&[dir.clone()]).unwrap();
+        let registry = ToolRegistry::load_from_dirs(std::slice::from_ref(&dir)).unwrap();
 
         assert!(registry.get("legacy").is_none());
 
@@ -436,7 +439,7 @@ mod tests {
                 default: None,
                 required: true,
             }],
-            |args| Ok(args),
+            Ok,
         );
 
         let tool = registry.get("echo").unwrap();

--- a/crates/chidori/src/tools/mod.rs
+++ b/crates/chidori/src/tools/mod.rs
@@ -22,8 +22,7 @@ pub struct ToolParam {
 
 /// How a tool is executed. File-backed tools are local `.ts` files; MCP-backed
 /// tools are dispatched to a running MCP server child process via `McpManager`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ToolBackend {
     /// The tool's body lives in a local .ts file with `export const tool` and
     /// `export async function run(args, chidori)`.
@@ -38,7 +37,6 @@ pub enum ToolBackend {
     /// application.
     Native,
 }
-
 
 /// A registered tool with its metadata and execution backend.
 #[derive(Debug, Clone)]

--- a/crates/test262-runner/Cargo.toml
+++ b/crates/test262-runner/Cargo.toml
@@ -19,3 +19,7 @@ chidori-js = { path = "../chidori-js" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+
+# Workspace-wide lint levels (see [workspace.lints] in the root Cargo.toml).
+[lints]
+workspace = true

--- a/docs/rust-style-guide.md
+++ b/docs/rust-style-guide.md
@@ -48,17 +48,21 @@ Applies to all Rust in the workspace:
 
 ## Clippy
 
-Run Clippy locally over everything CI builds and keep it clean:
+Clippy is enforced: CI and the pre-commit hook both run
 
 ```sh
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-Guidance on lint levels:
+so run it locally before pushing. Guidance on lint levels:
 
 - The default groups (`correctness`, `suspicious`, `complexity`, `perf`,
   `style`) are the baseline. `correctness` findings are bugs — fix them, never
   suppress them.
+- The few workspace-wide exceptions live in `[workspace.lints.clippy]` in the
+  root `Cargo.toml` (each crate inherits via `[lints] workspace = true`), each
+  with a comment saying why. That table is the *only* place for blanket
+  allows; think hard before growing it.
 - When a lint is wrong for a specific site, suppress it **narrowly** (item
   level, not module level) and prefer `#[expect(clippy::..., reason = "...")]`
   over `#[allow]`: `expect` warns when the suppression goes stale, and the
@@ -67,11 +71,12 @@ Guidance on lint levels:
   `#![allow(dead_code)]` on not-yet-wired runtime modules) are the pattern for
   the *rare* legitimate blanket case: generated code and scaffolding, with the
   module header saying so.
-- Lints we treat as always-on discipline even though they are not (yet)
-  machine-enforced: `undocumented_unsafe_blocks` (every `unsafe` block gets a
-  `// SAFETY:` comment), `await_holding_lock` (no sync lock guards across
-  `.await`), `dbg_macro` and stray `todo!`/`unimplemented!` (never merged),
-  `let_underscore_future` (a dropped future silently does nothing).
+- Some discipline goes beyond what the default groups machine-check; treat
+  these as always-on reviewer expectations: `undocumented_unsafe_blocks`
+  (every `unsafe` block gets a `// SAFETY:` comment), `await_holding_lock`
+  (no sync lock guards across `.await`), `dbg_macro` and stray
+  `todo!`/`unimplemented!` (never merged), `let_underscore_future` (a dropped
+  future silently does nothing).
 
 ## Naming
 
@@ -360,10 +365,9 @@ The policy for closing the gap:
 3. **No drive-by churn.** Don't send mass mechanical rewrites mixed into
    feature work; a focused, reviewable cleanup PR for one module at a time is
    fine.
-4. Machine enforcement (Clippy in CI and the pre-commit hook, lint tables in
-   `Cargo.toml`) should follow once the noise floor makes `-D warnings`
-   tractable; until then, the lints named in [Clippy](#clippy) are reviewer
-   expectations.
+4. Clippy is already gated in CI and the pre-commit hook, so the tree stays
+   warning-free by construction; the remaining gap is the `unwrap()` /
+   `println!` backlog, which items 1–3 burn down over time.
 
 ## References
 

--- a/docs/rust-style-guide.md
+++ b/docs/rust-style-guide.md
@@ -1,0 +1,378 @@
+# Rust style guide
+
+How we write Rust in this repository. The goal is a codebase that reads as if
+one careful person wrote it: predictable structure, errors that carry context,
+comments that explain *why*, and a formatter/linter setup that makes style a
+non-topic in review.
+
+This guide is grounded in the [Rust API Guidelines], the official
+[Rust Style Guide] (what `rustfmt` implements), the [Clippy lint
+groups][clippy-lints], and the panic policy articulated in
+["Using unwrap() in Rust is Okay"][burntsushi-unwrap] — adapted to this
+workspace's specifics. Where existing code diverges from a rule, the rule wins
+for new code; see [Adopting this guide](#adopting-this-guide) for how to handle
+the gap.
+
+[Rust API Guidelines]: https://rust-lang.github.io/api-guidelines/
+[Rust Style Guide]: https://doc.rust-lang.org/style-guide/
+[clippy-lints]: https://doc.rust-lang.org/clippy/lints.html
+[burntsushi-unwrap]: https://burntsushi.net/unwrap/
+
+## Scope
+
+Applies to all Rust in the workspace:
+
+| Crate | Role | Special rules |
+|---|---|---|
+| `crates/chidori` | Agent framework + CLI binary | `anyhow` errors, `tokio` async, `tracing` |
+| `crates/chidori-js` | Pure-Rust JS engine (lib) | Synchronous, `Result<_, Value>` errors, **zero `unsafe`** |
+| `crates/test262-runner` | Conformance harness (`publish = false`) | Test-tool leniency: `unwrap`/`expect` fine |
+
+## Toolchain and formatting
+
+- **Toolchain** is pinned by `rust-toolchain.toml` (stable channel, `rustfmt` +
+  `clippy` components). The workspace MSRV is `rust-version = "1.95"` in each
+  crate's `Cargo.toml`; bump it deliberately and note why (the current floor
+  comes from `oxc`).
+- **Formatting is default `cargo fmt`, no configuration.** There is
+  intentionally no `rustfmt.toml`: the upstream default style is the house
+  style, and every toolchain update applies it identically for everyone.
+  Never hand-format against the formatter. The pre-commit hook (`hk.pkl`,
+  installed via `mise`) auto-formats staged files, and CI rejects unformatted
+  code with `cargo fmt --check`.
+- `#[rustfmt::skip]` is reserved for genuinely tabular code — opcode tables,
+  test matrices, aligned bytecode listings — where alignment carries meaning.
+  Add a one-line comment saying what the alignment communicates.
+- **Edition 2021** across the workspace. Edition bumps are a workspace-wide,
+  single-PR affair.
+
+## Clippy
+
+Run Clippy locally over everything CI builds and keep it clean:
+
+```sh
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Guidance on lint levels:
+
+- The default groups (`correctness`, `suspicious`, `complexity`, `perf`,
+  `style`) are the baseline. `correctness` findings are bugs — fix them, never
+  suppress them.
+- When a lint is wrong for a specific site, suppress it **narrowly** (item
+  level, not module level) and prefer `#[expect(clippy::..., reason = "...")]`
+  over `#[allow]`: `expect` warns when the suppression goes stale, and the
+  mandatory reason documents the judgment call. Existing module-wide allows
+  (`#![allow(clippy::all)]` on generated `unicode_tables.rs`,
+  `#![allow(dead_code)]` on not-yet-wired runtime modules) are the pattern for
+  the *rare* legitimate blanket case: generated code and scaffolding, with the
+  module header saying so.
+- Lints we treat as always-on discipline even though they are not (yet)
+  machine-enforced: `undocumented_unsafe_blocks` (every `unsafe` block gets a
+  `// SAFETY:` comment), `await_holding_lock` (no sync lock guards across
+  `.await`), `dbg_macro` and stray `todo!`/`unimplemented!` (never merged),
+  `let_underscore_future` (a dropped future silently does nothing).
+
+## Naming
+
+Follow [RFC 430 casing][c-case] and the API-guidelines conventions; the ones
+that come up most here:
+
+- Types, traits, enum variants: `UpperCamelCase`. Functions, methods, modules,
+  fields: `snake_case`. Constants and statics: `SCREAMING_SNAKE_CASE`. Crate
+  features: concrete words, no `use-` / `with-` placeholders.
+- Conversions follow [`as_` / `to_` / `into_`][c-conv]: `as_` is a free
+  borrowed→borrowed view, `to_` is an expensive copy, `into_` consumes `self`.
+- Getters are the bare field name (`fn seq(&self) -> Seq`), not `get_seq`;
+  `get` is reserved for lookups that take a key and may miss.
+- Iterator-producing methods are `iter()`, `iter_mut()`, `into_iter()`
+  ([C-ITER][c-iter]); a custom iterator type is named after the method that
+  produces it.
+- Name things for the domain, and keep word order consistent with the
+  neighbors: an error variant family that starts as `ParseError`,
+  `CompileError` should not grow an `ErrorLimit`.
+
+[c-case]: https://rust-lang.github.io/api-guidelines/naming.html#c-case
+[c-conv]: https://rust-lang.github.io/api-guidelines/naming.html#c-conv
+[c-iter]: https://rust-lang.github.io/api-guidelines/naming.html#c-iter
+
+## Modules and visibility
+
+- **Directory modules use `mod.rs`** (`runtime/mod.rs`, `providers/mod.rs`,
+  ...). That is the established layout; don't mix in the `foo.rs` +
+  `foo/` sibling style — pick up the convention that is already there.
+- `chidori-js` stays **flat**: one file per engine concern (`vm.rs`, `gc.rs`,
+  `exec.rs`). Split a file when it grows a second responsibility, not at a
+  line count.
+- Every module starts with a `//!` header: what the module is, the one or two
+  invariants a reader must know, and pointers to the design doc under `docs/`
+  when one exists. Most of the tree already does this; new modules must.
+- **Default to `pub(crate)`.** Reach for plain `pub` only when the item is
+  deliberately part of the crate's public API — for `chidori`, that means it's
+  re-exported through the curated `framework` facade or otherwise documented
+  as stable. A `pub` item is a compatibility promise; a `pub(crate)` item is
+  refactorable on a whim. (The current tree is `pub`-heavy; tighten
+  opportunistically when touching a module.)
+- Keep `lib.rs` a table of contents: module declarations, curated re-exports,
+  crate docs. Logic lives in modules.
+
+## Error handling
+
+The workspace deliberately runs **two error regimes**. Know which side of the
+boundary you're on, and don't let them leak into each other.
+
+### `chidori` (framework, CLI, server): `anyhow`
+
+Application-style code uses `anyhow::Result<T>` end to end:
+
+- Propagate with `?`. Attach context at the point where a failure would
+  otherwise be ambiguous:
+
+  ```rust
+  let manifest = fs::read_to_string(&path)
+      .with_context(|| format!("reading package manifest {}", path.display()))?;
+  ```
+
+  Use `.context(...)` for cheap static messages and `.with_context(|| ...)`
+  when the message allocates. A good context line names the *operation and the
+  subject* ("reading package manifest X"), not the error class ("IO error").
+- `bail!` and `ensure!` for early exits and precondition checks that are
+  *error conditions* (bad user input, malformed config) rather than bugs.
+- Don't introduce `thiserror` enums or custom error types unless a caller
+  genuinely needs to **match** on the failure (e.g. a provider distinguishing
+  retryable rate limits from fatal auth errors). One unified error chain that
+  prints well is the point of the anyhow regime. If you do add a typed error,
+  it implements `std::error::Error` + `Debug` + `Display` and converts into
+  `anyhow::Error` at the boundary for free.
+
+### `chidori-js` (engine): errors are JS values
+
+Inside the engine, a failure is a **thrown JavaScript exception**, so the
+idiom is `Result<T, Value>` where the `Err` payload is the JS value routed
+through `Completion::Throw`. Constructor selection goes through the engine's
+`ErrorKind` mapping.
+
+- Never import `anyhow` (or any other error crate) into `chidori-js`. If an
+  engine-internal failure can't be expressed as a throwable JS value, it is a
+  bug — see panics below.
+- Host-boundary code in `chidori` that calls into the engine converts at the
+  boundary: JS exception → structured error/context on the anyhow chain, once,
+  in one place.
+
+### Panics: bugs, not errors
+
+We follow the [bug vs. error condition distinction][burntsushi-unwrap]: a
+`Result` models something that is *expected to fail* sometimes (I/O, user
+input, network, subprocesses); a panic asserts an *invariant* — something that
+cannot happen unless the program has a bug.
+
+- **In `Result`-returning code, reach for `?`, not `.unwrap()`.** An
+  `unwrap()` on an operation that can legitimately fail converts a recoverable
+  error into a process abort — in a runtime that promises durable, resumable
+  agents, that's the worst possible failure mode.
+- `unwrap()`/`expect()` are acceptable when the failure would be a bug:
+  a mutex poisoned only if another thread already panicked, a regex literal
+  known valid at compile time, an index established by the loop above, a
+  key inserted two lines earlier. Prefer `expect("...")` when the message adds
+  diagnostic value a stack trace wouldn't; write it as the *invariant that was
+  supposed to hold* ("bytecode register allocated by compile pass"), not a
+  restatement of the failure ("failed to get register").
+- `panic!`, `assert!`, `debug_assert!` follow the same rule: invariants only.
+  Prefer `debug_assert!` for hot-path checks the release interpreter can't
+  afford.
+- **Tests, benches, examples, and `test262-runner` may unwrap freely.** A
+  panic is exactly the right test-failure mechanism, and `?`-plumbing in tests
+  obscures the assertion under test.
+- Never `unwrap()` on a value derived from user input, agent code, the
+  network, the filesystem, or an LLM response. Agents run arbitrary
+  TypeScript; anything they can influence is an error condition by
+  definition.
+
+## Logging and output
+
+- **Library and runtime code speaks `tracing`, never `println!`.** Everything
+  under `runtime/`, `providers/`, `mcp/`, `pkg/` (except interactive install
+  progress), `server.rs`, `scheduler.rs`, `storage.rs`, and all of
+  `chidori-js` uses `tracing::{trace,debug,info,warn,error}` with structured
+  fields:
+
+  ```rust
+  tracing::debug!(session_id = %id, seq, "replaying journal entry");
+  ```
+
+  Structured fields (`field = value`), not format-string interpolation — the
+  OTLP exporter and any downstream collector can only filter on fields.
+- `println!`/`eprintln!` are for **CLI user-facing output only**: `main.rs`
+  command handlers, `init.rs`, interactive prompts, install progress. Rule of
+  thumb: if the text is the *product* of the command, print it (results to
+  stdout, user-facing errors to stderr); if it describes what the program is
+  doing internally, it's a `tracing` event.
+- Pick levels for an operator reading production logs: `error` = something
+  was lost or a request failed; `warn` = degraded but recovered; `info` =
+  lifecycle milestones (server started, session resumed); `debug`/`trace` =
+  developers only. Don't log at `info` inside per-opcode or per-journal-entry
+  loops.
+- No `dbg!` in committed code.
+
+## Async and concurrency
+
+`chidori` is async on `tokio`; `chidori-js` is deliberately **synchronous**
+(determinism and replay depend on it) and must stay free of async runtimes.
+
+- **Never block a runtime worker thread.** CPU-heavy or blocking work
+  (synchronous file I/O bursts, subprocess waits, running the JS engine) goes
+  through `tokio::task::spawn_blocking` or a dedicated thread. JS execution
+  threads must be spawned with the `JS_THREAD_STACK_BYTES` stack size — the
+  interpreter is deeply recursive and the default stack will overflow.
+- **No lock guards across `.await`.** Use `std::sync::Mutex` for short
+  critical sections that never span an await; if you genuinely must hold a
+  lock across an await point, that's the one case for `tokio::sync::Mutex` —
+  but first ask whether a channel or an owning task removes the shared state
+  entirely. Message passing over shared locks where either fits.
+- `tokio::spawn` is for actual concurrency, not a cheap function call. A
+  spawned task's `JoinHandle` is either awaited or its abandonment is
+  explicit and commented; `let _ = some_future;` silently does nothing.
+- Be deliberate about **cancellation safety** in `select!` loops: a branch
+  losing the race drops its future mid-flight. Anything with side effects that
+  must complete (journal writes, checkpoint flushes) belongs in a task or a
+  cancel-safe pattern, not directly in a `select!` arm. Use RAII/drop guards
+  for cleanup that must run even when a task is cancelled.
+- Bound everything: channels get explicit capacities, retries get caps and
+  backoff, per-run resource use goes through the existing limit machinery.
+
+## Unsafe code
+
+- **`chidori-js` contains zero `unsafe` and must stay that way** — "pure-Rust,
+  no `unsafe`" is a documented property of the engine (see
+  `docs/architecture.md`) and part of the sandbox story.
+- In `chidori`, `unsafe` is confined to the OS-isolation layer
+  (`runtime/isolate/*` — rlimits, seccomp, landlock FFI) and `mem_guard.rs`.
+  New `unsafe` outside that neighborhood needs a strong justification in the
+  PR description.
+- Every `unsafe` block is minimal (one operation per block where practical)
+  and carries a `// SAFETY:` comment stating the invariant that makes it
+  sound — what must be true, and why it is true *here*:
+
+  ```rust
+  // SAFETY: setrlimit is async-signal-safe and `lim` is a valid, initialized
+  // rlimit struct; we are single-threaded post-fork at this point.
+  unsafe { libc::setrlimit(libc::RLIMIT_AS, &lim) };
+  ```
+
+## Documentation and comments
+
+The house comment style is **prose-heavy and rationale-driven** — see the
+workspace `Cargo.toml` or any `runtime/` module header for the register. Keep
+it that way:
+
+- `//!` module docs on every module; `///` docs on every `pub` item. For
+  fallible or panicking public functions, document the failure modes
+  (`# Errors`, `# Panics`) — [C-FAILURE].
+- Comments explain **why, not what**: the constraint, the invariant, the
+  rejected alternative, the workaround's upstream issue link. If a comment
+  paraphrases the next line of code, delete it. If a decision took you ten
+  minutes of thought, spend one more writing down the reasoning — the comment
+  is for the person (possibly you) who would otherwise have to re-derive it.
+- Design-level reasoning goes in `docs/*.md` and gets linked from the module
+  header, not duplicated across code comments. New subsystems of any size get
+  a design doc; that's the established pattern (~30 docs and counting).
+- Doc examples compile (they're tests). Use `?` in examples rather than
+  `unwrap()` ([C-QUESTION-MARK]).
+
+[C-FAILURE]: https://rust-lang.github.io/api-guidelines/documentation.html#c-failure
+[C-QUESTION-MARK]: https://rust-lang.github.io/api-guidelines/documentation.html#c-question-mark
+
+## Testing and benchmarks
+
+- **Unit tests** live inline in `#[cfg(test)] mod tests` next to the code they
+  exercise. **Integration tests** live in the crate's `tests/` directory and
+  exercise the public surface. Async tests use `#[tokio::test]`.
+- Engine language behavior is validated by **Test262** via `test262-runner`
+  (see `docs/conformance.md`) — don't hand-write unit tests for spec behavior
+  the suite already covers; do add a focused regression test when fixing a bug
+  the suite missed.
+- Name tests for the behavior and the condition
+  (`resume_skips_replayed_llm_calls`), not `test_1`. A failing test's name
+  should tell you what broke before you open the file.
+- Tests must be deterministic and parallel-safe: `tempfile` for filesystem
+  state, no fixed ports, no sleeps as synchronization, no reliance on wall
+  clock. A test that needs the network is an integration test behind an
+  explicit opt-in, never part of `cargo test --workspace`.
+- Performance work goes through the **criterion** benches (`benches/`) and the
+  JS workload suite; claims about speedups in PRs come with bench numbers.
+  `cargo test --workspace` plus `cargo fmt --check` is the CI gate — keep both
+  green locally before pushing.
+
+## Dependencies and Cargo
+
+- Adding a dependency is an architectural decision: prefer std and existing
+  deps first; check maintenance, transitive weight, and license
+  (workspace is Apache-2.0; deps must be permissively licensed). Say why in
+  the PR.
+- **No unused dependencies.** A declared-but-unused crate is worse than a
+  missing one — it implies a convention nobody follows.
+- TLS is `rustls` everywhere (`reqwest` is configured without OpenSSL); don't
+  introduce anything that links OpenSSL or other C libraries lightly — the
+  single-static-binary install story depends on it.
+- Platform-specific code is `cfg`-gated the way `runtime/isolate` already is
+  (`cfg(unix)`, `cfg(target_os = "linux")`), with a portable fallback or a
+  clear compile error, and gets covered by the `os-isolation` CI workflow when
+  it touches sandboxing.
+- Shared package metadata is inherited from `[workspace.package]`
+  (`field.workspace = true`); keep new common fields there rather than
+  repeating them per crate.
+
+## Public API design
+
+For the publishable crates (`chidori`, `chidori-js`), the [Rust API
+Guidelines] checklist applies; the highlights we care most about:
+
+- Derive the common traits eagerly where semantically valid: `Debug` on every
+  public type (non-negotiable — [C-DEBUG]), plus `Clone`, `PartialEq`/`Eq`,
+  `Hash`, `Default`, and `serde` derives where they make sense.
+- Prefer **newtypes over primitives** for identifiers and quantities that can
+  be confused (`Seq`, session ids, byte budgets) — a `u64` parameter named
+  `seq` next to one named `limit` is an accident waiting to happen
+  ([C-NEWTYPE]).
+- Avoid boolean and `Option` parameters that read as mystery values at the
+  call site; use a two-variant enum or a builder ([C-CUSTOM-TYPE],
+  [C-BUILDER]). Constructors are static inherent methods (`new`,
+  `with_config`), conversions use `From`/`TryFrom` rather than ad-hoc methods.
+- Keep struct fields private and take `impl AsRef<Path>` / `impl Into<String>`
+  style generics at ergonomic boundaries — but only where the flexibility is
+  actually used; don't generalize speculatively.
+
+[C-DEBUG]: https://rust-lang.github.io/api-guidelines/debuggability.html#c-debug
+[C-NEWTYPE]: https://rust-lang.github.io/api-guidelines/type-safety.html#c-newtype
+[C-CUSTOM-TYPE]: https://rust-lang.github.io/api-guidelines/type-safety.html#c-custom-type
+[C-BUILDER]: https://rust-lang.github.io/api-guidelines/type-safety.html#c-builder
+
+## Adopting this guide
+
+Parts of the tree predate these rules — most visibly the density of
+`.unwrap()` in `crates/chidori/src` and stray `println!` in runtime modules.
+The policy for closing the gap:
+
+1. **New and modified code follows the guide.** Review against it.
+2. **Clean up opportunistically, in scope.** When a change touches a function,
+   bring that function up to the guide (convert unwraps on fallible
+   operations to `?` + context, replace runtime `println!` with `tracing`).
+3. **No drive-by churn.** Don't send mass mechanical rewrites mixed into
+   feature work; a focused, reviewable cleanup PR for one module at a time is
+   fine.
+4. Machine enforcement (Clippy in CI and the pre-commit hook, lint tables in
+   `Cargo.toml`) should follow once the noise floor makes `-D warnings`
+   tractable; until then, the lints named in [Clippy](#clippy) are reviewer
+   expectations.
+
+## References
+
+- [Rust API Guidelines] and the [checklist](https://rust-lang.github.io/api-guidelines/checklist.html)
+- [Rust Style Guide] (the spec `rustfmt` implements)
+- [Clippy lint list][clippy-lints] and [usage](https://doc.rust-lang.org/clippy/usage.html)
+- ["Using unwrap() in Rust is Okay"][burntsushi-unwrap] — the panic policy this guide adopts
+- [Tokio tutorial](https://tokio.rs/tokio/tutorial) — spawning, shared state, channels
+- [`tokio::sync::Mutex` docs](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html) — on when *not* to use it
+- Repo-specific design docs: [`docs/architecture.md`](./architecture.md),
+  [`docs/sandbox-model.md`](./sandbox-model.md),
+  [`docs/replay.md`](./replay.md), [`docs/conformance.md`](./conformance.md)

--- a/hk.pkl
+++ b/hk.pkl
@@ -16,9 +16,14 @@ import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtin
 
 local linters = new Mapping<String, Step> {
     // Rust formatter. `check` runs `cargo fmt --check`; `fix` runs `cargo fmt`.
-    // Only runs when *.rs files are involved. Add `Builtins.cargo_clippy` here
-    // later if we want lint enforcement too.
+    // Only runs when *.rs files are involved.
     ["cargo-fmt"] = Builtins.cargo_fmt
+    // Rust linter, mirroring the CI "Rust workspace → Clippy" gate
+    // (`cargo clippy --workspace --all-targets -- -D warnings`). `fix` applies
+    // machine-applicable suggestions; `check` verifies. Workspace-wide allows
+    // for the subjective lints live in `[workspace.lints.clippy]` in the root
+    // Cargo.toml, so the hook, CI, and a bare `cargo clippy` all agree.
+    ["cargo-clippy"] = Builtins.cargo_clippy
 }
 
 hooks {


### PR DESCRIPTION
## What

Adds `docs/rust-style-guide.md` — a style guide grounded in the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), the official style guide, Clippy's lint groups, and the [bugs-vs-error-conditions panic policy](https://burntsushi.net/unwrap/), tailored to this workspace's actual conventions — and then makes its tooling section true by wiring clippy enforcement in and bringing the tree to zero warnings.

## The guide

Covers toolchain/formatting (default rustfmt, deliberately no config file), clippy expectations, naming, module layout (`mod.rs` roots, flat `chidori-js`), `pub(crate)`-by-default visibility, the **two error regimes** (anyhow in `chidori`, thrown-JS-value `Result<_, Value>` in `chidori-js`) and the boundary between them, a panic policy (unwrap/expect for invariants only; tests exempt), tracing-vs-println rules, tokio discipline, an `unsafe` policy (`chidori-js` stays zero-unsafe), the rationale-driven comment style, testing/bench conventions, and an adoption policy for pre-existing code (notably the ~1,250 `unwrap()` calls in `crates/chidori/src`, which this PR deliberately does **not** mass-rewrite).

## Enforcement

- CI Rust job and the `hk` pre-commit hook now run `cargo clippy --workspace --all-targets -- -D warnings` (the hook's own comment anticipated this).
- `[workspace.lints.clippy]` in the root `Cargo.toml` is the single home for blanket allows — currently just the two refactor-heavy subjective lints (`type_complexity`, `too_many_arguments`), each with rationale. All three crates inherit via `[lints] workspace = true`.
- ~230 warnings fixed: clippy auto-fixes, doc-comment restructuring (lazy list continuations, over-indented aligned tables → fenced text blocks), mechanical fixes (`&PathBuf`→`&Path`, `&mut Vec`→`&mut [_]`, merged identical branches, while-let, deprecated `temporal_rs::Temporal::now`→`local_now`, `Capability::from_str`→`parse`, `run_agent`→`pub(crate)`), and `#[allow(dead_code)]` with a rationale note on staged/not-yet-wired API and test-only-used items (module-level for the scaffolding `workspace.rs` and generated `unicode_tables.rs`).
- Removed the unused `thiserror` and `derive_more` dependencies (zero source usages).

## Findings worth a look

- **A dormant test is now live**: `server.rs`'s `resume_resolves_persisted_pending_input_host_operation` was fully written but missing its `#[test]` attribute — it had never run. Re-enabled; it passes.
- **A shadowed match arm was deleted, not activated**: `fundamental.rs` had two `Internal::ModuleNamespace` arms in the same `[[GetOwnProperty]]` match; the unreachable second one mapped `Value::Uninitialized` → `Undefined` (per its comment, a TDZ-related fix). Deleting the dead arm preserves current behavior exactly, but if that mapping was an intended fix that got shadowed, it should be re-applied to the live arm at `fundamental.rs:1777`.
- Three unused `LlmProvider` test doubles in `server.rs`'s test module were deleted; several `#[allow(dead_code)]` sites are marked as deletion candidates in their notes if the staged API is actually abandoned.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (exit 0)
- `cargo test --workspace`: all passing, including the re-enabled test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVntYfpvfhANLsXZG7WCSx