### PR TITLE
Masked kernel register windows, kernel const-prop + fusions, object-literal templates (§6.12)

### DIFF
--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -1152,7 +1152,7 @@ impl<'a> JsonParser<'a> {
         match self.bytes[self.pos] {
             b'{' => self.parse_object(vm),
             b'[' => self.parse_array(vm),
-            b'"' => Ok(Value::str(self.parse_string(vm)?)),
+            b'"' => Ok(Value::String(self.parse_string(vm)?)),
             b't' => self.parse_lit(vm, "true", Value::Bool(true)),
             b'f' => self.parse_lit(vm, "false", Value::Bool(false)),
             b'n' => self.parse_lit(vm, "null", Value::Null),
@@ -1218,7 +1218,7 @@ impl<'a> JsonParser<'a> {
             .map(Value::Number)
             .map_err(|_| vm.throw_syntax("Invalid number in JSON"))
     }
-    fn parse_string(&mut self, vm: &mut Vm) -> Result<String, Value> {
+    fn parse_string(&mut self, vm: &mut Vm) -> Result<JsString, Value> {
         self.pos += 1; // opening quote
                        // Fast path: a string with no escapes and no control characters —
                        // the overwhelmingly common case — is ONE slice copy instead of
@@ -1230,7 +1230,9 @@ impl<'a> JsonParser<'a> {
             match self.bytes[i] {
                 b'"' => {
                     self.pos = i + 1;
-                    return Ok(self.src[start..i].to_string());
+                    // One allocation: straight from the source slice into the
+                    // Rc backing (the old String round-trip copied twice).
+                    return Ok(JsString::new(&self.src[start..i]));
                 }
                 b'\\' | 0x00..=0x1f => break,
                 _ => i += 1,
@@ -1245,7 +1247,7 @@ impl<'a> JsonParser<'a> {
             match c {
                 b'"' => {
                     self.pos += 1;
-                    return Ok(s);
+                    return Ok(JsString::from(s));
                 }
                 b'\\' => {
                     self.pos += 1;
@@ -1387,7 +1389,7 @@ impl<'a> JsonParser<'a> {
                 _ => i += 1,
             }
         }
-        Ok(PropertyKey::str(self.parse_string(vm)?))
+        Ok(PropertyKey::Str(self.parse_string(vm)?))
     }
 
     fn parse_object(&mut self, vm: &mut Vm) -> Result<Value, Value> {

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -1352,8 +1352,11 @@ impl<'a> JsonParser<'a> {
         Ok(Value::Object(vm.new_array(elems)))
     }
     /// An object key: the unescaped fast path is interned by source slice
-    /// (see the `keys` field); anything needing escape processing falls back
-    /// to the general string parser. `self.pos` is on the opening quote.
+    /// (see the `keys` field) and, across parses, through the Vm-level
+    /// `json_keys` cache (same-shaped documents parsed repeatedly reuse one
+    /// `Rc<str>` per distinct key — the poll/roundtrip pattern); anything
+    /// needing escape processing falls back to the general string parser.
+    /// `self.pos` is on the opening quote.
     fn parse_key(&mut self, vm: &mut Vm) -> Result<PropertyKey, Value> {
         let start = self.pos + 1;
         let mut i = start;
@@ -1365,7 +1368,18 @@ impl<'a> JsonParser<'a> {
                     if let Some(k) = self.keys.get(s) {
                         return Ok(k.clone());
                     }
-                    let k = PropertyKey::str(s);
+                    let k = if let Some(k) = vm.json_keys.get(s) {
+                        k.clone()
+                    } else {
+                        let k = PropertyKey::str(s);
+                        // Bounded: a pathological stream of distinct keys
+                        // resets the cache rather than growing it.
+                        if vm.json_keys.len() >= 4096 {
+                            vm.json_keys.clear();
+                        }
+                        vm.json_keys.insert(s.into(), k.clone());
+                        k
+                    };
                     self.keys.insert(s, k.clone());
                     return Ok(k);
                 }
@@ -1396,7 +1410,15 @@ impl<'a> JsonParser<'a> {
             }
             self.pos += 1;
             let v = self.parse_value(vm)?;
-            obj.borrow_mut().props.insert(key, Property::data(v));
+            {
+                let mut b = obj.borrow_mut();
+                // One up-front table allocation covers the common ≤8-member
+                // object instead of the 0→3→7 growth (two allocs + a rehash).
+                if b.props.capacity() == 0 {
+                    b.props.reserve(8);
+                }
+                b.props.insert(key, Property::data(v));
+            }
             self.skip_ws();
             if self.pos >= self.bytes.len() {
                 return Err(vm.throw_syntax("Unexpected end of JSON input"));

--- a/crates/chidori-js/src/builtins/string.rs
+++ b/crates/chidori-js/src/builtins/string.rs
@@ -344,6 +344,17 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
             Ok(Value::Number(f64::NAN))
         }
     });
+    // Pin the canonical `charCodeAt` for the kernel `CharCodeAt` entry
+    // guard (identity check + bail-shape reconstruction), exactly like
+    // `Array.prototype.push`.
+    let ccode = proto
+        .borrow()
+        .props
+        .get(&PropertyKey::str("charCodeAt"))
+        .and_then(|p| p.value().cloned());
+    if let Some(Value::Object(o)) = ccode {
+        vm.realm.string_char_code_at = Some(o);
+    }
     vm.define_method(proto, "codePointAt", 1, |vm, this, args| {
         let s = jsstr_this(vm, &this)?;
         let i = to_integer_or_infinity(vm, &arg(args, 0))?;

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1088,6 +1088,18 @@ pub enum KOp {
         a2: u16,
         b2: u16,
     },
+    /// `regs[dst] = <utf16 length>` of the pinned STRING in string slot
+    /// `str`. TOTAL (no bail): the entry guard proved the slot holds a flat
+    /// ASCII string, strings are immutable, and the local is pinned — the
+    /// length is an activation constant.
+    StrLen { dst: u16, str: u16 },
+    /// `regs[dst] = charCodeAt(regs[idx])` over the pinned ASCII string in
+    /// string slot `str`. TOTAL (no bail): the index conversion
+    /// (ToIntegerOrInfinity — NaN→0, truncate toward zero, saturating) and
+    /// the out-of-range NaN result are computed exactly in-kernel; the entry
+    /// guard proved the receiver a flat ASCII string (unit == byte) and the
+    /// canonical `String.prototype.charCodeAt` resolution.
+    CharCodeAt { dst: u16, str: u16, idx: u16 },
     /// SUPERINSTRUCTION: `LoadElem` followed by `Arith` — the
     /// `d += a[i] * b[i]` dot-product shape's second load feeding its
     /// multiply (which the `(Arith, Add)` fusion then folds separately).
@@ -1351,6 +1363,11 @@ pub enum KShapeSlot {
     Obj(u16),
     MathObj,
     MathFn(KMath),
+    /// The pinned string in string slot `s` (cached at kernel entry).
+    Str(u16),
+    /// The canonical `String.prototype.charCodeAt` function object (entry
+    /// guard proved the live resolution IS the canonical — like `MathFn`).
+    CharCodeFn,
 }
 
 /// The `Math` methods the loop kernels can execute directly. Every kind maps
@@ -1461,6 +1478,15 @@ pub struct Kernel {
     /// guard requires each to hold an object; per-access checks do the rest.
     /// Disjoint from `locals`, and never stored to inside the region.
     pub oslots: Box<[u32]>,
+    /// `frame.locals` indices of STRING BASES (`s` in `s.charCodeAt(i)` /
+    /// `s.length`): string slot `n` caches that local's `JsString` at kernel
+    /// entry. The guard requires each to hold a FLAT ASCII string (unit ==
+    /// byte, so every read is O(1)); strings are immutable and the local is
+    /// pinned, so no per-access re-checks exist. Disjoint from `locals`.
+    pub sslots: Box<[u32]>,
+    /// Whether the region calls `charCodeAt` (the entry guard then
+    /// identity-checks the canonical `String.prototype.charCodeAt`).
+    pub uses_char_code: bool,
     /// Operand-stack shapes for [`KOp::Exit`] (bottom-up).
     pub shapes: Box<[Box<[KShapeSlot]>]>,
     /// Named-property access classes ([`KOp::LoadProp`]/[`KOp::StoreProp`]),

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -195,6 +195,29 @@ pub struct FuncProto {
     /// at runtime by `(this proto's pointer, index)` — the spec's per-Parse
     /// Node template cache (a shared proto is the same Parse Node).
     pub templates: Vec<TemplateParts>,
+    /// Object-literal templates for [`Op::NewObjectTpl`]: each carries the
+    /// literal's static keys and a pre-built property map (placeholder
+    /// `undefined` values) that instantiation CLONES instead of re-hashing
+    /// and re-inserting every key per evaluation.
+    pub obj_tpls: Vec<std::rc::Rc<ObjTemplate>>,
+}
+
+/// Compile-time template for an all-static-data-key object literal (see
+/// [`Op::NewObjectTpl`]). `map` holds every key inserted in source order with
+/// a placeholder `undefined` data property (writable/enumerable/configurable
+/// — exactly what `CreateDataProperty` defines); instantiation clones the map
+/// (bucket layout included — no hashing) and overwrites slots `0..N` with the
+/// evaluated values.
+pub struct ObjTemplate {
+    pub map: crate::fxhash::FxIndexMap<crate::value::PropertyKey, crate::value::Property>,
+}
+
+impl std::fmt::Debug for ObjTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list()
+            .entries(self.map.keys().map(|k| format!("{k:?}")))
+            .finish()
+    }
 }
 
 /// One inline-cache entry (see [`FuncProto::ic`]). `own_slot` indexes the
@@ -236,6 +259,7 @@ impl FuncProto {
             this_cell: None,
             inherit_home: false,
             templates: Vec::new(),
+            obj_tpls: Vec::new(),
         }
     }
 }
@@ -613,6 +637,21 @@ pub enum Op {
 
     // ---- objects / arrays ----
     NewObject,
+    /// Instantiate an all-static-data-key object literal from the pre-built
+    /// template at [`FuncProto::obj_tpls`]\[payload\]: pops the template's N
+    /// values (pushed in source order) and pushes the object. The template's
+    /// property map is CLONED (no hashing, no growth rehash, no per-key
+    /// descriptor validation — the compiler proved every key a distinct
+    /// static string data property on a fresh ordinary extensible object,
+    /// where `CreateDataPropertyOrThrow` cannot observe anything and cannot
+    /// fail) and the popped values are written into slots `0..N` in order —
+    /// the exact map the generic `NewObject` + N×`DefineField` sequence
+    /// builds, at a fraction of the cost. `n` is the key count (kept in the
+    /// op so stack-effect tables need no template lookup).
+    NewObjectTpl {
+        idx: u32,
+        n: u32,
+    },
     NewArray(u32), // number of initial elements popped
     /// Push the cached, frozen template object for tagged-template literal
     /// `index` (into the function's `templates`): `[] -> [templateObject]`.
@@ -941,6 +980,18 @@ pub enum Op {
 // Typed loop kernels
 // =============================================================================
 
+/// Fixed size of one kernel register WINDOW. Translation declines any kernel
+/// needing more than `KWIN` registers (every observed kernel uses ≤ 10), so
+/// the executors can hold registers in a `&mut [f64; KWIN]` and index it as
+/// `regs[(r as usize) & KWIN_MASK]` — the mask proves the index in-bounds to
+/// the compiler, eliminating the per-access bounds check (measured at 12–17%
+/// of kernel-owned workloads) with zero `unsafe`. Translation guarantees every
+/// register index is `< n_regs ≤ KWIN`, so the mask never changes a valid
+/// index; it only removes the panic branch.
+pub const KWIN: usize = 32;
+/// `KWIN - 1`, the index mask (KWIN is a power of two).
+pub const KWIN_MASK: usize = KWIN - 1;
+
 /// The kernel register machine's instruction set: unboxed `f64` registers, no
 /// operand stack, no heap values. Produced by `kernel.rs` from an eligible
 /// loop region's bytecode; executed by `Vm::run_kernel`. `target` fields index
@@ -999,6 +1050,56 @@ pub enum KOp {
         a: u16,
         k: f64,
         target: u16,
+    },
+    /// SUPERINSTRUCTION: `ArithK` followed by `Add` — the `s += a <op> K`
+    /// accumulation shape after const-propagation folded the constant.
+    ArithKAdd {
+        kind: crate::exec::ArithKind,
+        dst: u16,
+        a: u16,
+        k: f64,
+        d2: u16,
+        a2: u16,
+        b2: u16,
+    },
+    /// SUPERINSTRUCTION: `LoadLen` followed by `BrCmp` — the `i < a.length`
+    /// loop header test in one dispatch. Element/length semantics (and the
+    /// `bail` edge) are exactly [`KOp::LoadLen`]'s; the compare-and-branch is
+    /// exactly [`KOp::BrCmp`]'s.
+    LenBrCmp {
+        dst: u16,
+        obj: u16,
+        bail: u16,
+        cmp: CmpOp,
+        a: u16,
+        b: u16,
+        if_true: bool,
+        target: u16,
+    },
+    /// SUPERINSTRUCTION: `LoadElem` followed by `Add` — the `s += a[i]`
+    /// accumulation shape. Element semantics (and the `bail` edge) are
+    /// exactly [`KOp::LoadElem`]'s.
+    LoadElemAdd {
+        dst: u16,
+        obj: u16,
+        idx: u16,
+        bail: u16,
+        d2: u16,
+        a2: u16,
+        b2: u16,
+    },
+    /// SUPERINSTRUCTION: `LoadElem` followed by `Arith` — the
+    /// `d += a[i] * b[i]` dot-product shape's second load feeding its
+    /// multiply (which the `(Arith, Add)` fusion then folds separately).
+    LoadElemArith {
+        dst: u16,
+        obj: u16,
+        idx: u16,
+        bail: u16,
+        kind: crate::exec::ArithKind,
+        d2: u16,
+        a2: u16,
+        b2: u16,
     },
     /// unconditional jump
     Br { target: u16 },

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -708,6 +708,8 @@ struct FnCtx {
     inherit_home: bool,
     /// Tagged-template literals compiled in this function (see `FuncProto`).
     templates: Vec<TemplateParts>,
+    /// Object-literal templates (see [`crate::bytecode::ObjTemplate`]).
+    obj_tpls: Vec<std::rc::Rc<crate::bytecode::ObjTemplate>>,
 }
 
 impl FnCtx {
@@ -746,6 +748,7 @@ impl FnCtx {
             stable_cells: Vec::new(),
             inherit_home: false,
             templates: Vec::new(),
+            obj_tpls: Vec::new(),
             home_super: false,
             eval_scopes: Vec::new(),
         }
@@ -1912,6 +1915,7 @@ impl Compiler {
             this_cell: fc.this_cell,
             inherit_home: fc.inherit_home,
             templates: fc.templates,
+            obj_tpls: fc.obj_tpls,
         }
     }
 
@@ -3851,7 +3855,65 @@ impl Compiler {
         Ok(())
     }
 
+    /// Try to compile `o` as a TEMPLATE literal (see [`Op::NewObjectTpl`]):
+    /// every property a plain (non-computed, non-method, non-accessor,
+    /// non-spread, non-`__proto__`) data property with a distinct static
+    /// string key. Returns the template index, or `None` when any property
+    /// needs the generic `DefineField` path.
+    fn try_object_template(&mut self, o: &ObjectExpression) -> Option<u32> {
+        if o.properties.len() < 2 {
+            return None;
+        }
+        let mut names: Vec<String> = Vec::with_capacity(o.properties.len());
+        for prop in &o.properties {
+            let ObjectPropertyKind::ObjectProperty(p) = prop else {
+                return None;
+            };
+            if p.computed || p.method || !matches!(p.kind, PropertyKind::Init) {
+                return None;
+            }
+            let name = property_key_name(&p.key);
+            // Plain `__proto__: v` is a [[Prototype]] SET, not a property
+            // definition; duplicate keys keep later-wins semantics on the
+            // generic path.
+            if name == "__proto__" && !p.shorthand || names.contains(&name) {
+                return None;
+            }
+            names.push(name);
+        }
+        let mut map = crate::fxhash::FxIndexMap::default();
+        map.reserve(names.len());
+        for name in &names {
+            map.insert(
+                crate::value::PropertyKey::Str(crate::value::JsString::from(name.as_str())),
+                crate::value::Property::data(crate::value::Value::Undefined),
+            );
+        }
+        let fc = self.fns.last_mut().expect("fn ctx");
+        fc.obj_tpls
+            .push(std::rc::Rc::new(crate::bytecode::ObjTemplate { map }));
+        Some((fc.obj_tpls.len() - 1) as u32)
+    }
+
     fn compile_object(&mut self, o: &ObjectExpression) -> R {
+        if let Some(idx) = self.try_object_template(o) {
+            // All-static-data-key literal: evaluate the values in source
+            // order (identical order and side effects to the generic path —
+            // static keys have no evaluation step), then instantiate from
+            // the pre-built template in one op.
+            for prop in &o.properties {
+                let ObjectPropertyKind::ObjectProperty(p) = prop else {
+                    unreachable!("template eligibility excluded spreads")
+                };
+                let name = property_key_name(&p.key);
+                self.compile_named_expr(&p.value, &name)?;
+            }
+            self.emit(Op::NewObjectTpl {
+                idx,
+                n: o.properties.len() as u32,
+            });
+            return Ok(());
+        }
         self.emit(Op::NewObject);
         // Duplicate plain `__proto__: v` definitions are an early SyntaxError
         // (computed/shorthand/method forms don't count).

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -4,7 +4,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::bytecode::{CmpOp, Const, FuncKind, KOp, Op, UpvalueSource};
+use crate::bytecode::{CmpOp, Const, FuncKind, KOp, Op, UpvalueSource, KWIN, KWIN_MASK};
 use crate::value::*;
 use crate::vm::*;
 
@@ -33,8 +33,8 @@ fn peek_plain_bytecode(v: &Value) -> Option<Rc<BytecodeFunction>> {
 /// [`Vm::prepare_kernel_callback`], executed by [`Vm::exec_prepared_kernel`].
 pub(crate) struct PreparedKernel {
     bf: Rc<BytecodeFunction>,
-    /// Kernel register file, allocated once for the whole invocation.
-    regs: Vec<f64>,
+    /// Kernel register window (fixed size; masked, bounds-check-free access).
+    regs: [f64; crate::bytecode::KWIN],
     /// Back-edge interrupt poll counter (cadence spans calls).
     poll: u32,
     interrupt: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
@@ -89,7 +89,6 @@ pub(crate) struct RecFamily {
     /// callee `c` (`c = 0` is `j` itself; `c = 1 + i` is `rec.globals[i]`).
     callee_map: Vec<Vec<u8>>,
     /// Per-member register-window size.
-    n_regs: Vec<usize>,
     /// Per-member (register, argument index) entry loads.
     arg_slots: Vec<Vec<(usize, usize)>>,
     /// Per-member (register, upvalue index, snapshot) — the VALUE is
@@ -583,7 +582,10 @@ impl Vm {
         // access re-checks kind/bounds and bails otherwise.
         if k.loads_len {
             for op in k.code.iter() {
-                let crate::bytecode::KOp::LoadLen { obj, .. } = op else {
+                // `LenBrCmp` is a fused `LoadLen` and needs the same check.
+                let (crate::bytecode::KOp::LoadLen { obj, .. }
+                | crate::bytecode::KOp::LenBrCmp { obj, .. }) = op
+                else {
                     continue;
                 };
                 if let Value::Object(o) = &frame.locals[k.oslots[*obj as usize] as usize] {
@@ -701,9 +703,14 @@ impl Vm {
         // slot is loaded below; stack-temp registers are written before any
         // read by the virtual-stack discipline), so re-zeroing would be pure
         // memset tax.
+        // Layout: the caller's window is the first KWIN slots; pinned-callee
+        // windows (CALLEES) follow at fixed KWIN strides. Translation capped
+        // every kernel at KWIN registers, so the dispatch loop below indexes
+        // its `[f64; KWIN]` window with `& KWIN_MASK` — no bounds checks.
         let mut regs = std::mem::take(&mut self.kernel_regs);
-        if regs.len() < k.n_regs as usize {
-            regs.resize(k.n_regs as usize, 0.0);
+        let need = KWIN * (1 + if CALLEES { k.callee_slots.len() } else { 0 });
+        if regs.len() < need {
+            regs.resize(need, 0.0);
         }
         for (r, slot) in k.locals.iter().enumerate() {
             let v = match slot {
@@ -763,7 +770,7 @@ impl Vm {
         callee_bfs.clear();
         if CALLEES {
             let mut ok = self.trace_sink.is_none() && self.call_depth < self.max_call_depth;
-            let mut win = k.n_regs as usize;
+            let mut win = KWIN;
             if ok {
                 for c in k.callee_slots.iter() {
                     let bf = {
@@ -807,9 +814,8 @@ impl Vm {
                         ok = false;
                         break;
                     }
-                    let n = ck.n_regs as usize;
                     callee_bfs.push((bf, win as u32));
-                    win += n;
+                    win += KWIN;
                 }
             }
             if !ok {
@@ -839,6 +845,13 @@ impl Vm {
                 }
             }
         }
+        // Masked fixed window: `w` is this kernel's window (first KWIN slots);
+        // `wtail` holds the pinned-callee windows at KWIN strides (CALLEES
+        // only). Every register index is `< n_regs ≤ KWIN` by translation, so
+        // `& KWIN_MASK` is an identity on valid indices that proves the access
+        // in-bounds — the dispatch loop below carries no bounds checks.
+        let (whead, wtail) = regs.split_at_mut(KWIN);
+        let w: &mut [f64; KWIN] = whead.try_into().expect("sized above");
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
         let code = &k.code;
@@ -859,14 +872,15 @@ impl Vm {
                                     // cannot resume execution.
                                     for (r, slot) in k.locals.iter().enumerate() {
                                         if let crate::bytecode::KSlot::Local(l) = slot {
-                                            frame.locals[*l as usize] = Value::Number(regs[r]);
+                                            frame.locals[*l as usize] =
+                                                Value::Number(w[r & KWIN_MASK]);
                                         }
                                     }
                                     for (j, &l) in k.bool_locals.iter().enumerate() {
                                         frame.locals[l as usize] =
-                                            Value::Bool(regs[bool_base + j] != 0.0);
+                                            Value::Bool(w[(bool_base + j) & KWIN_MASK] != 0.0);
                                     }
-                                    writeback_kernel_props(k, &objs, &prop_slots, &regs);
+                                    writeback_kernel_props(k, &objs, &prop_slots, &w[..]);
                                     self.kernel_regs = regs;
                                     objs.clear();
                                     self.kernel_objs = objs;
@@ -884,19 +898,27 @@ impl Vm {
                 }};
             }
             match code[pc] {
-                KOp::Mov { dst, src } => regs[dst as usize] = regs[src as usize],
-                KOp::Const { dst, k } => regs[dst as usize] = k,
-                KOp::Add { dst, a, b } => regs[dst as usize] = regs[a as usize] + regs[b as usize],
-                KOp::AddK { dst, a, k } => regs[dst as usize] = regs[a as usize] + k,
+                KOp::Mov { dst, src } => w[dst as usize & KWIN_MASK] = w[src as usize & KWIN_MASK],
+                KOp::Const { dst, k } => w[dst as usize & KWIN_MASK] = k,
+                KOp::Add { dst, a, b } => {
+                    w[dst as usize & KWIN_MASK] =
+                        w[a as usize & KWIN_MASK] + w[b as usize & KWIN_MASK]
+                }
+                KOp::AddK { dst, a, k } => {
+                    w[dst as usize & KWIN_MASK] = w[a as usize & KWIN_MASK] + k
+                }
                 KOp::Arith { kind, dst, a, b } => {
-                    regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind)
+                    w[dst as usize & KWIN_MASK] =
+                        number_arith_raw(w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK], kind)
                 }
                 KOp::ArithK { kind, dst, a, k } => {
-                    regs[dst as usize] = number_arith_raw(regs[a as usize], k, kind)
+                    w[dst as usize & KWIN_MASK] =
+                        number_arith_raw(w[a as usize & KWIN_MASK], k, kind)
                 }
-                KOp::Neg { dst, src } => regs[dst as usize] = -regs[src as usize],
+                KOp::Neg { dst, src } => w[dst as usize & KWIN_MASK] = -w[src as usize & KWIN_MASK],
                 KOp::BitNot { dst, src } => {
-                    regs[dst as usize] = !crate::vm::to_int32(regs[src as usize]) as f64
+                    w[dst as usize & KWIN_MASK] =
+                        !crate::vm::to_int32(w[src as usize & KWIN_MASK]) as f64
                 }
                 KOp::Br { target } => branch!(target),
                 KOp::BrCmp {
@@ -906,7 +928,9 @@ impl Vm {
                     if_true,
                     target,
                 } => {
-                    if knum_cmp(cmp, regs[a as usize], regs[b as usize]) == if_true {
+                    if knum_cmp(cmp, w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK])
+                        == if_true
+                    {
                         branch!(target)
                     }
                 }
@@ -917,17 +941,17 @@ impl Vm {
                     if_true,
                     target,
                 } => {
-                    if knum_cmp(cmp, regs[a as usize], k) == if_true {
+                    if knum_cmp(cmp, w[a as usize & KWIN_MASK], k) == if_true {
                         branch!(target)
                     }
                 }
                 KOp::BrFalsy { src, target } => {
-                    if !knum_truthy(regs[src as usize]) {
+                    if !knum_truthy(w[src as usize & KWIN_MASK]) {
                         branch!(target)
                     }
                 }
                 KOp::BrTruthy { src, target } => {
-                    if knum_truthy(regs[src as usize]) {
+                    if knum_truthy(w[src as usize & KWIN_MASK]) {
                         branch!(target)
                     }
                 }
@@ -939,14 +963,14 @@ impl Vm {
                     idx,
                     bail,
                 } => {
-                    let i = regs[idx as usize];
+                    let i = w[idx as usize & KWIN_MASK];
                     let mut ok = false;
-                    if i.fract() == 0.0 && (0.0..4294967295.0).contains(&i) {
+                    if let Some(iu) = dense_index(i) {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
                             Internal::Array(arr) if b.props.is_empty() => {
-                                if let Some(Value::Number(n)) = arr.get(i as usize) {
-                                    regs[dst as usize] = *n;
+                                if let Some(Value::Number(n)) = arr.get(iu) {
+                                    w[dst as usize & KWIN_MASK] = *n;
                                     ok = true;
                                 }
                             }
@@ -956,16 +980,16 @@ impl Vm {
                             // props/proto check is needed. OOB (incl.
                             // detached / shrunk-view) bails to the generic
                             // path, which owns the `undefined` absorption.
-                            Internal::TypedArray(t) if !t.kind.is_bigint() => {
-                                let iu = i as usize;
-                                if iu < crate::typed_array::ta_eff_length(t) {
-                                    let off = t.byte_offset + iu * t.kind.bytes();
-                                    let buf = t.buffer.borrow();
-                                    if let Internal::ArrayBuffer(Some(bytes)) = &buf.internal {
-                                        regs[dst as usize] =
-                                            crate::typed_array::decode(bytes, off, t.kind);
-                                        ok = true;
-                                    }
+                            Internal::TypedArray(t)
+                                if !t.kind.is_bigint()
+                                    && iu < crate::typed_array::ta_eff_length(t) =>
+                            {
+                                let off = t.byte_offset + iu * t.kind.bytes();
+                                let buf = t.buffer.borrow();
+                                if let Internal::ArrayBuffer(Some(bytes)) = &buf.internal {
+                                    w[dst as usize & KWIN_MASK] =
+                                        crate::typed_array::decode(bytes, off, t.kind);
+                                    ok = true;
                                 }
                             }
                             _ => {}
@@ -998,8 +1022,8 @@ impl Vm {
                         {
                             if let Internal::Array(arr) = &mut b.internal {
                                 if arr.len() < crate::value::MAX_DENSE_ARRAY {
-                                    arr.push(Value::Number(regs[val as usize]));
-                                    regs[dst as usize] = arr.len() as f64;
+                                    arr.push(Value::Number(w[val as usize & KWIN_MASK]));
+                                    w[dst as usize & KWIN_MASK] = arr.len() as f64;
                                     ok = true;
                                 }
                             }
@@ -1020,7 +1044,7 @@ impl Vm {
                         if b.props.is_empty() && b.extensible {
                             if let Internal::Array(arr) = &mut b.internal {
                                 if let Some(Value::Number(n)) = arr.last() {
-                                    regs[dst as usize] = *n;
+                                    w[dst as usize & KWIN_MASK] = *n;
                                     arr.pop();
                                     ok = true;
                                 }
@@ -1046,24 +1070,23 @@ impl Vm {
                     val,
                     bail,
                 } => {
-                    let i = regs[idx as usize];
+                    let i = w[idx as usize & KWIN_MASK];
                     let mut ok = false;
-                    if i.fract() == 0.0 && (0.0..4294967295.0).contains(&i) {
+                    if let Some(iu) = dense_index(i) {
                         let mut b = objs[obj as usize].borrow_mut();
                         let extensible = b.extensible;
                         let props_empty = b.props.is_empty();
                         match &mut b.internal {
                             Internal::Array(arr) if props_empty => {
-                                let iu = i as usize;
                                 match arr.get_mut(iu) {
                                     Some(slot) if !matches!(slot, Value::Hole) => {
-                                        *slot = Value::Number(regs[val as usize]);
+                                        *slot = Value::Number(w[val as usize & KWIN_MASK]);
                                         ok = true;
                                     }
                                     Some(slot) => {
                                         // In-bounds hole: creation.
                                         if extensible {
-                                            *slot = Value::Number(regs[val as usize]);
+                                            *slot = Value::Number(w[val as usize & KWIN_MASK]);
                                             ok = true;
                                         }
                                     }
@@ -1073,7 +1096,7 @@ impl Vm {
                                             && iu == arr.len()
                                             && iu < crate::value::MAX_DENSE_ARRAY
                                         {
-                                            arr.push(Value::Number(regs[val as usize]));
+                                            arr.push(Value::Number(w[val as usize & KWIN_MASK]));
                                             ok = true;
                                         }
                                     }
@@ -1087,21 +1110,21 @@ impl Vm {
                             // wrapping) as the builtin write path. OOB — a
                             // silent no-op per spec — bails to the generic
                             // path, which owns that behavior.
-                            Internal::TypedArray(t) if !t.kind.is_bigint() => {
-                                let iu = i as usize;
-                                if iu < crate::typed_array::ta_eff_length(t) {
-                                    let off = t.byte_offset + iu * t.kind.bytes();
-                                    let kind = t.kind;
-                                    let mut buf = t.buffer.borrow_mut();
-                                    if let Internal::ArrayBuffer(Some(bytes)) = &mut buf.internal {
-                                        crate::typed_array::encode(
-                                            bytes,
-                                            off,
-                                            kind,
-                                            regs[val as usize],
-                                        );
-                                        ok = true;
-                                    }
+                            Internal::TypedArray(t)
+                                if !t.kind.is_bigint()
+                                    && iu < crate::typed_array::ta_eff_length(t) =>
+                            {
+                                let off = t.byte_offset + iu * t.kind.bytes();
+                                let kind = t.kind;
+                                let mut buf = t.buffer.borrow_mut();
+                                if let Internal::ArrayBuffer(Some(bytes)) = &mut buf.internal {
+                                    crate::typed_array::encode(
+                                        bytes,
+                                        off,
+                                        kind,
+                                        w[val as usize & KWIN_MASK],
+                                    );
+                                    ok = true;
                                 }
                             }
                             _ => {}
@@ -1112,24 +1135,26 @@ impl Vm {
                     }
                 }
                 KOp::CmpSet { cmp, dst, a, b } => {
-                    regs[dst as usize] = if knum_cmp(cmp, regs[a as usize], regs[b as usize]) {
-                        1.0
-                    } else {
-                        0.0
-                    }
+                    w[dst as usize & KWIN_MASK] =
+                        if knum_cmp(cmp, w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK]) {
+                            1.0
+                        } else {
+                            0.0
+                        }
                 }
                 KOp::BoolNot { dst, src } => {
-                    regs[dst as usize] = if knum_truthy(regs[src as usize]) {
+                    w[dst as usize & KWIN_MASK] = if knum_truthy(w[src as usize & KWIN_MASK]) {
                         0.0
                     } else {
                         1.0
                     }
                 }
                 KOp::Math1 { kind, dst, src } => {
-                    regs[dst as usize] = kmath1(kind, regs[src as usize])
+                    w[dst as usize & KWIN_MASK] = kmath1(kind, w[src as usize & KWIN_MASK])
                 }
                 KOp::Math2 { kind, dst, a, b } => {
-                    regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
+                    w[dst as usize & KWIN_MASK] =
+                        kmath2(kind, w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK])
                 }
                 // Dense array `length` (unshadowed only) or typed-array
                 // effective length (the entry guard verified the canonical
@@ -1142,14 +1167,15 @@ impl Vm {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
                             Internal::Array(arr) if b.props.is_empty() => {
-                                regs[dst as usize] = arr.len() as f64;
+                                w[dst as usize & KWIN_MASK] = arr.len() as f64;
                                 ok = true;
                             }
                             // Any kind — a BigInt-element array's `.length`
                             // is the same plain count (its ELEMENT accesses
                             // are what bail).
                             Internal::TypedArray(t) => {
-                                regs[dst as usize] = crate::typed_array::ta_eff_length(t) as f64;
+                                w[dst as usize & KWIN_MASK] =
+                                    crate::typed_array::ta_eff_length(t) as f64;
                                 ok = true;
                             }
                             _ => {}
@@ -1166,8 +1192,8 @@ impl Vm {
                     unreachable!("prop op survived kernel build")
                 }
                 KOp::Mov2 { d1, s1, d2, s2 } => {
-                    regs[d1 as usize] = regs[s1 as usize];
-                    regs[d2 as usize] = regs[s2 as usize];
+                    w[d1 as usize & KWIN_MASK] = w[s1 as usize & KWIN_MASK];
+                    w[d2 as usize & KWIN_MASK] = w[s2 as usize & KWIN_MASK];
                     // The unfused second op remains in the next slot as a
                     // branch-target landing pad; skip it.
                     pc += 1;
@@ -1181,13 +1207,163 @@ impl Vm {
                     a2,
                     b2,
                 } => {
-                    regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind);
-                    regs[d2 as usize] = regs[a2 as usize] + regs[b2 as usize];
+                    w[dst as usize & KWIN_MASK] = number_arith_raw(
+                        w[a as usize & KWIN_MASK],
+                        w[b as usize & KWIN_MASK],
+                        kind,
+                    );
+                    w[d2 as usize & KWIN_MASK] =
+                        w[a2 as usize & KWIN_MASK] + w[b2 as usize & KWIN_MASK];
                     pc += 1;
                 }
                 KOp::AddKBr { dst, a, k, target } => {
-                    regs[dst as usize] = regs[a as usize] + k;
+                    w[dst as usize & KWIN_MASK] = w[a as usize & KWIN_MASK] + k;
                     branch!(target)
+                }
+                KOp::ArithKAdd {
+                    kind,
+                    dst,
+                    a,
+                    k,
+                    d2,
+                    a2,
+                    b2,
+                } => {
+                    w[dst as usize & KWIN_MASK] =
+                        number_arith_raw(w[a as usize & KWIN_MASK], k, kind);
+                    w[d2 as usize & KWIN_MASK] =
+                        w[a2 as usize & KWIN_MASK] + w[b2 as usize & KWIN_MASK];
+                    pc += 1;
+                }
+                // Fused `i < a.length` header test: LoadLen's semantics (and
+                // bail edge) then BrCmp's compare-and-branch, one dispatch.
+                KOp::LenBrCmp {
+                    dst,
+                    obj,
+                    bail,
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target,
+                } => {
+                    let mut ok = false;
+                    {
+                        let b = objs[obj as usize].borrow();
+                        match &b.internal {
+                            Internal::Array(arr) if b.props.is_empty() => {
+                                w[dst as usize & KWIN_MASK] = arr.len() as f64;
+                                ok = true;
+                            }
+                            Internal::TypedArray(t) => {
+                                w[dst as usize & KWIN_MASK] =
+                                    crate::typed_array::ta_eff_length(t) as f64;
+                                ok = true;
+                            }
+                            _ => {}
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                    if knum_cmp(cmp, w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK])
+                        == if_true
+                    {
+                        branch!(target)
+                    }
+                    pc += 1;
+                }
+                // Fused `s += a[i]`: LoadElem's semantics (and bail edge)
+                // then the accumulating Add, one dispatch.
+                KOp::LoadElemAdd {
+                    dst,
+                    obj,
+                    idx,
+                    bail,
+                    d2,
+                    a2,
+                    b2,
+                } => {
+                    let i = w[idx as usize & KWIN_MASK];
+                    let mut ok = false;
+                    if let Some(iu) = dense_index(i) {
+                        let b = objs[obj as usize].borrow();
+                        match &b.internal {
+                            Internal::Array(arr) if b.props.is_empty() => {
+                                if let Some(Value::Number(n)) = arr.get(iu) {
+                                    w[dst as usize & KWIN_MASK] = *n;
+                                    ok = true;
+                                }
+                            }
+                            Internal::TypedArray(t)
+                                if !t.kind.is_bigint()
+                                    && iu < crate::typed_array::ta_eff_length(t) =>
+                            {
+                                let off = t.byte_offset + iu * t.kind.bytes();
+                                let buf = t.buffer.borrow();
+                                if let Internal::ArrayBuffer(Some(bytes)) = &buf.internal {
+                                    w[dst as usize & KWIN_MASK] =
+                                        crate::typed_array::decode(bytes, off, t.kind);
+                                    ok = true;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                    w[d2 as usize & KWIN_MASK] =
+                        w[a2 as usize & KWIN_MASK] + w[b2 as usize & KWIN_MASK];
+                    pc += 1;
+                }
+                // Fused `a[i] <op> …` (the dot-product second load feeding
+                // its multiply): LoadElem then Arith, one dispatch.
+                KOp::LoadElemArith {
+                    dst,
+                    obj,
+                    idx,
+                    bail,
+                    kind,
+                    d2,
+                    a2,
+                    b2,
+                } => {
+                    let i = w[idx as usize & KWIN_MASK];
+                    let mut ok = false;
+                    if let Some(iu) = dense_index(i) {
+                        let b = objs[obj as usize].borrow();
+                        match &b.internal {
+                            Internal::Array(arr) if b.props.is_empty() => {
+                                if let Some(Value::Number(n)) = arr.get(iu) {
+                                    w[dst as usize & KWIN_MASK] = *n;
+                                    ok = true;
+                                }
+                            }
+                            Internal::TypedArray(t)
+                                if !t.kind.is_bigint()
+                                    && iu < crate::typed_array::ta_eff_length(t) =>
+                            {
+                                let off = t.byte_offset + iu * t.kind.bytes();
+                                let buf = t.buffer.borrow();
+                                if let Internal::ArrayBuffer(Some(bytes)) = &buf.internal {
+                                    w[dst as usize & KWIN_MASK] =
+                                        crate::typed_array::decode(bytes, off, t.kind);
+                                    ok = true;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    if !ok {
+                        branch!(bail)
+                    }
+                    w[d2 as usize & KWIN_MASK] = number_arith_raw(
+                        w[a2 as usize & KWIN_MASK],
+                        w[b2 as usize & KWIN_MASK],
+                        kind,
+                    );
+                    pc += 1;
                 }
                 // A pinned-closure call: copy the arguments into the
                 // callee's window and run its (guarded) kernel inline.
@@ -1199,24 +1375,32 @@ impl Vm {
                 } if CALLEES => {
                     let (bf, wb) = &callee_bfs[fslot as usize];
                     let ck = bf.proto.fn_kernel.as_ref().expect("guarded");
-                    let win = *wb as usize;
+                    // Callee windows live in `wtail` at KWIN strides (window
+                    // base `wb` counts from the buffer start, so subtract the
+                    // caller's window).
+                    let cw: &mut [f64; KWIN] = (&mut wtail[*wb as usize - KWIN..][..KWIN])
+                        .try_into()
+                        .expect("sized above");
                     for (r, slot) in ck.locals.iter().enumerate() {
                         if let crate::bytecode::KSlot::Arg(a) = slot {
-                            regs[win + r] = regs[base as usize + *a as usize];
+                            cw[r & KWIN_MASK] = w[(base as usize + *a as usize) & KWIN_MASK];
                         }
                     }
-                    if !run_callee_window(&mut regs, ck, win, dst as usize, &interrupt, &mut poll) {
+                    if let Some(ret) = run_callee_window(cw, ck, &interrupt, &mut poll) {
+                        w[dst as usize & KWIN_MASK] = ret;
+                    } else {
                         // Interrupted on a callee back-edge: the same
                         // latch-and-unwind as an interrupted caller edge.
                         for (r, slot) in k.locals.iter().enumerate() {
                             if let crate::bytecode::KSlot::Local(l) = slot {
-                                frame.locals[*l as usize] = Value::Number(regs[r]);
+                                frame.locals[*l as usize] = Value::Number(w[r & KWIN_MASK]);
                             }
                         }
                         for (j, &l) in k.bool_locals.iter().enumerate() {
-                            frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
+                            frame.locals[l as usize] =
+                                Value::Bool(w[(bool_base + j) & KWIN_MASK] != 0.0);
                         }
-                        writeback_kernel_props(k, &objs, &prop_slots, &regs);
+                        writeback_kernel_props(k, &objs, &prop_slots, &w[..]);
                         self.kernel_regs = regs;
                         objs.clear();
                         self.kernel_objs = objs;
@@ -1242,21 +1426,21 @@ impl Vm {
         // bytecode interpreter at the exit's target.
         for (r, slot) in k.locals.iter().enumerate() {
             if let crate::bytecode::KSlot::Local(l) = slot {
-                frame.locals[*l as usize] = Value::Number(regs[r]);
+                frame.locals[*l as usize] = Value::Number(w[r & KWIN_MASK]);
             }
         }
         for (j, &l) in k.bool_locals.iter().enumerate() {
-            frame.locals[l as usize] = Value::Bool(regs[bool_base + j] != 0.0);
+            frame.locals[l as usize] = Value::Bool(w[(bool_base + j) & KWIN_MASK] != 0.0);
         }
-        writeback_kernel_props(k, &objs, &prop_slots, &regs);
+        writeback_kernel_props(k, &objs, &prop_slots, &w[..]);
         for slot in k.shapes[shape as usize].iter() {
             match slot {
                 crate::bytecode::KShapeSlot::Num(r) => {
-                    frame.stack.push(Value::Number(regs[*r as usize]))
+                    frame.stack.push(Value::Number(w[*r as usize & KWIN_MASK]))
                 }
-                crate::bytecode::KShapeSlot::Bool(r) => {
-                    frame.stack.push(Value::Bool(regs[*r as usize] != 0.0))
-                }
+                crate::bytecode::KShapeSlot::Bool(r) => frame
+                    .stack
+                    .push(Value::Bool(w[*r as usize & KWIN_MASK] != 0.0)),
                 crate::bytecode::KShapeSlot::Obj(o) => {
                     frame.stack.push(Value::Object(objs[*o as usize].clone()))
                 }
@@ -1307,50 +1491,36 @@ impl Vm {
         if k.rec.is_some() {
             return self.run_fn_kernel_rec(bf, args);
         }
-        // Grow-only across activations (see `run_kernel_op_impl`): stale
-        // values are unreadable — args/upvalues load below, internal locals
-        // are store-before-read by translation proof.
-        let mut regs = std::mem::take(&mut self.kernel_regs);
-        if regs.len() < k.n_regs as usize {
-            regs.resize(k.n_regs as usize, 0.0);
-        }
+        // One fixed window on the native stack (function kernels are tiny and
+        // never nest at runtime); masked indexing inside the executor makes
+        // every register access bounds-check-free.
+        let mut regs = [0.0f64; KWIN];
         for (r, slot) in k.locals.iter().enumerate() {
             match slot {
                 crate::bytecode::KSlot::Arg(a) => match args.get(*a as usize) {
-                    Some(Value::Number(n)) => regs[r] = *n,
-                    _ => {
-                        self.kernel_regs = regs;
-                        return None;
-                    }
+                    Some(Value::Number(n)) => regs[r & KWIN_MASK] = *n,
+                    _ => return None,
                 },
                 // Internal locals are pure register scratch: translation
                 // proved a store dominates every read, so no frame slot is
                 // needed (and none exists).
                 crate::bytecode::KSlot::Local(_) => {}
                 crate::bytecode::KSlot::Upvalue(u) => match &*bf.upvalues[*u as usize].borrow() {
-                    Value::Number(n) => regs[r] = *n,
-                    _ => {
-                        self.kernel_regs = regs;
-                        return None;
-                    }
+                    Value::Number(n) => regs[r & KWIN_MASK] = *n,
+                    _ => return None,
                 },
             }
         }
         if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
-            self.kernel_regs = regs;
             return None;
         }
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
         match exec_fn_kernel_code(&k.code, &mut regs, &interrupt, &mut poll) {
-            Some(ret) => {
-                self.kernel_regs = regs;
-                Some(Ok(ret))
-            }
+            Some(ret) => Some(Ok(ret)),
             None => {
                 // Interrupted on a back-edge: registers are pure scratch,
                 // nothing to write back on the unwind.
-                self.kernel_regs = regs;
                 self.op_budget = Some(0);
                 Some(Err(self.throw_range("execution interrupted")))
             }
@@ -1403,16 +1573,19 @@ impl Vm {
         };
         let ret_bool = fam.ret_bool;
 
-        // --- Window 0: the invoked member's arguments and upvalues. The
-        // buffer is GROW-ONLY across activations: a deep recursion leaves it
-        // at its high-water length, so the next outer call's window pushes
-        // (`SelfCall`'s conditional resize) stop paying a zero-fill per
-        // window — which was ~11% of the mutual-recursion workload. Stale
-        // values are unreadable: args/upvalues are written here, locals are
-        // store-before-read by translation proof.
+        // --- Window 0: the invoked member's arguments and upvalues. Windows
+        // are FIXED KWIN-slot strides (window d = regs[d*KWIN..(d+1)*KWIN]),
+        // so the dispatch loop below runs over a `&mut [f64; KWIN]` with
+        // masked, bounds-check-free indexing. The buffer is GROW-ONLY across
+        // activations: a deep recursion leaves it at its high-water length,
+        // so the next outer call's window pushes (`SelfCall`'s conditional
+        // resize) stop paying a zero-fill per window — which was ~11% of the
+        // mutual-recursion workload. Stale values are unreadable:
+        // args/upvalues are written here, locals are store-before-read by
+        // translation proof.
         let mut regs = std::mem::take(&mut self.kernel_regs);
-        if regs.len() < fam.n_regs[0] {
-            regs.resize(fam.n_regs[0], 0.0);
+        if regs.len() < KWIN {
+            regs.resize(KWIN, 0.0);
         }
         for &(r, a) in &fam.arg_slots[0] {
             match args.get(a) {
@@ -1435,6 +1608,13 @@ impl Vm {
             Interrupted,
             Abandon,
         }
+        /// A window-crossing step the masked dispatch loop cannot perform
+        /// while it holds the current window borrow: perform it over the
+        /// full buffer, then re-enter with the new window.
+        enum Act {
+            Call { t: usize, abase: u16, dst: u16 },
+            Ret { v: f64 },
+        }
 
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
@@ -1447,241 +1627,272 @@ impl Vm {
         let mut base = 0usize;
         let mut pc = 0usize;
         let out = 'outer: loop {
+            // Member level: table hoists happen only when the executing
+            // MEMBER changes; same-kernel calls/returns (fib-class, the
+            // overwhelming case) stay inside the window loop below.
             let code: &[KOp] = &fam.funcs[cur]
                 .proto
                 .fn_kernel
                 .as_ref()
                 .expect("resolved family")
                 .code;
-            // Hoist the CURRENT member's tables: a same-kernel self-call
-            // (fib-class recursion, the overwhelming case) must not pay
-            // per-call indexed loads through the family tables.
             let cur_map = &fam.callee_map[cur][..];
-            let cur_args = &fam.arg_slots[cur][..];
-            let cur_uvs = &fam.uv_snaps[cur][..];
-            let cur_nregs = fam.n_regs[cur];
-            loop {
-                macro_rules! poll_interrupt {
-                    () => {{
-                        poll = poll.wrapping_add(1);
-                        if poll & 0xFF == 0 {
-                            if let Some(flag) = &interrupt {
-                                if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                                    break 'outer RecOut::Interrupted;
+            'win: loop {
+                // The current activation's fixed window (strided, sized above).
+                let w: &mut [f64; KWIN] = (&mut regs[base..base + KWIN])
+                    .try_into()
+                    .expect("strided window");
+                let act = loop {
+                    macro_rules! poll_interrupt {
+                        () => {{
+                            poll = poll.wrapping_add(1);
+                            if poll & 0xFF == 0 {
+                                if let Some(flag) = &interrupt {
+                                    if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                        break 'outer RecOut::Interrupted;
+                                    }
                                 }
                             }
+                        }};
+                    }
+                    macro_rules! branch {
+                        ($t:expr) => {{
+                            let t = $t as usize;
+                            if t <= pc {
+                                poll_interrupt!();
+                            }
+                            pc = t;
+                            continue;
+                        }};
+                    }
+                    match code[pc] {
+                        KOp::Mov { dst, src } => {
+                            w[dst as usize & KWIN_MASK] = w[src as usize & KWIN_MASK]
                         }
-                    }};
-                }
-                macro_rules! branch {
-                    ($t:expr) => {{
-                        let t = $t as usize;
-                        if t <= pc {
-                            poll_interrupt!();
+                        KOp::Const { dst, k } => w[dst as usize & KWIN_MASK] = k,
+                        KOp::Add { dst, a, b } => {
+                            w[dst as usize & KWIN_MASK] =
+                                w[a as usize & KWIN_MASK] + w[b as usize & KWIN_MASK]
                         }
-                        pc = t;
-                        continue;
-                    }};
-                }
-                match code[pc] {
-                    KOp::Mov { dst, src } => regs[base + dst as usize] = regs[base + src as usize],
-                    KOp::Const { dst, k } => regs[base + dst as usize] = k,
-                    KOp::Add { dst, a, b } => {
-                        regs[base + dst as usize] =
-                            regs[base + a as usize] + regs[base + b as usize]
-                    }
-                    KOp::AddK { dst, a, k } => {
-                        regs[base + dst as usize] = regs[base + a as usize] + k
-                    }
-                    KOp::Arith { kind, dst, a, b } => {
-                        regs[base + dst as usize] =
-                            number_arith_raw(regs[base + a as usize], regs[base + b as usize], kind)
-                    }
-                    KOp::ArithK { kind, dst, a, k } => {
-                        regs[base + dst as usize] =
-                            number_arith_raw(regs[base + a as usize], k, kind)
-                    }
-                    KOp::Neg { dst, src } => regs[base + dst as usize] = -regs[base + src as usize],
-                    KOp::BitNot { dst, src } => {
-                        regs[base + dst as usize] =
-                            !crate::vm::to_int32(regs[base + src as usize]) as f64
-                    }
-                    KOp::Br { target } => branch!(target),
-                    KOp::BrCmp {
-                        cmp,
-                        a,
-                        b,
-                        if_true,
-                        target,
-                    } => {
-                        if knum_cmp(cmp, regs[base + a as usize], regs[base + b as usize])
-                            == if_true
-                        {
-                            branch!(target)
+                        KOp::AddK { dst, a, k } => {
+                            w[dst as usize & KWIN_MASK] = w[a as usize & KWIN_MASK] + k
                         }
-                    }
-                    KOp::BrCmpK {
-                        cmp,
-                        a,
-                        k,
-                        if_true,
-                        target,
-                    } => {
-                        if knum_cmp(cmp, regs[base + a as usize], k) == if_true {
-                            branch!(target)
+                        KOp::Arith { kind, dst, a, b } => {
+                            w[dst as usize & KWIN_MASK] = number_arith_raw(
+                                w[a as usize & KWIN_MASK],
+                                w[b as usize & KWIN_MASK],
+                                kind,
+                            )
                         }
-                    }
-                    KOp::BrFalsy { src, target } => {
-                        if !knum_truthy(regs[base + src as usize]) {
-                            branch!(target)
+                        KOp::ArithK { kind, dst, a, k } => {
+                            w[dst as usize & KWIN_MASK] =
+                                number_arith_raw(w[a as usize & KWIN_MASK], k, kind)
                         }
-                    }
-                    KOp::BrTruthy { src, target } => {
-                        if knum_truthy(regs[base + src as usize]) {
-                            branch!(target)
+                        KOp::Neg { dst, src } => {
+                            w[dst as usize & KWIN_MASK] = -w[src as usize & KWIN_MASK]
                         }
-                    }
-                    KOp::CmpSet { cmp, dst, a, b } => {
-                        regs[base + dst as usize] =
-                            if knum_cmp(cmp, regs[base + a as usize], regs[base + b as usize]) {
+                        KOp::BitNot { dst, src } => {
+                            w[dst as usize & KWIN_MASK] =
+                                !crate::vm::to_int32(w[src as usize & KWIN_MASK]) as f64
+                        }
+                        KOp::Br { target } => branch!(target),
+                        KOp::BrCmp {
+                            cmp,
+                            a,
+                            b,
+                            if_true,
+                            target,
+                        } => {
+                            if knum_cmp(cmp, w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK])
+                                == if_true
+                            {
+                                branch!(target)
+                            }
+                        }
+                        KOp::BrCmpK {
+                            cmp,
+                            a,
+                            k,
+                            if_true,
+                            target,
+                        } => {
+                            if knum_cmp(cmp, w[a as usize & KWIN_MASK], k) == if_true {
+                                branch!(target)
+                            }
+                        }
+                        KOp::BrFalsy { src, target } => {
+                            if !knum_truthy(w[src as usize & KWIN_MASK]) {
+                                branch!(target)
+                            }
+                        }
+                        KOp::BrTruthy { src, target } => {
+                            if knum_truthy(w[src as usize & KWIN_MASK]) {
+                                branch!(target)
+                            }
+                        }
+                        KOp::CmpSet { cmp, dst, a, b } => {
+                            w[dst as usize & KWIN_MASK] = if knum_cmp(
+                                cmp,
+                                w[a as usize & KWIN_MASK],
+                                w[b as usize & KWIN_MASK],
+                            ) {
                                 1.0
                             } else {
                                 0.0
                             }
-                    }
-                    KOp::BoolNot { dst, src } => {
-                        regs[base + dst as usize] = if knum_truthy(regs[base + src as usize]) {
-                            0.0
-                        } else {
-                            1.0
                         }
-                    }
-                    KOp::Math1 { kind, dst, src } => {
-                        regs[base + dst as usize] = kmath1(kind, regs[base + src as usize])
-                    }
-                    KOp::Math2 { kind, dst, a, b } => {
-                        regs[base + dst as usize] =
-                            kmath2(kind, regs[base + a as usize], regs[base + b as usize])
-                    }
-                    KOp::Mov2 { d1, s1, d2, s2 } => {
-                        regs[base + d1 as usize] = regs[base + s1 as usize];
-                        regs[base + d2 as usize] = regs[base + s2 as usize];
-                        pc += 1;
-                    }
-                    KOp::ArithAdd {
-                        kind,
-                        dst,
-                        a,
-                        b,
-                        d2,
-                        a2,
-                        b2,
-                    } => {
-                        regs[base + dst as usize] = number_arith_raw(
-                            regs[base + a as usize],
-                            regs[base + b as usize],
+                        KOp::BoolNot { dst, src } => {
+                            w[dst as usize & KWIN_MASK] =
+                                if knum_truthy(w[src as usize & KWIN_MASK]) {
+                                    0.0
+                                } else {
+                                    1.0
+                                }
+                        }
+                        KOp::Math1 { kind, dst, src } => {
+                            w[dst as usize & KWIN_MASK] = kmath1(kind, w[src as usize & KWIN_MASK])
+                        }
+                        KOp::Math2 { kind, dst, a, b } => {
+                            w[dst as usize & KWIN_MASK] =
+                                kmath2(kind, w[a as usize & KWIN_MASK], w[b as usize & KWIN_MASK])
+                        }
+                        KOp::Mov2 { d1, s1, d2, s2 } => {
+                            w[d1 as usize & KWIN_MASK] = w[s1 as usize & KWIN_MASK];
+                            w[d2 as usize & KWIN_MASK] = w[s2 as usize & KWIN_MASK];
+                            pc += 1;
+                        }
+                        KOp::ArithAdd {
                             kind,
-                        );
-                        regs[base + d2 as usize] =
-                            regs[base + a2 as usize] + regs[base + b2 as usize];
-                        pc += 1;
+                            dst,
+                            a,
+                            b,
+                            d2,
+                            a2,
+                            b2,
+                        } => {
+                            w[dst as usize & KWIN_MASK] = number_arith_raw(
+                                w[a as usize & KWIN_MASK],
+                                w[b as usize & KWIN_MASK],
+                                kind,
+                            );
+                            w[d2 as usize & KWIN_MASK] =
+                                w[a2 as usize & KWIN_MASK] + w[b2 as usize & KWIN_MASK];
+                            pc += 1;
+                        }
+                        KOp::AddKBr { dst, a, k, target } => {
+                            w[dst as usize & KWIN_MASK] = w[a as usize & KWIN_MASK] + k;
+                            branch!(target)
+                        }
+                        KOp::ArithKAdd {
+                            kind,
+                            dst,
+                            a,
+                            k,
+                            d2,
+                            a2,
+                            b2,
+                        } => {
+                            w[dst as usize & KWIN_MASK] =
+                                number_arith_raw(w[a as usize & KWIN_MASK], k, kind);
+                            w[d2 as usize & KWIN_MASK] =
+                                w[a2 as usize & KWIN_MASK] + w[b2 as usize & KWIN_MASK];
+                            pc += 1;
+                        }
+                        KOp::SelfCall {
+                            dst,
+                            base: abase,
+                            argc: _,
+                            callee,
+                        } => {
+                            // Mirror the generic per-call depth guard: an
+                            // overflow abandons the pure activation; the generic
+                            // rerun then recurses to the same depth and raises
+                            // the RangeError.
+                            if self.call_depth + calls.len() + 1 > self.max_call_depth {
+                                break 'outer RecOut::Abandon;
+                            }
+                            poll_interrupt!();
+                            let t = cur_map[callee as usize] as usize;
+                            break Act::Call { t, abase, dst };
+                        }
+                        KOp::Ret { src, boolean } => {
+                            // Entry verified every member's Ret type against the
+                            // family's (`ret_bool`); registers carry booleans as
+                            // exactly 0.0/1.0, so the raw value moves across.
+                            debug_assert_eq!(boolean, ret_bool);
+                            break Act::Ret {
+                                v: w[src as usize & KWIN_MASK],
+                            };
+                        }
+                        KOp::ArrayPush { .. }
+                        | KOp::ArrayPop { .. }
+                        | KOp::LoadElem { .. }
+                        | KOp::StoreElem { .. }
+                        | KOp::LoadLen { .. }
+                        | KOp::LoadElemAdd { .. }
+                        | KOp::LoadElemArith { .. }
+                        | KOp::LenBrCmp { .. }
+                        | KOp::LoadProp { .. }
+                        | KOp::StoreProp { .. }
+                        | KOp::CallKernel { .. }
+                        | KOp::Exit { .. } => unreachable!("bail op in a function kernel"),
                     }
-                    KOp::AddKBr { dst, a, k, target } => {
-                        regs[base + dst as usize] = regs[base + a as usize] + k;
-                        branch!(target)
-                    }
-                    KOp::SelfCall {
-                        dst,
-                        base: abase,
-                        argc: _,
-                        callee,
-                    } => {
-                        // Mirror the generic per-call depth guard: an
-                        // overflow abandons the pure activation; the generic
-                        // rerun then recurses to the same depth and raises
-                        // the RangeError.
-                        if self.call_depth + calls.len() + 1 > self.max_call_depth {
-                            break 'outer RecOut::Abandon;
+                    pc += 1;
+                };
+                // Window-crossing steps run over the full buffer (the fixed
+                // window borrow has ended): populate the callee window / write
+                // the return value into the caller's dst. Same-member switches
+                // re-enter the window loop directly; a member change re-hoists.
+                match act {
+                    Act::Call { t, abase, dst } => {
+                        let new_base = base + KWIN;
+                        if regs.len() < new_base + KWIN {
+                            regs.resize(new_base + KWIN, 0.0);
                         }
-                        poll_interrupt!();
-                        let t = cur_map[callee as usize] as usize;
-                        let new_base = base + cur_nregs;
-                        // Populate the callee window: arguments MOVE from the
-                        // call site's contiguous registers (translation
-                        // guarantees argc covers every consumed index — the
-                        // entry cross-check re-verified it against the
-                        // RESOLVED callee), upvalues from the member's entry
-                        // snapshot, locals are scratch (store-before-read
-                        // proven at translation).
-                        if t == cur {
-                            // Same-kernel recursion: all tables are hoisted.
-                            if regs.len() < new_base + cur_nregs {
-                                regs.resize(new_base + cur_nregs, 0.0);
-                            }
-                            for &(r, a) in cur_args {
-                                regs[new_base + r] = regs[base + abase as usize + a];
-                            }
-                            for &(r, _, v) in cur_uvs {
-                                regs[new_base + r] = v;
-                            }
-                            calls.push((cur as u8, pc as u16 + 1, dst, base as u32));
-                            base = new_base;
-                            pc = 0;
-                            continue;
-                        }
-                        if regs.len() < new_base + fam.n_regs[t] {
-                            regs.resize(new_base + fam.n_regs[t], 0.0);
-                        }
+                        // Arguments MOVE from the call site's contiguous
+                        // registers (translation guarantees argc covers every
+                        // consumed index — the entry cross-check re-verified it
+                        // against the RESOLVED callee), upvalues from the
+                        // member's entry snapshot, locals are scratch
+                        // (store-before-read proven at translation).
+                        let (lo, hi) = regs.split_at_mut(new_base);
+                        let caller = &lo[base..];
+                        let cw = &mut hi[..KWIN];
                         for &(r, a) in &fam.arg_slots[t] {
-                            regs[new_base + r] = regs[base + abase as usize + a];
+                            cw[r] = caller[abase as usize + a];
                         }
                         for &(r, _, v) in &fam.uv_snaps[t] {
-                            regs[new_base + r] = v;
+                            cw[r] = v;
                         }
                         calls.push((cur as u8, pc as u16 + 1, dst, base as u32));
                         base = new_base;
                         pc = 0;
+                        if t == cur {
+                            continue 'win;
+                        }
                         cur = t;
                         continue 'outer;
                     }
-                    KOp::Ret { src, boolean } => {
-                        // Entry verified every member's Ret type against the
-                        // family's (`ret_bool`); registers carry booleans as
-                        // exactly 0.0/1.0, so the raw value moves across.
-                        debug_assert_eq!(boolean, ret_bool);
-                        let v = regs[base + src as usize];
-                        match calls.pop() {
-                            Some((cf, ret_pc, dst, prev)) => {
-                                base = prev as usize;
-                                regs[base + dst as usize] = v;
-                                pc = ret_pc as usize;
-                                let cf = cf as usize;
-                                if cf != cur {
-                                    cur = cf;
-                                    continue 'outer;
-                                }
-                                continue;
+                    Act::Ret { v } => match calls.pop() {
+                        Some((cf, ret_pc, dst, prev)) => {
+                            base = prev as usize;
+                            regs[base + (dst as usize)] = v;
+                            pc = ret_pc as usize;
+                            if cf as usize == cur {
+                                continue 'win;
                             }
-                            None => {
-                                break 'outer RecOut::Done(if ret_bool {
-                                    Value::Bool(v != 0.0)
-                                } else {
-                                    Value::Number(v)
-                                })
-                            }
+                            cur = cf as usize;
+                            continue 'outer;
                         }
-                    }
-                    KOp::ArrayPush { .. }
-                    | KOp::ArrayPop { .. }
-                    | KOp::LoadElem { .. }
-                    | KOp::StoreElem { .. }
-                    | KOp::LoadLen { .. }
-                    | KOp::LoadProp { .. }
-                    | KOp::StoreProp { .. }
-                    | KOp::CallKernel { .. }
-                    | KOp::Exit { .. } => unreachable!("bail op in a function kernel"),
+                        None => {
+                            break 'outer RecOut::Done(if ret_bool {
+                                Value::Bool(v != 0.0)
+                            } else {
+                                Value::Number(v)
+                            })
+                        }
+                    },
                 }
-                pc += 1;
             }
         };
         self.kernel_regs = regs;
@@ -1936,12 +2147,10 @@ impl Vm {
         // a kernel can write a cell). Then cross-check every call site's
         // argc against its RESOLVED callee's consumption.
         let n = funcs.len();
-        let mut n_regs: Vec<usize> = Vec::with_capacity(n);
         let mut arg_slots: Vec<Vec<(usize, usize)>> = Vec::with_capacity(n);
         let mut uv_snaps: Vec<Vec<(usize, u32, f64)>> = Vec::with_capacity(n);
         for f in funcs.iter() {
             let k = f.proto.fn_kernel.as_ref()?;
-            n_regs.push(k.n_regs as usize);
             let mut aslots = Vec::new();
             let mut uvs = Vec::new();
             for (r, slot) in k.locals.iter().enumerate() {
@@ -1974,7 +2183,6 @@ impl Vm {
         Some(RecFamily {
             funcs,
             callee_map,
-            n_regs,
             arg_slots,
             uv_snaps,
             global_checks,
@@ -2025,9 +2233,8 @@ impl Vm {
         if self.call_depth + 1 > self.max_call_depth {
             return None;
         }
-        let n_regs = bf.proto.fn_kernel.as_ref().expect("checked").n_regs as usize;
         Some(PreparedKernel {
-            regs: vec![0.0; n_regs],
+            regs: [0.0; KWIN],
             poll: 0,
             interrupt: self.interrupt.clone(),
             bf,
@@ -2060,7 +2267,7 @@ impl Vm {
         for (r, slot) in k.locals.iter().enumerate() {
             match slot {
                 crate::bytecode::KSlot::Arg(a) => match args.get(*a as usize) {
-                    Some(Value::Number(n)) => p.regs[r] = *n,
+                    Some(Value::Number(n)) => p.regs[r & KWIN_MASK] = *n,
                     _ => return None,
                 },
                 // Register scratch: translation proved a store dominates
@@ -2068,7 +2275,7 @@ impl Vm {
                 // never observable.
                 crate::bytecode::KSlot::Local(_) => {}
                 crate::bytecode::KSlot::Upvalue(u) => match &*p.bf.upvalues[*u as usize].borrow() {
-                    Value::Number(n) => p.regs[r] = *n,
+                    Value::Number(n) => p.regs[r & KWIN_MASK] = *n,
                     _ => return None,
                 },
             }
@@ -2128,7 +2335,7 @@ impl Vm {
                 crate::bytecode::KSlot::Arg(_) => return None,
                 crate::bytecode::KSlot::Local(_) => {}
                 crate::bytecode::KSlot::Upvalue(u) => match &*p.bf.upvalues[*u as usize].borrow() {
-                    Value::Number(n) => p.regs[r] = *n,
+                    Value::Number(n) => p.regs[r & KWIN_MASK] = *n,
                     _ => return None,
                 },
             }
@@ -2150,10 +2357,10 @@ impl Vm {
         y: f64,
     ) -> Result<i32, Value> {
         if let Some(r) = regs_ab.0 {
-            p.regs[r] = x;
+            p.regs[r & KWIN_MASK] = x;
         }
         if let Some(r) = regs_ab.1 {
-            p.regs[r] = y;
+            p.regs[r & KWIN_MASK] = y;
         }
         p.poll = p.poll.wrapping_add(1);
         let interrupted = if p.poll & 0xFF == 0 {
@@ -3403,11 +3610,11 @@ impl Vm {
         // the slot is a real element (in bounds, not a hole);
         // everything else takes the unchanged spec path.
         if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
-            if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
+            if let Some(iu) = dense_index(*n) {
                 let b = o.borrow();
                 if let Internal::Array(arr) = &b.internal {
                     if b.props.is_empty() {
-                        if let Some(v) = arr.get(*n as usize) {
+                        if let Some(v) = arr.get(iu) {
                             if !matches!(v, Value::Hole) {
                                 let v = v.clone();
                                 return Ok(v);
@@ -3423,8 +3630,8 @@ impl Vm {
         // `string_own_prop`. Out-of-bounds falls through — the spec path
         // climbs to String.prototype, which is observable.
         if let (Value::String(s), Value::Number(n)) = (&obj, &key_v) {
-            if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                if let Some(u) = s.code_unit_at(*n as usize) {
+            if let Some(iu) = dense_index(*n) {
+                if let Some(u) = s.code_unit_at(iu) {
                     return Ok(Value::String(JsString::from_code_units(&[u])));
                 }
             }
@@ -3463,8 +3670,7 @@ impl Vm {
         // (`protos_allow_index_create`). Gaps past the end, shadowed
         // elements, and non-arrays take the spec path.
         if let (Value::Object(o), Value::Number(n)) = (&obj, &key_v) {
-            if n.fract() == 0.0 && *n >= 0.0 && *n < 4294967295.0 {
-                let i = *n as usize;
+            if let Some(i) = dense_index(*n) {
                 let mut creates = None;
                 {
                     let mut b = o.borrow_mut();
@@ -4837,6 +5043,16 @@ impl Vm {
                 }
                 wr!(*dst, Value::Object(self.new_array(elems)));
             }
+            ROp::NewObjectTpl { dst, at, n, tpl } => {
+                let tpl = frame.func.proto.obj_tpls[*tpl as usize].clone();
+                let obj = self.new_object_from_tpl(
+                    &tpl,
+                    frame.locals[*at as usize..(*at + *n) as usize]
+                        .iter_mut()
+                        .map(|slot| std::mem::replace(slot, Value::Undefined)),
+                );
+                wr!(*dst, Value::Object(obj));
+            }
             ROp::ArraySpread { arr, src } => {
                 let (arr_v, src) = (rd!(*arr), rd!(*src));
                 self.array_spread(&arr_v, &src)?;
@@ -5304,6 +5520,12 @@ impl Vm {
             }
 
             Op::NewObject => push!(Value::Object(self.new_object())),
+            Op::NewObjectTpl { idx, n } => {
+                let tpl = frame.func.proto.obj_tpls[*idx as usize].clone();
+                let at = frame.stack.len() - *n as usize;
+                let obj = self.new_object_from_tpl(&tpl, frame.stack.drain(at..));
+                push!(Value::Object(obj));
+            }
             Op::NewArray(n) => {
                 let n = *n as usize;
                 let at = frame.stack.len() - n;
@@ -6979,6 +7201,37 @@ impl Vm {
         if let (Value::Number(x), Value::Number(y)) = (&a, &b) {
             return Ok(Value::Number(x + y));
         }
+        // Fast path: a small plain string ⊕ a Number. Both operands are
+        // already primitive (ToPrimitive is the identity) and the result is
+        // the concatenation with the number's decimal form —
+        // `push_number_string` produces the EXACT digits `to_js_string`
+        // would. Formatting straight into the once-allocated result buffer
+        // skips two intermediate allocations and copies per `+`. Restricted
+        // to sub-rope-threshold flat strings so a big accumulator keeps
+        // `concat`'s O(1) rope path (a number string is ≤ 24 bytes, so the
+        // bound keeps the total in eager-copy territory either way).
+        {
+            let sn = match (&a, &b) {
+                (Value::String(s), Value::Number(n)) => Some((s, *n, true)),
+                (Value::Number(n), Value::String(s)) => Some((s, *n, false)),
+                _ => None,
+            };
+            if let Some((s, n, str_first)) = sn {
+                if let Some(flat) = s.as_flat_utf8() {
+                    if flat.len() + 24 < crate::value::ROPE_MIN_BYTES {
+                        let mut out = String::with_capacity(flat.len() + 24);
+                        if str_first {
+                            out.push_str(flat);
+                            crate::vm::push_number_string(n, &mut out);
+                        } else {
+                            crate::vm::push_number_string(n, &mut out);
+                            out.push_str(flat);
+                        }
+                        return Ok(Value::String(JsString::from(out)));
+                    }
+                }
+            }
+        }
         let pa = self.to_primitive(&a, Hint::Default)?;
         let pb = self.to_primitive(&b, Hint::Default)?;
         if matches!(pa, Value::String(_)) || matches!(pb, Value::String(_)) {
@@ -7305,6 +7558,22 @@ impl Vm {
     }
 }
 
+/// Integral array-index probe without libm: `Some(i as usize)` exactly when
+/// `i.fract() == 0.0 && (0.0..4294967295.0).contains(&i)` — i.e. `i` is a
+/// non-negative integral f64 strictly below 2^32-1 (the array-index bound).
+/// The saturating u32 cast round-trip IS the integrality+range test (`-0.0`
+/// round-trips to `0` and compares equal, negatives/NaN/too-large all fail
+/// the equality), so no libm `trunc` call is emitted.
+#[inline]
+fn dense_index(i: f64) -> Option<usize> {
+    let iu = i as u32;
+    if iu as f64 == i && iu != u32::MAX {
+        Some(iu as usize)
+    } else {
+        None
+    }
+}
+
 fn js_mod(a: f64, b: f64) -> f64 {
     if b == 0.0 || a.is_nan() || b.is_nan() || a.is_infinite() {
         f64::NAN
@@ -7317,8 +7586,11 @@ fn js_mod(a: f64, b: f64) -> f64 {
         // zero result must carry the dividend's sign (-6 % 3 is -0 in JS, as
         // fmod also returns); restore that explicitly.
         const MAX_EXACT: f64 = 9_007_199_254_740_992.0; // 2^53
-        if a.fract() == 0.0 && b.fract() == 0.0 && a.abs() <= MAX_EXACT && b.abs() <= MAX_EXACT {
-            let r = (a as i64) % (b as i64);
+                                                        // Integrality via cast round-trip (no libm trunc): within ±2^53 the
+                                                        // i64 cast is exact, so equality holds iff the value is integral.
+        let (ai, bi) = (a as i64, b as i64);
+        if ai as f64 == a && bi as f64 == b && a.abs() <= MAX_EXACT && b.abs() <= MAX_EXACT {
+            let r = ai % bi;
             if r == 0 {
                 return if a.is_sign_negative() { -0.0 } else { 0.0 };
             }
@@ -7408,7 +7680,7 @@ fn writeback_kernel_props(
 /// poll — the caller owns the budget-zeroing unwind.
 fn exec_fn_kernel_code(
     code: &[KOp],
-    regs: &mut [f64],
+    regs: &mut [f64; KWIN],
     interrupt: &Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     poll: &mut u32,
 ) -> Option<Value> {
@@ -7432,19 +7704,34 @@ fn exec_fn_kernel_code(
             }};
         }
         match code[pc] {
-            KOp::Mov { dst, src } => regs[dst as usize] = regs[src as usize],
-            KOp::Const { dst, k } => regs[dst as usize] = k,
-            KOp::Add { dst, a, b } => regs[dst as usize] = regs[a as usize] + regs[b as usize],
-            KOp::AddK { dst, a, k } => regs[dst as usize] = regs[a as usize] + k,
+            KOp::Mov { dst, src } => {
+                regs[dst as usize & KWIN_MASK] = regs[src as usize & KWIN_MASK]
+            }
+            KOp::Const { dst, k } => regs[dst as usize & KWIN_MASK] = k,
+            KOp::Add { dst, a, b } => {
+                regs[dst as usize & KWIN_MASK] =
+                    regs[a as usize & KWIN_MASK] + regs[b as usize & KWIN_MASK]
+            }
+            KOp::AddK { dst, a, k } => {
+                regs[dst as usize & KWIN_MASK] = regs[a as usize & KWIN_MASK] + k
+            }
             KOp::Arith { kind, dst, a, b } => {
-                regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind)
+                regs[dst as usize & KWIN_MASK] = number_arith_raw(
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                    kind,
+                )
             }
             KOp::ArithK { kind, dst, a, k } => {
-                regs[dst as usize] = number_arith_raw(regs[a as usize], k, kind)
+                regs[dst as usize & KWIN_MASK] =
+                    number_arith_raw(regs[a as usize & KWIN_MASK], k, kind)
             }
-            KOp::Neg { dst, src } => regs[dst as usize] = -regs[src as usize],
+            KOp::Neg { dst, src } => {
+                regs[dst as usize & KWIN_MASK] = -regs[src as usize & KWIN_MASK]
+            }
             KOp::BitNot { dst, src } => {
-                regs[dst as usize] = !crate::vm::to_int32(regs[src as usize]) as f64
+                regs[dst as usize & KWIN_MASK] =
+                    !crate::vm::to_int32(regs[src as usize & KWIN_MASK]) as f64
             }
             KOp::Br { target } => branch!(target),
             KOp::BrCmp {
@@ -7454,7 +7741,12 @@ fn exec_fn_kernel_code(
                 if_true,
                 target,
             } => {
-                if knum_cmp(cmp, regs[a as usize], regs[b as usize]) == if_true {
+                if knum_cmp(
+                    cmp,
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                ) == if_true
+                {
                     branch!(target)
                 }
             }
@@ -7465,41 +7757,51 @@ fn exec_fn_kernel_code(
                 if_true,
                 target,
             } => {
-                if knum_cmp(cmp, regs[a as usize], k) == if_true {
+                if knum_cmp(cmp, regs[a as usize & KWIN_MASK], k) == if_true {
                     branch!(target)
                 }
             }
             KOp::BrFalsy { src, target } => {
-                if !knum_truthy(regs[src as usize]) {
+                if !knum_truthy(regs[src as usize & KWIN_MASK]) {
                     branch!(target)
                 }
             }
             KOp::BrTruthy { src, target } => {
-                if knum_truthy(regs[src as usize]) {
+                if knum_truthy(regs[src as usize & KWIN_MASK]) {
                     branch!(target)
                 }
             }
             KOp::CmpSet { cmp, dst, a, b } => {
-                regs[dst as usize] = if knum_cmp(cmp, regs[a as usize], regs[b as usize]) {
+                regs[dst as usize & KWIN_MASK] = if knum_cmp(
+                    cmp,
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                ) {
                     1.0
                 } else {
                     0.0
                 }
             }
             KOp::BoolNot { dst, src } => {
-                regs[dst as usize] = if knum_truthy(regs[src as usize]) {
+                regs[dst as usize & KWIN_MASK] = if knum_truthy(regs[src as usize & KWIN_MASK]) {
                     0.0
                 } else {
                     1.0
                 }
             }
-            KOp::Math1 { kind, dst, src } => regs[dst as usize] = kmath1(kind, regs[src as usize]),
+            KOp::Math1 { kind, dst, src } => {
+                regs[dst as usize & KWIN_MASK] = kmath1(kind, regs[src as usize & KWIN_MASK])
+            }
             KOp::Math2 { kind, dst, a, b } => {
-                regs[dst as usize] = kmath2(kind, regs[a as usize], regs[b as usize])
+                regs[dst as usize & KWIN_MASK] = kmath2(
+                    kind,
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                )
             }
             KOp::Mov2 { d1, s1, d2, s2 } => {
-                regs[d1 as usize] = regs[s1 as usize];
-                regs[d2 as usize] = regs[s2 as usize];
+                regs[d1 as usize & KWIN_MASK] = regs[s1 as usize & KWIN_MASK];
+                regs[d2 as usize & KWIN_MASK] = regs[s2 as usize & KWIN_MASK];
                 // The unfused second op remains in the next slot as a
                 // branch-target landing pad; skip it.
                 pc += 1;
@@ -7513,19 +7815,39 @@ fn exec_fn_kernel_code(
                 a2,
                 b2,
             } => {
-                regs[dst as usize] = number_arith_raw(regs[a as usize], regs[b as usize], kind);
-                regs[d2 as usize] = regs[a2 as usize] + regs[b2 as usize];
+                regs[dst as usize & KWIN_MASK] = number_arith_raw(
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                    kind,
+                );
+                regs[d2 as usize & KWIN_MASK] =
+                    regs[a2 as usize & KWIN_MASK] + regs[b2 as usize & KWIN_MASK];
                 pc += 1;
             }
             KOp::AddKBr { dst, a, k, target } => {
-                regs[dst as usize] = regs[a as usize] + k;
+                regs[dst as usize & KWIN_MASK] = regs[a as usize & KWIN_MASK] + k;
                 branch!(target)
+            }
+            KOp::ArithKAdd {
+                kind,
+                dst,
+                a,
+                k,
+                d2,
+                a2,
+                b2,
+            } => {
+                regs[dst as usize & KWIN_MASK] =
+                    number_arith_raw(regs[a as usize & KWIN_MASK], k, kind);
+                regs[d2 as usize & KWIN_MASK] =
+                    regs[a2 as usize & KWIN_MASK] + regs[b2 as usize & KWIN_MASK];
+                pc += 1;
             }
             KOp::Ret { src, boolean } => {
                 return Some(if boolean {
-                    Value::Bool(regs[src as usize] != 0.0)
+                    Value::Bool(regs[src as usize & KWIN_MASK] != 0.0)
                 } else {
-                    Value::Number(regs[src as usize])
+                    Value::Number(regs[src as usize & KWIN_MASK])
                 })
             }
             // A frameless kernel has no bytecode frame to bail into;
@@ -7536,6 +7858,9 @@ fn exec_fn_kernel_code(
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
+            | KOp::LoadElemAdd { .. }
+            | KOp::LoadElemArith { .. }
+            | KOp::LenBrCmp { .. }
             | KOp::LoadProp { .. }
             | KOp::StoreProp { .. }
             | KOp::Exit { .. }
@@ -7546,14 +7871,15 @@ fn exec_fn_kernel_code(
     }
 }
 
+/// Run a pinned-callee kernel over its own fixed window. Returns the callee's
+/// `Ret` value (Number-only — the caller guard rejected boolean returns), or
+/// `None` when the cooperative interrupt flag latched on a back-edge poll.
 fn run_callee_window(
-    regs: &mut [f64],
+    regs: &mut [f64; KWIN],
     ck: &crate::bytecode::Kernel,
-    win: usize,
-    dst: usize,
     interrupt: &Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     poll: &mut u32,
-) -> bool {
+) -> Option<f64> {
     let code = &ck.code;
     let mut pc = 0usize;
     loop {
@@ -7565,7 +7891,7 @@ fn run_callee_window(
                     if *poll & 0xFF == 0 {
                         if let Some(flag) = interrupt {
                             if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                                return false;
+                                return None;
                             }
                         }
                     }
@@ -7575,22 +7901,34 @@ fn run_callee_window(
             }};
         }
         match code[pc] {
-            KOp::Mov { dst, src } => regs[win + dst as usize] = regs[win + src as usize],
-            KOp::Const { dst, k } => regs[win + dst as usize] = k,
-            KOp::Add { dst, a, b } => {
-                regs[win + dst as usize] = regs[win + a as usize] + regs[win + b as usize]
+            KOp::Mov { dst, src } => {
+                regs[dst as usize & KWIN_MASK] = regs[src as usize & KWIN_MASK]
             }
-            KOp::AddK { dst, a, k } => regs[win + dst as usize] = regs[win + a as usize] + k,
+            KOp::Const { dst, k } => regs[dst as usize & KWIN_MASK] = k,
+            KOp::Add { dst, a, b } => {
+                regs[dst as usize & KWIN_MASK] =
+                    regs[a as usize & KWIN_MASK] + regs[b as usize & KWIN_MASK]
+            }
+            KOp::AddK { dst, a, k } => {
+                regs[dst as usize & KWIN_MASK] = regs[a as usize & KWIN_MASK] + k
+            }
             KOp::Arith { kind, dst, a, b } => {
-                regs[win + dst as usize] =
-                    number_arith_raw(regs[win + a as usize], regs[win + b as usize], kind)
+                regs[dst as usize & KWIN_MASK] = number_arith_raw(
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                    kind,
+                )
             }
             KOp::ArithK { kind, dst, a, k } => {
-                regs[win + dst as usize] = number_arith_raw(regs[win + a as usize], k, kind)
+                regs[dst as usize & KWIN_MASK] =
+                    number_arith_raw(regs[a as usize & KWIN_MASK], k, kind)
             }
-            KOp::Neg { dst, src } => regs[win + dst as usize] = -regs[win + src as usize],
+            KOp::Neg { dst, src } => {
+                regs[dst as usize & KWIN_MASK] = -regs[src as usize & KWIN_MASK]
+            }
             KOp::BitNot { dst, src } => {
-                regs[win + dst as usize] = !crate::vm::to_int32(regs[win + src as usize]) as f64
+                regs[dst as usize & KWIN_MASK] =
+                    !crate::vm::to_int32(regs[src as usize & KWIN_MASK]) as f64
             }
             KOp::Br { target } => branch!(target),
             KOp::BrCmp {
@@ -7600,7 +7938,12 @@ fn run_callee_window(
                 if_true,
                 target,
             } => {
-                if knum_cmp(cmp, regs[win + a as usize], regs[win + b as usize]) == if_true {
+                if knum_cmp(
+                    cmp,
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                ) == if_true
+                {
                     branch!(target)
                 }
             }
@@ -7611,45 +7954,51 @@ fn run_callee_window(
                 if_true,
                 target,
             } => {
-                if knum_cmp(cmp, regs[win + a as usize], k) == if_true {
+                if knum_cmp(cmp, regs[a as usize & KWIN_MASK], k) == if_true {
                     branch!(target)
                 }
             }
             KOp::BrFalsy { src, target } => {
-                if !knum_truthy(regs[win + src as usize]) {
+                if !knum_truthy(regs[src as usize & KWIN_MASK]) {
                     branch!(target)
                 }
             }
             KOp::BrTruthy { src, target } => {
-                if knum_truthy(regs[win + src as usize]) {
+                if knum_truthy(regs[src as usize & KWIN_MASK]) {
                     branch!(target)
                 }
             }
             KOp::CmpSet { cmp, dst, a, b } => {
-                regs[win + dst as usize] =
-                    if knum_cmp(cmp, regs[win + a as usize], regs[win + b as usize]) {
-                        1.0
-                    } else {
-                        0.0
-                    }
+                regs[dst as usize & KWIN_MASK] = if knum_cmp(
+                    cmp,
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                ) {
+                    1.0
+                } else {
+                    0.0
+                }
             }
             KOp::BoolNot { dst, src } => {
-                regs[win + dst as usize] = if knum_truthy(regs[win + src as usize]) {
+                regs[dst as usize & KWIN_MASK] = if knum_truthy(regs[src as usize & KWIN_MASK]) {
                     0.0
                 } else {
                     1.0
                 }
             }
             KOp::Math1 { kind, dst, src } => {
-                regs[win + dst as usize] = kmath1(kind, regs[win + src as usize])
+                regs[dst as usize & KWIN_MASK] = kmath1(kind, regs[src as usize & KWIN_MASK])
             }
             KOp::Math2 { kind, dst, a, b } => {
-                regs[win + dst as usize] =
-                    kmath2(kind, regs[win + a as usize], regs[win + b as usize])
+                regs[dst as usize & KWIN_MASK] = kmath2(
+                    kind,
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                )
             }
             KOp::Mov2 { d1, s1, d2, s2 } => {
-                regs[win + d1 as usize] = regs[win + s1 as usize];
-                regs[win + d2 as usize] = regs[win + s2 as usize];
+                regs[d1 as usize & KWIN_MASK] = regs[s1 as usize & KWIN_MASK];
+                regs[d2 as usize & KWIN_MASK] = regs[s2 as usize & KWIN_MASK];
                 pc += 1;
             }
             KOp::ArithAdd {
@@ -7661,19 +8010,36 @@ fn run_callee_window(
                 a2,
                 b2,
             } => {
-                regs[win + dst as usize] =
-                    number_arith_raw(regs[win + a as usize], regs[win + b as usize], kind);
-                regs[win + d2 as usize] = regs[win + a2 as usize] + regs[win + b2 as usize];
+                regs[dst as usize & KWIN_MASK] = number_arith_raw(
+                    regs[a as usize & KWIN_MASK],
+                    regs[b as usize & KWIN_MASK],
+                    kind,
+                );
+                regs[d2 as usize & KWIN_MASK] =
+                    regs[a2 as usize & KWIN_MASK] + regs[b2 as usize & KWIN_MASK];
                 pc += 1;
             }
             KOp::AddKBr { dst, a, k, target } => {
-                regs[win + dst as usize] = regs[win + a as usize] + k;
+                regs[dst as usize & KWIN_MASK] = regs[a as usize & KWIN_MASK] + k;
                 branch!(target)
             }
+            KOp::ArithKAdd {
+                kind,
+                dst,
+                a,
+                k,
+                d2,
+                a2,
+                b2,
+            } => {
+                regs[dst as usize & KWIN_MASK] =
+                    number_arith_raw(regs[a as usize & KWIN_MASK], k, kind);
+                regs[d2 as usize & KWIN_MASK] =
+                    regs[a2 as usize & KWIN_MASK] + regs[b2 as usize & KWIN_MASK];
+                pc += 1;
+            }
             KOp::Ret { src, boolean: _ } => {
-                // Number-only (the caller guard rejected boolean returns).
-                regs[dst] = regs[win + src as usize];
-                return true;
+                return Some(regs[src as usize & KWIN_MASK]);
             }
             // Impossible in a guarded callee: no bails, no exits, no
             // recursion, no nested closure calls.
@@ -7682,6 +8048,9 @@ fn run_callee_window(
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
+            | KOp::LoadElemAdd { .. }
+            | KOp::LoadElemArith { .. }
+            | KOp::LenBrCmp { .. }
             | KOp::LoadProp { .. }
             | KOp::StoreProp { .. }
             | KOp::Exit { .. }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -487,6 +487,29 @@ impl Vm {
         )
     }
 
+    /// `KOp::CharCodeAt` entry guard: `String.prototype.charCodeAt` must
+    /// still be a plain data property holding the canonical builtin (a
+    /// patched/replaced/accessor'd method must run generically, observably).
+    /// A string primitive receiver can carry no own shadow, and nothing
+    /// inside a kernel can write props, so one entry check covers the
+    /// activation.
+    fn kernel_char_code_ok(&self) -> bool {
+        let Some(canon) = &self.realm.string_char_code_at else {
+            return false;
+        };
+        matches!(
+            self.realm
+                .string_proto
+                .borrow()
+                .props
+                .get(&crate::value::StrKeyRef("charCodeAt")),
+            Some(Property {
+                kind: PropertyKind::Data { value: Value::Object(o), .. },
+                ..
+            }) if o.ptr_eq(canon)
+        )
+    }
+
     /// Execute the typed loop kernel at `Op::LoopKernel(idx)` (see
     /// `kernel.rs` for the model). Runs only when per-op accounting is off
     /// (no op budget), every mapped numeric local holds a `Number`, and every
@@ -557,6 +580,24 @@ impl Vm {
             if !matches!(frame.locals[l as usize], Value::Object(_)) {
                 return self.step(frame, &k.fallback);
             }
+        }
+        // Pinned STRING bases: each sslot local must hold a FLAT ASCII string
+        // (unit == byte, so `StrLen`/`CharCodeAt` are O(1) and total); a
+        // `charCodeAt` region additionally needs the canonical method
+        // resolution. Checked before any pooled state is taken; the strings
+        // themselves are cached below alongside the object bases.
+        for &l in k.sslots.iter() {
+            let ok = matches!(
+                &frame.locals[l as usize],
+                Value::String(st)
+                    if matches!(st.flatten_utf8(), Some(f) if f.len() == st.len_utf16())
+            );
+            if !ok {
+                return self.step(frame, &k.fallback);
+            }
+        }
+        if k.uses_char_code && !self.kernel_char_code_ok() {
+            return self.step(frame, &k.fallback);
         }
         // A `StoreElem` may CREATE an element (hole fill / exact append), and
         // the spec's OrdinarySet consults the prototype chain when the own
@@ -737,6 +778,14 @@ impl Vm {
                 objs.push(o.clone());
             }
         }
+        // Pinned strings (validated above; immutable, so no re-checks exist).
+        let mut sstrs = std::mem::take(&mut self.kernel_strs);
+        sstrs.clear();
+        for &l in k.sslots.iter() {
+            if let Value::String(st) = &frame.locals[l as usize] {
+                sstrs.push(st.clone());
+            }
+        }
         // Prop registers (the tail of the register file): load each resolved
         // slot's current value. The guard above proved every one a Number.
         if !k.props_used.is_empty() {
@@ -822,6 +871,8 @@ impl Vm {
                 self.kernel_regs = regs;
                 objs.clear();
                 self.kernel_objs = objs;
+                sstrs.clear();
+                self.kernel_strs = sstrs;
                 self.kernel_prop_slots = prop_slots;
                 callee_bfs.clear();
                 self.kernel_callees = callee_bfs;
@@ -884,6 +935,8 @@ impl Vm {
                                     self.kernel_regs = regs;
                                     objs.clear();
                                     self.kernel_objs = objs;
+                                    sstrs.clear();
+                                    self.kernel_strs = sstrs;
                                     self.kernel_prop_slots = prop_slots;
                                     callee_bfs.clear();
                                     self.kernel_callees = callee_bfs;
@@ -1365,6 +1418,27 @@ impl Vm {
                     );
                     pc += 1;
                 }
+                // Pinned-string reads: TOTAL on the entry-guarded flat-ASCII
+                // string (unit == byte). `StrLen` is an activation constant;
+                // `CharCodeAt` computes ToIntegerOrInfinity (NaN→0, truncate
+                // toward zero, saturating casts) and the out-of-range NaN
+                // exactly — no bail exists.
+                KOp::StrLen { dst, str } => {
+                    w[dst as usize & KWIN_MASK] = sstrs[str as usize].len_utf16() as f64;
+                }
+                KOp::CharCodeAt { dst, str, idx } => {
+                    let i = w[idx as usize & KWIN_MASK];
+                    let bytes = sstrs[str as usize]
+                        .flatten_utf8()
+                        .expect("entry-guarded flat ASCII")
+                        .as_bytes();
+                    let p = if i.is_nan() { 0i64 } else { i as i64 };
+                    w[dst as usize & KWIN_MASK] =
+                        match usize::try_from(p).ok().and_then(|p| bytes.get(p)) {
+                            Some(&b) => b as f64,
+                            None => f64::NAN,
+                        };
+                }
                 // A pinned-closure call: copy the arguments into the
                 // callee's window and run its (guarded) kernel inline.
                 KOp::CallKernel {
@@ -1404,6 +1478,8 @@ impl Vm {
                         self.kernel_regs = regs;
                         objs.clear();
                         self.kernel_objs = objs;
+                        sstrs.clear();
+                        self.kernel_strs = sstrs;
                         self.kernel_prop_slots = prop_slots;
                         callee_bfs.clear();
                         self.kernel_callees = callee_bfs;
@@ -1457,11 +1533,19 @@ impl Vm {
                 crate::bytecode::KShapeSlot::ArrayPopFn => frame.stack.push(Value::Object(
                     self.realm.array_pop.clone().expect("guarded"),
                 )),
+                crate::bytecode::KShapeSlot::Str(sl) => {
+                    frame.stack.push(Value::String(sstrs[*sl as usize].clone()))
+                }
+                crate::bytecode::KShapeSlot::CharCodeFn => frame.stack.push(Value::Object(
+                    self.realm.string_char_code_at.clone().expect("guarded"),
+                )),
             }
         }
         self.kernel_regs = regs;
         objs.clear();
         self.kernel_objs = objs;
+        sstrs.clear();
+        self.kernel_strs = sstrs;
         self.kernel_prop_slots = prop_slots;
         callee_bfs.clear();
         self.kernel_callees = callee_bfs;
@@ -1829,6 +1913,8 @@ impl Vm {
                         | KOp::LoadElem { .. }
                         | KOp::StoreElem { .. }
                         | KOp::LoadLen { .. }
+                        | KOp::StrLen { .. }
+                        | KOp::CharCodeAt { .. }
                         | KOp::LoadElemAdd { .. }
                         | KOp::LoadElemArith { .. }
                         | KOp::LenBrCmp { .. }
@@ -7858,6 +7944,8 @@ fn exec_fn_kernel_code(
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
+            | KOp::StrLen { .. }
+            | KOp::CharCodeAt { .. }
             | KOp::LoadElemAdd { .. }
             | KOp::LoadElemArith { .. }
             | KOp::LenBrCmp { .. }
@@ -8048,6 +8136,8 @@ fn run_callee_window(
             | KOp::LoadElem { .. }
             | KOp::StoreElem { .. }
             | KOp::LoadLen { .. }
+            | KOp::StrLen { .. }
+            | KOp::CharCodeAt { .. }
             | KOp::LoadElemAdd { .. }
             | KOp::LoadElemArith { .. }
             | KOp::LenBrCmp { .. }

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -138,23 +138,37 @@ pub fn kernelize(mut code: Vec<Op>, consts: &[Const]) -> (Vec<Op>, Vec<Kernel>) 
         // succeeded installs the kernel. (Discovery is monotone over a
         // bounded set, so the cap is belt-and-braces.)
         let mut oslots: Vec<u32> = Vec::new();
+        let mut sslots: Vec<u32> = Vec::new();
         let mut bools: Vec<u32> = Vec::new();
         let mut installed: Option<Kernel> = None;
         for _ in 0..6 {
-            let (k, d_obj, d_bool) = translate(
+            let (k, d_obj, d_bool, d_str) = translate(
                 &code[start..=end],
                 start as u32,
                 consts,
                 &kernels,
                 &oslots,
+                &sslots,
                 &bools,
                 false,
                 None,
                 false,
             );
             let mut grew = false;
+            // A string discovery WINS over a same-local array-base guess: a
+            // `.length` read alone looks like an array, but a `charCodeAt`
+            // call is string-specific. (If the local genuinely holds an
+            // array, the string entry guard declines and the loop runs
+            // generically — same failure mode either way.)
+            for st in d_str {
+                if !sslots.contains(&st) {
+                    oslots.retain(|&o| o != st);
+                    sslots.push(st);
+                    grew = true;
+                }
+            }
             for o in d_obj {
-                if !oslots.contains(&o) {
+                if !oslots.contains(&o) && !sslots.contains(&o) {
                     oslots.push(o);
                     grew = true;
                 }
@@ -217,18 +231,19 @@ pub fn kernelize_function(
         // reject outright (element access can't run frameless).
         let mut bools: Vec<u32> = Vec::new();
         for _ in 0..6 {
-            let (k, d_obj, d_bool) = translate(
+            let (k, d_obj, d_bool, d_str) = translate(
                 code,
                 0,
                 consts,
                 inner,
+                &[],
                 &[],
                 &bools,
                 true,
                 self_name,
                 ret_bool,
             );
-            if !d_obj.is_empty() {
+            if !d_obj.is_empty() || !d_str.is_empty() {
                 return None;
             }
             let mut grew = false;
@@ -339,6 +354,12 @@ enum VE {
     MathObj,
     /// A kernel-supported `Math` method, from `GetProp` on [`VE::MathObj`].
     MathFn(KMath),
+    /// A pinned STRING base: string slot index (loop mode; see
+    /// [`Kernel::sslots`]).
+    Str(u16),
+    /// The (entry-guarded canonical) `charCodeAt` method loaded off a
+    /// string base — the compiler's method-call prologue.
+    CharCodeFn(u16),
     /// The value `undefined`, from `LoadUndefined`. Exists only transiently
     /// within a basic block: its ONLY legal consumer is a store to a local
     /// that is provably re-stored before any read (the compiler's
@@ -401,6 +422,9 @@ struct Xlate<'a> {
     rec_globals: Vec<Box<str>>,
     /// Locals designated as array bases (phase 2) — empty in phase 1.
     oslot_locals: &'a [u32],
+    /// Locals designated as STRING bases (fixpoint-discovered from
+    /// `charCodeAt` usage) — empty until discovered.
+    sslot_locals: &'a [u32],
     /// Locals statically typed BOOLEAN (fixpoint-discovered from stores).
     bool_locals: &'a [u32],
     kops: Vec<KOp>,
@@ -422,6 +446,11 @@ struct Xlate<'a> {
     local_reg: Vec<(KSlot, u16)>,
     /// boolean locals: (frame-local index, register from BOOL_BASE).
     bool_reg: Vec<(u32, u16)>,
+    /// locals observed as STRING bases (from `charCodeAt` over a clean
+    /// local origin); fed back by the fixpoint driver like `discovered`.
+    discovered_strs: Vec<u32>,
+    /// Whether the region calls `charCodeAt` (entry guard checks canonical).
+    uses_char_code: bool,
     /// phase 1: locals observed as array bases (with clean origins).
     discovered: Vec<u32>,
     /// locals observed receiving BOOLEAN stores (fixpoint feedback).
@@ -466,11 +495,12 @@ fn translate(
     consts: &[Const],
     inner: &[Kernel],
     oslot_locals: &[u32],
+    sslot_locals: &[u32],
     bool_locals: &[u32],
     fn_mode: bool,
     self_name: Option<&str>,
     self_ret_bool: bool,
-) -> (Option<Kernel>, Vec<u32>, Vec<u32>) {
+) -> (Option<Kernel>, Vec<u32>, Vec<u32>, Vec<u32>) {
     let mut is_target = vec![false; region.len()];
     for op in region {
         for t in op_targets(op) {
@@ -492,6 +522,7 @@ fn translate(
         self_refs: Vec::new(),
         rec_globals: Vec::new(),
         oslot_locals,
+        sslot_locals,
         bool_locals,
         kops: Vec::new(),
         kpc: vec![u16::MAX; region.len()],
@@ -503,6 +534,8 @@ fn translate(
         bool_reg: Vec::new(),
         discovered: Vec::new(),
         discovered_bools: Vec::new(),
+        discovered_strs: Vec::new(),
+        uses_char_code: false,
         origins: Vec::new(),
         versions: std::collections::HashMap::new(),
         vstack: Vec::new(),
@@ -521,7 +554,8 @@ fn translate(
     let kernel = translate_inner(&mut x);
     let d_obj = std::mem::take(&mut x.discovered);
     let d_bool = std::mem::take(&mut x.discovered_bools);
-    (kernel, d_obj, d_bool)
+    let d_str = std::mem::take(&mut x.discovered_strs);
+    (kernel, d_obj, d_bool, d_str)
 }
 
 fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
@@ -710,7 +744,11 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                 *idx = remap(*idx);
                 *val = remap(*val);
             }
-            KOp::LoadLen { dst, .. } => *dst = remap(*dst),
+            KOp::LoadLen { dst, .. } | KOp::StrLen { dst, .. } => *dst = remap(*dst),
+            KOp::CharCodeAt { dst, idx, .. } => {
+                *dst = remap(*dst);
+                *idx = remap(*idx);
+            }
             KOp::LoadProp { dst, .. } => *dst = remap(*dst),
             KOp::StoreProp { src, .. } => *src = remap(*src),
             KOp::CallKernel { dst, base, .. } => {
@@ -757,6 +795,8 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::MathFn(k) => KShapeSlot::MathFn(*k),
                     VE::ArrayPushFn(_) => KShapeSlot::ArrayPushFn,
                     VE::ArrayPopFn(_) => KShapeSlot::ArrayPopFn,
+                    VE::Str(sl) => KShapeSlot::Str(*sl),
+                    VE::CharCodeFn(_) => KShapeSlot::CharCodeFn,
                     VE::Undef | VE::Opaque | VE::SelfFn(_) => {
                         unreachable!("undef/opaque/self never crosses block boundaries")
                     }
@@ -887,6 +927,8 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         locals: locals.into_boxed_slice(),
         bool_locals: bool_locals.into_boxed_slice(),
         oslots: x.oslot_locals.to_vec().into_boxed_slice(),
+        sslots: x.sslot_locals.to_vec().into_boxed_slice(),
+        uses_char_code: x.uses_char_code,
         shapes: shapes.into_boxed_slice(),
         math_used: std::mem::take(&mut x.math_used).into_boxed_slice(),
         props_used: std::mem::take(&mut x.props_used).into_boxed_slice(),
@@ -1224,6 +1266,8 @@ fn const_prop_kops(kops: &mut [KOp]) -> bool {
             | KOp::Math2 { dst, .. }
             | KOp::LoadElem { dst, .. }
             | KOp::LoadLen { dst, .. }
+            | KOp::StrLen { dst, .. }
+            | KOp::CharCodeAt { dst, .. }
             | KOp::LoadProp { dst, .. }
             | KOp::ArrayPush { dst, .. }
             | KOp::ArrayPop { dst, .. }
@@ -1376,7 +1420,13 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
                 resolve!(idx);
                 resolve!(val);
             }
-            KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => kill!(*dst),
+            KOp::LoadLen { dst, .. } | KOp::StrLen { dst, .. } | KOp::LoadProp { dst, .. } => {
+                kill!(*dst)
+            }
+            KOp::CharCodeAt { dst, idx, .. } => {
+                resolve!(idx);
+                kill!(*dst);
+            }
             KOp::ArrayPush { dst, val, .. } => {
                 resolve!(val);
                 kill!(*dst);
@@ -1428,7 +1478,14 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
             see(*dst);
             see(*src);
         }
-        KOp::Const { dst, .. } | KOp::LoadLen { dst, .. } | KOp::LoadProp { dst, .. } => see(*dst),
+        KOp::Const { dst, .. }
+        | KOp::LoadLen { dst, .. }
+        | KOp::StrLen { dst, .. }
+        | KOp::LoadProp { dst, .. } => see(*dst),
+        KOp::CharCodeAt { dst, idx, .. } => {
+            see(*dst);
+            see(*idx);
+        }
         KOp::Add { dst, a, b }
         | KOp::Arith { dst, a, b, .. }
         | KOp::CmpSet { dst, a, b, .. }
@@ -1553,6 +1610,11 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
             KOp::LoadLen { dst, bail, .. } => {
                 defs[i] = bit(*dst);
                 succ[i] = (true, Some(*bail));
+            }
+            KOp::StrLen { dst, .. } => defs[i] = bit(*dst),
+            KOp::CharCodeAt { dst, idx, .. } => {
+                uses[i] = bit(*idx);
+                defs[i] = bit(*dst);
             }
             KOp::ArrayPush { dst, val, bail, .. } => {
                 uses[i] = bit(*val);
@@ -1680,6 +1742,7 @@ impl Xlate<'_> {
     /// rejects the region (some iteration would bail every time anyway).
     fn lreg(&mut self, l: u32) -> Option<u16> {
         if self.oslot_locals.contains(&l)
+            || self.sslot_locals.contains(&l)
             || self.bool_locals.contains(&l)
             || self.bool_reg.iter().any(|&(ll, _)| ll == l)
         {
@@ -1768,6 +1831,7 @@ impl Xlate<'_> {
             self.discovered_bools.push(l);
         }
         if self.oslot_locals.contains(&l)
+            || self.sslot_locals.contains(&l)
             || self.local_reg.iter().any(|&(sl, _)| sl == KSlot::Local(l))
         {
             return None;
@@ -1907,6 +1971,8 @@ impl Xlate<'_> {
             | VE::SelfFn(_)
             | VE::MathObj
             | VE::MathFn(_)
+            | VE::Str(_)
+            | VE::CharCodeFn(_)
             | VE::ArrayPushFn(_)
             | VE::ArrayPopFn(_) => None,
             VE::Num => {
@@ -1926,6 +1992,35 @@ impl Xlate<'_> {
                 };
                 Some(u16::try_from(s).ok()?)
             }
+        }
+    }
+
+    /// Resolve the entry at `depth_from_top` as a STRING BASE (loop mode).
+    /// Phase 1: a clean local origin records the local as a discovered
+    /// string base (the fixpoint driver feeds it back, sslot precedence over
+    /// a same-round array-base discovery). Phase 2: it must be `VE::Str`.
+    fn str_slot(&mut self, depth_from_top: usize) -> Option<u16> {
+        if self.fn_mode {
+            return None; // no sslot machinery in frameless kernels
+        }
+        let p = self.vstack.len().checked_sub(1 + depth_from_top)?;
+        match self.vstack[p] {
+            VE::Str(s) => Some(s),
+            VE::Num => {
+                let (l, ver) = self.origins[p]?;
+                if *self.versions.get(&l).unwrap_or(&0) != ver {
+                    return None;
+                }
+                let s = match self.discovered_strs.iter().position(|&d| d == l) {
+                    Some(s) => s,
+                    None => {
+                        self.discovered_strs.push(l);
+                        self.discovered_strs.len() - 1
+                    }
+                };
+                Some(u16::try_from(s).ok()?)
+            }
+            _ => None,
         }
     }
 
@@ -2123,6 +2218,10 @@ impl Xlate<'_> {
                 if let Some(pos) = self.oslot_locals.iter().position(|&o| o == *l) {
                     // This local is an array base — push the object.
                     self.vstack.push(VE::Obj(pos as u16));
+                    self.origins.push(None);
+                } else if let Some(pos) = self.sslot_locals.iter().position(|&o| o == *l) {
+                    // A pinned string base.
+                    self.vstack.push(VE::Str(pos as u16));
                     self.origins.push(None);
                 } else if self.is_bool_local(*l) {
                     let src = self.blreg(*l)?;
@@ -2337,11 +2436,16 @@ impl Xlate<'_> {
                         self.vstack.push(VE::Obj(s));
                         self.origins.push(None);
                     }
+                    VE::Str(s) => {
+                        self.vstack.push(VE::Str(s));
+                        self.origins.push(None);
+                    }
                     VE::MathObj => {
                         self.vstack.push(VE::MathObj);
                         self.origins.push(None);
                     }
                     VE::MathFn(_)
+                    | VE::CharCodeFn(_)
                     | VE::Undef
                     | VE::Opaque
                     | VE::SelfFn(_)
@@ -2602,6 +2706,20 @@ impl Xlate<'_> {
                 // to this routing — the region then rejects at the
                 // consumer — which is acceptable for so method-shaped a
                 // name.
+                // `s.charCodeAt` (loop mode): route to the pinned-string
+                // machinery — the entry guard verifies the canonical method
+                // and the flat-ASCII receiver. An Ordinary object with a
+                // data property named "charCodeAt" loses its kernel to this
+                // routing (rejects at the consumer) — acceptable for so
+                // method-shaped a name.
+                if !self.fn_mode && key == "charCodeAt" {
+                    let sslot = self.str_slot(0)?;
+                    self.pop()?;
+                    self.vstack.push(VE::CharCodeFn(sslot));
+                    self.origins.push(None);
+                    self.uses_char_code = true;
+                    return Some(());
+                }
                 if !self.fn_mode && (key == "push" || key == "pop") {
                     let obj = self.base_slot(0)?;
                     self.pop()?;
@@ -2616,6 +2734,14 @@ impl Xlate<'_> {
                     return Some(());
                 }
                 if key == "length" {
+                    // A pinned STRING base's length: an activation constant
+                    // (immutable string, pinned local) — total, no bail.
+                    if let Some(VE::Str(sslot)) = self.vstack.last().copied() {
+                        self.pop()?;
+                        let dst = self.push_num()?;
+                        self.kops.push(K::StrLen { dst, str: sslot });
+                        return Some(());
+                    }
                     // Arrays: derived length, per-access checked, bailable.
                     let shape = self.vstack.clone();
                     let obj = self.base_slot(0)?;
@@ -2697,6 +2823,23 @@ impl Xlate<'_> {
                         argc: u16::try_from(n).ok()?,
                         callee,
                     });
+                    return Some(());
+                }
+                // `s.charCodeAt(i)`: the compiler's method-call pattern
+                // [.., CharCodeFn(s), Str(s), idx] with exactly one
+                // statically-Number argument. TOTAL on the entry-guarded
+                // flat-ASCII receiver — the index conversion and OOB NaN
+                // are computed exactly in-kernel, so no bail exists.
+                if let VE::CharCodeFn(sl) = *self.vstack.get(fn_pos)? {
+                    if n != 1 || !matches!(self.vstack.get(fn_pos + 1)?, VE::Str(s2) if *s2 == sl) {
+                        return None;
+                    }
+                    let idx = self.top_num_reg(0)?;
+                    self.pop()?; // arg
+                    self.pop()?; // this (the string)
+                    self.pop()?; // fn
+                    let dst = self.push_num()?;
+                    self.kops.push(K::CharCodeAt { dst, str: sl, idx });
                     return Some(());
                 }
                 // `a.push(x)`: the compiler's method-call pattern

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -733,7 +733,13 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
             }
             KOp::Br { .. } | KOp::Exit { .. } => {}
             // Fusion (`fuse_kops`) runs after this remap.
-            KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+            KOp::Mov2 { .. }
+            | KOp::ArithAdd { .. }
+            | KOp::ArithKAdd { .. }
+            | KOp::AddKBr { .. }
+            | KOp::LenBrCmp { .. }
+            | KOp::LoadElemAdd { .. }
+            | KOp::LoadElemArith { .. } => {
                 unreachable!("fused op before fusion")
             }
         }
@@ -849,7 +855,11 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         .kops
         .iter()
         .any(|op| matches!(op, KOp::StoreElem { .. } | KOp::ArrayPush { .. }));
-    let loads_len = x.kops.iter().any(|op| matches!(op, KOp::LoadLen { .. }));
+    // `LenBrCmp` is a fused `LoadLen` — the entry guard must see it too.
+    let loads_len = x
+        .kops
+        .iter()
+        .any(|op| matches!(op, KOp::LoadLen { .. } | KOp::LenBrCmp { .. }));
     // fn mode: recursion descriptor from the recorded self/extern references
     // (`kernelize_function` fills `ret_bool`/`args_used` and verifies the
     // recursive constraints).
@@ -861,6 +871,13 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
             globals: std::mem::take(&mut x.rec_globals).into_boxed_slice(),
         }))
     };
+    // The executors run registers in fixed [`crate::bytecode::KWIN`]-slot
+    // windows with masked (bounds-check-free) indexing; a kernel needing more
+    // registers declines translation and the region stays generic. No
+    // observed kernel comes near the cap (all ≤ 10 registers).
+    if (prop_base + n_props) as usize > crate::bytecode::KWIN {
+        return None;
+    }
     Some(Kernel {
         stores_elems,
         loads_len,
@@ -910,8 +927,14 @@ fn map_targets(op: &mut KOp, mut f: impl FnMut(u16) -> u16) {
         KOp::LoadElem { bail, .. }
         | KOp::StoreElem { bail, .. }
         | KOp::LoadLen { bail, .. }
+        | KOp::LoadElemAdd { bail, .. }
+        | KOp::LoadElemArith { bail, .. }
         | KOp::ArrayPush { bail, .. }
         | KOp::ArrayPop { bail, .. } => *bail = f(*bail),
+        KOp::LenBrCmp { bail, target, .. } => {
+            *bail = f(*bail);
+            *target = f(*target);
+        }
         _ => {}
     }
 }
@@ -956,6 +979,85 @@ fn fuse_kops(kops: &mut [KOp]) {
                 k: *k,
                 target: *target,
             }),
+            (
+                KOp::ArithK { kind, dst, a, k },
+                KOp::Add {
+                    dst: d2,
+                    a: a2,
+                    b: b2,
+                },
+            ) => Some(KOp::ArithKAdd {
+                kind: *kind,
+                dst: *dst,
+                a: *a,
+                k: *k,
+                d2: *d2,
+                a2: *a2,
+                b2: *b2,
+            }),
+            (
+                KOp::LoadLen { dst, obj, bail },
+                KOp::BrCmp {
+                    cmp,
+                    a,
+                    b,
+                    if_true,
+                    target,
+                },
+            ) => Some(KOp::LenBrCmp {
+                dst: *dst,
+                obj: *obj,
+                bail: *bail,
+                cmp: *cmp,
+                a: *a,
+                b: *b,
+                if_true: *if_true,
+                target: *target,
+            }),
+            (
+                KOp::LoadElem {
+                    dst,
+                    obj,
+                    idx,
+                    bail,
+                },
+                KOp::Add {
+                    dst: d2,
+                    a: a2,
+                    b: b2,
+                },
+            ) => Some(KOp::LoadElemAdd {
+                dst: *dst,
+                obj: *obj,
+                idx: *idx,
+                bail: *bail,
+                d2: *d2,
+                a2: *a2,
+                b2: *b2,
+            }),
+            (
+                KOp::LoadElem {
+                    dst,
+                    obj,
+                    idx,
+                    bail,
+                },
+                KOp::Arith {
+                    kind,
+                    dst: d2,
+                    a: a2,
+                    b: b2,
+                },
+            ) => Some(KOp::LoadElemArith {
+                dst: *dst,
+                obj: *obj,
+                idx: *idx,
+                bail: *bail,
+                kind: *kind,
+                d2: *d2,
+                a2: *a2,
+                b2: *b2,
+            }),
             _ => None,
         };
         if let Some(f) = fused {
@@ -983,16 +1085,186 @@ fn cleanup_kops(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_re
     if n_regs > 128 {
         return;
     }
-    // Alternate the two transforms to a fixpoint: propagation exposes dead
+    // Alternate the transforms to a fixpoint: propagation exposes dead
     // copies; deletion shortens chains for the next round. Each round
     // strictly reduces rewrites+ops, so this terminates quickly.
     loop {
         let mut changed = copy_prop_kops(kops);
+        changed |= const_prop_kops(kops);
         changed |= dce_movs(kops, always_live, upvalue_uses, n_regs);
         if !changed {
             break;
         }
     }
+}
+
+/// Mirror `cmp` across an operand swap: `cmp(k, b) == mirror(cmp)(b, k)`.
+fn mirror_cmp(cmp: CmpOp) -> CmpOp {
+    match cmp {
+        CmpOp::Lt => CmpOp::Gt,
+        CmpOp::Gt => CmpOp::Lt,
+        CmpOp::Le => CmpOp::Ge,
+        CmpOp::Ge => CmpOp::Le,
+        CmpOp::Eq | CmpOp::Ne | CmpOp::StrictEq | CmpOp::StrictNe => cmp,
+    }
+}
+
+/// Forward CONSTANT propagation within basic blocks (same block discipline
+/// as `copy_prop_kops`): after `Const { dst, k }`, ops reading `dst` as an
+/// operand rewrite to their immediate (`*K`) forms — `Add` → `AddK`,
+/// `Arith` → `ArithK` (right operand, or either for the commutative kinds),
+/// `BrCmp` → `BrCmpK` (mirroring the comparison when the constant is on the
+/// left), `Mov` → `Const`. The rewritten op computes the identical value
+/// through the identical helper (`number_arith_raw(a, k, kind)` — the K
+/// forms simply carry the operand inline), so results are bit-identical;
+/// `dce_movs` then deletes the dead `Const` defs.
+fn const_prop_kops(kops: &mut [KOp]) -> bool {
+    let n = kops.len();
+    let mut label = vec![false; n];
+    let mut preds = vec![0u32; n];
+    for (j, op) in kops.iter_mut().enumerate() {
+        let falls = !matches!(op, KOp::Br { .. } | KOp::Ret { .. } | KOp::Exit { .. });
+        if falls && j + 1 < n {
+            preds[j + 1] += 1;
+        }
+        map_targets(op, |t| {
+            label[t as usize] = true;
+            preds[t as usize] += 1;
+            t
+        });
+    }
+    let mut konst: Vec<Option<f64>> = vec![None; 1 + kops.iter().fold(0, max_reg) as usize];
+    let mut snapshots: Vec<Option<Vec<Option<f64>>>> = vec![None; n];
+    let mut changed = false;
+    for (i, op) in kops.iter_mut().enumerate() {
+        if label[i] {
+            match snapshots[i].take() {
+                Some(s) => konst = s,
+                None => konst.iter_mut().for_each(|e| *e = None),
+            }
+        }
+        // Rewrite reads of known-constant registers to immediate forms.
+        match *op {
+            KOp::Mov { dst, src } => {
+                if let Some(k) = konst[src as usize] {
+                    *op = KOp::Const { dst, k };
+                    changed = true;
+                }
+            }
+            KOp::Add { dst, a, b } => {
+                if let Some(k) = konst[b as usize] {
+                    *op = KOp::AddK { dst, a, k };
+                    changed = true;
+                } else if let Some(k) = konst[a as usize] {
+                    *op = KOp::AddK { dst, a: b, k };
+                    changed = true;
+                }
+            }
+            KOp::Arith { kind, dst, a, b } => {
+                let commutative = matches!(
+                    kind,
+                    crate::exec::ArithKind::Mul
+                        | crate::exec::ArithKind::BitAnd
+                        | crate::exec::ArithKind::BitOr
+                        | crate::exec::ArithKind::BitXor
+                );
+                if let Some(k) = konst[b as usize] {
+                    *op = KOp::ArithK { kind, dst, a, k };
+                    changed = true;
+                } else if commutative {
+                    if let Some(k) = konst[a as usize] {
+                        *op = KOp::ArithK { kind, dst, a: b, k };
+                        changed = true;
+                    }
+                }
+            }
+            KOp::BrCmp {
+                cmp,
+                a,
+                b,
+                if_true,
+                target,
+            } => {
+                if let Some(k) = konst[b as usize] {
+                    *op = KOp::BrCmpK {
+                        cmp,
+                        a,
+                        k,
+                        if_true,
+                        target,
+                    };
+                    changed = true;
+                } else if let Some(k) = konst[a as usize] {
+                    *op = KOp::BrCmpK {
+                        cmp: mirror_cmp(cmp),
+                        a: b,
+                        k,
+                        if_true,
+                        target,
+                    };
+                    changed = true;
+                }
+            }
+            _ => {}
+        }
+        // Update the constant map: a `Const` def records; any other def
+        // kills. (No aliasing exists — these are plain registers.)
+        match op {
+            KOp::Const { dst, k } => konst[*dst as usize] = Some(*k),
+            KOp::Mov { dst, .. }
+            | KOp::Add { dst, .. }
+            | KOp::AddK { dst, .. }
+            | KOp::Arith { dst, .. }
+            | KOp::ArithK { dst, .. }
+            | KOp::Neg { dst, .. }
+            | KOp::BitNot { dst, .. }
+            | KOp::BoolNot { dst, .. }
+            | KOp::CmpSet { dst, .. }
+            | KOp::Math1 { dst, .. }
+            | KOp::Math2 { dst, .. }
+            | KOp::LoadElem { dst, .. }
+            | KOp::LoadLen { dst, .. }
+            | KOp::LoadProp { dst, .. }
+            | KOp::ArrayPush { dst, .. }
+            | KOp::ArrayPop { dst, .. }
+            | KOp::CallKernel { dst, .. }
+            | KOp::SelfCall { dst, .. } => konst[*dst as usize] = None,
+            KOp::Br { .. }
+            | KOp::BrCmp { .. }
+            | KOp::BrCmpK { .. }
+            | KOp::BrFalsy { .. }
+            | KOp::BrTruthy { .. }
+            | KOp::StoreElem { .. }
+            | KOp::StoreProp { .. }
+            | KOp::Ret { .. }
+            | KOp::Exit { .. } => {}
+            // Fusion (`fuse_kops`) runs after cleanup.
+            KOp::Mov2 { .. }
+            | KOp::ArithAdd { .. }
+            | KOp::ArithKAdd { .. }
+            | KOp::AddKBr { .. }
+            | KOp::LenBrCmp { .. }
+            | KOp::LoadElemAdd { .. }
+            | KOp::LoadElemArith { .. } => {
+                unreachable!("fused op before fusion")
+            }
+        }
+        // Same forward-edge snapshot rule as `copy_prop_kops`.
+        let target = match op {
+            KOp::Br { target }
+            | KOp::BrCmp { target, .. }
+            | KOp::BrCmpK { target, .. }
+            | KOp::BrFalsy { target, .. }
+            | KOp::BrTruthy { target, .. } => Some(*target),
+            _ => None,
+        };
+        if let Some(t) = target {
+            if t as usize > i && preds[t as usize] == 1 {
+                snapshots[t as usize] = Some(konst.clone());
+            }
+        }
+    }
+    changed
 }
 
 /// Forward copy propagation within basic blocks: after `Mov d, s`, reads of
@@ -1116,7 +1388,13 @@ fn copy_prop_kops(kops: &mut [KOp]) -> bool {
             KOp::CallKernel { dst, .. } | KOp::SelfCall { dst, .. } => kill!(*dst),
             KOp::Br { .. } | KOp::Exit { .. } => {}
             // Fusion (`fuse_kops`) runs after cleanup.
-            KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+            KOp::Mov2 { .. }
+            | KOp::ArithAdd { .. }
+            | KOp::ArithKAdd { .. }
+            | KOp::AddKBr { .. }
+            | KOp::LenBrCmp { .. }
+            | KOp::LoadElemAdd { .. }
+            | KOp::LoadElemArith { .. } => {
                 unreachable!("fused op before fusion")
             }
         }
@@ -1194,7 +1472,13 @@ fn max_reg(acc: u16, op: &KOp) -> u16 {
         }
         KOp::Br { .. } | KOp::Exit { .. } => {}
         // Fusion (`fuse_kops`) runs after cleanup.
-        KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+        KOp::Mov2 { .. }
+        | KOp::ArithAdd { .. }
+        | KOp::ArithKAdd { .. }
+        | KOp::AddKBr { .. }
+        | KOp::LenBrCmp { .. }
+        | KOp::LoadElemAdd { .. }
+        | KOp::LoadElemArith { .. } => {
             unreachable!("fused op before fusion")
         }
     }
@@ -1301,7 +1585,13 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
                 defs[i] = bit(*dst);
             }
             // Fusion (`fuse_kops`) runs after cleanup.
-            KOp::Mov2 { .. } | KOp::ArithAdd { .. } | KOp::AddKBr { .. } => {
+            KOp::Mov2 { .. }
+            | KOp::ArithAdd { .. }
+            | KOp::ArithKAdd { .. }
+            | KOp::AddKBr { .. }
+            | KOp::LenBrCmp { .. }
+            | KOp::LoadElemAdd { .. }
+            | KOp::LoadElemArith { .. } => {
                 unreachable!("fused op before fusion")
             }
         }
@@ -1332,14 +1622,15 @@ fn dce_movs(kops: &mut Vec<KOp>, always_live: u128, upvalue_uses: u128, n_regs: 
             break;
         }
     }
-    // A Mov is dead when nothing can observe its destination: not live on
-    // any path out, not written back / shape-referenced (always_live), or a
-    // self-move.
+    // A Mov (or a Const — const-propagation strands them) is dead when
+    // nothing can observe its destination: not live on any path out, not
+    // written back / shape-referenced (always_live), or a self-move.
     let dead: Vec<bool> = kops
         .iter()
         .enumerate()
         .map(|(i, op)| match op {
             KOp::Mov { dst, src } => *dst == *src || (live_out[i] | always_live) & bit(*dst) == 0,
+            KOp::Const { dst, .. } => (live_out[i] | always_live) & bit(*dst) == 0,
             _ => false,
         })
         .collect();

--- a/crates/chidori-js/src/module.rs
+++ b/crates/chidori-js/src/module.rs
@@ -542,9 +542,9 @@ impl Vm {
         // (filled below by the outermost call) instead of recursing forever.
         let obj = self.alloc(crate::value::ObjectData::new(
             None,
-            crate::value::Internal::ModuleNamespace(crate::value::NamespaceData {
+            crate::value::Internal::ModuleNamespace(Box::new(crate::value::NamespaceData {
                 exports: indexmap::IndexMap::new(),
-            }),
+            })),
         ));
         module.borrow_mut().namespace = Some(Value::Object(obj.clone()));
         let mut names = self.exported_names(registry, module, &mut HashSet::new())?;

--- a/crates/chidori-js/src/promise.rs
+++ b/crates/chidori-js/src/promise.rs
@@ -17,13 +17,13 @@ impl Vm {
     pub fn new_promise(&self) -> JsObject {
         self.alloc(ObjectData::new(
             Some(self.realm.promise_proto.clone()),
-            Internal::Promise(PromiseData {
+            Internal::Promise(Box::new(PromiseData {
                 state: PromiseState::Pending,
                 fulfill_reactions: Vec::new(),
                 reject_reactions: Vec::new(),
                 handled: false,
                 host_id: None,
-            }),
+            })),
         ))
     }
 

--- a/crates/chidori-js/src/realm.rs
+++ b/crates/chidori-js/src/realm.rs
@@ -33,6 +33,9 @@ pub struct Realm {
     pub array_push: Option<JsObject>,
     /// As `array_push`, for `Array.prototype.pop` (`KOp::ArrayPop`).
     pub array_pop: Option<JsObject>,
+    /// The canonical `String.prototype.charCodeAt`, pinned at install for
+    /// the kernel `CharCodeAt` entry guard (and bail-shape reconstruction).
+    pub string_char_code_at: Option<JsObject>,
     /// The canonical `next` function objects of the four builtin iterator
     /// prototypes (array/string/map/set), pinned at install.
     /// `Op::IteratorStepValue` identity-checks the loop's iterator-record
@@ -196,6 +199,7 @@ impl Realm {
             math_kernel: Vec::new(),
             ta_length_getter: None,
             array_push: None,
+            string_char_code_at: None,
             array_pop: None,
             builtin_iter_next: Vec::new(),
             object_proto: bare(),

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -505,6 +505,14 @@ pub enum ROp {
         at: u16,
         n: u16,
     },
+    /// Object-literal template instantiation ([`Op::NewObjectTpl`]): values
+    /// move out of canonical registers `at..at+n`.
+    NewObjectTpl {
+        dst: u16,
+        at: u16,
+        n: u16,
+        tpl: u32,
+    },
     ArraySpread {
         arr: u16,
         src: u16,
@@ -636,6 +644,7 @@ fn effect(op: &Op) -> Option<(u32, u32)> {
         Dup => (0, 1),
         Swap | Rot3 => (0, 0),
         NewObject | GetTemplateObject(_) | NewRegExp { .. } | Closure(_) => (0, 1),
+        NewObjectTpl { n, .. } => (*n, 1),
         NewArray(n) | ConcatStrings(n) => (*n, 1),
         ArraySpread | ObjectSpread => (2, 1),
         CopyDataPropertiesExcept(n) => (*n + 2, 1),
@@ -1235,6 +1244,7 @@ fn rop_set_dst(op: &mut ROp, new_dst: u16) -> bool {
         | ROp::Closure { dst, .. }
         | ROp::NewObject { dst }
         | ROp::NewArray { dst, .. }
+        | ROp::NewObjectTpl { dst, .. }
         | ROp::GetTemplateObject { dst, .. }
         | ROp::NewRegExp { dst, .. }
         | ROp::ConcatStrings { dst, .. }
@@ -1862,6 +1872,23 @@ impl Emitter {
                     dst,
                     at,
                     n: n as u16,
+                });
+                self.push_temp();
+            }
+            NewObjectTpl { idx, n } => {
+                let n = *n as usize;
+                let base = self.entries.len() - n;
+                for pos in base..self.entries.len() {
+                    self.canonicalize(pos);
+                }
+                let at = self.canon(base);
+                self.entries.truncate(base);
+                let dst = self.dst();
+                self.push_def(ROp::NewObjectTpl {
+                    dst,
+                    at,
+                    n: n as u16,
+                    tpl: *idx,
                 });
                 self.push_temp();
             }

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -312,6 +312,17 @@ impl JsString {
         }
     }
 
+    /// The flat UTF-8 view of a well-formed string, FLATTENING a rope on
+    /// first use (the copy is cached in the rope node, so repeated calls —
+    /// a kernel's per-access reads — are O(1)). `None` for WTF-8 strings.
+    pub fn flatten_utf8(&self) -> Option<&str> {
+        match &self.0 {
+            Repr::Utf8(s, _) => Some(s),
+            Repr::Rope(_) => Some(self.as_str()),
+            Repr::Wtf8(_) => None,
+        }
+    }
+
     /// Concatenate, preserving code units. Two well-formed strings concatenate
     /// as plain UTF-8; otherwise we route through code units so a high+low
     /// surrogate straddling the boundary re-pairs into one astral code point.
@@ -978,7 +989,10 @@ pub enum Internal {
     /// expose collection and remain unsupported (determinism contract).
     WeakMap(crate::fxhash::FxIndexMap<MapKey, Value>),
     WeakSet(crate::fxhash::FxIndexMap<MapKey, ()>),
-    Promise(crate::vm::PromiseData),
+    /// Boxed: `PromiseData` is the largest inline payload (104 bytes) and
+    /// promises are allocation-rare next to plain objects — boxing it (and
+    /// `NamespaceData`) shrinks EVERY `ObjectData` by ~32 bytes.
+    Promise(Box<crate::vm::PromiseData>),
     Generator(crate::vm::GeneratorData),
     Date(f64),
     /// The `arguments` exotic object. For a MAPPED one (sloppy, simple
@@ -1002,7 +1016,7 @@ pub enum Internal {
     /// `import()` result): null prototype, non-extensible, exports exposed as
     /// live {writable:true, enumerable:true, configurable:false} data
     /// properties whose [[Set]] always fails and whose [[Delete]] refuses.
-    ModuleNamespace(NamespaceData),
+    ModuleNamespace(Box<NamespaceData>),
     /// A `Temporal.*` object. The spec arithmetic lives in `temporal_rs`; the
     /// slot holds the immutable backing value (no JS references, so the GC
     /// treats it as a leaf).

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -72,7 +72,7 @@ struct Rope {
 /// Minimum combined size before `concat` builds a rope node instead of
 /// copying. Below this, an eager copy is cheaper than the node + eventual
 /// flatten bookkeeping, and short-string behavior stays exactly as before.
-const ROPE_MIN_BYTES: usize = 64;
+pub(crate) const ROPE_MIN_BYTES: usize = 64;
 
 /// Sentinel for a `Repr::Utf8` whose code-unit count has not been computed
 /// yet. Safe: [`MAX_STRING_LEN`] (16M units) keeps every real count far below
@@ -303,6 +303,15 @@ impl JsString {
             Repr::Wtf8(w) => JsString::new(&*w.lossy),
         }
     }
+    /// The borrowed UTF-8 view IF this is a plain (non-rope, well-formed)
+    /// string — O(1), never flattens a rope. `None` for ropes and WTF-8.
+    pub fn as_flat_utf8(&self) -> Option<&str> {
+        match &self.0 {
+            Repr::Utf8(s, _) => Some(s),
+            _ => None,
+        }
+    }
+
     /// Concatenate, preserving code units. Two well-formed strings concatenate
     /// as plain UTF-8; otherwise we route through code units so a high+low
     /// surrogate straddling the boundary re-pairs into one astral code point.

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -368,6 +368,17 @@ pub struct Vm {
     /// Pooled (caller, return-pc, dst, window) stack for
     /// `run_fn_kernel_rec`; parked empty.
     pub(crate) rec_calls: Vec<(u8, u16, u16, u32)>,
+    /// Cross-parse JSON object-key intern cache: repeated `JSON.parse` of
+    /// same-shaped documents (the poll/roundtrip pattern) reuses one
+    /// `Rc<str>` per distinct key instead of allocating it per parse. Pure
+    /// perf: only the ALLOCATION IDENTITY of key strings is shared — content,
+    /// insertion order, and everything observable are unchanged. Bounded
+    /// (cleared at capacity), never serialized.
+    pub(crate) json_keys: std::collections::HashMap<
+        Box<str>,
+        crate::value::PropertyKey,
+        std::hash::BuildHasherDefault<crate::fxhash::FxHasher>,
+    >,
 }
 
 impl Default for Vm {
@@ -412,6 +423,7 @@ impl Vm {
             kernel_callees: Vec::new(),
             rec_families: Vec::new(),
             rec_calls: Vec::new(),
+            json_keys: std::collections::HashMap::default(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(
                     "",
@@ -459,6 +471,30 @@ impl Vm {
 
     pub fn new_object(&self) -> JsObject {
         self.alloc_ordinary(Some(self.realm.object_proto.clone()))
+    }
+
+    /// Instantiate an object-literal TEMPLATE (see [`crate::bytecode::Op::NewObjectTpl`]):
+    /// clone the pre-built property map (bucket layout included — no hashing,
+    /// no growth) and overwrite slots `0..N` with the evaluated values in
+    /// source order. Identical to `new_object()` + N× CreateDataProperty on
+    /// a fresh ordinary extensible object, where nothing user-visible can
+    /// intervene or fail.
+    pub fn new_object_from_tpl(
+        &self,
+        tpl: &crate::bytecode::ObjTemplate,
+        values: impl Iterator<Item = Value>,
+    ) -> JsObject {
+        let mut map = tpl.map.clone();
+        for (i, v) in values.enumerate() {
+            let (_, p) = map.get_index_mut(i).expect("template arity");
+            p.kind = PropertyKind::Data {
+                value: v,
+                writable: true,
+            };
+        }
+        let mut data = ObjectData::new(Some(self.realm.object_proto.clone()), Internal::Ordinary);
+        data.props = map;
+        self.alloc(data)
     }
 
     pub fn new_object_proto(&self, proto: Option<JsObject>) -> JsObject {

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -368,6 +368,10 @@ pub struct Vm {
     /// Pooled (caller, return-pc, dst, window) stack for
     /// `run_fn_kernel_rec`; parked empty.
     pub(crate) rec_calls: Vec<(u8, u16, u16, u32)>,
+    /// Pinned STRING bases for the active loop-kernel activation (mirrors
+    /// `kernel_objs`); cleared after every activation so the pool never
+    /// extends a string's lifetime.
+    pub(crate) kernel_strs: Vec<crate::value::JsString>,
     /// Cross-parse JSON object-key intern cache: repeated `JSON.parse` of
     /// same-shaped documents (the poll/roundtrip pattern) reuses one
     /// `Rc<str>` per distinct key instead of allocating it per parse. Pure
@@ -423,6 +427,7 @@ impl Vm {
             kernel_callees: Vec::new(),
             rec_families: Vec::new(),
             rec_calls: Vec::new(),
+            kernel_strs: Vec::new(),
             json_keys: std::collections::HashMap::default(),
             dummy_bf: Rc::new(BytecodeFunction {
                 proto: Rc::new(crate::bytecode::FuncProto::empty(

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -500,6 +500,27 @@ const CORPUS: &[&str] = &[
     "function h2(n) { return n <= 0 ? 0 : Math.max(n % 7, h2(n - 1)); } console.log(h2(40));",
     // Captured numeric upvalue inside a recursive const arrow.
     "const LIM = 3; const f2 = (n) => (n <= LIM ? n : f2(n - 2) + 1); console.log(f2(21));",
+    // ---- pinned-string charCodeAt/length (KOp::StrLen / KOp::CharCodeAt) ----
+    // The canonical tokenizer hash loop over a flat ASCII string.
+    "const s = \"hello world, kernel strings!\"; let h = 0; for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) % 1000000007; } console.log(h);",
+    // Rope-built accumulator (flattened once at kernel entry).
+    "let s = \"\"; for (let i = 0; i < 200; i++) s += \"ab\"; let h = 0; for (let i = 0; i < s.length; i++) h += s.charCodeAt(i); console.log(h, s.length);",
+    // ToIntegerOrInfinity edges computed in-kernel: negative, OOB, NaN,
+    // fractional, negative-fraction indices.
+    "const s = \"abc\"; let out = \"\"; for (let i = -2; i < 6; i++) out += s.charCodeAt(i + 0.5) + \",\"; console.log(out, s.charCodeAt(NaN));",
+    // Non-ASCII receiver: the entry guard declines, the loop runs generic.
+    "const s = \"héllo wörld\"; let h = 0; for (let i = 0; i < s.length; i++) h = h * 3 + s.charCodeAt(i); console.log(h, s.length);",
+    // Astral (surrogate pair) receiver: WTF-16 code units via the generic path.
+    "const s = \"x𝒳y\"; let h = 0; for (let i = 0; i < s.length; i++) h = h * 7 + s.charCodeAt(i); console.log(h, s.length);",
+    // Monkeypatched charCodeAt: canonical check declines, the patch runs.
+    "const orig = String.prototype.charCodeAt; String.prototype.charCodeAt = function () { return 42; }; const s = \"abcdef\"; let h = 0; for (let i = 0; i < s.length; i++) h += s.charCodeAt(i); String.prototype.charCodeAt = orig; console.log(h);",
+    // String local reassigned between activations (re-guarded each entry).
+    "let t = \"abc\"; let h = 0; for (let r = 0; r < 3; r++) { for (let i = 0; i < t.length; i++) h += t.charCodeAt(i); t = t + \"z\"; } console.log(h);",
+    // Non-string in the local: guard declines to the generic path (TypeError
+    // class behavior must be identical).
+    "let s = \"ok\"; let h = 0; for (let r = 0; r < 2; r++) { for (let i = 0; i < s.length; i++) h += s.charCodeAt(i); s = \"next\"; } console.log(h);",
+    // charCodeAt result feeding arithmetic, compares, and a stored boolean.
+    "const s = \"mixed13chars\"; let digits = 0; for (let i = 0; i < s.length; i++) { const c = s.charCodeAt(i); const isd = c >= 48 && c <= 57; if (isd) digits++; } console.log(digits);",
 ];
 
 #[test]
@@ -1039,5 +1060,38 @@ fn kernel_register_cap() {
         (threw_on, &con_on, &err_on),
         (threw_off, &con_off, &err_off),
         "cap-boundary loop must behave identically"
+    );
+}
+
+/// The canonical charCodeAt scan loop actually kernelizes with the
+/// pinned-string ops (pins the string tier).
+#[test]
+fn char_code_loops_get_kernels() {
+    fn kernel_ops(src: &str) -> Vec<KOp> {
+        fn collect(p: &FuncProto, out: &mut Vec<KOp>) {
+            for k in &p.kernels {
+                out.extend(k.code.iter().copied());
+            }
+            for c in &p.consts {
+                if let Const::Func(f) = c {
+                    collect(f, out);
+                }
+            }
+        }
+        let proto = compile_script(src).expect("compiles");
+        let mut out = Vec::new();
+        collect(&proto, &mut out);
+        out
+    }
+    let ops = kernel_ops(
+        "function f(s) { let h = 0; for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) % 1000000007; } return h; }",
+    );
+    assert!(
+        ops.iter().any(|op| matches!(op, KOp::CharCodeAt { .. })),
+        "charCodeAt scan must kernelize: {ops:?}"
+    );
+    assert!(
+        ops.iter().any(|op| matches!(op, KOp::StrLen { .. })),
+        "string length must use StrLen: {ops:?}"
     );
 }

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -14,7 +14,7 @@
 
 use std::rc::Rc;
 
-use chidori_js::bytecode::{Const, FuncProto, Op};
+use chidori_js::bytecode::{Const, FuncProto, KOp, Op};
 use chidori_js::compiler::{compile_script, compile_script_kernels};
 use chidori_js::{Engine, Value};
 
@@ -964,4 +964,80 @@ fn op_budget_identical_with_kernels() {
             );
         }
     }
+}
+
+/// The cleanup/fusion pipeline actually produces the new superinstructions
+/// (const-propagated K-forms, the fused loop-header test, and the fused
+/// element-load accumulations) on the canonical shapes — pins the
+/// masked-window round's dispatch counts.
+#[test]
+fn kernel_superinstructions_fire() {
+    fn kernel_ops(src: &str) -> Vec<KOp> {
+        fn collect(p: &FuncProto, out: &mut Vec<KOp>) {
+            for k in &p.kernels {
+                out.extend(k.code.iter().copied());
+            }
+            for c in &p.consts {
+                if let Const::Func(f) = c {
+                    collect(f, out);
+                }
+            }
+        }
+        let proto = compile_script(src).expect("compiles");
+        let mut out = Vec::new();
+        collect(&proto, &mut out);
+        out
+    }
+    // `i < a.length` header: one fused LenBrCmp dispatch.
+    let ops = kernel_ops(
+        "function f(a) { let s = 0; for (let i = 0; i < a.length; i++) { s += a[i]; } return s; }",
+    );
+    assert!(
+        ops.iter().any(|op| matches!(op, KOp::LenBrCmp { .. })),
+        "length header must fuse: {ops:?}"
+    );
+    // `s += a[i]`: one fused LoadElemAdd dispatch.
+    assert!(
+        ops.iter().any(|op| matches!(op, KOp::LoadElemAdd { .. })),
+        "element accumulation must fuse: {ops:?}"
+    );
+    // Constant operands reach the immediate forms: no materialized `Const`
+    // feeding an `Arith`/`BrCmp` survives in the canonical modular loop.
+    let ops = kernel_ops(
+        "function f(n) { let s = 0; for (let i = 0; i < n; i++) { s += (i * 7919) % 10007; } return s; }",
+    );
+    assert!(
+        ops.iter()
+            .any(|op| matches!(op, KOp::ArithK { .. } | KOp::ArithKAdd { .. })),
+        "constant arithmetic must use K-forms: {ops:?}"
+    );
+    assert!(
+        !ops.iter().any(|op| matches!(op, KOp::Const { .. })),
+        "no stranded Const feeding const-propagated ops: {ops:?}"
+    );
+}
+
+/// The masked-window executors run kernels correctly at the register-count
+/// CAP boundary (KWIN registers is the translation limit; a body needing
+/// more must decline and stay generic — never corrupt).
+#[test]
+fn kernel_register_cap() {
+    // Many distinct live locals in one loop body push the register count up;
+    // whether or not this kernelizes, the RESULT must be exact.
+    let mut body = String::new();
+    let mut sum = String::new();
+    for i in 0..24 {
+        body.push_str(&format!("let v{i} = i + {i}; "));
+        sum.push_str(&format!("+ v{i} "));
+    }
+    let src = format!(
+        "let s = 0; for (let i = 0; i < 100; i++) {{ {body} s = (s {sum}) % 1000003; }} console.log(s);"
+    );
+    let (threw_on, con_on, err_on) = run(&src, true);
+    let (threw_off, con_off, err_off) = run(&src, false);
+    assert_eq!(
+        (threw_on, &con_on, &err_on),
+        (threw_off, &con_off, &err_off),
+        "cap-boundary loop must behave identically"
+    );
 }

--- a/crates/chidori-js/tests/obj_tpl.rs
+++ b/crates/chidori-js/tests/obj_tpl.rs
@@ -1,0 +1,123 @@
+//! Structural + behavioral tests for object-literal TEMPLATES
+//! (`Op::NewObjectTpl` / `FuncProto::obj_tpls`): an all-static-data-key
+//! literal instantiates by cloning a pre-built property map instead of
+//! running the generic `NewObject` + N×`DefineField` sequence. The template
+//! path must be observably identical — key order, enumeration, JSON output,
+//! descriptors, later mutation — and every shape it cannot represent
+//! (computed keys, accessors, methods, spread, `__proto__`, duplicates)
+//! must keep the generic path.
+
+use chidori_js::bytecode::{Const, FuncProto, Op};
+use chidori_js::compiler::compile_script;
+use chidori_js::Engine;
+
+fn count_tpl_ops(p: &FuncProto) -> usize {
+    let mut n = p
+        .code
+        .iter()
+        .filter(|op| matches!(op, Op::NewObjectTpl { .. }))
+        .count();
+    for c in &p.consts {
+        if let Const::Func(f) = c {
+            n += count_tpl_ops(f);
+        }
+    }
+    n
+}
+
+#[test]
+fn eligible_literals_compile_to_templates() {
+    for src in [
+        "const o = { a: 1, b: 2 };",
+        "const o = { id: 0, name: \"w\", tags: [1], nested: { x: 1, y: 2 }, flag: false };",
+        "function f(x) { return { value: x, done: false }; }",
+        "const a = 1, b = 2; const o = { a, b };", // shorthand
+        "const o = { 0: \"a\", 1: \"b\" };",       // numeric-string keys
+        "const o = { fn: () => 1, g: function () {} };", // plain data closures
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert!(
+            count_tpl_ops(&proto) >= 1,
+            "expected a template literal in {src:?}"
+        );
+    }
+}
+
+#[test]
+fn ineligible_literals_stay_generic() {
+    for src in [
+        "const o = { a: 1 };", // single key: not worth a template
+        "const k = \"a\"; const o = { [k]: 1, b: 2 };", // computed key
+        "const o = { get a() { return 1; }, b: 2 };", // accessor
+        "const o = { m() {}, b: 2 };", // method (home object)
+        "const p = { x: 1 }; const o = { ...p, b: 2 };", // spread
+        "const o = { __proto__: null, b: 2 };", // prototype set
+        "const o = { a: 1, a: 2 };", // duplicate (later wins)
+    ] {
+        let proto = compile_script(src).expect("compiles");
+        assert_eq!(count_tpl_ops(&proto), 0, "expected NO template in {src:?}");
+    }
+}
+
+/// Behavior parity corpus: each program's console output is pinned to the
+/// value Node.js 22 produces (cross-checked when this test was written).
+#[test]
+fn template_objects_behave_identically() {
+    let cases: &[(&str, &[&str])] = &[
+        (
+            "const o = { a: 1, b: \"x\", c: true }; console.log(JSON.stringify(o)); console.log(Object.keys(o).join(\",\"));",
+            &["{\"a\":1,\"b\":\"x\",\"c\":true}", "a,b,c"],
+        ),
+        // Later mutation, extension, delete.
+        (
+            "const o = { a: 1, b: 2 }; o.c = 3; delete o.a; console.log(JSON.stringify(o));",
+            &["{\"b\":2,\"c\":3}"],
+        ),
+        // Descriptors: template properties are plain writable/enumerable/configurable data.
+        (
+            "const o = { a: 1, b: 2 }; const d = Object.getOwnPropertyDescriptor(o, \"a\"); console.log(d.value, d.writable, d.enumerable, d.configurable);",
+            &["1 true true true"],
+        ),
+        // Integer-like keys enumerate first, ascending (spec own-key order).
+        (
+            "const o = { b: 1, 2: \"two\", a: 3, 0: \"zero\" }; console.log(Object.keys(o).join(\",\"));",
+            &["0,2,b,a"],
+        ),
+        // Value expressions evaluate in source order with visible side effects.
+        (
+            "let log = \"\"; const t = (x) => { log += x; return x; }; const o = { a: t(1), b: t(2), c: t(3) }; console.log(log, o.a + o.b + o.c);",
+            &["123 6"],
+        ),
+        // A throwing value expression aborts the literal (no partial object escapes).
+        (
+            "try { const o = { a: 1, b: (() => { throw new Error(\"boom\"); })() }; } catch (e) { console.log(\"caught\", e.message); }",
+            &["caught boom"],
+        ),
+        // Anonymous function values get named from their key.
+        (
+            "const o = { f: () => 1, g: function () {} }; console.log(o.f.name, o.g.name);",
+            &["f g"],
+        ),
+        // Shorthand `__proto__` is a plain data property (no proto set).
+        (
+            "const __proto__ = 5; const o = { __proto__, z: 1 }; console.log(o.__proto__, Object.getPrototypeOf(o) === Object.prototype);",
+            &["5 true"],
+        ),
+        // for-in over a template object.
+        (
+            "const rec = { id: 7, name: \"n\", kind: \"y\" }; let s = \"\"; for (const k in rec) s += k + \"=\" + rec[k] + \";\"; console.log(s);",
+            &["id=7;name=n;kind=y;"],
+        ),
+        // Template objects freeze/seal like ordinary objects.
+        (
+            "const o = Object.freeze({ a: 1, b: 2 }); o.a = 9; console.log(o.a, Object.isFrozen(o));",
+            &["1 true"],
+        ),
+    ];
+    for (src, expected) in cases {
+        let mut e = Engine::new();
+        e.eval(src)
+            .unwrap_or_else(|err| panic!("{src:?} threw {err}"));
+        assert_eq!(e.console(), *expected, "output mismatch for {src:?}");
+    }
+}

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1345,6 +1345,157 @@ whole reg corpus; the 18-case for-in differential vs Node; Test262 gate
 green — now running the register tier under the runner's budget for the
 first time, i.e. 40k+ conformance tests newly executing the tier.
 
+## 6.12 Masked kernel windows, kernel const-prop + fusion round 2, and
+object-literal templates (landed 2026-07-11)
+
+A fresh callgrind review of the post-§6.11 profiles found three structural
+costs, attacked in one round. All safe Rust, zero new dependencies, RESULT
+checksums byte-identical across the suite (cross-checked against node/bun by
+the benchmark harness).
+
+1. **Masked fixed register windows (`bytecode::KWIN = 32`).** Every kernel
+   executor indexed its register file through `Vec<f64>` slice indexing —
+   and the resulting bounds checks were **12–17% of every kernel-owned
+   workload** (they never predict away: the panic branch sits in the hot
+   dispatch loop). Registers now live in fixed `[f64; KWIN]` WINDOWS indexed
+   as `regs[(r as usize) & KWIN_MASK]` — translation caps every kernel at
+   KWIN registers (observed max: 10) so the mask is an identity on valid
+   indices that PROVES the access in-bounds; the compiler drops the check
+   and the panic branch entirely, zero `unsafe`. Loop kernels run one window
+   (pinned-callee windows at KWIN strides above it, re-split per
+   `CallKernel`); plain function kernels run one stack-allocated window (no
+   pool traffic at all); the recursive executor strides windows at KWIN with
+   a member-level/window-level loop split so same-kernel calls re-derive
+   only the window view, never the member tables.
+2. **Kernel const-propagation + fusion round 2** (`const_prop_kops`, three
+   new superinstructions). The loop translator materialized constants that
+   fed two-register ops (`(i*7919) % 10007` ran `Const` + `Arith` where
+   `ArithK` exists), so cleanup gained a forward const-prop pass (same
+   block discipline as `copy_prop_kops`): `Add`/`Arith`/`BrCmp` operands
+   that are known constants rewrite to their `*K` immediate forms
+   (mirroring the comparison when the constant is on the left; only
+   commutative kinds swap `Arith` operands), `Mov`-of-constant becomes
+   `Const`, and dead `Const` defs die in DCE (extended past `Mov`s). Fusion
+   gained the shapes the array_sum dump showed dominating: `LenBrCmp` (the
+   `i < a.length` header test — LoadLen + BrCmp in one dispatch, with the
+   LoadLen entry-guard scan taught to see the fused form), `LoadElemAdd`
+   (`s += a[i]`), `LoadElemArith` (the dot-product second load feeding its
+   multiply), and `ArithKAdd` (`s += a <op> K` after const-prop). The
+   canonical `s += a[i]` loop: 8 dispatches per iteration → 5. En route,
+   the `i.fract() == 0.0` integrality probe in every element fast path
+   (kernel and interpreter) became a cast round-trip (`dense_index`) —
+   `fract` lowers to a libm `trunc` CALL on baseline x86-64, ~3% of
+   array-heavy workloads.
+3. **Object-literal templates** (`Op::NewObjectTpl`,
+   `FuncProto::obj_tpls`). mixed_helpers spent ~12% (inclusive) in
+   `define_own_property` + `IndexMap::insert_full`: every `{ id: …, name:
+   …, … }` evaluation re-hashed and re-inserted every key through the full
+   spec descriptor path — on a fresh ordinary extensible object, where
+   none of that machinery can observe anything or fail. The compiler now
+   detects all-static-data-key literals (≥2 distinct plain keys; computed
+   keys, accessors, methods, spread, `__proto__`, and duplicates keep the
+   generic path), pre-builds the property map ONCE at compile time, and
+   instantiation CLONES it (bucket layout included — no hashing, no
+   growth-rehash, no descriptor validation) and writes the evaluated
+   values into slots `0..N`. Value expressions still evaluate in exact
+   source order (static keys have no evaluation step, and the object
+   cannot be observed mid-literal — no binding exists and every
+   template-eligible property is plain data). Both tiers execute it
+   (`ROp::NewObjectTpl` mirrors `NewArray`'s canonical window; budget cost
+   is its exact 1 stack unit); kernel regions decline it as before. A
+   side benefit: all objects from one site share one insertion layout, so
+   the key-verified property ICs hit consistently.
+4. **Smaller wins along the way**: `op_add` gained a String⊕Number fast
+   path (both operands already primitive: format the number's digits
+   straight into the once-allocated result buffer via
+   `push_number_string` — the exact digits `to_js_string` produces —
+   skipping two intermediate allocations per `+`; restricted below the
+   rope threshold so big accumulators keep the O(1) rope path);
+   `JSON.parse` interns object keys across parses (Vm-level bounded
+   cache — repeated same-shaped documents reuse one `Rc<str>` per key)
+   and pre-sizes each object's property map (one table allocation instead
+   of the 0→3→7 growth); `js_mod`'s integer fast path also dropped its
+   libm `trunc` calls.
+
+### 6.12.1 Measured (callgrind, whole workload, deterministic)
+
+Baseline = the branch point, same toolchain (rustc 1.97), same container;
+RESULT checksums byte-identical on every workload:
+
+| workload | before | after | Δ |
+| --- | ---: | ---: | ---: |
+| array_sum | 1.948 G | 1.522 G | **−21.8%** |
+| mixed_helpers | 2.953 G | 2.324 G | **−21.3%** |
+| string_build | 118.1 M | 94.0 M | **−20.4%** |
+| typed_array | 521.0 M | 429.4 M | **−17.6%** |
+| property_access | 247.4 M | 204.4 M | **−17.4%** |
+| arith_loop | 382.3 M | 322.3 M | **−15.7%** |
+| array_push_sum | 282.0 M | 240.0 M | −14.9% |
+| closures | 378.4 M | 326.4 M | −13.7% |
+| mutual_recursion | 1.097 G | 958.9 M | −12.6% |
+| array_hof | 340.2 M | 327.4 M | −3.8% |
+| sort | 2.051 G | 1.992 G | −2.9% |
+| string_scan | 355.3 M | 351.4 M | −1.1% |
+| json_roundtrip | 1.191 G | 1.186 G | −0.4% |
+| fib_recursive | 676.5 M | 695.3 M | +2.8% ¹ |
+
+Geomean across the suite: **−12%** instructions; −15 to −22% on the
+kernel-owned and object/string-glue workloads the round targeted.
+
+¹ fib runs the recursive windowed executor, where the window-loop
+restructure costs a few instructions per call/return crossing against the
+masking savings inside the (tiny, ~10-op) activations — the member/window
+loop split recovered most of an initial +19%; the residual is the price
+the other recursion shapes' wins ride on (mutual_recursion −12.6%).
+
+Wall-clock under the RECOMMENDED (PGO) build — interleaved best-of-7 A/B,
+both sides PGO'd on the same corpus, same idle container (plain-release
+wall on two workloads swung the OTHER way purely from fat-LTO code layout;
+cachegrind showed the new binary better on every simulated metric while
+plain-release wall read slower — exactly the layout sensitivity that made
+PGO the recommended benchmark build, and why callgrind stays the
+load-bearing gate):
+
+| workload | PGO before | PGO after | Δ |
+| --- | ---: | ---: | ---: |
+| array_sum | 201 ms | 138 ms | **−31%** |
+| property_access | 29 ms | 20 ms | **−31%** |
+| typed_array | 56 ms | 42 ms | **−25%** |
+| arith_loop | 38 ms | 29 ms | **−24%** |
+| mixed_helpers | 307 ms | 240 ms | **−22%** |
+| mutual_recursion | 93 ms | 80 ms | −14% |
+| array_push_sum / closures | 38 / 32 ms | 33 / 28 ms | −13% |
+| string_build | 18 ms | 16 ms | −11% |
+| string_scan / array_hof / sort / json | — | — | 0 to −5% |
+| fib_recursive | 58 ms | 62 ms | +7% |
+
+### 6.12.2 What the profiles say now
+
+- **json_roundtrip barely moved (−0.4%)**: its cost is diffuse allocator
+  traffic (~20% malloc/free) across parse-side ObjectData/array/string
+  construction and teardown — per-key and per-table tweaks are rounding
+  errors against one `Rc<RefCell<ObjectData>>` + map + value allocations
+  per node. The structural answer is an ObjectData pool or arena (needs a
+  recycle point for Rc-dropped objects) — tracked as the next
+  allocation-side lever.
+- **mixed_helpers (the "real agent glue" proxy)** is now dominated by the
+  register tier's own dispatch (~15%), `Value` drop glue (~8%), and the
+  remaining allocator share (~10%) — the object-literal define path and
+  the string `+` machinery have left the top ranks. Further movement needs
+  either reg-tier superinstructions or a smaller `Value`.
+- **sort / array_hof** remain comparator-call-ceremony bound around the
+  prepared-kernel paths; **string_scan** is `charCodeAt` loop glue the
+  register tier already carries.
+
+**Gates:** full suites for both crates green (chidori-js 129 incl. the new
+`obj_tpl.rs` template structural+behavior tests and kernels structural pins
+for `LenBrCmp`/`LoadElemAdd`/K-form const-prop; record→replay byte-identity
+unchanged); kernels + reg differential corpora and 300-case fuzzes green —
+the kernels corpus caught a real bug during development (the fused
+`LenBrCmp` escaped the typed-array `length`-shadow entry guard scan, fixed
+by teaching the guard the fused form); Test262 gate green (0 regressions,
+99.11%); clippy clean across the workspace.
+
 ## 7. References
 
 - [`docs/interpreter-optimization.md`](./interpreter-optimization.md) —

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1496,6 +1496,67 @@ the kernels corpus caught a real bug during development (the fused
 by teaching the guard the fused form); Test262 gate green (0 regressions,
 99.11%); clippy clean across the workspace.
 
+## 6.13 Pinned-string kernels (charCodeAt/length) + allocation diet
+(landed 2026-07-11, follow-up round)
+
+Round 2 on the §6.12 baseline: the biggest remaining per-workload gap with a
+clear shape was string_scan (~6× behind bun — the tokenizer idiom
+`for (i = 0; i < s.length; i++) s.charCodeAt(i)`, §6.5.1 candidate (a),
+unlocked by §6.7's O(1) ASCII accessors), plus a first pass at the
+allocation costs that dominate json_roundtrip.
+
+1. **Pinned STRING bases in loop kernels** (`Kernel::sslots`,
+   `KOp::StrLen`, `KOp::CharCodeAt`). A local used as `s.charCodeAt(i)` /
+   `s.length` inside a kernel region is discovered (fixpoint, like array
+   bases; string discovery WINS over a same-local array-base guess) and
+   PINNED: the entry guard requires a FLAT ASCII string — flattening a
+   rope-built accumulator once, cached in the rope node — and, for
+   `charCodeAt`, the canonical `String.prototype.charCodeAt` resolution
+   (pinned at install like `Array.prototype.push`; a monkeypatched method
+   runs generically, observably). Both ops are then TOTAL — no bail path
+   exists: strings are immutable and the local is pinned, so `StrLen` is an
+   activation constant, and `CharCodeAt` computes ToIntegerOrInfinity
+   (NaN→0, truncate-toward-zero via saturating casts — no libm) and the
+   out-of-range NaN exactly as the builtin does. Non-ASCII/WTF-8 receivers
+   decline the activation into the generic loop.
+2. **Allocation diet**: `Internal::Promise`/`Internal::ModuleNamespace`
+   carried the enum's largest payloads inline (104/72 bytes) — boxing the
+   two cold variants shrinks `Internal` 104→64 and **every `ObjectData`
+   184→144 bytes** (~20% less memory traffic per object allocation,
+   json_roundtrip's dominant cost). JSON string values now parse straight
+   from the source slice into the `Rc` backing (one allocation instead of
+   the String round-trip's two).
+3. Not taken: a `Vec<[f64; KWIN]>` window pool for the recursive executor
+   measured WORSE on instructions than §6.12's slice+`try_into` windows
+   (fib 695→713 M) and was reverted — fib's residual +2.8% stands as the
+   accepted price of the recursion tier's masked windows. An ObjectData
+   pool/arena (the real json lever) needs a recycle point for Rc-dropped
+   objects — a GC-design change, still tracked.
+
+### 6.13.1 Measured (callgrind, whole workload; wall best-of-5 plain release)
+
+| workload | §6.12 baseline | after | Δ instructions | wall |
+| --- | ---: | ---: | ---: | ---: |
+| string_scan | 351.4 M | 145.2 M | **−58.7%** | 46 → 21 ms |
+| json_roundtrip | 1.186 G | 1.176 G | −0.8% | 165 → 144 ms |
+| mixed_helpers | 2.324 G | 2.318 G | −0.3% | 315 → 273 ms |
+| fib_recursive | 695.3 M | 683.2 M | −1.7% | — |
+| string_build / others | — | — | unchanged | — |
+
+The wall movement beyond the instruction deltas on json/mixed is the
+allocation diet (smaller objects, one less copy per parsed string) — cache
+effects callgrind cannot see; plain-release layout noise caveats (§6.12)
+apply, but the direction is consistent across repeated interleaved runs.
+
+**Gates:** kernels differential corpus grew 9 pinned-string programs
+(rope-built receivers, ToIntegerOrInfinity edges incl. NaN/fractional/
+negative/OOB indices, non-ASCII and astral receivers declining to generic,
+monkeypatched `charCodeAt` observed, mid-program reassignment re-guarded,
+results feeding arithmetic/booleans) plus a structural pin
+(`char_code_loops_get_kernels`); a 7-case differential vs Node 22
+byte-identical; full suites green for both crates; Test262 gate green
+(0 regressions); clippy clean.
+
 ## 7. References
 
 - [`docs/interpreter-optimization.md`](./interpreter-optimization.md) —


### PR DESCRIPTION
Three structural costs found by a fresh callgrind review, attacked in one
round. Callgrind geomean −12% instructions across the benchmark suite;
under the recommended PGO build, wall-clock −13% to −31% on eleven of
fourteen workloads (array_sum/property_access −31%, mixed_helpers −22%),
fib_recursive +7% (the recursive executor's window-crossing cost — the
price mutual_recursion's −14% rides on). RESULT checksums byte-identical
across chidori/node/bun on every workload.

- Masked fixed register windows (KWIN=32): every kernel executor now runs
  registers in [f64; KWIN] windows indexed with `& KWIN_MASK` — the mask
  proves the access in-bounds, deleting the slice bounds checks that were
  12–17% of kernel-owned workloads, with zero unsafe. Translation caps
  kernels at KWIN registers (observed max 10); the recursive executor
  strides windows at KWIN with a member/window loop split so same-kernel
  calls never re-hoist member tables.
- Kernel const-propagation (const_prop_kops) + fusion round 2: constant
  operands rewrite Add/Arith/BrCmp to their *K immediate forms (dead
  Consts die in DCE, now extended past Movs); new superinstructions
  LenBrCmp (i < a.length header test), LoadElemAdd (s += a[i]),
  LoadElemArith (dot-product load), ArithKAdd. The canonical s += a[i]
  loop drops 8 → 5 dispatches per iteration. The LoadLen entry guard scan
  learned the fused form (caught by the kernels differential corpus).
- Object-literal templates (Op::NewObjectTpl / FuncProto::obj_tpls):
  all-static-data-key literals pre-build their property map at compile
  time; instantiation clones it (no hashing, no growth-rehash, no
  descriptor validation) and writes evaluated values by slot. Both tiers
  execute it; ineligible shapes (computed keys, accessors, methods,
  spread, __proto__, duplicates) keep the generic path. ~12% of
  mixed_helpers (define_own_property + insert_full) leaves the profile.
- Smaller wins: op_add String⊕Number fast path (format digits straight
  into the result buffer; below the rope threshold only); dense_index
  cast-round-trip integrality probe replaces libm-trunc fract() calls in
  every element fast path and js_mod; JSON.parse interns object keys
  across parses (bounded Vm cache) and pre-sizes object maps.

Gates: full suites green for both crates (129 + 363 incl. new
tests/obj_tpl.rs structural+behavior corpus and kernels structural pins);
kernels + reg differential corpora and fuzzes green; record→replay
byte-identity green; Test262 gate green (0 regressions, 99.11%); clippy
clean; docs/js-performance-roadmap.md §6.12 documents design +
measurements.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018RCGFHvBqX8BrAzbGV6E6W