### PR TITLE
Add CPython to the cross-runtime benchmark suite

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -1,7 +1,7 @@
 name: JS benchmarks
 
 # Runs the chidori-js cross-runtime benchmark suite (chidori-js vs Node.js vs
-# Bun, wall-clock + peak memory) plus the in-process heap-utilization bench
+# Bun vs CPython, wall-clock + peak memory) plus the in-process heap-utilization bench
 # (`cargo bench -p chidori-js --bench memory`) on PRs that touch the engine,
 # and posts the results tables as a single sticky comment on the PR (updated
 # in place on each run, not re-posted).
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   benchmark:
-    name: chidori-js vs Node vs Bun
+    name: chidori-js vs Node vs Bun vs CPython
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +46,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # The runner image ships a python3, but pin explicitly so the cpython
+      # column doesn't silently vanish (the harness skips missing runtimes)
+      # or drift across image updates.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       # GNU time gives the harness exact peak-RSS (ru_maxrss) for the memory
       # table. Best-effort: without it the harness falls back to polling

--- a/crates/chidori-js/benches/execution.rs
+++ b/crates/chidori-js/benches/execution.rs
@@ -16,8 +16,8 @@
 //! Run with: `cargo bench -p chidori-js`
 //!
 //! These isolate chidori-js's own hot paths in-process. For a cross-runtime
-//! comparison of the same workloads against Node.js and Bun, see the harness in
-//! `benchmarks/` (`node crates/chidori-js/benchmarks/run.mjs`).
+//! comparison of the same workloads against Node.js, Bun, and CPython, see the
+//! harness in `benchmarks/` (`node crates/chidori-js/benchmarks/run.mjs`).
 
 use std::rc::Rc;
 use std::time::Duration;

--- a/crates/chidori-js/benchmarks/README.md
+++ b/crates/chidori-js/benchmarks/README.md
@@ -1,13 +1,24 @@
 # chidori-js cross-runtime benchmarks
 
-A suite that runs the **same JavaScript workloads** under three runtimes and
-compares wall-clock execution time and peak memory (max RSS):
+A suite that runs the **same workloads** under four runtimes and compares
+wall-clock execution time and peak memory (max RSS):
 
 | runtime    | what it is                                                            |
 | ---------- | --------------------------------------------------------------------- |
 | `chidori`  | the pure-Rust `chidori-js` engine (via the `run` example binary)      |
 | `node`     | Node.js (V8)                                                          |
 | `bun`      | Bun (JavaScriptCore)                                                  |
+| `cpython`  | CPython (`python3`), running each workload's hand-ported `.py` twin   |
+
+The three JS runtimes execute the identical `.js` file. CPython executes a
+line-by-line Python port of the same workload (`workloads/<name>.py`) that
+must print the **same `RESULT=` value** — see
+[Adding a workload](#adding-a-workload). Node and Bun answer "how far are we
+from the JITs people ship?"; CPython answers the like-for-like question "is
+chidori-js in the right ballpark *for an interpreter*?" — it's the
+reference-grade bytecode interpreter with the same execution model
+(no JIT), so it is the fairest available yardstick for interpreter-tier
+performance.
 
 This sits alongside two in-process benchmarks over the same workload corpus:
 the [`benches/execution.rs`](../benches/execution.rs) criterion
@@ -32,8 +43,9 @@ node crates/chidori-js/benchmarks/run.mjs --quick
 node crates/chidori-js/benchmarks/run.mjs --filter fib --runs 15 --json out.json
 ```
 
-Node.js is required to run the harness. Bun is optional — if `bun` isn't on
-`PATH` it is skipped with a warning. The chidori binary is built automatically
+Node.js is required to run the harness. Bun and CPython are optional — if
+`bun` (or `python3`/`python`) isn't on `PATH` that runtime is skipped with a
+warning. The chidori binary is built automatically
 unless you pass `--no-build` (and point at a prebuilt binary via `--chidori-bin`
 or `$CHIDORI_RUN_BIN`).
 
@@ -41,12 +53,12 @@ or `$CHIDORI_RUN_BIN`).
 
 ```
 Execution-only time (subprocess wall-clock minus startup baseline)
-Startup baselines: chidori 3.4ms  node 33.8ms  bun 9.8ms
+Startup baselines: chidori 3.4ms  node 33.8ms  bun 9.8ms  cpython 17.8ms
 
-workload             chidori         node          bun    fastest
------------------------------------------------------------------
-arith_loop       727.1ms 167.0x   7.2ms 1.6x        4.4ms        bun
-fib_recursive    2.15s 228.4x  11.8ms 1.3x        9.4ms        bun
+workload             chidori         node          bun      cpython    fastest
+-------------------------------------------------------------------------------
+arith_loop       727.1ms 167.0x   7.2ms 1.6x        4.4ms  156.7ms 35.6x        bun
+fib_recursive    2.15s 228.4x  11.8ms 1.3x        9.4ms  136.7ms 14.5x        bun
 ...
 ```
 
@@ -135,13 +147,24 @@ Every workload prints exactly one `RESULT=<value>` line. The harness extracts it
 from each runtime's stdout and **asserts all runtimes produced the same value**
 before reporting timings — a fast-but-wrong engine is not a faster engine. If any
 workload disagrees the row is flagged and the process exits non-zero. The
-`sort` workload seeds a deterministic LCG so all three runtimes sort identical
+`sort` workload seeds a deterministic LCG so all runtimes sort identical
 input and must agree on the checksum.
+
+The cross-check spans languages: the Python twins must print the identical
+`RESULT=` string, which also keeps the ports honest — a `.py` file that
+"simplifies" the workload into different math gets caught immediately. Where
+JS double semantics leak into the result (the `sort` LCG overflows 2^53
+before truncating; the `array_sum`/`typed_array` checksums accumulate near
+2^53), the Python twin reproduces the IEEE-double rounding explicitly rather
+than silently computing a different (exact) value — each such spot carries a
+comment in the `.py` file.
 
 ## Workloads
 
-Each file in `workloads/` is plain ES that runs unmodified on all three runtimes
-and mirrors (scaled up) an `execution.rs` micro-benchmark where one exists:
+Each `.js` file in `workloads/` is plain ES that runs unmodified on the three
+JS runtimes and mirrors (scaled up) an `execution.rs` micro-benchmark where
+one exists. Each has a `.py` twin for CPython that follows the same shape
+loop-for-loop (indexed loops stay indexed loops, closures stay closures):
 
 | workload          | exercises                                                       |
 | ----------------- | -------------------------------------------------------------- |
@@ -154,7 +177,7 @@ and mirrors (scaled up) an `execution.rs` micro-benchmark where one exists:
 | `closures`        | closure capture + higher-order calls in a loop                 |
 | `json_roundtrip`  | `JSON.stringify` / `JSON.parse` over a nested object           |
 | `sort`            | `Array.prototype.sort` with a comparator                       |
-| `startup.js`      | near-empty script — used only for the startup baseline         |
+| `startup.js/.py`  | near-empty script — used only for the startup baseline         |
 
 Iteration counts are tuned so each workload takes a meaningful-but-bounded time
 on the chidori-js interpreter (~0.2–2s); on the JITs they finish in single-digit
@@ -169,7 +192,21 @@ constant at the top of a workload file — they're deliberately one-liners.
 2. End it with `console.log("RESULT=" + <deterministic value>)` so the harness
    can cross-check correctness. Avoid `Date.now()`, `Math.random()`, or anything
    else that varies between runs or runtimes in the reported value.
-3. Run `node run.mjs --filter <name>` and confirm it reports `ok` (not a
+3. Add the `<name>.py` twin: the same algorithm, ported line-for-line, ending
+   with `print("RESULT=" + str(<value>))`. Watch the two classic
+   cross-language traps:
+   - **Number formatting** — JS prints integer-valued doubles without a
+     decimal point; wrap float results in `int(...)` before printing.
+   - **Double semantics** — JS numbers are IEEE doubles. If any value in the
+     `RESULT=` chain can exceed 2^53 (or relies on `|0`/`>>>` wrapping),
+     Python's exact ints will diverge; reproduce the rounding with float math
+     and explicit `% 2**32`-style wraps as `sort.py` / `typed_array.py` do.
+     Easiest is to keep results comfortably below 2^53.
+
+   If a workload genuinely has no sensible Python analog, skipping the twin is
+   allowed — the harness prints a `—` for cpython on that row instead of
+   failing — but the default expectation is that every workload has one.
+4. Run `node run.mjs --filter <name>` and confirm it reports `ok` (not a
    `RESULT MISMATCH`).
 
 ## Caveats
@@ -178,6 +215,11 @@ constant at the top of a workload file — they're deliberately one-liners.
   ratios on a quiet machine, not as a leaderboard. The sample table above is
   illustrative.
 - This measures whole-script subprocess runs, so it captures parse + compile +
-  execute, not steady-state JIT throughput. For chidori-js (an interpreter) that
-  is representative; for V8/JSC it understates peak throughput on long-running
-  code because much of the run is spent warming up.
+  execute, not steady-state JIT throughput. For chidori-js and CPython
+  (interpreters) that is representative; for V8/JSC it understates peak
+  throughput on long-running code because much of the run is spent warming up.
+- The CPython column is a cross-*language* comparison: the ports follow the JS
+  shape loop-for-loop, but each runtime still plays to its own strengths
+  (CPython's in-place `str +=` realloc, comparator-free `list.sort`, C-level
+  `json`). Read it as "interpreter-class ballpark", not a strict language
+  shootout — the per-file comments note where the port had to deviate and why.

--- a/crates/chidori-js/benchmarks/run.mjs
+++ b/crates/chidori-js/benchmarks/run.mjs
@@ -2,11 +2,12 @@
 // Cross-runtime benchmark harness for the chidori-js JavaScript engine.
 //
 // Runs each workload in `workloads/` as a standalone script under chidori-js,
-// Node.js, and Bun, measuring subprocess wall-clock time and peak memory
-// (max RSS). The same `.js` file is fed to all three runtimes and every
-// workload prints a single `RESULT=...` line, so the harness can confirm the
-// runtimes agree before trusting the numbers (a fast-but-wrong engine is not
-// a faster engine).
+// Node.js, Bun, and CPython, measuring subprocess wall-clock time and peak
+// memory (max RSS). The same `.js` file is fed to the three JS runtimes;
+// CPython runs the workload's hand-ported `.py` twin. Every workload prints a
+// single `RESULT=...` line, so the harness can confirm all runtimes —
+// including the cross-language port — agree before trusting the numbers (a
+// fast-but-wrong engine is not a faster engine).
 //
 // Each runtime pays a fixed process-startup cost (binary load + realm setup).
 // We measure that separately with `workloads/startup.js` and subtract it to
@@ -19,7 +20,7 @@
 //   --runs N            timed runs per workload (default 5)
 //   --warmup N          untimed warmup runs per workload (default 1)
 //   --filter SUBSTR     only run workloads whose name contains SUBSTR
-//   --runtimes LIST     comma-separated subset of {chidori,node,bun}
+//   --runtimes LIST     comma-separated subset of {chidori,node,bun,cpython}
 //   --chidori-bin PATH  path to the chidori `run` example binary
 //   --no-build          do not `cargo build` the chidori binary first
 //   --json PATH         also write the full results as JSON to PATH
@@ -93,14 +94,14 @@ function printHelp() {
   // The banner comment at the top of this file is the canonical help text.
   console.log(
     [
-      "Cross-runtime benchmark harness for chidori-js (vs Node.js and Bun).",
+      "Cross-runtime benchmark harness for chidori-js (vs Node.js, Bun, and CPython).",
       "",
       "Usage: node benchmarks/run.mjs [options]",
       "",
       "  --runs N            timed runs per workload (default 5)",
       "  --warmup N          untimed warmup runs per workload (default 1)",
       "  --filter SUBSTR     only run workloads whose name contains SUBSTR",
-      "  --runtimes LIST     comma-separated subset of {chidori,node,bun}",
+      "  --runtimes LIST     comma-separated subset of {chidori,node,bun,cpython}",
       "  --chidori-bin PATH  path to the chidori `run` example binary",
       "  --no-build          do not cargo build the chidori binary first",
       "  --json PATH         also write the full results as JSON to PATH",
@@ -155,15 +156,21 @@ function resolveChidoriBin(opts) {
 }
 
 function discoverRuntimes(opts) {
-  const names = opts.runtimes ?? ["chidori", "node", "bun"];
+  const names = opts.runtimes ?? ["chidori", "node", "bun", "cpython"];
   // Resolve each requested runtime lazily so excluding chidori doesn't force a
-  // Rust build, and a missing optional runtime (bun) is skipped, not fatal.
+  // Rust build, and a missing optional runtime (bun, cpython) is skipped, not
+  // fatal. `ext` selects the workload file: the JS runtimes share the same
+  // `.js` source; cpython runs the workload's hand-ported `.py` twin.
   const resolvers = {
-    chidori: () => ({ name: "chidori", cmd: resolveChidoriBin(opts), args: [] }),
-    node: () => ({ name: "node", cmd: process.execPath, args: [] }),
+    chidori: () => ({ name: "chidori", cmd: resolveChidoriBin(opts), args: [], ext: ".js" }),
+    node: () => ({ name: "node", cmd: process.execPath, args: [], ext: ".js" }),
     bun: () => {
       const bun = whichSync("bun");
-      return bun ? { name: "bun", cmd: bun, args: [] } : null;
+      return bun ? { name: "bun", cmd: bun, args: [], ext: ".js" } : null;
+    },
+    cpython: () => {
+      const py = whichSync("python3") || whichSync("python");
+      return py ? { name: "cpython", cmd: py, args: [], ext: ".py" } : null;
     },
   };
 
@@ -466,13 +473,16 @@ const MARKDOWN_MARKER = "<!-- chidori-js-benchmarks -->";
 // Render the results as a Markdown report (used for the PR comment).
 function renderMarkdown(workloads, runtimes, baselines, opts, mem) {
   const rtNames = runtimes.map((r) => r.name);
+  const RT_LABELS = { chidori: "chidori-js", node: "Node.js", bun: "Bun", cpython: "CPython" };
+  const rtLabels = rtNames.map((n) => `**${RT_LABELS[n] ?? n}**`);
   const lines = [];
   lines.push(MARKDOWN_MARKER);
   lines.push("## chidori-js cross-runtime benchmarks");
   lines.push("");
   lines.push(
-    `Same JS workloads run under **chidori-js**, **Node.js**, and **Bun** ` +
-      `(${opts.runs} timed run(s) + ${opts.warmup} warmup each, median reported). ` +
+    `Same workloads run under ${rtLabels.join(", ")} ` +
+      `(${opts.runs} timed run(s) + ${opts.warmup} warmup each, median reported; ` +
+      `CPython runs each workload's hand-ported .py twin). ` +
       `All workloads cross-checked to produce identical results.`,
   );
   lines.push("");
@@ -539,7 +549,8 @@ function renderMarkdown(workloads, runtimes, baselines, opts, mem) {
   lines.push(
     "<sub>Numbers are machine- and load-dependent (shared CI runner) — read them " +
       "as ratios, not absolutes. chidori-js is an interpreter, so it trails the " +
-      "V8/JSC JITs on compute but starts far faster and in far less memory. " +
+      "V8/JSC JITs on compute but starts far faster and in far less memory; " +
+      "CPython (also an interpreter) is the like-for-like reference point. " +
       "A ⚠️ marks a workload whose result disagreed across runtimes.</sub>",
   );
   return lines.join("\n") + "\n";
@@ -577,11 +588,12 @@ async function main() {
 
   // Startup baseline per runtime (median of a few extra runs — it's cheap).
   // With memory on, also probe startup peak RSS: the runtime's floor
-  // footprint before any workload allocates.
+  // footprint before any workload allocates. Each runtime probes its own
+  // startup file (startup.js / startup.py).
   const baselines = {};
   const startupRss = {};
-  const startupFile = join(WORKLOAD_DIR, "startup.js");
   for (const rt of runtimes) {
+    const startupFile = join(WORKLOAD_DIR, "startup" + rt.ext);
     const { median } = await timeWorkload(rt, startupFile, Math.max(opts.runs, 5), 1);
     baselines[rt.name] = median;
     if (memStrategy) {
@@ -592,13 +604,21 @@ async function main() {
   const workloads = [];
   let mismatches = 0;
   for (const f of files) {
-    const file = join(WORKLOAD_DIR, f);
     const name = f.replace(/\.js$/, "");
     process.stderr.write(`  ${name} ... `);
     const byRuntime = {};
     const rssByRuntime = {};
     const results = new Set();
+    const skipped = [];
     for (const rt of runtimes) {
+      // The JS runtimes share the workload's .js source; cpython runs its .py
+      // twin. A workload without a port for some runtime gets a — cell rather
+      // than failing the whole suite.
+      const file = join(WORKLOAD_DIR, name + rt.ext);
+      if (!existsSync(file)) {
+        skipped.push(rt.name);
+        continue;
+      }
       const r = await timeWorkload(rt, file, opts.runs, opts.warmup);
       byRuntime[rt.name] = r;
       if (memStrategy) {
@@ -611,8 +631,12 @@ async function main() {
       mismatches++;
       process.stderr.write("RESULT MISMATCH\n");
       for (const rt of runtimes) {
-        process.stderr.write(`      ${rt.name}: ${byRuntime[rt.name].result}\n`);
+        if (byRuntime[rt.name]) {
+          process.stderr.write(`      ${rt.name}: ${byRuntime[rt.name].result}\n`);
+        }
       }
+    } else if (skipped.length > 0) {
+      process.stderr.write(`ok (no port for: ${skipped.join(", ")})\n`);
     } else {
       process.stderr.write("ok\n");
     }

--- a/crates/chidori-js/benchmarks/workloads/arith_loop.py
+++ b/crates/chidori-js/benchmarks/workloads/arith_loop.py
@@ -1,0 +1,8 @@
+# Python twin of arith_loop.js — tight numeric loop (interpreter dispatch +
+# arithmetic). All values stay far below 2^53, so exact Python ints match the
+# exact JS doubles digit for digit.
+N = 1_000_000
+s = 0
+for i in range(N):
+    s += i * 2 - (i % 3)
+print("RESULT=" + str(s))

--- a/crates/chidori-js/benchmarks/workloads/array_hof.py
+++ b/crates/chidori-js/benchmarks/workloads/array_hof.py
@@ -1,0 +1,16 @@
+# Python twin of array_hof.js — map/filter/reduce with per-element lambdas.
+# The intermediate results are materialized with list() because JS
+# Array.prototype.map/filter allocate real arrays, not lazy iterators.
+# The final sum stays below 2^53, so exact ints match the JS doubles.
+from functools import reduce
+
+N = 200_000
+a = []
+for i in range(N):
+    a.append(i)
+result = reduce(
+    lambda p, c: p + c,
+    list(filter(lambda x: x % 2 == 0, list(map(lambda x: x * x, a)))),
+    0,
+)
+print("RESULT=" + str(result))

--- a/crates/chidori-js/benchmarks/workloads/array_push_sum.py
+++ b/crates/chidori-js/benchmarks/workloads/array_push_sum.py
@@ -1,0 +1,10 @@
+# Python twin of array_push_sum.js — list growth + indexed read loop.
+# Indexed `for i in range(len(a))` (not `for x in a`) to mirror the JS loop.
+N = 500_000
+a = []
+for i in range(N):
+    a.append(i)
+s = 0
+for i in range(len(a)):
+    s += a[i]
+print("RESULT=" + str(s))

--- a/crates/chidori-js/benchmarks/workloads/array_sum.py
+++ b/crates/chidori-js/benchmarks/workloads/array_sum.py
@@ -1,0 +1,34 @@
+# Python twin of array_sum.js — dense-list traversal with index arithmetic:
+# reads, in-place writes, a two-list dot product, and a nested 2D walk.
+# Deterministic fill (no RNG) so every runtime computes the same checksum.
+#
+# The checksum is accumulated in float, not int: JS does this math in IEEE
+# doubles, and `checksum + s + d` can graze 2^53 where doubles round. Python
+# floats reproduce that rounding exactly; exact ints would not.
+N = 200_000
+ROUNDS = 5
+a = [0] * N
+b = [0] * N
+for i in range(N):
+    a[i] = (i * 7919) % 10007
+    b[i] = (i * 104729) % 7919
+checksum = 0.0
+for r in range(ROUNDS):
+    # read + accumulate
+    s = 0
+    for i in range(len(a)):
+        s += a[i]
+    # dot product
+    d = 0
+    for i in range(len(a)):
+        d += a[i] * b[i]
+    # in-place transform
+    for i in range(len(a)):
+        a[i] = (a[i] + b[i]) % 10007
+    checksum = (checksum + s + d) % 9007199254740991
+# nested 2D walk
+m = 0
+for i in range(500):
+    for j in range(500):
+        m += (i * j) % 13
+print("RESULT=" + str(int(checksum + m)))

--- a/crates/chidori-js/benchmarks/workloads/closures.py
+++ b/crates/chidori-js/benchmarks/workloads/closures.py
@@ -1,0 +1,16 @@
+# Python twin of closures.js — closure capture + higher-order calls in a loop.
+N = 1_000_000
+
+
+def adder(n):
+    def add(x):
+        return x + n
+
+    return add
+
+
+f = adder(5)
+s = 0
+for i in range(N):
+    s = f(s) - 4
+print("RESULT=" + str(s))

--- a/crates/chidori-js/benchmarks/workloads/fib_recursive.py
+++ b/crates/chidori-js/benchmarks/workloads/fib_recursive.py
@@ -1,0 +1,7 @@
+# Python twin of fib_recursive.js — recursion + function-call overhead
+# (frame setup/teardown).
+def fib(n):
+    return n if n < 2 else fib(n - 1) + fib(n - 2)
+
+
+print("RESULT=" + str(fib(30)))

--- a/crates/chidori-js/benchmarks/workloads/json_roundtrip.py
+++ b/crates/chidori-js/benchmarks/workloads/json_roundtrip.py
@@ -1,0 +1,20 @@
+# Python twin of json_roundtrip.js — json.dumps / json.loads round-trips over
+# a nested object. separators=(",", ":") matches JSON.stringify's compact
+# output, and dicts preserve insertion order, so len(s) agrees with JS.
+import json
+
+N = 20_000
+obj = {
+    "id": 0,
+    "name": "widget",
+    "tags": ["a", "b", "c"],
+    "nested": {"x": 1, "y": 2, "z": {"deep": True, "items": [1, 2, 3, 4, 5]}},
+    "flag": False,
+}
+acc = 0
+for i in range(N):
+    obj["id"] = i
+    s = json.dumps(obj, separators=(",", ":"))
+    back = json.loads(s)
+    acc += back["id"] + len(back["nested"]["z"]["items"]) + len(s)
+print("RESULT=" + str(acc))

--- a/crates/chidori-js/benchmarks/workloads/mixed_helpers.py
+++ b/crates/chidori-js/benchmarks/workloads/mixed_helpers.py
@@ -1,0 +1,57 @@
+# Python twin of mixed_helpers.js — small helper functions over dicts and
+# strings, the shape of real agent/tool plumbing: key iteration, per-value
+# type dispatch, string building, and dict property traffic across calls.
+# All strings are ASCII, so Python len() agrees with JS .length.
+N = 60_000
+
+
+def normalize(rec):
+    out = {"id": rec["id"], "label": "", "score": 0}
+    for k in rec:
+        if k == "id":
+            continue
+        v = rec[k]
+        if isinstance(v, int):
+            out["score"] = out["score"] + v
+        elif isinstance(v, str):
+            out["label"] = out["label"] + ":" + v if out["label"] else v
+    return out
+
+
+def render(rec):
+    return "[" + str(rec["id"]) + "] " + (rec["label"] or "?") + " => " + str(rec["score"])
+
+
+def classify(score):
+    return "hi" if score > 40 else "mid" if score > 15 else "lo"
+
+
+buckets = {"hi": 0, "mid": 0, "lo": 0}
+text = ""
+checksum = 0
+for i in range(N):
+    rec = {
+        "id": i,
+        "name": "item" + str(i % 7),
+        "a": i % 13,
+        "b": (i * 3) % 29,
+        "kind": "x" if i % 2 else "y",
+    }
+    norm = normalize(rec)
+    line = render(norm)
+    buckets[classify(norm["score"])] += 1
+    checksum = (checksum + len(line) + norm["score"]) % 1000000007
+    if (i & 1023) == 0:
+        text += line + "\n"
+print(
+    "RESULT="
+    + str(checksum)
+    + "|"
+    + str(buckets["hi"])
+    + ","
+    + str(buckets["mid"])
+    + ","
+    + str(buckets["lo"])
+    + "|"
+    + str(len(text))
+)

--- a/crates/chidori-js/benchmarks/workloads/mutual_recursion.py
+++ b/crates/chidori-js/benchmarks/workloads/mutual_recursion.py
@@ -1,0 +1,21 @@
+# Python twin of mutual_recursion.js — mutual recursion between two globals,
+# boolean returns, and self-recursion through a local binding (gcd). Max
+# depth is ~300 (is_even(299)), comfortably inside CPython's default 1000
+# recursion limit.
+def is_even(n):
+    return True if n == 0 else is_odd(n - 1)
+
+
+def is_odd(n):
+    return False if n == 0 else is_even(n - 1)
+
+
+gcd = lambda a, b: a if b == 0 else gcd(b, a % b)  # noqa: E731 — mirrors the JS arrow
+
+N = 20_000
+checksum = 0
+for i in range(N):
+    if is_even(i % 300):
+        checksum += 1
+    checksum += gcd(i + 123456, 991)
+print("RESULT=" + str(checksum))

--- a/crates/chidori-js/benchmarks/workloads/property_access.py
+++ b/crates/chidori-js/benchmarks/workloads/property_access.py
@@ -1,0 +1,19 @@
+# Python twin of property_access.js — object attribute get/set in a loop.
+# A plain (dict-backed) instance is CPython's equivalent of a JS object with
+# named properties.
+N = 1_000_000
+
+
+class Obj:
+    pass
+
+
+o = Obj()
+o.a = 0
+o.b = 0
+o.c = 0
+for i in range(N):
+    o.a = i
+    o.b = o.a + 1
+    o.c = o.b + o.a
+print("RESULT=" + str(o.c))

--- a/crates/chidori-js/benchmarks/workloads/sort.py
+++ b/crates/chidori-js/benchmarks/workloads/sort.py
@@ -1,0 +1,33 @@
+# Python twin of sort.js — sorting with a deterministic LCG fill.
+#
+# Two deliberate divergences from a naive line-by-line port, both needed to
+# keep RESULT identical to the JS runtimes:
+#
+# - The JS LCG multiplies a 32-bit seed by 1103515245 as a *double*, which
+#   overflows 2^53 and rounds before `>>> 0` truncates to uint32. Python ints
+#   would compute that product exactly and drift from every JS engine, so the
+#   multiply-add is done in float (IEEE double, same rounding) and int() % 2^32
+#   reproduces ToUint32.
+# - list.sort() takes no comparator; Python's natural int ordering is what the
+#   JS `(x, y) => x - y` comparator requests. The comparator-call overhead the
+#   JS side measures has no idiomatic CPython equivalent (cmp_to_key would
+#   measure its wrapper, not the sort).
+N = 50_000
+ROUNDS = 6
+seed = 123456789
+
+
+def rnd():
+    global seed
+    seed = int(seed * 1103515245.0 + 12345.0) % 4294967296
+    return seed
+
+
+checksum = 0
+for r in range(ROUNDS):
+    a = [0] * N
+    for i in range(N):
+        a[i] = rnd()
+    a.sort()
+    checksum = (checksum + a[0] + a[N - 1] + a[N >> 1]) % 4294967296
+print("RESULT=" + str(checksum))

--- a/crates/chidori-js/benchmarks/workloads/startup.py
+++ b/crates/chidori-js/benchmarks/workloads/startup.py
@@ -1,0 +1,4 @@
+# Near-empty script used to measure CPython's process-startup baseline
+# (binary load + interpreter setup), which the harness subtracts from the
+# workload totals to estimate execution-only time. Twin of startup.js.
+print("RESULT=ok")

--- a/crates/chidori-js/benchmarks/workloads/string_build.py
+++ b/crates/chidori-js/benchmarks/workloads/string_build.py
@@ -1,0 +1,9 @@
+# Python twin of string_build.js — string building via += in a loop
+# (concatenation + number→string coercion). CPython's in-place str realloc
+# optimization makes this its natural fast path, just as ropes would for a JS
+# engine — both are fair game, it's the same idiom.
+N = 30_000
+s = ""
+for i in range(N):
+    s += "x" + str(i)
+print("RESULT=" + str(len(s)))

--- a/crates/chidori-js/benchmarks/workloads/string_scan.py
+++ b/crates/chidori-js/benchmarks/workloads/string_scan.py
@@ -1,0 +1,20 @@
+# Python twin of string_scan.js — per-character string reads via indexing +
+# ord(), the tokenizer/parser/hash idiom. Indexed loops (not `for c in s`)
+# to mirror the JS charCodeAt/charAt access pattern. ASCII only, so Python's
+# len/ord agree with JS's UTF-16 code-unit view.
+N = 8192  # string length
+ROUNDS = 12
+s = ""
+for i in range(N):
+    s += chr(97 + ((i * 31) % 26))
+h = 0
+for r in range(ROUNDS):
+    for i in range(len(s)):
+        h = (h * 31 + ord(s[i])) % 1000000007
+# A smaller charAt-style pass so single-character reads are covered too.
+vowels = 0
+for i in range(len(s)):
+    c = s[i]
+    if c == "a" or c == "e" or c == "i" or c == "o" or c == "u":
+        vowels += 1
+print("RESULT=" + str(h + vowels))

--- a/crates/chidori-js/benchmarks/workloads/typed_array.py
+++ b/crates/chidori-js/benchmarks/workloads/typed_array.py
@@ -1,0 +1,44 @@
+# Python twin of typed_array.js — numeric-buffer traffic over array('d')
+# (CPython's unboxed float64 buffer, the stdlib analog of Float64Array):
+# fill, sum, dot product, in-place transform, plus an int32 bit-mix pass.
+#
+# JS-semantics notes: the float64 work is IEEE doubles on both sides, so the
+# checksum matches by construction (Python float % and JS % agree for
+# positive operands). Int32Array wrap-around is reproduced with an explicit
+# to_int32 — array('i') would raise OverflowError instead of wrapping, so the
+# mix pass runs on plain ints kept in int32 range.
+from array import array
+
+N = 50_000
+ROUNDS = 4
+a = array("d", bytes(8 * N))
+b = array("d", bytes(8 * N))
+for i in range(N):
+    a[i] = (i * 7919) % 10007
+    b[i] = (i * 104729) % 7919
+checksum = 0.0
+for r in range(ROUNDS):
+    s = 0.0
+    for i in range(len(a)):
+        s += a[i]
+    d = 0.0
+    for i in range(len(a)):
+        d += a[i] * b[i]
+    for i in range(len(a)):
+        a[i] = (a[i] + b[i]) % 10007
+    checksum = (checksum + s + d) % 9007199254740991
+
+
+# Int32 pass: integer wrap + shift semantics (JS `| 0`).
+def to_int32(x):
+    return ((x & 0xFFFFFFFF) ^ 0x80000000) - 0x80000000
+
+
+m = [0] * 1024
+for i in range(len(m)):
+    m[i] = to_int32(i * 2654435761)
+mix = 0
+for r in range(50):
+    for i in range(len(m)):
+        mix = to_int32((mix ^ m[i]) + to_int32(mix << 5))
+print("RESULT=" + str(int(checksum + (mix % 4294967296))))

--- a/crates/chidori-js/examples/dump_ops.rs
+++ b/crates/chidori-js/examples/dump_ops.rs
@@ -24,8 +24,8 @@ fn dump(proto: &chidori_js::bytecode::FuncProto, depth: usize, kernels: bool) {
         }
         if let Some(k) = &proto.fn_kernel {
             println!(
-                "{pad}  fn kernel: n_regs={} locals={:?}",
-                k.n_regs, k.locals
+                "{pad}  fn kernel: n_regs={} locals={:?} uv_writes={:?}",
+                k.n_regs, k.locals, k.uv_writes
             );
             for (i, op) in k.code.iter().enumerate() {
                 println!("{pad}    {i:4}  {op:?}");

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -1579,12 +1579,108 @@ fn merge_sort(vm: &mut Vm, items: &mut [Value], cmp: &Value, has_cmp: bool) -> R
             }
         }
     }
+    // Default (no-comparator) SortCompare over an ALL-PRIMITIVE snapshot:
+    // ToString of a Number/String/Bool/Null/BigInt is pure — no user code,
+    // no throw — so the string keys can be computed ONCE per element
+    // (n conversions) instead of twice per comparison (~2·n·log n, each
+    // allocating). The permutation is computed by the IDENTICAL stable
+    // merge recursion over precomputed keys, so the result is bit-identical
+    // to the per-comparison path. Objects (toString/valueOf run user code,
+    // observable in call order and count) and Symbols (must throw
+    // TypeError from the comparison) keep the exact spec sequence below.
+    if !has_cmp
+        && items.iter().all(|v| {
+            matches!(
+                v,
+                Value::Number(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::Null
+                    | Value::BigInt(_)
+            )
+        })
+    {
+        return sort_default_primitive(vm, items);
+    }
     // One scratch buffer for the whole sort (max use: the larger half) instead
     // of two fresh Vec clones per recursion node — the naive version's
     // malloc/free + refcount churn was a measurable slice of sort-heavy runs.
     let mut aux: Vec<Value> = Vec::with_capacity(items.len() / 2 + 1);
     let n = items.len();
     merge_sort_range(vm, items, &mut aux, 0, n, cmp, has_cmp, &mut prep)
+}
+
+/// Default-comparator sort of an all-primitive snapshot by precomputed
+/// ToString keys (see the call site in [`merge_sort`] for why this is
+/// unobservable). The index-permutation merge mirrors `merge_sort_range`'s
+/// recursion and take-left-on-ties merge exactly, so equal keys keep their
+/// original relative order and the output matches the generic path
+/// element-for-element. When every key is ASCII (the overwhelming case —
+/// number-to-string output always is), the UTF-16 code-unit comparison
+/// collapses to a byte comparison.
+fn sort_default_primitive(vm: &mut Vm, items: &mut [Value]) -> Result<(), Value> {
+    let n = items.len();
+    let mut keys: Vec<JsString> = Vec::with_capacity(n);
+    for v in items.iter() {
+        keys.push(vm.to_js_string(v)?);
+    }
+    let all_ascii = keys.iter().all(|k| k.as_str().is_ascii());
+    let mut idx: Vec<u32> = (0..n as u32).collect();
+    let mut aux: Vec<u32> = Vec::with_capacity(n / 2 + 1);
+    fn rec(
+        idx: &mut [u32],
+        aux: &mut Vec<u32>,
+        lo: usize,
+        hi: usize,
+        keys: &[JsString],
+        ascii: bool,
+    ) {
+        let n = hi - lo;
+        if n <= 1 {
+            return;
+        }
+        let mid = lo + n / 2;
+        rec(idx, aux, lo, mid, keys, ascii);
+        rec(idx, aux, mid, hi, keys, ascii);
+        aux.clear();
+        aux.extend_from_slice(&idx[lo..mid]);
+        let (mut i, mut j, mut k) = (0, mid, lo);
+        while i < aux.len() && j < hi {
+            let (a, b) = (&keys[aux[i] as usize], &keys[idx[j] as usize]);
+            let order = if ascii {
+                match a.as_str().as_bytes().cmp(b.as_str().as_bytes()) {
+                    std::cmp::Ordering::Less => -1,
+                    std::cmp::Ordering::Equal => 0,
+                    std::cmp::Ordering::Greater => 1,
+                }
+            } else {
+                utf16_cmp(a.as_str(), b.as_str())
+            };
+            if order <= 0 {
+                idx[k] = aux[i];
+                i += 1;
+            } else {
+                idx[k] = idx[j];
+                j += 1;
+            }
+            k += 1;
+        }
+        while i < aux.len() {
+            idx[k] = aux[i];
+            i += 1;
+            k += 1;
+        }
+    }
+    rec(&mut idx, &mut aux, 0, n, &keys, all_ascii);
+    // Apply the permutation: every value moves exactly once.
+    let sorted: Vec<Value> = idx
+        .iter()
+        .map(|&i| std::mem::replace(&mut items[i as usize], Value::Undefined))
+        .collect();
+    for (slot, v) in items.iter_mut().zip(sorted) {
+        *slot = v;
+    }
+    Ok(())
 }
 
 /// [`merge_sort_range`] over raw `f64`s for the all-Number/kernel-comparator

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1457,10 +1457,12 @@ impl KMath {
 pub struct Kernel {
     pub code: Box<[KOp]>,
     /// Numeric slots mirrored into registers `0..locals.len()`: frame locals
-    /// (read/write) and UPVALUES (read-only snapshots — no call can run
-    /// inside a kernel, so nothing can write a captured cell mid-activation;
-    /// in-region upvalue WRITES reject at translation). The guard requires
-    /// `Value::Number` in every one; only `Local` slots write back.
+    /// (read/write) and UPVALUES (snapshots — no call can run inside a
+    /// kernel, so nothing else can write a captured cell mid-activation).
+    /// The guard requires `Value::Number` in every one; `Local` slots write
+    /// back in loop kernels, and upvalue slots listed in [`Kernel::uv_writes`]
+    /// flush back in function kernels. Loop-kernel regions still reject
+    /// in-region upvalue writes at translation.
     ///
     /// FUNCTION kernels additionally use `Arg` slots (read-only; the guard
     /// requires the argument present and a `Number`), and their `Local` slots
@@ -1519,6 +1521,22 @@ pub struct Kernel {
     /// call sites are checked against the RESOLVED callee's value by the
     /// entry guard.
     pub args_used: u32,
+    /// NON-RECURSIVE FUNCTION kernels: captured upvalue cells the body
+    /// WRITES, as `(register, upvalue index)` pairs (the register is the
+    /// cell's `locals` slot). The cell's value lives in the register for the
+    /// whole frameless call — nothing else can run mid-kernel — and is
+    /// flushed back as `Value::Number` on every completion (return AND the
+    /// interrupt unwind), so the cell holds exactly what the generic
+    /// write-through path would leave. A conditionally-skipped store flushes
+    /// the entry snapshot back: same value, unobservable (plain cells, no
+    /// setters). Only `Number` stores translate — a boolean/undefined store
+    /// would change the cell's type vs. the generic path and declines.
+    /// Non-empty `uv_writes` declines the recursion tier (its entry
+    /// resolution assumes cells are activation constants), the prepared
+    /// callback paths, and the loop-kernel pinned-callee guard — those run
+    /// many calls per guard and snapshot upvalues once. Always empty for
+    /// loop kernels.
+    pub uv_writes: Box<[(u16, u32)]>,
     /// Whether the code contains a [`KOp::StoreElem`]. A store may CREATE an
     /// element (hole fill / exact append), and the spec's OrdinarySet
     /// consults the prototype chain when the own property is absent — so the

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -1228,15 +1228,20 @@ pub enum KOp {
     /// `Op::SetProp` fast-path conditions). See [`KOp::LoadProp`] for why no
     /// per-access check is needed.
     StoreProp { prop: u16, src: u16 },
-    /// LOOP kernels only: call the PINNED CLOSURE in oslot
+    /// LOOP kernels only: call the PINNED CLOSURE of
     /// [`Kernel::callee_slots`]`[fslot]` — a plain bytecode function whose
     /// proto carries a (non-recursive, Number-returning) function kernel —
     /// by running that kernel's register program on a dedicated window above
     /// the caller's registers. The window's upvalue registers were loaded
-    /// ONCE at entry (the callee local is an oslot: in-region stores to it
-    /// reject, so the closure identity is pinned); per call only the `argc`
-    /// argument registers at `base..` copy in, and the callee's `Ret` value
-    /// copies out to `dst`. The entry guard verified everything a per-call
+    /// ONCE at entry (the callee resolution — an oslot local or a
+    /// global-object own data property, see [`KCalleeSrc`] — is an
+    /// activation constant, so the closure identity is pinned); per call
+    /// only the `argc` argument registers at `base..` copy in, and the
+    /// callee's `Ret` value copies out to `dst`. A cell-writing callee
+    /// ([`Kernel::uv_writes`]) additionally flushes its written registers
+    /// back to the cells after EVERY call, so a mid-loop bail resumes the
+    /// generic loop against current cell state; cross-window cell aliasing
+    /// declines at entry. The entry guard verified everything a per-call
     /// `run_fn_kernel` guard would (arguments are statically Numbers here),
     /// plus one depth check for the whole activation (the loop calls at a
     /// CONSTANT depth). No trace sink may be active (it would see an
@@ -1333,15 +1338,33 @@ pub struct KProp {
     pub store: bool,
 }
 
-/// One pinned CALLEE of a loop kernel (see [`KOp::CallKernel`]): the oslot
-/// local holding the closure, and the smallest `argc` any call site in the
+/// One pinned CALLEE of a loop kernel (see [`KOp::CallKernel`]): where the
+/// closure resolves from, and the smallest `argc` any call site in the
 /// region supplies — the entry guard requires the callee's function kernel
 /// to consume no argument index at or beyond it (a shorter call would need
 /// the generic `undefined` parameter).
 #[derive(Clone, Debug)]
 pub struct KCallee {
-    pub oslot: u16,
+    pub source: KCalleeSrc,
     pub min_argc: u16,
+}
+
+/// Where a pinned callee's closure lives. Both are activation constants: an
+/// oslot local is never stored to in-region, and nothing inside a kernel
+/// region can rebind a global — `StoreGlobal` is not on the allowlist, and
+/// a [`KProp`] store aimed at the same global-object property cannot pass
+/// its own holds-a-Number entry check while this guard sees a closure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KCalleeSrc {
+    /// The closure is held in this oslot local (discovered like an array
+    /// base; in-region stores to it reject).
+    Oslot(u16),
+    /// The closure is the value of a global-object OWN DATA property — the
+    /// exact fast path `LoadGlobal` takes for a top-level `function`
+    /// binding. Accessor, proto-inherited, and missing globals decline the
+    /// activation into the generic loop (which then resolves or throws
+    /// exactly as the spec says).
+    Global(Box<str>),
 }
 
 /// One operand-stack slot of a kernel exit shape, bottom-up: a `Number` read

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -786,6 +786,15 @@ struct ClassPrivCtx {
 
 struct Compiler {
     fns: Vec<FnCtx>,
+    /// One `JsString` allocation per distinct string across the WHOLE
+    /// compilation (const pools, object-template keys): identical names in
+    /// different functions then share an `Rc`, so runtime equality — a
+    /// for-in key against a compare literal, a property probe against a
+    /// template-built map — confirms on `JsString`'s pointer fast path
+    /// instead of comparing bytes. Compile-scoped (dropped with the
+    /// Compiler), so nothing is retained across programs; content is
+    /// unchanged, only allocation identity is shared.
+    str_intern: std::collections::HashMap<Box<str>, JsString>,
     /// The toplevel being compiled is global EVAL code (indirect eval), not a
     /// script: `return` is illegal and global var bindings are deletable.
     toplevel_is_eval: bool,
@@ -849,6 +858,7 @@ impl Compiler {
     fn new() -> Compiler {
         Compiler {
             fns: Vec::new(),
+            str_intern: std::collections::HashMap::new(),
             toplevel_is_eval: false,
             class_privs: Vec::new(),
             next_class_id: 0,
@@ -947,8 +957,26 @@ impl Compiler {
         (c.consts.len() - 1) as u32
     }
 
+    /// The compile-scoped interned `JsString` for `s` (see
+    /// [`Compiler::str_intern`]). The eight typeof names route to the
+    /// process-wide table in `names.rs` instead, so `typeof x === "number"`
+    /// compares pointer-equal against the interpreter's interned typeof
+    /// results.
+    fn interned(&mut self, s: &str) -> JsString {
+        if let Some(js) = crate::names::typeof_name(s) {
+            return js;
+        }
+        if let Some(js) = self.str_intern.get(s) {
+            return js.clone();
+        }
+        let js = JsString::new(s);
+        self.str_intern.insert(s.into(), js.clone());
+        js
+    }
+
     fn str_const(&mut self, s: &str) -> u32 {
-        self.intern_str(JsString::new(s))
+        let js = self.interned(s);
+        self.intern_str(js)
     }
 
     fn load_str(&mut self, s: &str) {
@@ -1872,7 +1900,7 @@ impl Compiler {
         // functions), as does anything with try/finally handlers, `with`/
         // direct-eval machinery, suspension, or super/private class wiring.
         let reg = if self.regify {
-            crate::reg::regify(&code, loc.num_locals).map(std::rc::Rc::new)
+            crate::reg::regify(&code, loc.num_locals, &fc.consts).map(std::rc::Rc::new)
         } else {
             None
         };
@@ -3881,11 +3909,15 @@ impl Compiler {
             }
             names.push(name);
         }
+        // Keys go through the compile-scoped interner: a for-in key cloned
+        // out of an instantiated template then pointer-matches compare
+        // literals and property-name consts built anywhere in this program.
+        let keys: Vec<crate::value::JsString> = names.iter().map(|n| self.interned(n)).collect();
         let mut map = crate::fxhash::FxIndexMap::default();
         map.reserve(names.len());
-        for name in &names {
+        for key in keys {
             map.insert(
-                crate::value::PropertyKey::Str(crate::value::JsString::from(name.as_str())),
+                crate::value::PropertyKey::Str(key),
                 crate::value::Property::data(crate::value::Value::Undefined),
             );
         }

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -4793,6 +4793,19 @@ impl Vm {
                         pc = *target as usize;
                     }
                 }
+                ROp::TypeofBr {
+                    src,
+                    tag,
+                    br_on_eq,
+                    target,
+                } => {
+                    // Total: `typeof` never throws, and the tag is one of
+                    // the eight statics `Value::type_of` returns, so this
+                    // is content equality of the unmaterialized compare.
+                    if (frame.locals[*src as usize].type_of() == *tag) == *br_on_eq {
+                        pc = *target as usize;
+                    }
+                }
                 ROp::CmpBrCellK {
                     cmp,
                     cell,
@@ -5359,7 +5372,9 @@ impl Vm {
                 }
             }
             ROp::ForInPop => {
-                frame.enumerators.pop();
+                if let Some((keys, _)) = frame.enumerators.pop() {
+                    self.park_forin_vec(keys);
+                }
             }
             _ => unreachable!("op handled inline in run_reg_frame: {op:?}"),
         }
@@ -6116,7 +6131,9 @@ impl Vm {
                 push!(Value::Bool(done));
             }
             Op::ForInPop => {
-                frame.enumerators.pop();
+                if let Some((keys, _)) = frame.enumerators.pop() {
+                    self.park_forin_vec(keys);
+                }
             }
             Op::ForInNext => {
                 let (k, more) = Self::for_in_next(frame);
@@ -7365,6 +7382,18 @@ impl Vm {
         // is by far the most common `+` in numeric code (loop counters, sums).
         if let (Value::Number(x), Value::Number(y)) = (&a, &b) {
             return Ok(Value::Number(x + y));
+        }
+        // Fast path: String + String. Both operands are already primitive —
+        // ToPrimitive and ToString are identities — so the result is their
+        // concatenation, with the same length cap and the same `concat` as
+        // the generic route below; skipped are two identity-clone
+        // ToPrimitive calls and two identity ToString round-trips (the glue
+        // idiom `label + ":" + v` pays this twice per join).
+        if let (Value::String(sa), Value::String(sb)) = (&a, &b) {
+            if sa.byte_len() + sb.byte_len() > crate::value::MAX_STRING_LEN {
+                return Err(self.throw_range("invalid string length"));
+            }
+            return Ok(Value::String(sa.concat(sb)));
         }
         // Fast path: a small plain string ⊕ a Number. Both operands are
         // already primitive (ToPrimitive is the identity) and the result is

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -810,27 +810,57 @@ impl Vm {
         }
         // Pinned closure callees (`KOp::CallKernel`): ONE guard per
         // activation covers everything the per-call `run_fn_kernel` guard
-        // would check — the callee object is an oslot (in-region stores to
-        // it reject), so its identity, kernel, upvalue types and the Math
-        // canonicals cannot change while the loop runs. Loop calls happen at
-        // one constant depth, so a single depth check suffices; a trace sink
-        // declines (it must see an enter/exit per call).
+        // would check — the callee resolution (an oslot local that in-region
+        // stores reject, or a global-object own data property that nothing
+        // in-region can rebind), so its identity, kernel, upvalue types and
+        // the Math canonicals cannot change while the loop runs. Loop calls
+        // happen at one constant depth, so a single depth check suffices; a
+        // trace sink declines (it must see an enter/exit per call).
         let mut callee_bfs = std::mem::take(&mut self.kernel_callees);
         callee_bfs.clear();
         if CALLEES {
             let mut ok = self.trace_sink.is_none() && self.call_depth < self.max_call_depth;
             let mut win = KWIN;
+            let mut any_uv_writes = false;
             if ok {
                 for c in k.callee_slots.iter() {
-                    let bf = {
-                        let b = objs[c.oslot as usize].borrow();
-                        match &b.internal {
-                            Internal::Function(FunctionInner::Bytecode(bf))
-                                if !bf.is_class_ctor =>
-                            {
-                                Some(bf.clone())
+                    let bf = match &c.source {
+                        crate::bytecode::KCalleeSrc::Oslot(oslot) => {
+                            let b = objs[*oslot as usize].borrow();
+                            match &b.internal {
+                                Internal::Function(FunctionInner::Bytecode(bf))
+                                    if !bf.is_class_ctor =>
+                                {
+                                    Some(bf.clone())
+                                }
+                                _ => None,
                             }
-                            _ => None,
+                        }
+                        // The `LoadGlobal` fast path: an own DATA property
+                        // of the global object. Accessor / proto-inherited /
+                        // missing globals decline — the generic loop then
+                        // resolves (or throws the ReferenceError) exactly as
+                        // the spec says.
+                        crate::bytecode::KCalleeSrc::Global(name) => {
+                            let g = self.realm.global.borrow();
+                            match g.props.get(&PropertyKey::str(name)) {
+                                Some(Property {
+                                    kind:
+                                        PropertyKind::Data {
+                                            value: Value::Object(o),
+                                            ..
+                                        },
+                                    ..
+                                }) => match &o.borrow().internal {
+                                    Internal::Function(FunctionInner::Bytecode(bf))
+                                        if !bf.is_class_ctor =>
+                                    {
+                                        Some(bf.clone())
+                                    }
+                                    _ => None,
+                                },
+                                _ => None,
+                            }
                         }
                     };
                     let Some(bf) = bf else {
@@ -841,12 +871,12 @@ impl Vm {
                         ok = false;
                         break;
                     };
-                    // Number-returning, non-recursive, no upvalue writes
-                    // (this path snapshots upvalues ONCE per activation and
-                    // never flushes), fully-supplied args, canonical Math,
-                    // Number upvalues — else stay generic.
+                    // Number-returning, non-recursive, fully-supplied args,
+                    // canonical Math, Number upvalues — else stay generic.
+                    // Cell-writing callees are admitted (their windows flush
+                    // written cells back per call) unless a written cell
+                    // aliases another of the callee's own captured cells.
                     let ck_ok = ck.rec.is_none()
-                        && ck.uv_writes.is_empty()
                         && ck
                             .code
                             .iter()
@@ -861,14 +891,24 @@ impl Vm {
                                 matches!(*bf.upvalues[*u as usize].borrow(), Value::Number(_))
                             }
                             _ => true,
-                        });
+                        })
+                        && (ck.uv_writes.is_empty() || !uv_write_cells_alias(ck, &bf));
                     if !ck_ok {
                         ok = false;
                         break;
                     }
+                    any_uv_writes |= !ck.uv_writes.is_empty();
                     callee_bfs.push((bf, win as u32));
                     win += KWIN;
                 }
+            }
+            // Cross-window aliasing: a cell one callee WRITES must not be
+            // captured by any other callee window (their once-per-activation
+            // snapshots would go stale) or snapshot by the caller kernel's
+            // own upvalue registers. Distinct bindings are distinct cells,
+            // so this only fires when the same closure/cell is pinned twice.
+            if ok && any_uv_writes {
+                ok = !callee_cell_writes_alias(&callee_bfs, k, &frame.func.upvalues);
             }
             if !ok {
                 self.kernel_regs = regs;
@@ -1463,7 +1503,18 @@ impl Vm {
                             cw[r & KWIN_MASK] = w[(base as usize + *a as usize) & KWIN_MASK];
                         }
                     }
-                    if let Some(ret) = run_callee_window(cw, ck, &interrupt, &mut poll) {
+                    let ret = run_callee_window(cw, ck, &interrupt, &mut poll);
+                    // A cell-writing callee flushes after EVERY call (return
+                    // or interrupt): the cell must be current before any
+                    // subsequent op that can bail to the generic loop, whose
+                    // remaining iterations call the callee generically. The
+                    // register persists in the pinned window, so no reload
+                    // is needed — nothing else can write the cell mid-loop
+                    // (cross-window aliasing declined at entry).
+                    if !ck.uv_writes.is_empty() {
+                        flush_uv_writes(ck, bf, cw);
+                    }
+                    if let Some(ret) = ret {
                         w[dst as usize & KWIN_MASK] = ret;
                     } else {
                         // Interrupted on a callee back-edge: the same
@@ -7814,6 +7865,51 @@ fn flush_uv_writes(k: &crate::bytecode::Kernel, bf: &BytecodeFunction, regs: &[f
     for &(r, u) in k.uv_writes.iter() {
         *bf.upvalues[u as usize].borrow_mut() = Value::Number(regs[usize::from(r) & KWIN_MASK]);
     }
+}
+
+/// Cross-window alias check for the pinned-callee path when any callee
+/// writes cells: a written cell captured by ANOTHER callee window (whose
+/// upvalue snapshot loads once per activation) or by the CALLER kernel's
+/// own upvalue registers would go stale after the first flush, so any such
+/// overlap declines the activation. Distinct bindings are distinct cells —
+/// this only fires when the same closure (or a shared captured binding) is
+/// pinned more than once. Out of line: write-free activations never call it.
+#[inline(never)]
+fn callee_cell_writes_alias(
+    callee_bfs: &[(Rc<BytecodeFunction>, u32)],
+    caller: &crate::bytecode::Kernel,
+    caller_upvalues: &[Rc<RefCell<Value>>],
+) -> bool {
+    for (i, (bf, _)) in callee_bfs.iter().enumerate() {
+        let ck = bf.proto.fn_kernel.as_ref().expect("guarded");
+        for &(_, u) in ck.uv_writes.iter() {
+            let cell = &bf.upvalues[u as usize];
+            // The caller kernel's own upvalue snapshots.
+            for slot in caller.locals.iter() {
+                if let crate::bytecode::KSlot::Upvalue(cu) = slot {
+                    if Rc::ptr_eq(cell, &caller_upvalues[*cu as usize]) {
+                        return true;
+                    }
+                }
+            }
+            // Every OTHER callee window's captured cells (the same callee's
+            // own aliases were declined per-callee at entry).
+            for (j, (bf2, _)) in callee_bfs.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                let ck2 = bf2.proto.fn_kernel.as_ref().expect("guarded");
+                for slot in ck2.locals.iter() {
+                    if let crate::bytecode::KSlot::Upvalue(u2) = slot {
+                        if Rc::ptr_eq(cell, &bf2.upvalues[*u2 as usize]) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Execute a plain (non-recursive, frameless) FUNCTION kernel body over

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -841,9 +841,12 @@ impl Vm {
                         ok = false;
                         break;
                     };
-                    // Number-returning, non-recursive, fully-supplied args,
-                    // canonical Math, Number upvalues — else stay generic.
+                    // Number-returning, non-recursive, no upvalue writes
+                    // (this path snapshots upvalues ONCE per activation and
+                    // never flushes), fully-supplied args, canonical Math,
+                    // Number upvalues — else stay generic.
                     let ck_ok = ck.rec.is_none()
+                        && ck.uv_writes.is_empty()
                         && ck
                             .code
                             .iter()
@@ -1556,8 +1559,10 @@ impl Vm {
     /// runs in unboxed registers with no frame at all. `None` = the entry
     /// guard declined (an op budget installed — per-op counts are observable;
     /// a trace sink active — it must see an enter/exit per call; a consumed
-    /// argument or captured upvalue not a `Number`; a monkeypatched `Math`) —
-    /// the caller proceeds down the ordinary frame path. `Some` is the call's
+    /// argument or captured upvalue not a `Number`; a monkeypatched `Math`;
+    /// a written cell aliasing another captured cell) — the caller proceeds
+    /// down the ordinary frame path. Cells the body writes (`uv_writes`)
+    /// buffer in registers and flush back on completion. `Some` is the call's
     /// exact result, bit-identical to the generic path by the loop-kernel
     /// argument (shared numeric cores, an op set closed over numbers, typed
     /// returns). Callers have already applied the depth guard, so the
@@ -1598,13 +1603,23 @@ impl Vm {
         if !k.math_used.is_empty() && !self.kernel_math_ok(&k.math_used) {
             return None;
         }
+        // Written cells (`uv_writes`) buffer in their registers and flush on
+        // completion (out-of-line: most kernels have no writes, and keeping
+        // this function small protects the LTO inlining of the hot paths).
+        if !k.uv_writes.is_empty() && uv_write_cells_alias(k, bf) {
+            return None;
+        }
         let interrupt = self.interrupt.clone();
         let mut poll: u32 = 0;
-        match exec_fn_kernel_code(&k.code, &mut regs, &interrupt, &mut poll) {
+        let ret = exec_fn_kernel_code(&k.code, &mut regs, &interrupt, &mut poll);
+        if !k.uv_writes.is_empty() {
+            flush_uv_writes(k, bf, &regs);
+        }
+        match ret {
             Some(ret) => Some(Ok(ret)),
             None => {
-                // Interrupted on a back-edge: registers are pure scratch,
-                // nothing to write back on the unwind.
+                // Interrupted on a back-edge: latch the zero budget so a JS
+                // catch cannot resume execution.
                 self.op_budget = Some(0);
                 Some(Err(self.throw_range("execution interrupted")))
             }
@@ -1627,8 +1642,10 @@ impl Vm {
     ///   matching the entry kernel's and every call site supplying at least
     ///   the resolved callee's consumed arguments.
     ///
-    /// Nothing inside a kernel can write globals or cells, so the entry
-    /// resolution holds for the whole activation. Depth mirrors the
+    /// Nothing inside a RECURSIVE kernel can write globals or cells
+    /// (upvalue-writing kernels decline this tier at translation and at
+    /// family resolution), so the entry resolution holds for the whole
+    /// activation. Depth mirrors the
     /// interpreter's limit; on overflow the activation is ABANDONED and
     /// `None` returned — sound because kernels are pure (registers only),
     /// and the caller's generic rerun then raises the spec RangeError from
@@ -2109,6 +2126,14 @@ impl Vm {
             }
             let f = funcs[wl].clone();
             let k = f.proto.fn_kernel.as_ref()?;
+            // No member may write cells: the windowed executor snapshots
+            // upvalues once per member and the family cache treats them as
+            // activation constants. (Recursive members can't have writes —
+            // translation declines — but a NON-recursive helper pulled in as
+            // a call target can.)
+            if !k.uv_writes.is_empty() {
+                return None;
+            }
             // Every member's Ret type must match the entry kernel's: a
             // mismatched value would land in a caller register of the wrong
             // static type. (Also rejects mixed-type non-recursive members.)
@@ -2309,7 +2334,10 @@ impl Vm {
         }
         {
             let k = bf.proto.fn_kernel.as_ref()?;
-            if k.rec.is_some() {
+            // No upvalue writes: the prepared paths snapshot upvalues per
+            // call (or once per sort) and never flush, so a cell-writing
+            // callback falls back to the generic `Vm::call` per element.
+            if k.rec.is_some() || !k.uv_writes.is_empty() {
                 return None;
             }
         }
@@ -7755,6 +7783,36 @@ fn writeback_kernel_props(
             )) => *value = Value::Number(regs[prop_base + i]),
             _ => unreachable!("kernel prop slot invariant"),
         }
+    }
+}
+
+/// Belt-and-braces alias check for a cell-writing function kernel
+/// ([`crate::bytecode::Kernel::uv_writes`]): distinct upvalue indices are
+/// distinct bindings by construction, but the buffered writes must never be
+/// able to diverge from the generic write-through order, so a written cell
+/// aliasing any other captured cell declines the call. Out of line to keep
+/// `run_fn_kernel` small (write-free kernels skip it entirely).
+#[inline(never)]
+fn uv_write_cells_alias(k: &crate::bytecode::Kernel, bf: &BytecodeFunction) -> bool {
+    k.uv_writes.iter().any(|&(_, u)| {
+        let cell = &bf.upvalues[u as usize];
+        k.locals.iter().any(|slot| {
+            matches!(slot, crate::bytecode::KSlot::Upvalue(u2)
+                if *u2 != u && Rc::ptr_eq(cell, &bf.upvalues[*u2 as usize]))
+        })
+    })
+}
+
+/// Flush a cell-writing kernel's written registers back to their cells, on
+/// BOTH completions. On return this is the generic path's final cell state.
+/// On an interrupt the registers hold every completed store (an upvalue
+/// register is written only by translated stores), so the flush leaves
+/// exactly the generic prefix state at that poll point — the same contract
+/// as the loop kernels' local write-back on the interrupt unwind.
+#[inline(never)]
+fn flush_uv_writes(k: &crate::bytecode::Kernel, bf: &BytecodeFunction, regs: &[f64; KWIN]) {
+    for &(r, u) in k.uv_writes.iter() {
+        *bf.upvalues[u as usize].borrow_mut() = Value::Number(regs[usize::from(r) & KWIN_MASK]);
     }
 }
 

--- a/crates/chidori-js/src/iter.rs
+++ b/crates/chidori-js/src/iter.rs
@@ -401,11 +401,16 @@ impl Vm {
     }
 
     /// Collect enumerable string keys across the prototype chain for `for-in`,
-    /// in deterministic order, de-duplicated, skipping shadowed keys.
+    /// in deterministic order, de-duplicated, skipping shadowed keys. The
+    /// returned buffer comes from the Vm's `forin_pool` (`ForInPop` parks it
+    /// back) — a glue loop for-inning a fresh object per iteration reuses
+    /// one allocation instead of a malloc/free per loop entry.
     pub fn for_in_keys(&mut self, v: &Value) -> Result<Vec<JsString>, Value> {
+        let mut out = self.forin_pool.pop().unwrap_or_default();
+        debug_assert!(out.is_empty());
         let obj = match v {
             Value::Object(o) => o.clone(),
-            Value::Undefined | Value::Null => return Ok(Vec::new()),
+            Value::Undefined | Value::Null => return Ok(out),
             _ => self.to_object(v)?,
         };
         // FAST PATH — the overwhelmingly common shape: an ORDINARY receiver
@@ -417,10 +422,10 @@ impl Vm {
         // ~14% of glue-shaped workloads) are skipped entirely. Anything
         // else — proxy, exotic index sources, an enumerable proto key —
         // falls back to the generic walk below, unchanged.
-        if let Some(out) = self.for_in_keys_fast(&obj) {
+        if self.for_in_keys_fast(&obj, &mut out) {
             return Ok(out);
         }
-        let mut out: Vec<JsString> = Vec::new();
+        out.clear();
         // Dedup by `JsString` (an insert clones an `Rc`, not the bytes) under
         // the deterministic Fx hasher — the std SipHash `HashSet<String>` it
         // replaces paid a fresh `String` per key per chain level.
@@ -478,16 +483,26 @@ impl Vm {
         Ok(out)
     }
 
-    /// `for_in_keys`' allocation-free fast path. `Some(keys)` iff the
-    /// receiver is an ordinary object and NO prototype-chain level
-    /// contributes an enumerable string key — then the receiver's own
-    /// enumerable string keys (index-likes sorted first, per
-    /// `[[OwnPropertyKeys]]`) ARE the for-in keys, no shadow set needed.
-    /// `None` = use the generic walk; the split is decided by the same
-    /// facts that walk reads, so both produce identical keys where this
-    /// path applies.
-    fn for_in_keys_fast(&self, obj: &JsObject) -> Option<Vec<JsString>> {
-        let mut out: Vec<JsString> = Vec::new();
+    /// Park a for-in enumerator's key buffer back in the pool (cleared —
+    /// the pool never extends a key's lifetime past the `ForInPop` that
+    /// parked it). Capacity-less buffers (empty enumerations that never
+    /// grew) and a full pool just drop.
+    pub(crate) fn park_forin_vec(&mut self, mut keys: Vec<JsString>) {
+        keys.clear();
+        if self.forin_pool.len() < 8 && keys.capacity() > 0 {
+            self.forin_pool.push(keys);
+        }
+    }
+
+    /// `for_in_keys`' allocation-free fast path, filling the caller's
+    /// (pooled) buffer. `true` iff the receiver is an ordinary object and NO
+    /// prototype-chain level contributes an enumerable string key — then
+    /// the receiver's own enumerable string keys (index-likes sorted first,
+    /// per `[[OwnPropertyKeys]]`) ARE the for-in keys, no shadow set
+    /// needed. `false` = use the generic walk (the caller clears the
+    /// buffer); the split is decided by the same facts that walk reads, so
+    /// both produce identical keys where this path applies.
+    fn for_in_keys_fast(&self, obj: &JsObject, out: &mut Vec<JsString>) -> bool {
         let mut ints: Vec<u32> = Vec::new();
         let proto = {
             let b = obj.borrow();
@@ -495,7 +510,7 @@ impl Vm {
             // string indices, typed arrays, proxies, namespace exports)
             // synthesize own keys that live outside `props`.
             if !matches!(b.internal, Internal::Ordinary) {
-                return None;
+                return false;
             }
             for (k, p) in b.props.iter() {
                 if let PropertyKey::Str(s) = k {
@@ -524,8 +539,8 @@ impl Vm {
                     PropertyKey::Sym(_) => unreachable!("index keys are strings"),
                 }
             }
-            merged.append(&mut out);
-            out = merged;
+            merged.append(out);
+            std::mem::swap(out, &mut merged);
         }
         // The rest of the chain must contribute NOTHING: no enumerable
         // string key in `props`, and no internal that synthesizes own
@@ -538,23 +553,23 @@ impl Vm {
                 Internal::Proxy(_)
                 | Internal::StringObj(_)
                 | Internal::TypedArray(_)
-                | Internal::ModuleNamespace(_) => return None,
+                | Internal::ModuleNamespace(_) => return false,
                 // An EMPTY dense array (Array.prototype!) contributes only
                 // its non-enumerable `length`; any element is enumerable.
                 Internal::Array(arr) if arr.iter().any(|v| !matches!(v, Value::Hole)) => {
-                    return None;
+                    return false;
                 }
                 _ => {}
             }
             for (k, p) in b.props.iter() {
                 if p.enumerable && matches!(k, PropertyKey::Str(_)) {
-                    return None;
+                    return false;
                 }
             }
             let next = b.proto.clone();
             drop(b);
             cur = next;
         }
-        Some(out)
+        true
     }
 }

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -2,11 +2,15 @@
 //! register programs (docs/js-performance-roadmap.md §6.5).
 //!
 //! The same translator also compiles FUNCTION kernels
-//! ([`kernelize_function`]): a tiny pure-scalar body — a sort comparator, a
-//! `map`/`filter`/`reduce` callback — becomes a register program the call
-//! paths execute FRAMELESS when its per-call entry guard passes (arguments
-//! present and `Number`s, upvalues `Number`s, no op budget, no trace sink);
-//! any guard failure takes the ordinary frame path. See `Vm::run_fn_kernel`.
+//! ([`kernelize_function`]): a tiny scalar body — a sort comparator, a
+//! `map`/`filter`/`reduce` callback, a `seed = …; return seed` PRNG step —
+//! becomes a register program the call paths execute FRAMELESS when its
+//! per-call entry guard passes (arguments present and `Number`s, upvalues
+//! `Number`s, no op budget, no trace sink); any guard failure takes the
+//! ordinary frame path. Non-recursive bodies may WRITE captured cells: the
+//! value buffers in the cell's register (nothing else can run mid-kernel)
+//! and flushes back on completion ([`crate::bytecode::Kernel::uv_writes`]).
+//! See `Vm::run_fn_kernel`.
 //!
 //! ## Why
 //!
@@ -269,7 +273,16 @@ pub fn kernelize_function(
                     .max()
                     .unwrap_or(0);
                 if k.rec.is_some() {
-                    // RECURSIVE kernel. Every SELF-call must supply every
+                    // RECURSIVE kernel. Upvalue writes decline outright: the
+                    // recursion tier's entry resolution (and its cached
+                    // family's upvalue snapshots) treat cells as activation
+                    // constants — a self-call chain interleaving cell writes
+                    // would need per-window flushes to stay observably
+                    // generic. The write-back shape is non-recursive-only.
+                    if !k.uv_writes.is_empty() {
+                        return None;
+                    }
+                    // Every SELF-call must supply every
                     // argument the body consumes (a short call would need
                     // the generic `undefined` parameter; mutual-recursion
                     // call sites are checked against the RESOLVED callee by
@@ -446,6 +459,9 @@ struct Xlate<'a> {
     local_reg: Vec<(KSlot, u16)>,
     /// boolean locals: (frame-local index, register from BOOL_BASE).
     bool_reg: Vec<(u32, u16)>,
+    /// fn mode: upvalue indices the body STORES to (their registers flush
+    /// back to the cells on completion — see [`Kernel::uv_writes`]).
+    uv_writes: Vec<u32>,
     /// locals observed as STRING bases (from `charCodeAt` over a clean
     /// local origin); fed back by the fixpoint driver like `discovered`.
     discovered_strs: Vec<u32>,
@@ -532,6 +548,7 @@ fn translate(
         is_target,
         local_reg: Vec::new(),
         bool_reg: Vec::new(),
+        uv_writes: Vec::new(),
         discovered: Vec::new(),
         discovered_bools: Vec::new(),
         discovered_strs: Vec::new(),
@@ -809,6 +826,18 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     for &(sl, r) in &x.local_reg {
         locals[r as usize] = sl;
     }
+    // fn mode: written upvalue slots, as (register, upvalue index) — the
+    // runtime flushes these registers back to the cells on completion.
+    // Numeric-local registers are identity under the remap above, so the
+    // `locals` position IS the runtime register.
+    let uv_writes: Vec<(u16, u32)> = locals
+        .iter()
+        .enumerate()
+        .filter_map(|(r, sl)| match sl {
+            KSlot::Upvalue(u) if x.uv_writes.contains(u) => Some((r as u16, *u)),
+            _ => None,
+        })
+        .collect();
     let mut bool_locals: Vec<u32> = vec![0; n_bools as usize];
     for &(l, r) in &x.bool_reg {
         bool_locals[(r - BOOL_BASE) as usize] = l;
@@ -860,6 +889,11 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     if matches!(slot, KSlot::Upvalue(_)) {
                         upvalue_uses |= 1 << r;
                     }
+                }
+                // Written upvalue registers are observed by the completion
+                // flush — their stores are never dead.
+                for &(r, _) in &uv_writes {
+                    always_live |= 1 << r;
                 }
             } else {
                 for (r, slot) in locals.iter().enumerate() {
@@ -937,6 +971,7 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
         rec,
         ret_bool: false, // `kernelize_function` fills for recursive kernels
         args_used: 0,    // `kernelize_function` fills for fn kernels
+        uv_writes: uv_writes.into_boxed_slice(),
         fallback: Box::new(Op::Nop), // caller stores the real header op
     })
 }
@@ -1760,9 +1795,12 @@ impl Xlate<'_> {
         Some(r)
     }
 
-    /// Register snapshotting captured upvalue cell `u` (read-only: nothing
-    /// can write the cell during a kernel — regions contain no calls — and
-    /// in-region upvalue writes are not on the allowlist).
+    /// Register snapshotting captured upvalue cell `u`. Nothing but the
+    /// kernel itself can write the cell during an activation (regions
+    /// contain no calls), so the register IS the cell's live value: loop
+    /// mode keeps it read-only (upvalue stores are not on the loop
+    /// allowlist), fn mode additionally routes `StoreUpvalue*` through it
+    /// and flushes written registers back on completion (`uv_writes`).
     fn uvreg(&mut self, u: u32) -> Option<u16> {
         let slot = KSlot::Upvalue(u);
         if let Some(&(_, r)) = self.local_reg.iter().find(|(sl, _)| *sl == slot) {
@@ -2324,6 +2362,26 @@ impl Xlate<'_> {
                         self.store_of(*l);
                         self.mark_init(*l);
                     }
+                }
+            }
+            // fn mode: a captured cell WRITE. The upvalue's register becomes
+            // the cell's live value for the rest of the body (later
+            // `LoadUpvalue`s read the same register), and the runtime
+            // flushes written registers back to their cells on completion.
+            // The entry guard already requires the cell to hold a Number, so
+            // the Checked form's TDZ test is statically satisfied (a TDZ'd
+            // cell declines at the guard and throws on the generic path).
+            // Only Number stores translate: the flush materializes
+            // `Value::Number`, so a boolean/undefined store would change the
+            // cell's observable type vs. the generic path — those decline
+            // (via `pop_num` / the catch-all). Loop mode keeps rejecting
+            // upvalue stores entirely (write-back there covers locals only).
+            Op::StoreUpvalue(u) | Op::StoreUpvalueChecked(u) if self.fn_mode => {
+                let dst = self.uvreg(*u)?;
+                let src = self.pop_num()?;
+                self.kops.push(K::Mov { dst, src });
+                if !self.uv_writes.contains(u) {
+                    self.uv_writes.push(*u);
                 }
             }
             // A block-scoped declaration's TDZ marker: writes `Uninitialized`

--- a/crates/chidori-js/src/kernel.rs
+++ b/crates/chidori-js/src/kernel.rs
@@ -394,6 +394,16 @@ enum VE {
     /// ONLY legal consumer is a `Call` (which fuses to [`KOp::SelfCall`]
     /// with `callee` = the payload); everything else rejects.
     SelfFn(u16),
+    /// LOOP mode only: a speculative pinned GLOBAL callee —
+    /// `global_callee_names[i]`, from `LoadGlobal` of a non-`Math` name
+    /// (`rnd()` in a fill loop). The activation entry guard resolves the
+    /// name as an own DATA property of the global object holding a
+    /// kernel-carrying closure — the exact `LoadGlobal` fast path — and
+    /// declines otherwise. Its ONLY legal consumer is a `Call` under an
+    /// `undefined` this (fusing to [`KOp::CallKernel`]); everything else
+    /// rejects translation, which never loses a kernel that exists today
+    /// (non-Math globals previously rejected loop regions outright).
+    GlobalFn(u16),
     /// `a.push` on the array base in the oslot — speculative: the entry
     /// guard verifies the canonical `Array.prototype.push` still backs the
     /// `push` property of the canonical prototype, and the op re-checks the
@@ -490,9 +500,12 @@ struct Xlate<'a> {
     /// Named-property access classes over oslot bases (entry-resolved; see
     /// [`KProp`]). Deduplicated by (oslot, key); flags OR together.
     props_used: Vec<KProp>,
-    /// Pinned closure callees (loop mode; see [`KCallee`]): per oslot, the
+    /// Pinned closure callees (loop mode; see [`KCallee`]): per source, the
     /// smallest argc any call site supplies.
     callees: Vec<KCallee>,
+    /// LOOP mode: names speculated as pinned GLOBAL callees (the
+    /// [`VE::GlobalFn`] payload indexes this).
+    global_callee_names: Vec<Box<str>>,
     /// a compare op fused with its following conditional jump: skip that ip.
     absorbed: Option<usize>,
     max_stack: u16,
@@ -563,6 +576,7 @@ fn translate(
         uses_array_pop: false,
         props_used: Vec::new(),
         callees: Vec::new(),
+        global_callee_names: Vec::new(),
         absorbed: None,
         max_stack: 0,
     };
@@ -672,9 +686,9 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
     for (kidx, resume_ip, shape) in exits {
         if shape
             .iter()
-            .any(|e| matches!(e, VE::Undef | VE::Opaque | VE::SelfFn(_)))
+            .any(|e| matches!(e, VE::Undef | VE::Opaque | VE::SelfFn(_) | VE::GlobalFn(_)))
         {
-            return None; // undefined/opaque/self never survives to an exit
+            return None; // undefined/opaque/self/global-callee never survives to an exit
         }
         let sidx = match shapes.iter().position(|s| *s == shape) {
             Some(p) => p as u16,
@@ -814,8 +828,10 @@ fn translate_inner(x: &mut Xlate) -> Option<Kernel> {
                     VE::ArrayPopFn(_) => KShapeSlot::ArrayPopFn,
                     VE::Str(sl) => KShapeSlot::Str(*sl),
                     VE::CharCodeFn(_) => KShapeSlot::CharCodeFn,
-                    VE::Undef | VE::Opaque | VE::SelfFn(_) => {
-                        unreachable!("undef/opaque/self never crosses block boundaries")
+                    VE::Undef | VE::Opaque | VE::SelfFn(_) | VE::GlobalFn(_) => {
+                        unreachable!(
+                            "undef/opaque/self/global-callee never crosses block boundaries"
+                        )
                     }
                 })
                 .collect()
@@ -2007,6 +2023,7 @@ impl Xlate<'_> {
             | VE::Undef
             | VE::Opaque
             | VE::SelfFn(_)
+            | VE::GlobalFn(_)
             | VE::MathObj
             | VE::MathFn(_)
             | VE::Str(_)
@@ -2236,7 +2253,25 @@ impl Xlate<'_> {
                     };
                     self.vstack.push(VE::SelfFn(1 + idx as u16));
                 } else {
-                    return None;
+                    // LOOP mode: speculate a pinned GLOBAL callee (the fill
+                    // idiom `for (...) a[i] = rnd();`). Only a Call under an
+                    // `undefined` this can consume the entry, so a
+                    // mis-speculated non-callee global just fails
+                    // translation — exactly today's outcome.
+                    let idx = match self.global_callee_names.iter().position(|g| &**g == name) {
+                        Some(i) => i,
+                        None => {
+                            // Bounded like fn mode's rec_globals: a region
+                            // calling many distinct globals is not worth a
+                            // window per callee.
+                            if self.global_callee_names.len() >= 4 {
+                                return None;
+                            }
+                            self.global_callee_names.push(name.into());
+                            self.global_callee_names.len() - 1
+                        }
+                    };
+                    self.vstack.push(VE::GlobalFn(u16::try_from(idx).ok()?));
                 }
                 self.origins.push(None);
             }
@@ -2507,6 +2542,7 @@ impl Xlate<'_> {
                     | VE::Undef
                     | VE::Opaque
                     | VE::SelfFn(_)
+                    | VE::GlobalFn(_)
                     | VE::ArrayPushFn(_)
                     | VE::ArrayPopFn(_) => return None,
                 }
@@ -2944,9 +2980,10 @@ impl Xlate<'_> {
                     self.exits.push((kidx, self.base_ip + i as u32, shape));
                     return Some(());
                 }
-                // LOOP mode: a call of a PINNED closure — the callee is an
-                // object-typed local (oslot machinery, discovered exactly
-                // like an array base) under a plain `undefined` this.
+                // LOOP mode: a call of a PINNED closure under a plain
+                // `undefined` this — the callee is either an object-typed
+                // local (oslot machinery, discovered exactly like an array
+                // base) or a speculated GLOBAL binding ([`VE::GlobalFn`]).
                 // Arguments must be statically NUMBER registers: they copy
                 // raw into the callee kernel's guarded-Number arg registers.
                 if !self.fn_mode
@@ -2956,18 +2993,23 @@ impl Xlate<'_> {
                     for d in 0..n {
                         self.top_num_reg(d)?;
                     }
-                    let oslot = self.base_slot(n + 1)?;
+                    let source = match *self.vstack.get(fn_pos)? {
+                        VE::GlobalFn(g) => crate::bytecode::KCalleeSrc::Global(
+                            self.global_callee_names.get(g as usize)?.clone(),
+                        ),
+                        _ => crate::bytecode::KCalleeSrc::Oslot(self.base_slot(n + 1)?),
+                    };
                     let argc = u16::try_from(n).ok()?;
                     // `fslot` indexes the CALLEE table (parallel to the
                     // executor's per-activation window list), NOT the oslots.
-                    let fslot = match self.callees.iter().position(|c| c.oslot == oslot) {
+                    let fslot = match self.callees.iter().position(|c| c.source == source) {
                         Some(i) => {
                             self.callees[i].min_argc = self.callees[i].min_argc.min(argc);
                             i
                         }
                         None => {
                             self.callees.push(KCallee {
-                                oslot,
+                                source,
                                 min_argc: argc,
                             });
                             self.callees.len() - 1

--- a/crates/chidori-js/src/names.rs
+++ b/crates/chidori-js/src/names.rs
@@ -110,3 +110,41 @@ pub fn typeof_result(t: &'static str) -> JsString {
         _ => JsString::new(t),
     }
 }
+
+/// The interned typeof-name string for an arbitrary `&str`, or `None` when
+/// it is not one of the eight. Lets the compiler build `"number"`-class
+/// STRING CONSTANTS from the same allocation the interpreter's `typeof`
+/// results use, so an unfused `typeof x === "number"` confirms equality on
+/// the `JsString` pointer fast path instead of comparing bytes.
+pub fn typeof_name(s: &str) -> Option<JsString> {
+    Some(match s {
+        "undefined" => tof_undefined(),
+        "object" => tof_object(),
+        "boolean" => tof_boolean(),
+        "number" => tof_number(),
+        "string" => tof_string(),
+        "symbol" => tof_symbol(),
+        "function" => tof_function(),
+        "bigint" => tof_bigint(),
+        _ => return None,
+    })
+}
+
+/// The `&'static str` type tag matching an arbitrary string, when it is one
+/// of the eight `typeof` names — the compile-time half of the fused
+/// typeof-dispatch test (`ROp::TypeofBr`): `Value::type_of` returns exactly
+/// these statics, so content equality of a typeof result against such a
+/// literal is `type_of(v) == tag`.
+pub fn typeof_tag(s: &str) -> Option<&'static str> {
+    Some(match s {
+        "undefined" => "undefined",
+        "object" => "object",
+        "boolean" => "boolean",
+        "number" => "number",
+        "string" => "string",
+        "symbol" => "symbol",
+        "function" => "function",
+        "bigint" => "bigint",
+        _ => return None,
+    })
+}

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -383,6 +383,23 @@ pub enum ROp {
         if_true: bool,
         target: u32,
     },
+    /// Fused `typeof x ===/!== "<one of the eight typeof names>"` in branch
+    /// position — a direct type-tag test replacing the
+    /// `Unary{Typeof}; CmpBrK` pair: no typeof string materialized, no
+    /// `Value` clone/drop, no string comparison, no const load. Sound
+    /// because `typeof` is total and effect-free (dropping its intermediate
+    /// string is unobservable) and `Value::type_of` returns exactly these
+    /// eight statics, so content equality against such a literal is
+    /// `type_of(x) == tag` (loose `==` on two strings is strict). Literals
+    /// outside the eight names keep the generic compare. `br_on_eq` folds
+    /// the comparison kind and branch polarity: branch when
+    /// `(type_of == tag) == br_on_eq`.
+    TypeofBr {
+        src: u16,
+        tag: &'static str,
+        br_on_eq: bool,
+        target: u32,
+    },
 
     // ---- property access ----
     GetProp {
@@ -818,7 +835,10 @@ enum Entry {
     NewTarget,
 }
 
-struct Emitter {
+struct Emitter<'a> {
+    /// The function's const pool — read only by build-time fusions that
+    /// need a constant's value (the `TypeofBr` typeof-name check).
+    consts: &'a [crate::bytecode::Const],
     num_locals: u16,
     code: Vec<ROp>,
     entries: Vec<Entry>,
@@ -877,8 +897,10 @@ fn rop_budget_pure(op: &ROp) -> bool {
 
 /// Translate a function's final stack bytecode into a register program.
 /// Returns `None` when the function contains any op outside the translated
-/// subset, contains loop kernels, or exceeds the register budget.
-pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
+/// subset, contains loop kernels, or exceeds the register budget. `consts`
+/// is read only by build-time fusions that need a constant's VALUE (the
+/// `TypeofBr` typeof-name check).
+pub fn regify(code: &[Op], num_locals: u32, consts: &[crate::bytecode::Const]) -> Option<RegProto> {
     if code.is_empty() || num_locals > u16::MAX as u32 / 2 {
         return None;
     }
@@ -1074,6 +1096,7 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
 
     // Phase 3: emission.
     let mut e = Emitter {
+        consts,
         num_locals: num_locals as u16,
         code: Vec::with_capacity(code.len()),
         entries: Vec::new(),
@@ -1197,6 +1220,7 @@ fn rop_target_mut(op: &mut ROp) -> Option<&mut u32> {
         | ROp::CmpBr { target, .. }
         | ROp::CmpBrK { target, .. }
         | ROp::CmpBrCellK { target, .. }
+        | ROp::TypeofBr { target, .. }
         | ROp::CompletionJump { target, .. } => Some(target),
         _ => None,
     }
@@ -1257,7 +1281,7 @@ fn rop_set_dst(op: &mut ROp, new_dst: u16) -> bool {
     }
 }
 
-impl Emitter {
+impl Emitter<'_> {
     fn canon(&self, depth: usize) -> u16 {
         self.num_locals + depth as u16
     }
@@ -2244,15 +2268,74 @@ impl Emitter {
                 };
                 match konst {
                     Some(k) => {
-                        let a = self.pop_reg();
-                        self.flush_all();
-                        self.push_op(ROp::CmpBrK {
-                            cmp: *cmp,
-                            a,
-                            konst: k,
-                            if_true,
-                            target: *target,
-                        });
+                        // `TypeofBr` fusion — the dispatch idiom
+                        // `typeof x === "number"`. Conditions: an equality
+                        // compare against a string literal that IS one of
+                        // the eight typeof names, whose left operand is the
+                        // Temp defined by the immediately preceding
+                        // `Unary{Typeof}` into this position's canonical
+                        // register (`code.last()` — any interleaving
+                        // materialization or flush would have emitted a
+                        // later op, and a consumed/aliased result would not
+                        // sit here as a Temp). The popped op's charge moves
+                        // to `pending` so the fused branch charges both
+                        // stack ops' units before the edge. A literal
+                        // outside the eight names (`typeof x === "Number"`)
+                        // keeps the generic compare — it is reachable but
+                        // cold.
+                        let eq_kind = matches!(cmp, CmpOp::StrictEq | CmpOp::Eq);
+                        let ne_kind = matches!(cmp, CmpOp::StrictNe | CmpOp::Ne);
+                        let tag = if eq_kind || ne_kind {
+                            match self.consts.get(k as usize) {
+                                Some(crate::bytecode::Const::String(s)) => {
+                                    crate::names::typeof_tag(s.as_str())
+                                }
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        };
+                        let p = self.entries.len().wrapping_sub(1);
+                        let fusable = tag.is_some()
+                            && matches!(self.entries.last(), Some(Entry::Temp))
+                            && matches!(
+                                self.code.last(),
+                                Some(ROp::Unary { kind: RUnary::Typeof, dst, .. })
+                                    if *dst == self.canon(p)
+                            );
+                        if fusable {
+                            // The fused-away Unary becomes a `Charge`
+                            // carrying its already-assigned units, so a
+                            // budgeted run drains at exactly the stack
+                            // tier's points (deferring the units to the
+                            // branch would misattribute them across the
+                            // edge — the sweep differentials catch it).
+                            let unary_idx = self.code.len() - 1;
+                            let src = match self.code[unary_idx] {
+                                ROp::Unary { src, .. } => src,
+                                _ => unreachable!("checked above"),
+                            };
+                            self.code[unary_idx] = ROp::Charge;
+                            self.entries.pop();
+                            self.last_def = None;
+                            self.flush_all();
+                            self.push_op(ROp::TypeofBr {
+                                src,
+                                tag: tag.expect("checked above"),
+                                br_on_eq: if eq_kind { if_true } else { !if_true },
+                                target: *target,
+                            });
+                        } else {
+                            let a = self.pop_reg();
+                            self.flush_all();
+                            self.push_op(ROp::CmpBrK {
+                                cmp: *cmp,
+                                a,
+                                konst: k,
+                                if_true,
+                                target: *target,
+                            });
+                        }
                     }
                     None => {
                         let b = self.pop_reg();

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -368,6 +368,13 @@ pub struct Vm {
     /// Pooled (caller, return-pc, dst, window) stack for
     /// `run_fn_kernel_rec`; parked empty.
     pub(crate) rec_calls: Vec<(u8, u16, u16, u32)>,
+    /// Pooled key buffers for `for-in` enumerators (`for_in_keys`): a
+    /// glue-code loop that for-ins a fresh object per iteration otherwise
+    /// pays a malloc/free per loop entry just to hold the keys. Parked
+    /// CLEARED at `ForInPop` (best-effort: an unwound frame drops its
+    /// enumerators without parking — a pool miss, never a stale key). Pure
+    /// perf: only the buffer allocation is reused. Bounded.
+    pub(crate) forin_pool: Vec<Vec<crate::value::JsString>>,
     /// Pinned STRING bases for the active loop-kernel activation (mirrors
     /// `kernel_objs`); cleared after every activation so the pool never
     /// extends a string's lifetime.
@@ -427,6 +434,7 @@ impl Vm {
             kernel_callees: Vec::new(),
             rec_families: Vec::new(),
             rec_calls: Vec::new(),
+            forin_pool: Vec::new(),
             kernel_strs: Vec::new(),
             json_keys: std::collections::HashMap::default(),
             dummy_bf: Rc::new(BytecodeFunction {

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -358,6 +358,39 @@ const CORPUS: &[&str] = &[
     "let depth = 0; function down(n) { depth = depth + 1; return n <= 0 ? depth : down(n - 1); } console.log(down(5), depth);",
     // A cell-writing callee inside a hot numeric LOOP (the fill idiom).
     "let seed2 = 42; function r2() { seed2 = (seed2 * 31 + 7) % 1000003; return seed2; } const arr = new Array(20); for (let i = 0; i < 20; i++) arr[i] = r2(); console.log(arr[0], arr[19], seed2);",
+    // ---- pinned GLOBAL callees in loop kernels ----
+    // Plain global callee with arguments, result consumed numerically.
+    "function twice(x) { return x * 2; } let s = 0; for (let i = 0; i < 40; i++) { s += twice(i) - 1; } console.log(s);",
+    // Two distinct global callees in one region.
+    "function inc(x) { return x + 1; } function sq(x) { return x * x; } let s = 0; for (let i = 0; i < 25; i++) { s += sq(inc(i)); } console.log(s);",
+    // The same global callee at two call sites (one window, min_argc).
+    "function h(a, b) { return a - b; } let s = 0; for (let i = 0; i < 20; i++) { s += h(i, 1) + h(2 * i, i); } console.log(s);",
+    // UNDER-supplied global callee: args_used > min_argc declines the
+    // activation; the generic loop computes the NaN coercions.
+    "function add(a, b) { return a + b; } let s = 0; for (let i = 0; i < 5; i++) { s += add(i); } console.log(s, s !== s);",
+    // REBINDING the global between loop executions: each activation
+    // re-guards, so run 2 must call the NEW closure.
+    "function r() { return 1; } function fill() { let s = 0; for (let i = 0; i < 10; i++) { s += r(); } return s; } console.log(fill()); globalThis.r = () => 5; console.log(fill());",
+    // Rebound to a NON-function mid-program: run 2 throws generically.
+    "var q = function () { return 2; }; function go() { let s = 0; for (let i = 0; i < 5; i++) { s += q(); } return s; } console.log(go()); q = 7; try { go(); } catch (e) { console.log('ok', e instanceof TypeError); }",
+    // ACCESSOR global: the guard declines (own DATA property only), and the
+    // generic loop calls the getter once per iteration — the count proves it.
+    "let gets = 0; Object.defineProperty(globalThis, 'gf', { get() { gets++; return () => 3; } }); let s = 0; for (let i = 0; i < 4; i++) { s += gf(); } console.log(s, gets);",
+    // Cell-writing GLOBAL callee where generic code reads the cell right
+    // after the loop (per-call flush must have landed the final state).
+    "let acc2 = 0; function step(x) { acc2 = acc2 + x; return acc2; } let last = 0; for (let i = 1; i <= 10; i++) { last = step(i); } console.log(last, acc2);",
+    // Cell-writing callee + a mid-loop BAIL (the store target goes
+    // string-tainted): the generic tail keeps calling the callee, so the
+    // cell must be current at the bail point.
+    "let n2 = 0; function bump() { n2 = n2 + 1; return n2; } let a = [0, 0, 0, 0, 0]; for (let i = 0; i < 5; i++) { if (i === 3) a = { 3: 0, 4: 0 }; a[i] = bump(); } console.log(a[4], n2);",
+    // The callee's written cell is ALSO read by generic code inside the
+    // loop-adjacent expression (loop kernel itself must not snapshot it).
+    "let c3 = 100; function dec3() { c3 = c3 - 1; return c3; } let s = 0; for (let i = 0; i < 6; i++) { s += dec3(); } console.log(s + c3);",
+    // ALIAS DECLINE: the caller's loop reads the same cell the callee
+    // writes (both capture `seed3` as an upvalue) — the caller's snapshot
+    // would go stale after the first flush, so the activation must stay
+    // generic and see every intermediate value.
+    "let seed3 = 1; function stir() { seed3 = seed3 * 3 + 1; return seed3; } function fill3() { let s = 0; for (let i = 0; i < 8; i++) { s += stir() + seed3; } return s; } console.log(fill3(), seed3);",
     // ---- self-recursive function kernels (SelfCall) ----
     // The canonical fib shape (global function declaration).
     "function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); } console.log(fib(15), fib(0), fib(1));",
@@ -717,6 +750,37 @@ fn tiny_functions_get_fn_kernels() {
             "expected NO function kernel in {src:?}"
         );
     }
+}
+
+/// The fill idiom — a numeric loop whose body calls a GLOBAL function —
+/// kernelizes as one loop kernel with a pinned global callee (pins the
+/// `KCalleeSrc::Global` shape).
+#[test]
+fn global_callee_loops_get_kernels() {
+    fn kernels_in(p: &FuncProto) -> usize {
+        let mut n = p.kernels.len();
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                n += kernels_in(f);
+            }
+        }
+        n
+    }
+    // The sort workload's fill loop: a cell-writing global callee.
+    let src = "let seed = 1; function rnd() { seed = (seed * 1103515245 + 12345) >>> 0; return seed; } const a = new Array(10); for (let i = 0; i < 10; i++) a[i] = rnd(); console.log(a[9]);";
+    let proto = compile_script(src).expect("compiles");
+    assert!(
+        kernels_in(&proto) >= 1,
+        "fill loop with a global callee must kernelize"
+    );
+    let has_call_kernel = proto
+        .kernels
+        .iter()
+        .any(|k| k.code.iter().any(|op| matches!(op, KOp::CallKernel { .. })));
+    assert!(
+        has_call_kernel,
+        "the fill loop's kernel must carry a CallKernel to the global callee"
+    );
 }
 
 /// Cell-writing scalar bodies (the PRNG idiom) get a function kernel with

--- a/crates/chidori-js/tests/kernels.rs
+++ b/crates/chidori-js/tests/kernels.rs
@@ -322,6 +322,42 @@ const CORPUS: &[&str] = &[
     "'use strict'; function f(a, b) { return a * b; } console.log(f(6, 7));",
     // Boolean ARGUMENT declines (guard is Number-only) — generic coercion.
     "const f = (a, b) => a - b; console.log(f(true, 1), f(5, false));",
+    // ---- upvalue-WRITING function kernels (buffered cell writes) ----
+    // The PRNG idiom (the sort workload's `rnd`): write a captured cell,
+    // return it. Cell state must advance identically call over call.
+    "let seed = 123456789; function rnd() { seed = (seed * 1103515245 + 12345) >>> 0; return seed; } let s = 0; for (let i = 0; i < 50; i++) s = (s + rnd()) >>> 0; console.log(s, seed);",
+    // Generic code reads the cell BETWEEN kernel calls (per-call flush).
+    "let acc = 0; const bump = x => { acc = acc + x; return acc; }; bump(1); const mid = acc; bump(2); console.log(mid, acc);",
+    // Two kernels sharing one cell: each entry re-reads the other's flush.
+    "let s = 10; const inc = () => { s = s + 1; return s; }; const dec = () => { s = s - 2; return s; }; console.log(inc(), dec(), inc(), s);",
+    // Conditional store: the skipped path leaves the cell untouched (the
+    // flush writes the entry snapshot back — same value, unobservable).
+    "let hi = 0; const f = x => { if (x > 10) hi = x; return hi; }; console.log(f(5), f(20), f(7), hi);",
+    // Write-only cell (no read in the body).
+    "let last = -1; const f = x => { last = x * 2; return x; }; f(3); f(4); console.log(last);",
+    // Store then read-back within the body (register forwarding).
+    "let t = 1; const f = x => { t = t * x; return t + t; }; console.log(f(3), f(5), t);",
+    // Self-assignment (a dead store — the flush is value-identical anyway).
+    "let v = 7; const f = x => { v = v; return v + x; }; console.log(f(1), v);",
+    // -0 and NaN round through the cell bit-exactly.
+    "let z = 0; const f = x => { z = x * -0; return 1 / z; }; console.log(f(5), f(-5), Object.is(z, -0));",
+    "let n = 0; const f = x => { n = n + x; return n; }; f(NaN); console.log(n === n, typeof n);",
+    // Non-Number stores decline (the generic path must store the actual
+    // boolean/undefined — a flushed Number would change typeof).
+    "let b = 0; const f = x => { b = x > 0; return 1; }; console.log(f(5), b, typeof b);",
+    "let u = 0; const f = x => { u = undefined; return x; }; console.log(f(1), u, typeof u);",
+    // TDZ at call time: the cell isn't a Number yet — the guard declines and
+    // the generic path throws the spec ReferenceError.
+    "try { const f = () => { w = 1; return w; }; f(); let w; } catch (e) { console.log('tdz', e instanceof ReferenceError); }",
+    // A cell-writing COMPARATOR: the prepared sort path declines per-sort,
+    // results and the final call-count cell state stay exact.
+    "let calls = 0; const a = [5,3,8,1]; a.sort((x, y) => { calls = calls + 1; return x - y; }); console.log(a.join(','), calls > 0);",
+    // A cell-writing HOF callback (prepared map path declines per-run).
+    "let sum = 0; console.log([1,2,3,4].map(x => { sum = sum + x; return sum; }).join(','), sum);",
+    // Cell-writing SELF-RECURSION declines the recursion tier, stays exact.
+    "let depth = 0; function down(n) { depth = depth + 1; return n <= 0 ? depth : down(n - 1); } console.log(down(5), depth);",
+    // A cell-writing callee inside a hot numeric LOOP (the fill idiom).
+    "let seed2 = 42; function r2() { seed2 = (seed2 * 31 + 7) % 1000003; return seed2; } const arr = new Array(20); for (let i = 0; i < 20; i++) arr[i] = r2(); console.log(arr[0], arr[19], seed2);",
     // ---- self-recursive function kernels (SelfCall) ----
     // The canonical fib shape (global function declaration).
     "function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); } console.log(fib(15), fib(0), fib(1));",
@@ -680,6 +716,56 @@ fn tiny_functions_get_fn_kernels() {
             0,
             "expected NO function kernel in {src:?}"
         );
+    }
+}
+
+/// Cell-writing scalar bodies (the PRNG idiom) get a function kernel with
+/// `uv_writes` populated; non-Number stores and cell-writing recursion stay
+/// generic (pins the upvalue write-back shape).
+#[test]
+fn cell_writing_functions_get_fn_kernels() {
+    /// (fn kernels found, of which with non-empty uv_writes, of which rec)
+    fn scan(p: &FuncProto) -> (usize, usize, usize) {
+        let mut t = match &p.fn_kernel {
+            Some(k) => (
+                1,
+                usize::from(!k.uv_writes.is_empty()),
+                usize::from(k.rec.is_some()),
+            ),
+            None => (0, 0, 0),
+        };
+        for c in &p.consts {
+            if let Const::Func(f) = c {
+                let s = scan(f);
+                t = (t.0 + s.0, t.1 + s.1, t.2 + s.2);
+            }
+        }
+        t
+    }
+    // The PRNG idiom kernelizes WITH a recorded cell write.
+    for src in [
+        "let seed = 1; function rnd() { seed = (seed * 1103515245 + 12345) >>> 0; return seed; }",
+        "let acc = 0; const f = x => { acc = acc + x; return acc; };",
+        "let hi = 0; const f = x => { if (x > 10) hi = x; return hi; };",
+    ] {
+        let (kernels, writing, rec) = scan(&compile_script(src).expect("compiles"));
+        assert!(
+            kernels >= 1 && writing >= 1 && rec == 0,
+            "expected a non-recursive cell-writing fn kernel in {src:?}"
+        );
+    }
+    // Non-Number stores and cell-writing recursion stay generic.
+    for src in [
+        // Boolean store: a flushed Number would change typeof.
+        "let b = 0; const f = x => { b = x > 0; return 1; };",
+        // Undefined store: unrepresentable in a register.
+        "let u = 0; const f = x => { u = undefined; return x; };",
+        // Self-recursion + cell write: the recursion tier's entry resolution
+        // treats cells as activation constants.
+        "let d = 0; function f(n) { d = d + 1; return n <= 0 ? d : f(n - 1); }",
+    ] {
+        let (kernels, _, _) = scan(&compile_script(src).expect("compiles"));
+        assert_eq!(kernels, 0, "expected NO fn kernel in {src:?}");
     }
 }
 

--- a/crates/chidori-js/tests/reg.rs
+++ b/crates/chidori-js/tests/reg.rs
@@ -181,6 +181,21 @@ const CORPUS: &[&str] = &[
     "class HI { static [Symbol.hasInstance](v) { return v === 42; } } console.log(42 instanceof HI, 41 instanceof HI);",
     // typeof on every kind.
     "console.log(typeof 1, typeof 's', typeof true, typeof undefined, typeof null, typeof {}, typeof [], typeof (() => 0), typeof Symbol(), typeof 1n);",
+    // ---- typeof-dispatch branches (the TypeofBr fusion) ----
+    // Every tag in branch position, against a value of every kind.
+    "function tf(v) { if (typeof v === 'number') return 'n'; if (typeof v === 'string') return 's'; if (typeof v === 'boolean') return 'b'; if (typeof v === 'undefined') return 'u'; if (typeof v === 'object') return 'o'; if (typeof v === 'function') return 'f'; if (typeof v === 'symbol') return 'y'; if (typeof v === 'bigint') return 'g'; return '?'; } console.log([1, 'x', true, undefined, null, {}, [], tf, Symbol(), 9n].map(tf).join(''));",
+    // Negated and loose forms; literal on the left is NOT the fused shape
+    // (Typeof lands as the K-fold operand) — must still agree.
+    "const nn = (v) => typeof v !== 'number'; const lo = (v) => typeof v == 'string'; console.log(nn(1), nn('a'), lo('a'), lo(1), 'number' === typeof 5, 'x' === typeof 5);",
+    // A literal OUTSIDE the eight names stays a generic (false) compare.
+    "const w = (v) => typeof v === 'Number' || typeof v === 'numbre'; console.log(w(1), w('Number'));",
+    // typeof result flowing into a NON-branch consumer (no fusion: stored,
+    // concatenated, returned).
+    "const t = typeof 42; const u = t + '!'; console.log(t, u, (typeof 'a').length);",
+    // typeof in a ternary chain (the mixed_helpers normalize shape).
+    "function dis(v) { return typeof v === 'number' ? v + 1 : typeof v === 'string' ? v + '!' : 'other'; } console.log(dis(1), dis('a'), dis(true));",
+    // typeof of an UNDECLARED global (LoadGlobalTypeof path, unfused).
+    "console.log(typeof totally_undeclared === 'undefined', typeof totally_undeclared !== 'undefined');",
     // String building via += (rope path through op_add).
     "let sb2 = ''; for (let i = 0; i < 50; i++) sb2 += 'ab'; console.log(sb2.length, sb2.slice(0, 4), sb2.charCodeAt(99));",
 
@@ -438,6 +453,44 @@ fn walk_protos(p: &FuncProto, f: &mut impl FnMut(&FuncProto)) {
             walk_protos(nested, f);
         }
     }
+}
+
+/// The typeof-dispatch idiom compiles to the fused [`chidori_js::reg::ROp::TypeofBr`]
+/// (no typeof string materialized, no compare) — and near-miss shapes do not.
+#[test]
+fn typeof_branches_fuse() {
+    use chidori_js::reg::ROp;
+    fn count_ops(p: &FuncProto, pred: &dyn Fn(&ROp) -> bool) -> usize {
+        let mut n = 0;
+        walk_protos(p, &mut |p| {
+            if let Some(reg) = &p.reg {
+                n += reg.code.iter().filter(|op| pred(op)).count();
+            }
+        });
+        n
+    }
+    // The mixed_helpers normalize shape: both dispatches fuse.
+    let proto = compile_script_regs(
+        "function f(v) { if (typeof v === 'number') return 1; else if (typeof v !== 'string') return 2; return 3; }",
+        true,
+    )
+    .expect("compiles");
+    assert_eq!(
+        count_ops(&proto, &|op| matches!(op, ROp::TypeofBr { .. })),
+        2,
+        "typeof-dispatch branches must fuse to TypeofBr"
+    );
+    // A literal outside the eight names must NOT fuse (generic compare).
+    let proto = compile_script_regs(
+        "function g(v) { if (typeof v === 'Number') return 1; return 2; }",
+        true,
+    )
+    .expect("compiles");
+    assert_eq!(
+        count_ops(&proto, &|op| matches!(op, ROp::TypeofBr { .. })),
+        0,
+        "non-typeof-name literals must stay generic"
+    );
 }
 
 /// Structural pins: the canonical shapes MUST carry register programs, and

--- a/crates/chidori-js/tests/smoke.rs
+++ b/crates/chidori-js/tests/smoke.rs
@@ -338,3 +338,48 @@ fn console_output() {
         "{ a: 1, b: 'two' }"
     );
 }
+
+#[test]
+fn default_sort_precomputed_keys() {
+    // The all-primitive default sort takes the precomputed-ToString-keys
+    // fast path (`sort_default_primitive`); these pin that its results are
+    // exactly the spec's per-comparison SortCompare order.
+    // Numbers sort as STRINGS under the default comparator.
+    assert_eq!(run("[10, 9, 100, 1].sort().join(',')"), "1,10,100,9");
+    // Mixed primitives: numeric strings interleave with numbers; booleans
+    // and null stringify for the SORT (null lands between "false" and
+    // "true") — join() then renders the null element as "" per spec.
+    assert_eq!(
+        run(r#"[10, "9", 2, true, null, "abc", false].sort().join('|')"#),
+        "10|2|9|abc|false||true"
+    );
+    // -0 stringifies as "0" and holds its slot; NaN sorts as "NaN".
+    assert_eq!(
+        run("const a=[-0, NaN, 0, 1]; a.sort(); (Object.is(a[0],-0)) + ',' + a.join(',')"),
+        "true,0,0,1,NaN"
+    );
+    // Stability: equal keys keep original order (indices via epsilon tags).
+    assert_eq!(
+        run(
+            r#"const a=[{k:"b",i:0},{k:"a",i:1},{k:"b",i:2}].map(o=>o); const s=["b","a","b"]; const t=[0,1,2]; const z=t.map((i)=>({toString(){return s[i];}, i})); z.sort(); z.map(o=>o.i).join(',')"#
+        ),
+        "1,0,2"
+    );
+    // An OBJECT element keeps the per-comparison path (its toString runs
+    // user code) — order still correct.
+    assert_eq!(
+        run(r#"const o={toString(){return "5";}}; [7,o,3,"4"].sort().map(String).join(',')"#),
+        "3,4,5,7"
+    );
+    // A Symbol element throws TypeError (never silently stringified).
+    assert!(run("[Symbol(), 1].sort()").contains("TypeError"));
+    // Undefineds sort to the end without entering the key path.
+    assert_eq!(
+        run("[undefined, 2, 10, undefined, 1].sort().map(String).join(',')"),
+        "1,10,2,undefined,undefined"
+    );
+    // Non-ASCII keys: UTF-16 code-unit order (astral pairs before U+E000+).
+    assert_eq!(run(r#"["￿", "a", "𐀀"].sort().join(',')"#), "a,𐀀,￿");
+    // toSorted shares the same path.
+    assert_eq!(run("[3,20,1].toSorted().join(',')"), "1,20,3");
+}

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1622,7 +1622,7 @@ loop kernel can't contain a call to a GLOBAL callee (pinned callees are
 local-held only, and cell-writing callees decline the pinned path). Extending
 `KOp::CallKernel` to entry-guarded global callees with per-call flush would
 kernelize the entire fill loop (the inlined-LCG equivalent measured 26 ms
-total, another ~3× on this phase).
+total, another ~3× on this phase). **Landed as §6.15.**
 
 **Gates:** kernels differential corpus grew 16 cell-writing programs (PRNG,
 shared cells across two kernels, conditional/write-only/self-assign stores,
@@ -1632,6 +1632,79 @@ declining their tiers, the fill idiom) plus a structural pin
 (`cell_writing_functions_get_fn_kernels`); benchmark suite cross-checks
 green (all four runtimes agree on every workload); full suites green;
 clippy clean.
+
+## 6.15 Global pinned callees, cell-writing callee flush, and the
+default-sort key precompute (landed 2026-07-11, follow-up round)
+
+The two follow-ups §6.14 queued: kernelize the sort workload's fill loop
+END TO END, and fix the latent no-comparator `Array.prototype.sort` cliff
+(868 ms vs Bun's 129 ms on a 6×50k numeric sort — per-comparison ToString).
+
+1. **Pinned GLOBAL callees in loop kernels** ([`KCalleeSrc`]). `LoadGlobal`
+   of a non-`Math` name in a loop region now speculates a pinned callee
+   ([`VE::GlobalFn`]) — its only legal consumer is a `Call` under an
+   `undefined` this, fusing to the existing `KOp::CallKernel`, so a
+   mis-speculated non-callee global just fails translation (exactly
+   today's decline). The activation entry guard resolves the name the way
+   `LoadGlobal`'s fast path does — an own DATA property of the global
+   object holding a kernel-carrying closure — and declines
+   accessor/proto-inherited/missing bindings to the generic loop (which
+   then runs the getter per iteration / throws the ReferenceError
+   exactly per spec). The binding is an activation constant: nothing on
+   the kernel allowlist can rebind a global, and a `KProp` store aimed at
+   the same global-object property can't pass its holds-a-Number entry
+   check while this guard sees a closure.
+2. **Cell-writing callees in the pinned path.** §6.14's `uv_writes`
+   kernels are now admitted by the `CallKernel` guard: the callee window
+   still snapshots upvalues once per activation, the written register IS
+   the cell's live value across calls (nothing else can touch it
+   mid-loop), and the window flushes written cells back after EVERY call
+   — so a mid-loop bail (a store target going string-tainted) resumes the
+   generic loop against current cell state, and the interrupt unwind
+   keeps the generic-prefix contract. Cross-window aliasing (a written
+   cell captured by another callee window or snapshot by the caller
+   kernel's own upvalue registers) declines the activation — the
+   differential corpus pins the caller-reads-the-cell shape staying
+   generic.
+3. **Default-sort ToString precompute** (`sort_default_primitive`,
+   independent of the kernel tiers). The spec's default SortCompare
+   stringifies both operands per comparison — ~2·n·log n allocating
+   conversions. ToString of a Number/String/Bool/Null/BigInt is pure, so
+   an all-primitive snapshot now precomputes the n keys once and sorts an
+   index permutation with the IDENTICAL stable take-left merge — same
+   output element-for-element, no observable difference (objects keep the
+   exact per-comparison path: their toString/valueOf call order and count
+   are user-visible; a Symbol element still throws from the comparison).
+   All-ASCII keys (number-to-string output always is) compare as bytes
+   instead of UTF-16 code units.
+
+### 6.15.1 Measured (callgrind, whole workload; wall interleaved 7-run median)
+
+| workload | §6.14 baseline | after | Δ instructions | wall |
+| --- | ---: | ---: | ---: | ---: |
+| sort (benchmark workload) | 1.554 G | 1.144 G | **−26.3%** | 175 → 125 ms |
+| sort fill phase only | 669.1 M | 259.8 M | **−61.2%** | 85 → 33 ms |
+| default-sort probe (6×50k, no comparator) | 9.900 G | 1.618 G | **−83.7%** | 838 → 184 ms |
+| fib_recursive | 694.0 M | 694.0 M | ±0.0% | 64 → 66 ms |
+
+Cumulative on the sort benchmark row since §6.13: 1.992 G → 1.144 G
+instructions (−42.6%), 232 → 125 ms — on the cross-runtime suite chidori
+now posts the FASTEST execution-only sort of all four runtimes (Node
+~1.6×, Bun ~1.5×, CPython ~1.0–1.3× behind on the same box). The
+no-comparator cliff drops from 6.7× behind Bun to ~1.4×. fib is
+bit-identical this round (the §6.14 layout shift did not compound).
+
+**Gates:** kernels differential corpus grew 12 global-callee programs
+(args/two-callees/two-sites-min-argc, under-supplied args declining,
+rebinding between activations, rebound-to-non-function throwing, accessor
+global counting its per-iteration getter calls, cell-writing callee with
+post-loop reads, mid-loop bail with a live cell, caller-reads-cell alias
+decline) plus a structural pin (`global_callee_loops_get_kernels`); the
+default sort gained a smoke pin (`default_sort_precomputed_keys`:
+string-order numerics, mixed primitives, -0/NaN, stability, object and
+Symbol elements, UTF-16 astral order, toSorted) all verified against Node
+per case; benchmark suite cross-checks green on all four runtimes; full
+suites green; clippy and rustfmt clean.
 
 ## 7. References
 

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1706,6 +1706,77 @@ Symbol elements, UTF-16 astral order, toSorted) all verified against Node
 per case; benchmark suite cross-checks green on all four runtimes; full
 suites green; clippy and rustfmt clean.
 
+## 6.16 Glue-code round: typeof-dispatch fusion, compile-scoped string
+interning, String+String add, for-in buffer pool (landed 2026-07-12)
+
+mixed_helpers ran ~2.3× slower than CPython (~255 vs ~112 ms execution) —
+by design the workload where every function declines the kernel tiers and
+the register interpreter carries everything. Phase isolation split its
+~255 ms into normalize/for-in ~120 ms, render/string-build ~66 ms, object
+allocation ~41 ms, buckets/classify ~38 ms; the profile showed no cliff,
+just the aggregate per-iteration tax (~38.6 k instructions each): dispatch
+~30%, `Value` drops + malloc ~13%, string equality ~4.5%, map hashing ~5%.
+This round took every bounded lever; the rest is the tracked
+arena/GC-design work.
+
+1. **`ROp::TypeofBr`** — the dispatch idiom `typeof v === "number"` fuses
+   at register-translation time into a direct type-tag test: no typeof
+   string materialized, no `Value` clone/drop, no string compare, no const
+   load. Build-time conditions: an equality compare (`===`/`!==`/`==`/
+   `!=`) K-folded against a string literal that IS one of the eight typeof
+   names, whose operand is the Temp defined by the immediately preceding
+   `Unary{Typeof}` (`code.last()` — any interleaving materialization would
+   have emitted a later op). The fused-away Unary becomes a `Charge`
+   carrying its already-assigned units, so budgeted runs drain at exactly
+   the stack tier's points — the first cut deferred those units across the
+   branch edge and the reg budget-sweep differential caught it precisely
+   (per-path charge divergence). Literals outside the eight names
+   (`typeof x === "Number"`) keep the generic compare.
+2. **Compile-scoped string interning** (`Compiler::str_intern`): one
+   `JsString` allocation per distinct string across a whole compilation —
+   const pools AND object-template keys — so a for-in key cloned out of an
+   instantiated template pointer-matches `k === "id"` literals and
+   property-name consts in any function of the program. The eight typeof
+   names route to the process-wide `names.rs` table instead, giving
+   unfused/stack-tier `typeof` compares the pointer fast path too.
+   Compile-scoped, so nothing is retained across programs.
+3. **`op_add` String+String fast path**: both operands already primitive —
+   ToPrimitive and ToString are identities — so concatenate directly under
+   the same length cap; skipped are two identity-clone ToPrimitive calls
+   and two ToString round-trips per join (`label + ":" + v` pays it
+   twice).
+4. **Pooled for-in key buffers** (`Vm::forin_pool`): a glue loop
+   for-inning a fresh object per iteration reused one buffer allocation
+   instead of a malloc/free per loop entry; parked cleared at `ForInPop`
+   (unwound frames just miss the pool).
+
+Evaluated and REJECTED: a for-in slot-carry for `rec[k]` re-hashing —
+the measured cost is ~1.7% of the row and soundness needs a generation
+counter on every `ObjectData`, undoing §6.13's size diet; the arena/GC
+recycle point remains the real allocation lever (drops + malloc still
+~12% after this round).
+
+### 6.16.1 Measured (callgrind, whole workload; wall interleaved medians)
+
+| workload | before | after | Δ instructions | wall |
+| --- | ---: | ---: | ---: | ---: |
+| mixed_helpers | 2.319 G | 1.996 G | **−13.9%** | 260 → 226 ms |
+| normalize/for-in phase probe | 1.504 G | ~1.26 G | −16% | 166 → 142 ms |
+| fib_recursive / sort / others | — | — | ±0.001% | unchanged |
+
+The row stays ~2× CPython (~227 vs ~116 ms execution on the same box) —
+CPython's dict iteration, type dispatch, and string concat are its own
+C-tuned native gait, and parity for chidori on this shape needs the
+ObjectData arena or a baseline-compile step, both tracked.
+
+**Gates:** reg differential corpus grew 7 typeof-dispatch programs (every
+tag × every value kind, negated/loose/literal-on-the-left forms, a
+non-typeof-name literal, non-branch consumers, the LoadGlobalTypeof path)
+plus a structural pin (`typeof_branches_fuse`, positive and negative);
+the reg budget sweep runs over the new corpus entries (and caught the
+first cost-model cut); full suites green; benchmark cross-checks green on
+all four runtimes; clippy and rustfmt clean.
+
 ## 7. References
 
 - [`docs/interpreter-optimization.md`](./interpreter-optimization.md) —

--- a/docs/js-performance-roadmap.md
+++ b/docs/js-performance-roadmap.md
@@ -1557,6 +1557,82 @@ results feeding arithmetic/booleans) plus a structural pin
 byte-identical; full suites green for both crates; Test262 gate green
 (0 regressions); clippy clean.
 
+## 6.14 Cell-writing function kernels (landed 2026-07-11): the PRNG idiom
+
+Motivated by the CPython benchmark column: on the `sort` workload chidori
+trailed every other runtime, and phase isolation showed the sort itself was
+already at Bun parity (§6.5's prepared f64 comparator) — the deficit was the
+LCG **fill loop**, 300k calls to
+`function rnd() { seed = (seed * 1103515245 + 12345) >>> 0; return seed; }`
+at ~370 ns each. `rnd` declined the function-kernel tier for exactly one op:
+`StoreUpvalueChecked` (function kernels were pure — "nothing inside a kernel
+can write globals or cells"). A function that mutates captured state through
+a cell is the PRNG/accumulator/counter idiom, common in exactly the glue
+code the fn-kernel tier targets.
+
+1. **Translation** (`kernel.rs`): fn mode now accepts
+   `StoreUpvalue`/`StoreUpvalueChecked` of a NUMBER — the value moves into
+   the upvalue's register (later loads read the same register), and the
+   kernel records the write in `Kernel::uv_writes` (`(register, upvalue)`
+   pairs). Written registers join the always-live set so the completion
+   flush's source survives DCE. The Checked form's TDZ test is statically
+   satisfied: the entry guard already requires the cell to hold a Number
+   (a TDZ'd cell declines to the generic path, which raises the spec
+   ReferenceError). Non-Number stores (boolean/undefined — the flush would
+   change the cell's observable type) and loop-mode upvalue stores keep
+   declining.
+2. **Execution** (`run_fn_kernel`): written cells buffer in registers for
+   the whole frameless call — nothing else can run mid-kernel — and flush
+   back as `Value::Number` on BOTH completions (return and the interrupt
+   unwind, mirroring the loop kernels' local write-back), so the cell holds
+   exactly the generic write-through path's state; a conditionally-skipped
+   store flushes the entry snapshot back (same value, unobservable). A
+   belt-and-braces entry check declines if a written cell aliases another
+   captured cell. Both helpers live out of line so write-free kernels' hot
+   paths are untouched.
+3. **Tier boundaries**: non-empty `uv_writes` declines the recursion tier
+   (its family resolution and cache treat cells as activation constants —
+   checked at translation for self-recursion and at `build_rec_family` for
+   non-recursive helpers pulled into a family), the prepared-callback paths
+   (sort/HOF: they snapshot upvalues once per run), and the loop-kernel
+   pinned-callee guard (one snapshot per activation). Those shapes run
+   generically, exactly as before.
+
+### 6.14.1 Measured (callgrind, whole workload; wall interleaved 6-run median)
+
+| workload | before | after | Δ instructions | wall |
+| --- | ---: | ---: | ---: | ---: |
+| sort | 1.992 G | 1.554 G | **−22.0%** | 232 → 179 ms |
+| sort fill phase only | 1.107 G | 657 M | −40.6% | 166 → 85 ms |
+| 300k bare `rnd()` calls | 976 M | 526 M | −46.1% | 118 → 69 ms |
+| fib_recursive | 683.2 M | 694.0 M | +1.6% | 65 → 64 ms |
+| mutual_recursion | 940.2 M | 958.8 M | +2.0% | 79 → 81 ms |
+| array_hof / others | — | — | ±0.1% | — |
+
+Per-call cost of the PRNG shape drops ~370 → ~210 ns (the remaining cost is
+the generic caller loop: `LoadGlobal; Call` dispatch around the frameless
+body). On the cross-runtime suite the sort row goes from slowest-of-four to
+ahead of Node and CPython (~1.5× Bun, from 2.0×). The fib/mutual instruction
+upticks are the §6.13-class fat-LTO layout shift (their wall is flat, and
+neither workload executes any new code on its hot path); the residual
+stands as accepted noise, same as §6.13's window-pool revert.
+
+**What's next here:** the fill loop itself still runs generic bytecode — a
+loop kernel can't contain a call to a GLOBAL callee (pinned callees are
+local-held only, and cell-writing callees decline the pinned path). Extending
+`KOp::CallKernel` to entry-guarded global callees with per-call flush would
+kernelize the entire fill loop (the inlined-LCG equivalent measured 26 ms
+total, another ~3× on this phase).
+
+**Gates:** kernels differential corpus grew 16 cell-writing programs (PRNG,
+shared cells across two kernels, conditional/write-only/self-assign stores,
+-0/NaN round-trips, boolean/undefined stores declining, call-time TDZ
+throwing generically, cell-writing comparator/HOF-callback/self-recursion
+declining their tiers, the fill idiom) plus a structural pin
+(`cell_writing_functions_get_fn_kernels`); benchmark suite cross-checks
+green (all four runtimes agree on every workload); full suites green;
+clippy clean.
+
 ## 7. References
 
 - [`docs/interpreter-optimization.md`](./interpreter-optimization.md) —


### PR DESCRIPTION
Every workload in crates/chidori-js/benchmarks/workloads/ now has a
hand-ported .py twin that CPython runs alongside the JS runtimes. The
ports follow the JS shape loop-for-loop and must print a byte-identical
RESULT= line, so the harness's existing cross-runtime correctness check
now spans languages too. Where JS double semantics leak into the result
(the sort LCG overflows 2^53 before ToUint32; the array_sum/typed_array
checksums accumulate near 2^53), the Python twin reproduces the IEEE
rounding explicitly, with a comment explaining each deviation.

Harness: runtimes carry an ext (.js/.py) that selects the workload file,
cpython (python3, optional like bun) joins the default runtime set, each
runtime probes its own startup baseline file, and a workload missing a
port for some runtime reports a — cell instead of failing the suite.

Rationale, documented in the README: Node/Bun answer "how far are we
from the shipping JITs?", while CPython — an interpreter with the same
execution model — is the like-for-like yardstick for interpreter-tier
performance.

CI pins python3.12 via setup-python so the cpython column can't silently
vanish from the sticky PR comment.

Verified locally: all 14 workloads produce identical RESULT= values
across chidori, node, bun, and cpython (harness exits 0).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TRa7kCGdAMSGDgjGH6z5mT