### PR TITLE
Recursion-entry + for-in fast paths; register tier joins budgeted runs

### DIFF
--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -59,6 +59,55 @@ enum Ctl {
     GeneratorStart,
 }
 
+/// One slot-verified global identity check for a cached [`RecFamily`]:
+/// `globals.props` slot `slot` must still carry `key` as a plain data
+/// property holding the very closure `funcs[func]`. Insertion slots are
+/// stable under value writes and appends, so a hit costs an indexed read +
+/// two pointer compares — no hashing; a restructured table or a rebound
+/// name fails the key/identity match and the family re-resolves from
+/// scratch (today's full path).
+pub(crate) struct RecGlobalCheck {
+    key: PropertyKey,
+    slot: u32,
+    func: u8,
+}
+
+/// A resolved recursion FAMILY for the windowed recursive-kernel executor
+/// ([`Vm::run_fn_kernel_rec`]), cached on the Vm keyed by the entry
+/// closure's identity (`funcs[0]`). Everything here is a pure function of
+/// the member closures (immutable protos) plus the recorded identity
+/// checks, so a validated hit skips resolution entirely: the per-activation
+/// cost drops from half a dozen table allocations + O(code) scans per
+/// member to O(members) pointer compares. Holding member closures alive
+/// across activations is the same retention class as the prototype-holder
+/// inline caches ([`crate::bytecode::IcEntry`]); the cache is bounded and
+/// eviction is only ever a perf event, never observable.
+pub(crate) struct RecFamily {
+    /// The family members; `funcs[0]` is the entry closure (cache key).
+    funcs: Vec<Rc<BytecodeFunction>>,
+    /// `callee_map[j][c]` = `funcs` index for member `j`'s `SelfCall`
+    /// callee `c` (`c = 0` is `j` itself; `c = 1 + i` is `rec.globals[i]`).
+    callee_map: Vec<Vec<u8>>,
+    /// Per-member register-window size.
+    n_regs: Vec<usize>,
+    /// Per-member (register, argument index) entry loads.
+    arg_slots: Vec<Vec<(usize, usize)>>,
+    /// Per-member (register, upvalue index, snapshot) — the VALUE is
+    /// refreshed on every activation (cells can change between calls, never
+    /// during one).
+    uv_snaps: Vec<Vec<(usize, u32, f64)>>,
+    /// Every global binding the family's guard depends on.
+    global_checks: Vec<RecGlobalCheck>,
+    /// (member, upvalue index) self-references: the cell must hold that
+    /// member's own closure.
+    upval_self_checks: Vec<(u8, u32)>,
+    /// Members whose kernels use `Math` intrinsics (canonicals re-verified
+    /// per activation).
+    math_members: Vec<u8>,
+    /// The family's uniform `Ret` register type.
+    ret_bool: bool,
+}
+
 impl Vm {
     // =====================================================================
     // Calling
@@ -647,9 +696,15 @@ impl Vm {
         // kernels never nest at runtime). The base objects are pinned for the
         // whole activation — sound because stores to base LOCALS inside the
         // region are rejected at translation.
+        // The buffer is GROW-ONLY across activations: stale values from a
+        // previous activation are unreadable by construction (every mapped
+        // slot is loaded below; stack-temp registers are written before any
+        // read by the virtual-stack discipline), so re-zeroing would be pure
+        // memset tax.
         let mut regs = std::mem::take(&mut self.kernel_regs);
-        regs.clear();
-        regs.resize(k.n_regs as usize, 0.0);
+        if regs.len() < k.n_regs as usize {
+            regs.resize(k.n_regs as usize, 0.0);
+        }
         for (r, slot) in k.locals.iter().enumerate() {
             let v = match slot {
                 crate::bytecode::KSlot::Local(l) => frame.locals[*l as usize].clone(),
@@ -768,8 +823,11 @@ impl Vm {
             }
             // Extend the register file with the callee windows and load each
             // window's upvalue snapshot ONCE (identities are pinned; callee
-            // code never writes an upvalue register).
-            regs.resize(win, 0.0);
+            // code never writes an upvalue register). Grow-only: the buffer
+            // may already be longer than this activation needs.
+            if regs.len() < win {
+                regs.resize(win, 0.0);
+            }
             for (bf, wb) in callee_bfs.iter() {
                 let ck = bf.proto.fn_kernel.as_ref().expect("guarded");
                 for (r, slot) in ck.locals.iter().enumerate() {
@@ -1249,9 +1307,13 @@ impl Vm {
         if k.rec.is_some() {
             return self.run_fn_kernel_rec(bf, args);
         }
+        // Grow-only across activations (see `run_kernel_op_impl`): stale
+        // values are unreadable — args/upvalues load below, internal locals
+        // are store-before-read by translation proof.
         let mut regs = std::mem::take(&mut self.kernel_regs);
-        regs.clear();
-        regs.resize(k.n_regs as usize, 0.0);
+        if regs.len() < k.n_regs as usize {
+            regs.resize(k.n_regs as usize, 0.0);
+        }
         for (r, slot) in k.locals.iter().enumerate() {
             match slot {
                 crate::bytecode::KSlot::Arg(a) => match args.get(*a as usize) {
@@ -1317,6 +1379,16 @@ impl Vm {
     /// `None` returned — sound because kernels are pure (registers only),
     /// and the caller's generic rerun then raises the spec RangeError from
     /// the exact frame it belongs to.
+    ///
+    /// The resolved family is CACHED ([`RecFamily`], keyed by the entry
+    /// closure's identity): resolution allocates half a dozen tables and
+    /// walks every member's code, which dominated shallow recursions
+    /// (isEven-class) when paid per outer call. A hit re-verifies only the
+    /// dynamic facts — recorded global slots (key-verified, no hashing),
+    /// upvalue self-cells, canonical `Math` — and re-snapshots upvalue
+    /// values; any failure drops the entry and re-resolves from scratch,
+    /// which is exactly the uncached behavior. Hit or miss is therefore
+    /// unobservable: same declines, same results.
     fn run_fn_kernel_rec(
         &mut self,
         bf: &Rc<BytecodeFunction>,
@@ -1324,187 +1396,70 @@ impl Vm {
     ) -> Option<Result<Value, Value>> {
         let k0 = bf.proto.fn_kernel.as_ref()?;
         k0.rec.as_deref()?;
-        let ret_bool = k0.ret_bool;
 
-        // --- Resolve the recursion family (funcs[0] = the invoked closure).
-        let mut funcs: Vec<Rc<BytecodeFunction>> = vec![bf.clone()];
-        // callee_map[j][c] = funcs index for member j's SelfCall callee c
-        // (c = 0 is j itself; c = 1 + i is j's rec.globals[i]).
-        let mut callee_map: Vec<Vec<u8>> = Vec::new();
-        let mut wl = 0usize;
-        while wl < funcs.len() {
-            if funcs.len() > 8 {
-                return None;
-            }
-            let f = funcs[wl].clone();
-            let k = f.proto.fn_kernel.as_ref()?;
-            // Every member's Ret type must match the entry kernel's: a
-            // mismatched value would land in a caller register of the wrong
-            // static type. (Also rejects mixed-type non-recursive members.)
-            if k.code
-                .iter()
-                .any(|op| matches!(op, KOp::Ret { boolean, .. } if *boolean != ret_bool))
-            {
-                return None;
-            }
-            // Self references must hold for THIS member's closure.
-            if let Some(rec) = k.rec.as_deref() {
-                for r in rec.self_refs.iter() {
-                    let ok = match r {
-                        crate::bytecode::SelfRefKind::Global(name) => {
-                            let g = self.realm.global.borrow();
-                            matches!(
-                                g.props.get(&PropertyKey::str(name)),
-                                Some(Property {
-                                    kind: PropertyKind::Data { value: Value::Object(o), .. },
-                                    ..
-                                }) if matches!(
-                                    &o.borrow().internal,
-                                    Internal::Function(FunctionInner::Bytecode(bf2))
-                                        if Rc::ptr_eq(bf2, &f)
-                                )
-                            )
-                        }
-                        crate::bytecode::SelfRefKind::Upvalue(u) => {
-                            let cell = f.upvalues.get(*u as usize)?;
-                            matches!(
-                                &*cell.borrow(),
-                                Value::Object(o) if matches!(
-                                    &o.borrow().internal,
-                                    Internal::Function(FunctionInner::Bytecode(bf2))
-                                        if Rc::ptr_eq(bf2, &f)
-                                )
-                            )
-                        }
-                    };
-                    if !ok {
-                        return None;
-                    }
-                }
-            }
-            if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
-                return None;
-            }
-            // Resolve this member's mutual-recursion partners.
-            let mut cmap: Vec<u8> = vec![wl as u8];
-            if let Some(rec) = k.rec.as_deref() {
-                for name in rec.globals.iter() {
-                    let bf2 = {
-                        let g = self.realm.global.borrow();
-                        match g.props.get(&PropertyKey::str(name)) {
-                            Some(Property {
-                                kind:
-                                    PropertyKind::Data {
-                                        value: Value::Object(o),
-                                        ..
-                                    },
-                                ..
-                            }) => match &o.borrow().internal {
-                                Internal::Function(FunctionInner::Bytecode(bf2))
-                                    if !bf2.is_class_ctor
-                                        && !bf2.proto.kind.is_generator()
-                                        && !bf2.proto.kind.is_async() =>
-                                {
-                                    bf2.clone()
-                                }
-                                _ => return None,
-                            },
-                            _ => return None,
-                        }
-                    };
-                    bf2.proto.fn_kernel.as_ref()?;
-                    let idx = match funcs.iter().position(|x| Rc::ptr_eq(x, &bf2)) {
-                        Some(i) => i,
-                        None => {
-                            funcs.push(bf2);
-                            funcs.len() - 1
-                        }
-                    };
-                    cmap.push(u8::try_from(idx).ok()?);
-                }
-            }
-            callee_map.push(cmap);
-            wl += 1;
-        }
+        let fam = match self.take_rec_family(bf) {
+            Some(f) => f,
+            None => self.build_rec_family(bf)?,
+        };
+        let ret_bool = fam.ret_bool;
 
-        // --- Per-member tables: code, window size, arg slots, upvalue
-        // snapshots (a member's upvalue cells are activation constants:
-        // nothing inside a kernel can write a cell). Then cross-check every
-        // call site's argc against its RESOLVED callee's consumption.
-        let n = funcs.len();
-        let mut n_regs: Vec<usize> = Vec::with_capacity(n);
-        let mut arg_slots: Vec<Vec<(usize, usize)>> = Vec::with_capacity(n);
-        let mut uv_snaps: Vec<Vec<(usize, f64)>> = Vec::with_capacity(n);
-        for f in funcs.iter() {
-            let k = f.proto.fn_kernel.as_ref()?;
-            n_regs.push(k.n_regs as usize);
-            let mut aslots = Vec::new();
-            let mut uvs = Vec::new();
-            for (r, slot) in k.locals.iter().enumerate() {
-                match slot {
-                    crate::bytecode::KSlot::Arg(a) => aslots.push((r, *a as usize)),
-                    crate::bytecode::KSlot::Upvalue(u) => {
-                        match &*f.upvalues.get(*u as usize)?.borrow() {
-                            Value::Number(v) => uvs.push((r, *v)),
-                            _ => return None,
-                        }
-                    }
-                    crate::bytecode::KSlot::Local(_) => {}
-                }
-            }
-            arg_slots.push(aslots);
-            uv_snaps.push(uvs);
-        }
-        for (j, f) in funcs.iter().enumerate() {
-            let k = f.proto.fn_kernel.as_ref()?;
-            for op in k.code.iter() {
-                if let KOp::SelfCall { argc, callee, .. } = op {
-                    let t = *callee_map[j].get(*callee as usize)? as usize;
-                    let tk = funcs[t].proto.fn_kernel.as_ref()?;
-                    if u32::from(*argc) < tk.args_used {
-                        return None;
-                    }
-                }
-            }
-        }
-        let codes: Vec<&[KOp]> = funcs
-            .iter()
-            .map(|f| &f.proto.fn_kernel.as_ref().expect("resolved above").code[..])
-            .collect();
-
-        // --- Window 0: the invoked member's arguments and upvalues.
+        // --- Window 0: the invoked member's arguments and upvalues. The
+        // buffer is GROW-ONLY across activations: a deep recursion leaves it
+        // at its high-water length, so the next outer call's window pushes
+        // (`SelfCall`'s conditional resize) stop paying a zero-fill per
+        // window — which was ~11% of the mutual-recursion workload. Stale
+        // values are unreadable: args/upvalues are written here, locals are
+        // store-before-read by translation proof.
         let mut regs = std::mem::take(&mut self.kernel_regs);
-        regs.clear();
-        regs.resize(n_regs[0], 0.0);
-        for &(r, a) in &arg_slots[0] {
+        if regs.len() < fam.n_regs[0] {
+            regs.resize(fam.n_regs[0], 0.0);
+        }
+        for &(r, a) in &fam.arg_slots[0] {
             match args.get(a) {
                 Some(Value::Number(v)) => regs[r] = *v,
                 _ => {
                     self.kernel_regs = regs;
+                    self.park_rec_family(fam);
                     return None;
                 }
             }
         }
-        for &(r, v) in &uv_snaps[0] {
+        for &(r, _, v) in &fam.uv_snaps[0] {
             regs[r] = v;
+        }
+
+        /// How the windowed loop below exited; the single tail then parks
+        /// the pooled buffers + family exactly once on every path.
+        enum RecOut {
+            Done(Value),
+            Interrupted,
+            Abandon,
         }
 
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
-        // (caller member, return pc, dst register, caller window base).
-        let mut calls: Vec<(u8, u16, u16, u32)> = Vec::new();
+        // (caller member, return pc, dst register, caller window base) —
+        // pooled on the Vm so a deep recursion allocates its stack once per
+        // Vm, not once per outer call.
+        let mut calls = std::mem::take(&mut self.rec_calls);
+        debug_assert!(calls.is_empty());
         let mut cur = 0usize;
         let mut base = 0usize;
         let mut pc = 0usize;
-        let ret = 'outer: loop {
-            let code = codes[cur];
+        let out = 'outer: loop {
+            let code: &[KOp] = &fam.funcs[cur]
+                .proto
+                .fn_kernel
+                .as_ref()
+                .expect("resolved family")
+                .code;
             // Hoist the CURRENT member's tables: a same-kernel self-call
             // (fib-class recursion, the overwhelming case) must not pay
             // per-call indexed loads through the family tables.
-            let cur_map = &callee_map[cur][..];
-            let cur_args = &arg_slots[cur][..];
-            let cur_uvs = &uv_snaps[cur][..];
-            let cur_nregs = n_regs[cur];
+            let cur_map = &fam.callee_map[cur][..];
+            let cur_args = &fam.arg_slots[cur][..];
+            let cur_uvs = &fam.uv_snaps[cur][..];
+            let cur_nregs = fam.n_regs[cur];
             loop {
                 macro_rules! poll_interrupt {
                     () => {{
@@ -1512,9 +1467,7 @@ impl Vm {
                         if poll & 0xFF == 0 {
                             if let Some(flag) = &interrupt {
                                 if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                                    self.kernel_regs = regs;
-                                    self.op_budget = Some(0);
-                                    return Some(Err(self.throw_range("execution interrupted")));
+                                    break 'outer RecOut::Interrupted;
                                 }
                             }
                         }
@@ -1648,8 +1601,7 @@ impl Vm {
                         // rerun then recurses to the same depth and raises
                         // the RangeError.
                         if self.call_depth + calls.len() + 1 > self.max_call_depth {
-                            self.kernel_regs = regs;
-                            return None;
+                            break 'outer RecOut::Abandon;
                         }
                         poll_interrupt!();
                         let t = cur_map[callee as usize] as usize;
@@ -1669,7 +1621,7 @@ impl Vm {
                             for &(r, a) in cur_args {
                                 regs[new_base + r] = regs[base + abase as usize + a];
                             }
-                            for &(r, v) in cur_uvs {
+                            for &(r, _, v) in cur_uvs {
                                 regs[new_base + r] = v;
                             }
                             calls.push((cur as u8, pc as u16 + 1, dst, base as u32));
@@ -1677,13 +1629,13 @@ impl Vm {
                             pc = 0;
                             continue;
                         }
-                        if regs.len() < new_base + n_regs[t] {
-                            regs.resize(new_base + n_regs[t], 0.0);
+                        if regs.len() < new_base + fam.n_regs[t] {
+                            regs.resize(new_base + fam.n_regs[t], 0.0);
                         }
-                        for &(r, a) in &arg_slots[t] {
+                        for &(r, a) in &fam.arg_slots[t] {
                             regs[new_base + r] = regs[base + abase as usize + a];
                         }
-                        for &(r, v) in &uv_snaps[t] {
+                        for &(r, _, v) in &fam.uv_snaps[t] {
                             regs[new_base + r] = v;
                         }
                         calls.push((cur as u8, pc as u16 + 1, dst, base as u32));
@@ -1711,11 +1663,11 @@ impl Vm {
                                 continue;
                             }
                             None => {
-                                break 'outer if ret_bool {
+                                break 'outer RecOut::Done(if ret_bool {
                                     Value::Bool(v != 0.0)
                                 } else {
                                     Value::Number(v)
-                                }
+                                })
                             }
                         }
                     }
@@ -1733,7 +1685,303 @@ impl Vm {
             }
         };
         self.kernel_regs = regs;
-        Some(Ok(ret))
+        calls.clear();
+        self.rec_calls = calls;
+        self.park_rec_family(fam);
+        match out {
+            RecOut::Done(v) => Some(Ok(v)),
+            RecOut::Abandon => None,
+            RecOut::Interrupted => {
+                self.op_budget = Some(0);
+                Some(Err(self.throw_range("execution interrupted")))
+            }
+        }
+    }
+
+    /// Take a cached, VALIDATED family for entry closure `bf`, or `None`
+    /// (miss, or a dynamic check failed — the entry is dropped and the
+    /// caller re-resolves, which is the uncached path and may itself
+    /// decline).
+    fn take_rec_family(&mut self, bf: &Rc<BytecodeFunction>) -> Option<RecFamily> {
+        let i = self
+            .rec_families
+            .iter()
+            .position(|f| Rc::ptr_eq(&f.funcs[0], bf))?;
+        let mut fam = self.rec_families.swap_remove(i);
+        if self.validate_rec_family(&mut fam) {
+            Some(fam)
+        } else {
+            None
+        }
+    }
+
+    /// Re-verify a cached family's DYNAMIC facts and refresh its upvalue
+    /// snapshots. Static facts (kernel presence, Ret types, argc coverage,
+    /// window sizes) live on immutable protos pinned by the identity checks,
+    /// so they never need re-checking.
+    fn validate_rec_family(&self, fam: &mut RecFamily) -> bool {
+        {
+            let g = self.realm.global.borrow();
+            for c in fam.global_checks.iter() {
+                let ok = matches!(
+                    g.props.get_index(c.slot as usize),
+                    Some((
+                        k,
+                        Property {
+                            kind: PropertyKind::Data { value: Value::Object(o), .. },
+                            ..
+                        },
+                    )) if *k == c.key && matches!(
+                        &o.borrow().internal,
+                        Internal::Function(FunctionInner::Bytecode(bf2))
+                            if Rc::ptr_eq(bf2, &fam.funcs[c.func as usize])
+                    )
+                );
+                if !ok {
+                    return false;
+                }
+            }
+        }
+        for &(m, u) in fam.upval_self_checks.iter() {
+            let f = &fam.funcs[m as usize];
+            let ok = matches!(
+                &*f.upvalues[u as usize].borrow(),
+                Value::Object(o) if matches!(
+                    &o.borrow().internal,
+                    Internal::Function(FunctionInner::Bytecode(bf2))
+                        if Rc::ptr_eq(bf2, f)
+                )
+            );
+            if !ok {
+                return false;
+            }
+        }
+        for &m in fam.math_members.iter() {
+            let k = fam.funcs[m as usize]
+                .proto
+                .fn_kernel
+                .as_ref()
+                .expect("family member");
+            if !self.kernel_math_ok(&k.math_used) {
+                return false;
+            }
+        }
+        // Refresh upvalue snapshots: cells can change BETWEEN activations
+        // (never during one — kernels contain no calls).
+        let RecFamily {
+            funcs, uv_snaps, ..
+        } = fam;
+        for (f, uvs) in funcs.iter().zip(uv_snaps.iter_mut()) {
+            for (_, u, v) in uvs.iter_mut() {
+                match &*f.upvalues[*u as usize].borrow() {
+                    Value::Number(n) => *v = *n,
+                    _ => return false,
+                }
+            }
+        }
+        true
+    }
+
+    /// Park a family back in the cache (MRU at the tail, bounded). Eviction
+    /// only ever costs the evicted entry a re-resolution on its next call.
+    fn park_rec_family(&mut self, fam: RecFamily) {
+        const REC_FAMILY_CACHE_CAP: usize = 8;
+        if self.rec_families.len() >= REC_FAMILY_CACHE_CAP {
+            self.rec_families.remove(0);
+        }
+        self.rec_families.push(fam);
+    }
+
+    /// Resolve the recursion family for entry closure `bf` from scratch
+    /// (`funcs[0]` = `bf`), recording the identity checks a cache hit will
+    /// re-verify. `None` = the family declines kernelization (this
+    /// activation runs generically); nothing is cached on decline.
+    fn build_rec_family(&self, bf: &Rc<BytecodeFunction>) -> Option<RecFamily> {
+        let ret_bool = bf.proto.fn_kernel.as_ref()?.ret_bool;
+        let mut funcs: Vec<Rc<BytecodeFunction>> = vec![bf.clone()];
+        // callee_map[j][c] = funcs index for member j's SelfCall callee c
+        // (c = 0 is j itself; c = 1 + i is j's rec.globals[i]).
+        let mut callee_map: Vec<Vec<u8>> = Vec::new();
+        let mut global_checks: Vec<RecGlobalCheck> = Vec::new();
+        let mut upval_self_checks: Vec<(u8, u32)> = Vec::new();
+        let mut math_members: Vec<u8> = Vec::new();
+        let mut wl = 0usize;
+        while wl < funcs.len() {
+            if funcs.len() > 8 {
+                return None;
+            }
+            let f = funcs[wl].clone();
+            let k = f.proto.fn_kernel.as_ref()?;
+            // Every member's Ret type must match the entry kernel's: a
+            // mismatched value would land in a caller register of the wrong
+            // static type. (Also rejects mixed-type non-recursive members.)
+            if k.code
+                .iter()
+                .any(|op| matches!(op, KOp::Ret { boolean, .. } if *boolean != ret_bool))
+            {
+                return None;
+            }
+            // Self references must hold for THIS member's closure.
+            if let Some(rec) = k.rec.as_deref() {
+                for r in rec.self_refs.iter() {
+                    match r {
+                        crate::bytecode::SelfRefKind::Global(name) => {
+                            let g = self.realm.global.borrow();
+                            match g.props.get_full(&PropertyKey::str(name)) {
+                                Some((
+                                    slot,
+                                    key,
+                                    Property {
+                                        kind:
+                                            PropertyKind::Data {
+                                                value: Value::Object(o),
+                                                ..
+                                            },
+                                        ..
+                                    },
+                                )) if matches!(
+                                    &o.borrow().internal,
+                                    Internal::Function(FunctionInner::Bytecode(bf2))
+                                        if Rc::ptr_eq(bf2, &f)
+                                ) =>
+                                {
+                                    global_checks.push(RecGlobalCheck {
+                                        // The MAP's key, so validation's
+                                        // equality hits the Rc fast path.
+                                        key: key.clone(),
+                                        slot: u32::try_from(slot).ok()?,
+                                        func: wl as u8,
+                                    });
+                                }
+                                _ => return None,
+                            }
+                        }
+                        crate::bytecode::SelfRefKind::Upvalue(u) => {
+                            let cell = f.upvalues.get(*u as usize)?;
+                            let ok = matches!(
+                                &*cell.borrow(),
+                                Value::Object(o) if matches!(
+                                    &o.borrow().internal,
+                                    Internal::Function(FunctionInner::Bytecode(bf2))
+                                        if Rc::ptr_eq(bf2, &f)
+                                )
+                            );
+                            if !ok {
+                                return None;
+                            }
+                            upval_self_checks.push((wl as u8, *u));
+                        }
+                    }
+                }
+            }
+            if !k.math_used.is_empty() {
+                if !self.kernel_math_ok(&k.math_used) {
+                    return None;
+                }
+                math_members.push(wl as u8);
+            }
+            // Resolve this member's mutual-recursion partners.
+            let mut cmap: Vec<u8> = vec![wl as u8];
+            if let Some(rec) = k.rec.as_deref() {
+                for name in rec.globals.iter() {
+                    let (bf2, slot, key) = {
+                        let g = self.realm.global.borrow();
+                        match g.props.get_full(&PropertyKey::str(name)) {
+                            Some((
+                                slot,
+                                key,
+                                Property {
+                                    kind:
+                                        PropertyKind::Data {
+                                            value: Value::Object(o),
+                                            ..
+                                        },
+                                    ..
+                                },
+                            )) => match &o.borrow().internal {
+                                Internal::Function(FunctionInner::Bytecode(bf2))
+                                    if !bf2.is_class_ctor
+                                        && !bf2.proto.kind.is_generator()
+                                        && !bf2.proto.kind.is_async() =>
+                                {
+                                    (bf2.clone(), slot, key.clone())
+                                }
+                                _ => return None,
+                            },
+                            _ => return None,
+                        }
+                    };
+                    bf2.proto.fn_kernel.as_ref()?;
+                    let idx = match funcs.iter().position(|x| Rc::ptr_eq(x, &bf2)) {
+                        Some(i) => i,
+                        None => {
+                            funcs.push(bf2);
+                            funcs.len() - 1
+                        }
+                    };
+                    global_checks.push(RecGlobalCheck {
+                        key,
+                        slot: u32::try_from(slot).ok()?,
+                        func: idx as u8,
+                    });
+                    cmap.push(u8::try_from(idx).ok()?);
+                }
+            }
+            callee_map.push(cmap);
+            wl += 1;
+        }
+
+        // --- Per-member tables: window size, arg slots, upvalue snapshots
+        // (a member's upvalue cells are activation constants: nothing inside
+        // a kernel can write a cell). Then cross-check every call site's
+        // argc against its RESOLVED callee's consumption.
+        let n = funcs.len();
+        let mut n_regs: Vec<usize> = Vec::with_capacity(n);
+        let mut arg_slots: Vec<Vec<(usize, usize)>> = Vec::with_capacity(n);
+        let mut uv_snaps: Vec<Vec<(usize, u32, f64)>> = Vec::with_capacity(n);
+        for f in funcs.iter() {
+            let k = f.proto.fn_kernel.as_ref()?;
+            n_regs.push(k.n_regs as usize);
+            let mut aslots = Vec::new();
+            let mut uvs = Vec::new();
+            for (r, slot) in k.locals.iter().enumerate() {
+                match slot {
+                    crate::bytecode::KSlot::Arg(a) => aslots.push((r, *a as usize)),
+                    crate::bytecode::KSlot::Upvalue(u) => {
+                        match &*f.upvalues.get(*u as usize)?.borrow() {
+                            Value::Number(v) => uvs.push((r, *u, *v)),
+                            _ => return None,
+                        }
+                    }
+                    crate::bytecode::KSlot::Local(_) => {}
+                }
+            }
+            arg_slots.push(aslots);
+            uv_snaps.push(uvs);
+        }
+        for (j, f) in funcs.iter().enumerate() {
+            let k = f.proto.fn_kernel.as_ref()?;
+            for op in k.code.iter() {
+                if let KOp::SelfCall { argc, callee, .. } = op {
+                    let t = *callee_map[j].get(*callee as usize)? as usize;
+                    let tk = funcs[t].proto.fn_kernel.as_ref()?;
+                    if u32::from(*argc) < tk.args_used {
+                        return None;
+                    }
+                }
+            }
+        }
+        Some(RecFamily {
+            funcs,
+            callee_map,
+            n_regs,
+            arg_slots,
+            uv_snaps,
+            global_checks,
+            upval_self_checks,
+            math_members,
+            ret_bool,
+        })
     }
 
     /// Prepare a callback for REPEATED calls from a native higher-order
@@ -2571,17 +2819,19 @@ impl Vm {
     /// decline register translation.
     pub fn run_frame(&mut self, frame: Box<Frame>) -> Flow {
         if let Some(reg) = &frame.func.proto.reg {
-            // The op budget demands EXACT per-stack-op accounting, so a
-            // budgeted run (the conformance runner, untrusted eval) stays on
-            // the generic path — the same rule the kernel tiers follow. The
-            // debug-assert documents the resumed-frame invariant.
+            // Budgeted runs (the production op budget, the conformance
+            // runner, untrusted eval) stay on the register tier too:
+            // `RegProto::costs` charges each register op its EXACT
+            // stack-op units, so the budget drains — and exhausts —
+            // identically on both tiers (gated by the budget-sweep
+            // differential in tests/reg.rs). The kernel tiers still decline
+            // under a budget. The debug-assert documents the resumed-frame
+            // invariant.
             debug_assert!(
                 frame.ip == 0 && frame.pending_throw.is_none() && frame.pending_return.is_none()
             );
-            if self.op_budget.is_none() {
-                let reg = reg.clone();
-                return self.run_reg_frame(frame, &reg);
-            }
+            let reg = reg.clone();
+            return self.run_reg_frame(frame, &reg);
         }
         self.run_stack_frame(frame)
     }
@@ -3862,22 +4112,39 @@ impl Vm {
         // Registers 0..num_locals are the localized bindings (already sized
         // by `init_frame`); the rest are the canonical operand slots.
         frame.locals.resize(reg.num_regs as usize, Value::Undefined);
-        // Cooperative cancellation: the same latch-and-throw protocol as the
-        // stack loop (which polls every 256 ops). The op BUDGET never applies
-        // here — `run_frame` routes budgeted runs to the stack tier.
-        let interruptible = self.interrupt.is_some();
+        // Budget + cooperative cancellation mirror the stack loop's
+        // `counting` protocol (one predicted branch when neither is
+        // installed). Each register op charges its EXACT stack-op units
+        // (`RegProto::costs`): the charge is hard-checked BEFORE the op —
+        // the budget-exceeded throw fires exactly where the stack loop's
+        // per-op check would have, and no op the stack tier would not have
+        // reached can run. Pure stack ops charge at the NEXT anchor on
+        // their path (see `RegProto::costs` for why that is exact).
+        let counting = self.op_budget.is_some() || self.interrupt.is_some();
+        let costs = &reg.costs[..];
         let mut poll: u32 = 0;
         let code = &reg.code[..];
         let num_locals = proto.num_locals as usize;
         let mut pc: usize = 0;
         loop {
-            if interruptible {
-                poll = poll.wrapping_add(1);
-                if poll & 0xFF == 0 {
-                    if let Some(flag) = &self.interrupt {
-                        if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                            self.op_budget = Some(0);
-                            done!(Flow::Throw(self.throw_range("execution interrupted")));
+            if counting {
+                if let Some(budget) = self.op_budget.as_mut() {
+                    let cost = u64::from(costs[pc]);
+                    if *budget < cost {
+                        *budget = 0;
+                        // Uncatchable so execution is guaranteed to terminate.
+                        done!(Flow::Throw(self.throw_range("execution budget exceeded")));
+                    }
+                    *budget -= cost;
+                }
+                if self.interrupt.is_some() {
+                    poll = poll.wrapping_add(1);
+                    if poll & 0xFF == 0 {
+                        if let Some(flag) = &self.interrupt {
+                            if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                self.op_budget = Some(0);
+                                done!(Flow::Throw(self.throw_range("execution interrupted")));
+                            }
                         }
                     }
                 }
@@ -3939,6 +4206,9 @@ impl Vm {
                 };
             }
             match op {
+                // Pure budget landing: its units are charged by the loop
+                // head via the cost table; the op itself runs nothing.
+                ROp::Charge => {}
                 ROp::Mov { dst, src } => wr!(*dst, rd!(*src)),
                 ROp::Const { dst, idx } => wr!(*dst, self.const_val(&frame, *idx)),
                 ROp::Undef { dst } => wr!(*dst, Value::Undefined),
@@ -4243,7 +4513,15 @@ impl Vm {
                     argc,
                 } => {
                     let ctor_v = rd!(*ctor);
-                    let args = &frame.locals[*at as usize..(*at + *argc) as usize];
+                    // A ZERO-arg window's `at` may sit one past the register
+                    // file (nothing was ever materialized there, so the
+                    // emitter never grew it): slicing would panic on the
+                    // out-of-range START even though the range is empty.
+                    let args = if *argc == 0 {
+                        &[]
+                    } else {
+                        &frame.locals[*at as usize..(*at + *argc) as usize]
+                    };
                     let v = tryv!(self.construct(&ctor_v, args, &ctor_v));
                     wr!(*dst, v);
                 }
@@ -4726,11 +5004,17 @@ impl Vm {
             return Err(self.throw_range("Maximum call stack size exceeded"));
         }
         // Function kernel: run frameless straight off the caller's registers
-        // (the arguments sit contiguously at `at..at+argc`).
+        // (the arguments sit contiguously at `at..at+argc`). A ZERO-arg
+        // window's `at` may sit one past the register file — nothing was
+        // ever materialized there — so slicing it would panic on the
+        // out-of-range start even though the range is empty.
         if bf.proto.fn_kernel.is_some() {
-            if let Some(r) =
-                self.run_fn_kernel(&bf, &caller.locals[at as usize..(at + argc) as usize])
-            {
+            let args: &[Value] = if argc == 0 {
+                &[]
+            } else {
+                &caller.locals[at as usize..(at + argc) as usize]
+            };
+            if let Some(r) = self.run_fn_kernel(&bf, args) {
                 self.call_depth -= 1;
                 return r;
             }

--- a/crates/chidori-js/src/iter.rs
+++ b/crates/chidori-js/src/iter.rs
@@ -403,6 +403,23 @@ impl Vm {
     /// Collect enumerable string keys across the prototype chain for `for-in`,
     /// in deterministic order, de-duplicated, skipping shadowed keys.
     pub fn for_in_keys(&mut self, v: &Value) -> Result<Vec<JsString>, Value> {
+        let obj = match v {
+            Value::Object(o) => o.clone(),
+            Value::Undefined | Value::Null => return Ok(Vec::new()),
+            _ => self.to_object(v)?,
+        };
+        // FAST PATH — the overwhelmingly common shape: an ORDINARY receiver
+        // whose prototype chain CONTRIBUTES no enumerable string key (every
+        // standard prototype is fully non-enumerable). One object's own
+        // enumerable string keys are unique by construction, and a chain
+        // that contributes nothing makes shadowing irrelevant — so the
+        // shadow set and the per-level `own_keys` key-clone Vecs (together
+        // ~14% of glue-shaped workloads) are skipped entirely. Anything
+        // else — proxy, exotic index sources, an enumerable proto key —
+        // falls back to the generic walk below, unchanged.
+        if let Some(out) = self.for_in_keys_fast(&obj) {
+            return Ok(out);
+        }
         let mut out: Vec<JsString> = Vec::new();
         // Dedup by `JsString` (an insert clones an `Rc`, not the bytes) under
         // the deterministic Fx hasher — the std SipHash `HashSet<String>` it
@@ -416,11 +433,6 @@ impl Vm {
             JsString,
             std::hash::BuildHasherDefault<crate::fxhash::FxHasher>,
         > = Default::default();
-        let obj = match v {
-            Value::Object(o) => o.clone(),
-            Value::Undefined | Value::Null => return Ok(out),
-            _ => self.to_object(v)?,
-        };
         let mut cur = Some(obj);
         while let Some(o) = cur {
             if self.is_proxy(&o) {
@@ -464,5 +476,85 @@ impl Vm {
             cur = o.borrow().proto.clone();
         }
         Ok(out)
+    }
+
+    /// `for_in_keys`' allocation-free fast path. `Some(keys)` iff the
+    /// receiver is an ordinary object and NO prototype-chain level
+    /// contributes an enumerable string key — then the receiver's own
+    /// enumerable string keys (index-likes sorted first, per
+    /// `[[OwnPropertyKeys]]`) ARE the for-in keys, no shadow set needed.
+    /// `None` = use the generic walk; the split is decided by the same
+    /// facts that walk reads, so both produce identical keys where this
+    /// path applies.
+    fn for_in_keys_fast(&self, obj: &JsObject) -> Option<Vec<JsString>> {
+        let mut out: Vec<JsString> = Vec::new();
+        let mut ints: Vec<u32> = Vec::new();
+        let proto = {
+            let b = obj.borrow();
+            // Ordinary receivers only: exotic internals (dense elements,
+            // string indices, typed arrays, proxies, namespace exports)
+            // synthesize own keys that live outside `props`.
+            if !matches!(b.internal, Internal::Ordinary) {
+                return None;
+            }
+            for (k, p) in b.props.iter() {
+                if let PropertyKey::Str(s) = k {
+                    // Internal-slot keys are non-enumerable by contract, so
+                    // `p.enumerable` alone excludes them, as on the generic
+                    // path.
+                    if !p.enumerable {
+                        continue;
+                    }
+                    match k.array_index() {
+                        Some(i) => ints.push(i),
+                        None => out.push(s.clone()),
+                    }
+                }
+            }
+            b.proto.clone()
+        };
+        // Index-like keys enumerate first, ascending (map keys are unique,
+        // so no dedup); the plain names keep insertion order after them.
+        if !ints.is_empty() {
+            ints.sort_unstable();
+            let mut merged: Vec<JsString> = Vec::with_capacity(ints.len() + out.len());
+            for i in ints {
+                match PropertyKey::from_index(i) {
+                    PropertyKey::Str(s) => merged.push(s),
+                    PropertyKey::Sym(_) => unreachable!("index keys are strings"),
+                }
+            }
+            merged.append(&mut out);
+            out = merged;
+        }
+        // The rest of the chain must contribute NOTHING: no enumerable
+        // string key in `props`, and no internal that synthesizes own
+        // enumerable keys. Any contribution (or a proxy, whose traps must
+        // run) sends the whole walk down the generic path.
+        let mut cur = proto;
+        while let Some(o) = cur {
+            let b = o.borrow();
+            match &b.internal {
+                Internal::Proxy(_)
+                | Internal::StringObj(_)
+                | Internal::TypedArray(_)
+                | Internal::ModuleNamespace(_) => return None,
+                // An EMPTY dense array (Array.prototype!) contributes only
+                // its non-enumerable `length`; any element is enumerable.
+                Internal::Array(arr) if arr.iter().any(|v| !matches!(v, Value::Hole)) => {
+                    return None;
+                }
+                _ => {}
+            }
+            for (k, p) in b.props.iter() {
+                if p.enumerable && matches!(k, PropertyKey::Str(_)) {
+                    return None;
+                }
+            }
+            let next = b.proto.clone();
+            drop(b);
+            cur = next;
+        }
+        Some(out)
     }
 }

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -31,9 +31,11 @@
 //!   bytecode at compile finish — a pure function of the source. Execution
 //!   order of every observable operation is identical to the stack path
 //!   (gated by the reg-on/off differential corpus in `tests/reg.rs`), so the
-//!   replay journal is byte-identical either way. Like kernels, the tier is
-//!   OFF whenever an op budget is installed: per-op accounting stays exact
-//!   on the generic path.
+//!   replay journal is byte-identical either way. Unlike the kernel tiers,
+//!   the register tier stays ON under an op budget: [`RegProto::costs`]
+//!   charges each register op its EXACT stack-op units, so a budgeted run
+//!   drains — and exhausts — identically on both tiers (gated by the
+//!   budget-sweep and corpus budget differentials in `tests/reg.rs`).
 //!
 //! # Translation scheme
 //!
@@ -75,6 +77,27 @@ use crate::exec::ArithKind;
 #[derive(Debug)]
 pub struct RegProto {
     pub code: Vec<ROp>,
+    /// Per-op budget charge, index-parallel to `code`: the EXACT number of
+    /// final stack-bytecode ops this register op stands for, so a budgeted
+    /// run drains and exhausts identically on both tiers.
+    ///
+    /// The charge is hard-checked before the op runs: `budget < cost`
+    /// throws the budget-exceeded RangeError WITHOUT executing it, exactly
+    /// where the stack loop's per-op check would have fired — no observable
+    /// op (user code, throw, heap write, host effect) can run that the
+    /// stack tier would not have reached. PURE stack ops (elided lazy
+    /// loads, a fused window's trailing `Swap`) accumulate into the next
+    /// anchor's charge on the same path — or a [`ROp::Charge`] at a
+    /// fall-through join — which is exact both ways: between a pure stack
+    /// op and the next anchor nothing observable runs, so dying at the
+    /// anchor's check is indistinguishable from dying mid-pures, and a
+    /// window's trailing units are charged only after its user-visible part
+    /// (a getter inside the fused method-call window) already ran, with the
+    /// budget it would have seen on the stack tier.
+    ///
+    /// Termination stays guaranteed: every control op (branch, jump,
+    /// return) is an anchor with cost >= 1, so no cycle executes at 0.
+    pub costs: Box<[u32]>,
     /// Total register-file size: `num_locals` localized bindings followed by
     /// the canonical operand slots. `Frame.locals` is resized to this on
     /// register-mode entry.
@@ -119,6 +142,11 @@ pub enum DefKind {
 #[derive(Clone, Debug)]
 pub enum ROp {
     // ---- moves / constants / frame values ----
+    /// Pure budget landing: runs nothing; exists so stranded pure stack-op
+    /// units on a fall-through edge into a label are charged on that path
+    /// (jump-in paths charged theirs at their control op). Its units live
+    /// in [`RegProto::costs`] like any anchor's.
+    Charge,
     Mov {
         dst: u16,
         src: u16,
@@ -801,6 +829,41 @@ struct Emitter {
     /// Reached only through parked completions, so phase 2 draws no edge for
     /// them; emitting a reachable jump to one declines the function.
     unseeded_cj: Vec<u32>,
+    /// Per-op budget charges, index-parallel to `code` (see
+    /// [`RegProto::costs`]).
+    costs: Vec<u32>,
+    /// Stack-op units consumed but not yet charged (elided lazy loads,
+    /// `Nop`s, peepholed stores, a fused window's trailing pure ops):
+    /// charged into the next anchor on the same path, or sunk into a
+    /// [`ROp::Charge`] at a fall-through edge.
+    pending: u32,
+    /// Set by a fusion arm whose window has trailing PURE stack ops after
+    /// the semantic anchor (the method-call prologue's `Swap`): the number
+    /// of window units up to and including the anchor. `None` = the anchor
+    /// is the window's last unit.
+    anchor_units: Option<u32>,
+}
+
+/// Register ops that are PURE for budget purposes: no user code, no throw,
+/// no heap- or host-visible effect — executing one past the stack tier's
+/// exhaustion point is unobservable, because the uncatchable budget throw
+/// kills the frame before anything can read a register. Everything else is
+/// an ANCHOR: it takes the accumulated charge as a hard `pre` check and
+/// must not execute unless the stack tier would have reached its twin.
+/// (Whitelist deliberately minimal — anchoring a pure op is always sound.)
+fn rop_budget_pure(op: &ROp) -> bool {
+    matches!(
+        op,
+        ROp::Charge
+            | ROp::Mov { .. }
+            | ROp::Const { .. }
+            | ROp::Undef { .. }
+            | ROp::Null { .. }
+            | ROp::Bool { .. }
+            | ROp::Hole { .. }
+            | ROp::This { .. }
+            | ROp::NewTarget { .. }
+    )
 }
 
 /// Translate a function's final stack bytecode into a register program.
@@ -1011,6 +1074,9 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
         last_def: None,
         normal_visited,
         unseeded_cj,
+        costs: Vec::with_capacity(code.len()),
+        pending: 0,
+        anchor_units: None,
     };
     // rpc of each stack ip (branch targets remapped through this at the end).
     let mut rpc_at: Vec<u32> = vec![0; code.len() + 1];
@@ -1020,10 +1086,16 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
         if is_label(ip) {
             if live {
                 e.flush_all();
+                // Charge stranded pure units on this fall-through edge
+                // BEFORE the join (jump-in paths charged theirs at their
+                // control op; `rpc_at` below makes them land past this).
+                e.sink_pending();
                 debug_assert_eq!(
                     e.entries.len() as u32,
                     label_states.get(&ip).map(|s| s.depth).unwrap_or(0)
                 );
+            } else {
+                debug_assert_eq!(e.pending, 0, "dead code cannot strand units");
             }
             match label_states.get(&ip) {
                 Some(st) => {
@@ -1043,7 +1115,9 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
             ip += 1;
             continue;
         }
+        let emit_start = e.code.len();
         let (fallthrough, consumed) = e.emit_op(code, ip, &is_label)?;
+        e.assign_cost(emit_start, consumed);
         live = fallthrough;
         for k in 0..consumed {
             tdz_transfer(&code[(ip + k) as usize], &mut e.tdz);
@@ -1053,11 +1127,19 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
         }
         ip += consumed;
     }
+    // Stranded pure units on a live fall-off-the-end path charge before the
+    // landing pad (jump-to-end targets land ON the pad, past this).
+    if live {
+        e.sink_pending();
+    }
+    debug_assert_eq!(e.pending, 0);
     rpc_at[code.len()] = e.code.len() as u32;
     // Falling off the end of the code returns like the stack loop's
     // `ip >= code.len()` exit; also the landing pad for end-of-code jump
-    // targets, so pc can never overrun.
+    // targets, so pc can never overrun. Costs one unit: the stack loop
+    // charges at its head BEFORE the `ip >= len` return check.
     e.code.push(ROp::RetCompletion);
+    e.costs.push(1);
     // Remap branch targets from stack ips to rpcs.
     for op in &mut e.code {
         if let ROp::PushTryHandler { catch, finally, .. } = op {
@@ -1084,8 +1166,10 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
             holder: std::cell::RefCell::new(None),
         })
         .collect();
+    debug_assert_eq!(e.code.len(), e.costs.len());
     Some(RegProto {
         code: e.code,
+        costs: e.costs.into_boxed_slice(),
         num_regs: num_regs as u16,
         ic,
     })
@@ -1177,13 +1261,46 @@ impl Emitter {
     fn push_op(&mut self, op: ROp) {
         self.last_def = None;
         self.code.push(op);
+        self.costs.push(0);
     }
 
     /// Emit an op whose single `dst` produced the new virtual-stack top
     /// (arming the `StoreLocal` rewrite peephole).
     fn push_def(&mut self, op: ROp) {
         self.code.push(op);
+        self.costs.push(0);
         self.last_def = Some(self.code.len() - 1);
+    }
+
+    /// Attach one emission window's stack-op units up to and including its
+    /// semantic anchor (`anchor_units`, defaulting to all `consumed`) to the
+    /// FIRST anchor op it emitted (see [`rop_budget_pure`]); trailing pure
+    /// window units re-enter `pending`. An all-pure emission accumulates
+    /// all of its units into `pending` for the next anchor.
+    fn assign_cost(&mut self, start: usize, consumed: u32) {
+        let anchor_units = self.anchor_units.take().unwrap_or(consumed);
+        for i in start..self.code.len() {
+            if !rop_budget_pure(&self.code[i]) {
+                debug_assert!((1..=consumed).contains(&anchor_units));
+                self.costs[i] = self.pending + anchor_units;
+                self.pending = consumed - anchor_units;
+                return;
+            }
+        }
+        self.pending += consumed;
+    }
+
+    /// Sink accumulated pure units into a [`ROp::Charge`] — required before
+    /// a control-flow join reached by fall-through, so every path into the
+    /// join has charged exactly its own units.
+    fn sink_pending(&mut self) {
+        if self.pending > 0 {
+            let n = self.pending;
+            self.pending = 0;
+            self.push_op(ROp::Charge);
+            let i = self.code.len() - 1;
+            self.costs[i] = n;
+        }
     }
 
     /// Register that currently holds the value of `entries[pos]`, emitting a
@@ -1687,6 +1804,12 @@ impl Emitter {
                             Entry::Temp => Entry::Temp,
                             other => other,
                         });
+                        // Budget anchor: the window's observable op is the
+                        // `GetProp` at unit 2 of [Dup, GetProp, Swap] — the
+                        // trailing pure `Swap` unit re-enters `pending`, so
+                        // a getter still runs when the stack tier would
+                        // have died exactly AT the Swap.
+                        self.anchor_units = Some(2);
                         return Some((true, 3));
                     }
                 }

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -343,7 +343,11 @@ pub struct Vm {
     /// across activations so entering a kernel allocates nothing. Kernels
     /// never nest (a region containing a `LoopKernel` op is not kernelized),
     /// and the generic interpreter running under a kernel's fallback path
-    /// never touches this, so one buffer per Vm suffices.
+    /// never touches this, so one buffer per Vm suffices. GROW-ONLY: the
+    /// buffer keeps its high-water length across activations and is never
+    /// re-zeroed — stale `f64`s are unreadable (every register is either
+    /// loaded at entry or store-before-read by translation proof), and
+    /// zero-filling deep recursion windows per outer call was measurable.
     pub(crate) kernel_regs: Vec<f64>,
     /// Scratch cache of the array-base objects for the active kernel (see
     /// `kernel_regs`); cleared after every activation so the pool never
@@ -355,6 +359,15 @@ pub struct Vm {
     /// Pooled entry-verified closure callees for kernel `CallKernel`:
     /// (callee function, register-window base).
     pub(crate) kernel_callees: Vec<(std::rc::Rc<crate::value::BytecodeFunction>, u32)>,
+    /// Cached recursion-family resolutions for the windowed recursive-kernel
+    /// executor (see `exec::RecFamily`): resolving a family allocates tables
+    /// and walks member code, which dominated shallow recursions when paid
+    /// per outer call. Bounded; validated per activation; a pure perf cache
+    /// (hit vs miss is unobservable).
+    pub(crate) rec_families: Vec<crate::exec::RecFamily>,
+    /// Pooled (caller, return-pc, dst, window) stack for
+    /// `run_fn_kernel_rec`; parked empty.
+    pub(crate) rec_calls: Vec<(u8, u16, u16, u32)>,
 }
 
 impl Default for Vm {
@@ -397,6 +410,8 @@ impl Vm {
             kernel_objs: Vec::new(),
             kernel_prop_slots: Vec::new(),
             kernel_callees: Vec::new(),
+            rec_families: Vec::new(),
+            rec_calls: Vec::new(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(
                     "",

--- a/crates/chidori-js/tests/reg.rs
+++ b/crates/chidori-js/tests/reg.rs
@@ -56,6 +56,12 @@ const CORPUS: &[&str] = &[
     "const obj = { v: 2, m() { return this.v; }, chain() { return this.m() + this.m(); } }; console.log(obj.chain());",
     // Swap without the fusion window (computed method key).
     "const k = 'm'; const o2 = { m(v) { return v * 2; } }; console.log(o2[k](21));",
+    // ZERO-arg call whose argument window starts one past every touched
+    // register (Test262 S13.2.2_A10 shape): `at` may exceed `num_regs`, so
+    // the executor must not slice `locals[at..at]` (pre-existing panic,
+    // masked while budgeted runs took the stack tier).
+    "function FACTORY() { this.id = 0; this.func = function () { return 5; }; this.id = this.func(); } \
+     console.log(new FACTORY().id);",
     // Deeply nested call expressions (argument ranges stay contiguous).
     "function add(a, b) { return a + b; } console.log(add(add(1, add(2, 3)), add(add(4, 5), 6)));",
 
@@ -297,10 +303,11 @@ fn reg_depth_overflow_matches_stack() {
         .expect("no panic");
 }
 
-/// An installed op budget must keep per-stack-op accounting EXACT: the
-/// register tier declines and the budgeted run terminates with the same
-/// uncatchable RangeError either way — including for call-heavy programs
-/// whose callees carry register programs.
+/// An installed op budget must keep per-stack-op accounting EXACT. The
+/// register tier now runs UNDER the budget (`RegProto::costs` charges each
+/// register op its exact stack-op units), so a budgeted run terminates with
+/// the same uncatchable RangeError and the same drain on both compiles —
+/// including for call-heavy programs whose callees carry register programs.
 #[test]
 fn op_budget_stays_exact_with_reg_protos() {
     let src =
@@ -322,6 +329,105 @@ fn op_budget_stays_exact_with_reg_protos() {
         // Identical budget consumption on both compiles: the remaining
         // budget after the abort must match exactly.
         assert_eq!(engine.vm.op_budget, Some(0), "budget drained (regs={regs})");
+    }
+}
+
+/// THE budget gate for the register tier: for EVERY budget value from 0 to
+/// past the program's total cost, a budgeted run must be observably
+/// IDENTICAL on both compiles — same console output, same completion
+/// (success or error message), same remaining budget. This pins both the
+/// exact-drain property (completed runs, the tail of the sweep) and the
+/// exhaustion BOUNDARY: the uncatchable throw fires between the same two
+/// observable effects on both tiers, including inside the fused
+/// `Dup; GetProp; Swap` method-call window, whose logging getter must run
+/// iff the stack tier's per-op check would have reached the `GetProp` —
+/// even when the budget dies exactly at the window's trailing `Swap`.
+#[test]
+fn op_budget_sweep_differential() {
+    let src = r#"
+        function tag(x) { console.log("t" + x); return x; }
+        const o = {
+            n: 40,
+            get m() { console.log("getter"); return function () { return this.n; }; },
+        };
+        let s = 0;
+        for (let i = 0; i < 4; i++) {
+            s += i % 2 ? tag(i) : i;
+            console.log("i" + i + ":" + s);
+        }
+        s += o.m();
+        const t = s > 3 ? "hi" : "lo";
+        try { null.x; } catch (e) { console.log("caught"); }
+        console.log("end:" + t + s);
+    "#;
+    let protos = [
+        Rc::new(compile_script_regs(src, false).expect("compiles")),
+        Rc::new(compile_script_regs(src, true).expect("compiles")),
+    ];
+    let run_budgeted = |proto: &Rc<FuncProto>, k: u64| {
+        let mut engine = Engine::new();
+        engine.vm.op_budget = Some(k);
+        let func = engine.vm.make_closure(proto.clone(), Vec::new());
+        let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+        let err = match res {
+            Ok(_) => String::new(),
+            Err(e) => engine.vm.error_to_string(&e),
+        };
+        (engine.console().to_vec(), err, engine.vm.op_budget)
+    };
+    // Total cost measured on the stack tier; the sweep's tail (k >= total)
+    // asserts completed runs drain identically.
+    let big = 1_000_000u64;
+    let (_, err, left) = run_budgeted(&protos[0], big);
+    assert!(err.is_empty(), "must complete under a large budget: {err}");
+    let total = big - left.expect("budget still installed");
+    assert!(total > 50 && total < 10_000, "sane sweep bound: {total}");
+    for k in 0..=total + 2 {
+        let stack = run_budgeted(&protos[0], k);
+        let reg = run_budgeted(&protos[1], k);
+        assert_eq!(stack, reg, "budget {k} diverged");
+    }
+}
+
+/// Budget differential over the WHOLE corpus at strategic budget values
+/// (start, midpoints, and the exhaustion/completion boundary): every
+/// translated op shape must charge exactly. A full 0..=total sweep per
+/// program would dominate CI time; the boundary probes catch per-op cost
+/// errors (they shift `total`) and the midpoints catch divergent
+/// exhaustion behavior.
+#[test]
+fn op_budget_corpus_differential() {
+    for src in CORPUS {
+        let protos = [
+            Rc::new(compile_script_regs(src, false).expect("compiles")),
+            Rc::new(compile_script_regs(src, true).expect("compiles")),
+        ];
+        let run_budgeted = |proto: &Rc<FuncProto>, k: u64| {
+            let mut engine = Engine::new();
+            engine.vm.op_budget = Some(k);
+            let func = engine.vm.make_closure(proto.clone(), Vec::new());
+            let res = engine.vm.call(Value::Object(func), Value::Undefined, &[]);
+            let _ = engine.vm.run_jobs_until_blocked();
+            let err = match res {
+                Ok(_) => String::new(),
+                Err(e) => engine.vm.error_to_string(&e),
+            };
+            (engine.console().to_vec(), err, engine.vm.op_budget)
+        };
+        let big = 50_000_000u64;
+        let (_, _, left) = run_budgeted(&protos[0], big);
+        let total = big - left.expect("budget still installed");
+        let mut probes = vec![0, 1, 2, total / 3, total / 2, 2 * total / 3];
+        for d in 0..=4 {
+            probes.push((total + 2).saturating_sub(d));
+        }
+        probes.sort_unstable();
+        probes.dedup();
+        for k in probes {
+            let stack = run_budgeted(&protos[0], k);
+            let reg = run_budgeted(&protos[1], k);
+            assert_eq!(stack, reg, "budget {k} diverged on: {src}");
+        }
     }
 }
 

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1066,7 +1066,8 @@ Measured (idle machine, interleaved A/B medians): **mutual_recursion
 (6.9×)**; fib_recursive / closures / sort unchanged. RESULT byte-identical.
 Remaining headroom: the per-activation family resolution allocates its
 tables per OUTER call (~40k entries here) — an entry cache or Vm-pooled
-scratch would shave the shallow-recursion case further.
+scratch would shave the shallow-recursion case further. *(→ landed as the
+family cache + grow-only register buffer, §6.11.)*
 
 Gates: the kernels differential corpus grew 16 recursion programs
 (boolean/mutual/const-binding families, typeof/strict-eq observation,
@@ -1147,15 +1148,12 @@ values):
   through parked completions (a `while(true)` whose sole exits break
   through a `finally`) has no seeded state and declines the function.
 - **Determinism.** The register program is a pure function of the source,
-  compiled at compile finish. Like the kernel tiers, the register tier is
-  OFF whenever an op budget is installed — per-stack-op accounting stays
-  exact on the generic path — and it polls the cooperative interrupt flag
-  at the stack loop's cadence. (Consequence, inherited from the kernel
-  tiers' rule: the production server's default `CHIDORI_JS_OP_BUDGET=5e9
-  keeps agent runs on the stack tier; the tier pays off today in
-  unbudgeted embeddings, replay/test tooling, and the benchmark harness.
-  Making budget accounting conservative-but-deterministic on the fast
-  tiers is tracked as follow-up work.)
+  compiled at compile finish. It polls the cooperative interrupt flag at
+  the stack loop's cadence. ~~Like the kernel tiers, the register tier is
+  OFF whenever an op budget is installed~~ — superseded by §6.11: the tier
+  now carries EXACT per-op stack-unit costs and stays on under a budget,
+  so the production server's default `CHIDORI_JS_OP_BUDGET=5e9` runs get
+  the register tier too. The kernel tiers still decline under a budget.
 - **Native stack discipline.** `run_reg_frame` keeps the hot ops inline and
   delegates everything rare to an `#[inline(never)]` `rstep_cold`, the same
   split (and reason) as `step`/`step_cold`; the depth-overflow differential
@@ -1235,9 +1233,117 @@ vs reg-off across the board.
 - **Register-mode loop-kernel embedding** — let a function carry BOTH
   kernels and a register program by teaching kernel bail-out to resume at a
   register pc instead of a stack ip.
-- **Budget-compatible fast tiers** — a conservative deterministic op-count
-  mapping so production budgeted runs can use kernels + registers.
+- ~~**Budget-compatible fast tiers**~~ — the register half landed (§6.11):
+  budgeted runs keep the register tier with EXACT drain. The kernel tiers
+  (whose fused unboxed regions have no 1:1 stack-op correspondence at
+  bail boundaries) still decline under a budget; mapping them stays open.
 - Re-run the callgrind sweep before choosing; §1.1's caveats stand.
+
+## 6.11 Recursion-entry + for-in fast paths; the register tier joins budgeted runs (landed 2026-07-11)
+
+Four items from a fresh callgrind review of the two workloads the previous
+rounds left richest — mutual_recursion (1.43 G, ~22% per-activation
+overhead) and mixed_helpers (4.16 G, ~14% for-in machinery) — plus the
+op-budget follow-up §6.10.2 tracked. All safe Rust, zero new dependencies.
+
+1. **Grow-only kernel register buffer.** `Vm::kernel_regs` was cleared and
+   re-zeroed per activation, so a 300-deep `isEven` recursion re-zero-filled
+   every window on each of 40k outer calls — `Vec::resize` + memset were
+   11% of mutual_recursion. The buffer now keeps its high-water length
+   across activations and is never re-zeroed: stale `f64`s are unreadable
+   by construction (every register is loaded at entry or store-before-read
+   by translation proof — the same proofs the kernels already rely on).
+2. **Recursion-family cache** (`exec::RecFamily`, `Vm::rec_families`). v9's
+   per-activation family resolution allocated ~8 table Vecs and re-scanned
+   every member's kernel code (Ret-type + argc cross-checks) per OUTER
+   call. The resolved family is now cached keyed by the entry closure's
+   identity; a hit re-verifies only the dynamic facts — each recorded
+   global SLOT still holds its member (key-verified indexed read, no
+   hashing — insertion slots are stable under value writes and appends),
+   upvalue self-cells intact, `Math` canonical — and re-snapshots upvalue
+   values. Any failure drops the entry and re-resolves from scratch
+   (exactly the uncached path), so hit vs miss is unobservable. The
+   windowed executor's (return-pc, dst, window) stack is Vm-pooled, and
+   the family's tables are read through the cache during execution.
+   Bounded (8 entries, MRU); holding member closures across activations is
+   the same retention class as the prototype-holder ICs.
+3. **for-in fast path** (`Vm::for_in_keys_fast`). Every `for (k in o)`
+   built a shadowing `HashSet` and per-chain-level `own_keys` key-clone
+   Vecs — so a 5-key plain object also inserted Object.prototype's ~12
+   non-enumerable keys into a set that then rehashed and dropped, 60k
+   times (~14% of mixed_helpers + a large share of its allocator
+   traffic). Now: an ORDINARY receiver's own enumerable string keys come
+   straight off its property map (index-likes sorted first, own keys
+   unique by construction — no dedup needed for one level), and the
+   prototype chain is walked with an allocation-free "contributes any
+   enumerable string key?" scan. If nothing contributes (every standard
+   prototype), shadowing is irrelevant and the walk is done; a proxy, an
+   exotic index source, or any enumerable proto key falls back to the
+   generic path unchanged. Gated by an 18-case differential vs Node
+   (index ordering, shadowing incl. non-enumerable shadows, null proto,
+   mid-program `Object.prototype` injection, arrays/holes/strings,
+   enumerable accessors, frozen objects, array-valued protos).
+4. **The register tier joins budgeted runs** (`RegProto::costs`). The tier
+   previously declined whenever an op budget was installed — so the
+   production server's `CHIDORI_JS_OP_BUDGET=5e9` kept every agent run on
+   the stack tier, and §6.10's wins never reached production. Each
+   register op now carries the EXACT number of final stack-bytecode ops it
+   stands for, attributed during translation: elided pure loads accumulate
+   into the next ANCHOR op on their path (between a pure stack op and the
+   next anchor nothing observable runs, so charging there is exact); a
+   fall-through edge into a join sinks stranded units into a pure
+   `ROp::Charge`; the fused method-call window anchors at its `GetProp`
+   (unit 2 of 3) so a getter still runs — with the same remaining budget —
+   when the stack tier would have died exactly at the trailing `Swap`.
+   The charge is hard-checked before each op: the budget-exceeded throw
+   fires exactly where the stack loop's per-op check would have, no op
+   the stack tier would not have reached can run, and every control op
+   costs ≥ 1 so termination stays guaranteed. Unbudgeted runs pay one
+   predicted branch per op (the stack loop's own `counting` protocol).
+
+   En route this EXPOSED a pre-existing register-tier crash that budgeted
+   runs had masked: a zero-arg call/construct whose argument window starts
+   one past every touched register (`new`/method-call at virtual-stack
+   top, the Test262 `S13.2.2_A10` shape) panicked slicing
+   `locals[at..at]` out of range — the process-killing kind of bug the
+   conformance gate exists to catch, and it only surfaced because the gate
+   (which installs a 50M budget) now exercises the register tier at all.
+   Fixed with explicit empty-window guards; the shape is pinned in the reg
+   corpus.
+
+### 6.11.1 Measured (callgrind, whole workload, deterministic)
+
+Baseline = the branch point, same toolchain; RESULT checksums
+byte-identical across the suite and cross-checked against node/bun by the
+benchmark harness:
+
+| workload | before | after | Δ |
+| --- | ---: | ---: | ---: |
+| mixed_helpers | 4.157 G | 2.953 G | **−29.0%** |
+| mutual_recursion | 1.434 G | 1.097 G | **−23.5%** |
+| json_roundtrip | 1.193 G | 1.191 G | −0.2% |
+| sort | 2.045 G | 2.051 G | +0.3% ¹ |
+| string_scan | 353.8 M | 354.9 M | +0.3% ¹ |
+| fib_recursive | 673.8 M | 676.5 M | +0.4% ² |
+| closures / arith_loop / property_access / array_sum / typed_array / array_hof / array_push_sum / string_build | — | — | unchanged (±0.1%) |
+
+¹ The register loop's `counting` branch — the price of budget
+eligibility, paid only by reg-carried workloads.
+² One instruction per self-call reading window sizes through the cached
+family instead of hoisted locals.
+
+Wall-clock (idle container, indicative per §1.1): mutual_recursion
+150 → 113 ms, mixed_helpers 587 → 427 ms.
+
+**Gates:** full suites for both crates green; kernels + reg differential
+corpora green (reg corpus grew the zero-arg-window pin); the op-budget
+test now genuinely exercises the register tier, joined by TWO new budget
+differentials — a full 0..=total budget sweep on a side-effecting program
+(every budget value must produce identical console output, completion,
+and remaining budget on both compiles) and boundary probes across the
+whole reg corpus; the 18-case for-in differential vs Node; Test262 gate
+green — now running the register tier under the runner's budget for the
+first time, i.e. 40k+ conformance tests newly executing the tier.
 
 ## 7. References
 


### PR DESCRIPTION
# Summary

Four items from a fresh callgrind review of the two workloads the previous optimization rounds left richest — `mutual_recursion` (~22% per-activation overhead) and `mixed_helpers` (~14% for-in machinery) — plus the op-budget follow-up that §6.10.2 tracked. All safe Rust, zero new dependencies; full write-up in `docs/js-performance-roadmap.md` §6.11.

1. **Grow-only kernel register buffer.** `Vm::kernel_regs` was cleared and re-zeroed per activation, so a 300-deep `isEven` recursion re-zero-filled every window on each of 40k outer calls (`Vec::resize` + memset = 11% of mutual_recursion). The buffer now keeps its high-water length across activations; stale `f64`s are unreadable by construction (entry loads + the store-before-read translation proofs the kernels already rely on).

2. **Recursion-family cache** (`exec::RecFamily`). Kernel v9's per-outer-call family resolution allocated ~8 table Vecs, re-scanned every member's kernel code, and did hashed global lookups. The resolved family is now cached keyed by the entry closure's identity; a hit re-verifies only the dynamic facts — key-verified global slots (indexed read + pointer compares, no hashing), upvalue self-cells, canonical `Math` — and re-snapshots upvalue values. Any failure drops the entry and takes the exact uncached path, so hit vs miss is unobservable. The windowed executor's call stack is Vm-pooled.

3. **for-in fast path.** Every `for (k in o)` built a shadowing HashSet and per-chain-level `own_keys` key-clone Vecs — a 5-key plain object also inserted Object.prototype's ~12 non-enumerable keys into a set that then rehashed and dropped, per iteration. An ordinary receiver whose prototype chain contributes no enumerable string key (every standard prototype) now skips all of it; proxies, exotic index sources, and enumerable proto keys fall back to the generic walk unchanged.

4. **The register tier joins budgeted runs** (`RegProto::costs`). The tier previously declined whenever an op budget was installed — so the production server's `CHIDORI_JS_OP_BUDGET=5e9` kept every agent run on the stack tier and §6.10's wins never reached production. Each register op now carries the EXACT number of final stack ops it stands for: elided pure loads charge at the next anchor on their path, stranded units sink into a pure `ROp::Charge` at fall-through joins, and the fused method-call window anchors at its `GetProp` so a getter observes the same remaining budget as on the stack tier. Budgeted runs now keep the register tier with byte-identical drain and exhaustion behavior; unbudgeted runs pay one predicted branch per op.

   En route this **exposed a pre-existing register-tier crash** that budgeted runs had masked: a zero-arg call/construct whose argument window starts one past every touched register panicked slicing `locals[at..at]` out of range (the Test262 `S13.2.2_A10` shape — `this.id = this.func()` inside a constructor). It only surfaced because the conformance gate (which installs a 50M budget) now exercises the register tier at all. Fixed with empty-window guards; the shape is pinned in the reg corpus.

# Measured (callgrind, whole workload, deterministic; baseline = branch point, same toolchain)

| workload | before | after | Δ |
| --- | ---: | ---: | ---: |
| mixed_helpers | 4.157 G | 2.953 G | **−29.0%** |
| mutual_recursion | 1.434 G | 1.097 G | **−23.5%** |
| sort / string_scan | — | — | +0.3% (the counting branch — the price of budget eligibility) |
| fib_recursive | 673.8 M | 676.5 M | +0.4% (family-table indirection, 1 instr/self-call) |
| closures / arith_loop / property_access / array_sum / typed_array / array_hof / array_push_sum / string_build / json_roundtrip | — | — | unchanged (±0.2%) |

Wall-clock (indicative): mutual_recursion 150 → 113 ms, mixed_helpers 587 → 427 ms. RESULT checksums byte-identical and cross-validated against node + bun by the benchmark harness.

# Gates

- Full suites for both crates green (incl. record→replay byte-identity, kernels + localize + fusion + ic differential corpora).
- reg corpus grew the zero-arg-window pin, plus **two new budget differentials**: a full `0..=total` budget sweep on a side-effecting program (every budget value must produce identical console output, completion, and remaining budget on both compiles — this caught a real boundary bug during development), and boundary probes across the whole reg corpus.
- 18-case for-in differential vs Node (index ordering, shadowing incl. non-enumerable shadows, null proto, mid-program `Object.prototype` injection, arrays/holes/strings, enumerable accessors, frozen objects, array-valued protos).
- **Test262 gate: PASS, 0 regressions** — now running the register tier under the runner's budget for the first time (~40k conformance tests newly executing the tier).
- clippy + rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kYK3G7abKVZfdzWR7U4Hq

---
_Generated by [Claude Code](https://claude.ai/code/session_014kYK3G7abKVZfdzWR7U4Hq)_