### PR TITLE
Object shapes (hidden classes): shared key layouts for plain objects

### DIFF
--- a/crates/chidori-js/benches/common/workloads.rs
+++ b/crates/chidori-js/benches/common/workloads.rs
@@ -52,6 +52,19 @@ pub const WORKLOADS: &[(&str, &str)] = &[
         "string_scan",
         "(function(){ let s = ''; for (let i = 0; i < 512; i++) s += String.fromCharCode(97 + (i % 26)); let h = 0; for (let r = 0; r < 40; r++) { for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) % 1000000007; } } return h; })()",
     ),
+    // JSON stringify+parse round-trips over a nested record — the shapes
+    // workload (docs/js-object-shapes-design.md §1): per-record construction
+    // (shared shape + one slot vec), key interning, enumeration.
+    (
+        "json_roundtrip",
+        "(function(){ const obj = { id: 0, name: 'widget', tags: ['a', 'b', 'c'], nested: { x: 1, y: 2, z: { deep: true, items: [1, 2, 3, 4, 5] } } }; let acc = 0; for (let i = 0; i < 2000; i++) { obj.id = i; const back = JSON.parse(JSON.stringify(obj)); acc = (acc + back.id + back.nested.z.items[i % 5]) % 1000003; } return acc; })()",
+    ),
+    // Same-shape object literals allocated per iteration (the closures-
+    // workload record pattern): literal-site shape cache + shaped birth.
+    (
+        "object_literals",
+        "(function(){ let s = 0; for (let i = 0; i < 20000; i++) { const p = { x: i, y: i * 2, tag: 'pt' }; s = (s + p.x + p.y) % 1000003; } return s; })()",
+    ),
     // Typed-array element traffic (fill, dot product, in-place transform).
     // Same shape as the dense-array workloads but over Float64Array, which the
     // loop kernels do not yet accept as a base.

--- a/crates/chidori-js/examples/shapebench.rs
+++ b/crates/chidori-js/examples/shapebench.rs
@@ -1,0 +1,16 @@
+//! Deterministic-instruction benchmark runner for the shapes work: runs one
+//! named workload from the shared bench corpus once (compile excluded from
+//! the interesting region is not needed for callgrind ratios).
+#[path = "../benches/common/workloads.rs"]
+mod workloads;
+
+fn main() {
+    let name = std::env::args().nth(1).expect("workload name");
+    let (_, src) = workloads::WORKLOADS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .expect("unknown workload");
+    let mut e = chidori_js::Engine::new();
+    let v = e.eval(src).expect("workload must not throw");
+    println!("{name}: {:?}", v);
+}

--- a/crates/chidori-js/src/builtins/array.rs
+++ b/crates/chidori-js/src/builtins/array.rs
@@ -151,8 +151,7 @@ pub fn install(vm: &mut Vm) {
     for (name, slot) in [("push", 0), ("pop", 1)] {
         let f = proto
             .borrow()
-            .props
-            .get(&PropertyKey::str(name))
+            .own_get(&PropertyKey::str(name))
             .and_then(|p| p.value().cloned());
         if let Some(Value::Object(o)) = f {
             if slot == 0 {
@@ -261,7 +260,7 @@ fn has_get_elem(vm: &mut Vm, base: &Value, idx: f64) -> Result<Option<Value>, Va
         if let Value::Object(o) = base {
             let b = o.borrow();
             if let Internal::Array(arr) = &b.internal {
-                if b.props.is_empty() {
+                if b.own_is_empty() {
                     if let Some(v) = arr.get(idx as usize) {
                         if !matches!(v, Value::Hole) {
                             return Ok(Some(v.clone()));
@@ -304,7 +303,7 @@ fn set_elem(vm: &mut Vm, base: &Value, idx: f64, v: Value) -> Result<(), Value> 
     if idx >= 0.0 && idx <= u32::MAX as f64 {
         if let Value::Object(o) = base {
             let mut b = o.borrow_mut();
-            if b.props.is_empty() {
+            if b.own_is_empty() {
                 if let Internal::Array(arr) = &mut b.internal {
                     if let Some(slot) = arr.get_mut(idx as usize) {
                         if !matches!(slot, Value::Hole) {
@@ -365,7 +364,7 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         if let Value::Object(o) = &this {
             let start = {
                 let b = o.borrow();
-                if b.props.is_empty() && b.extensible {
+                if b.own_is_empty() && b.extensible {
                     match &b.internal {
                         Internal::Array(arr)
                             if arr.len() + args.len() <= crate::value::MAX_DENSE_ARRAY =>
@@ -413,7 +412,7 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         // prototype chain), as does an empty array's length write-back.
         if let Value::Object(o) = &this {
             let mut b = o.borrow_mut();
-            if b.props.is_empty() && b.extensible {
+            if b.own_is_empty() && b.extensible {
                 if let Internal::Array(arr) = &mut b.internal {
                     match arr.last() {
                         Some(v) if !matches!(v, Value::Hole) => {
@@ -1161,7 +1160,7 @@ fn install_proto_methods(vm: &mut Vm, proto: &JsObject) {
         let dense_ok = {
             let b = o.borrow();
             matches!(b.internal, Internal::Array(_))
-                && !b.props.keys().any(|k| k.array_index().is_some())
+                && !b.own_keys_iter().any(|k| k.array_index().is_some())
                 && matches!(&b.internal, Internal::Array(a) if !a.iter().any(|v| matches!(v, Value::Hole)))
         };
         if dense_ok {
@@ -1464,12 +1463,11 @@ fn install_unscopables(vm: &mut Vm, proto: &JsObject) {
             "toSpliced",
             "values",
         ] {
-            b.props
-                .insert(PropertyKey::str(name), Property::data(Value::Bool(true)));
+            b.own_insert(PropertyKey::str(name), Property::data(Value::Bool(true)));
         }
     }
     let sym = vm.realm.symbol_unscopables.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(sym),
         Property {
             kind: PropertyKind::Data {
@@ -1897,7 +1895,7 @@ fn install_iterator_protos(vm: &mut Vm) {
             };
             vm.builtin_iterator_next(&o)
         });
-        proto.borrow_mut().props.insert(
+        proto.borrow_mut().own_insert(
             PropertyKey::str("next"),
             Property::builtin(Value::Object(next_fn.clone())),
         );
@@ -1907,7 +1905,7 @@ fn install_iterator_protos(vm: &mut Vm) {
         // %XIteratorPrototype%[@@toStringTag] — non-writable, non-enumerable,
         // configurable.
         let sym = vm.realm.symbol_to_string_tag.clone();
-        proto.borrow_mut().props.insert(
+        proto.borrow_mut().own_insert(
             PropertyKey::Sym(sym),
             Property {
                 kind: PropertyKind::Data {

--- a/crates/chidori-js/src/builtins/async_builtins.rs
+++ b/crates/chidori-js/src/builtins/async_builtins.rs
@@ -79,7 +79,7 @@ fn install_promise(vm: &mut Vm) {
     // Promise.prototype[Symbol.toStringTag] = "Promise" (non-writable,
     // non-enumerable, configurable) when the engine has Symbol.toStringTag.
     let to_string_tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(to_string_tag),
         Property {
             kind: PropertyKind::Data {
@@ -426,11 +426,11 @@ fn perform_promise_all_settled(
                     let o = vm.new_object();
                     {
                         let mut b = o.borrow_mut();
-                        b.props.insert(
+                        b.own_insert(
                             PropertyKey::str("status"),
                             Property::data(Value::str(status)),
                         );
-                        b.props.insert(PropertyKey::str(key), Property::data(v));
+                        b.own_insert(PropertyKey::str(key), Property::data(v));
                     }
                     Value::Object(o)
                 };
@@ -594,11 +594,11 @@ fn make_aggregate_error(vm: &mut Vm, errors: Vec<Value>) -> Value {
     if let Value::Object(o) = &agg {
         let arr = vm.new_array(errors);
         let mut b = o.borrow_mut();
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("errors"),
             Property::data(Value::Object(arr)),
         );
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("name"),
             Property::builtin(Value::str("AggregateError")),
         );

--- a/crates/chidori-js/src/builtins/bigint.rs
+++ b/crates/chidori-js/src/builtins/bigint.rs
@@ -65,7 +65,7 @@ pub fn install(vm: &mut Vm) {
 
     // BigInt.prototype[Symbol.toStringTag] = "BigInt" (non-writable, configurable).
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {

--- a/crates/chidori-js/src/builtins/collections.rs
+++ b/crates/chidori-js/src/builtins/collections.rs
@@ -767,7 +767,7 @@ fn define_size_getter(vm: &mut Vm, proto: &JsObject, is_map: bool) {
 /// Install a non-enumerable, non-writable, configurable `Symbol.toStringTag`.
 fn define_to_string_tag(vm: &mut Vm, proto: &JsObject, tag: &str) {
     let sym = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(sym),
         Property {
             kind: PropertyKind::Data {

--- a/crates/chidori-js/src/builtins/date.rs
+++ b/crates/chidori-js/src/builtins/date.rs
@@ -1160,7 +1160,7 @@ pub fn install(vm: &mut Vm) {
     {
         // Symbol.toPrimitive is non-enumerable, non-writable, configurable.
         let mut b = proto.borrow_mut();
-        b.props.insert(
+        b.own_insert(
             PropertyKey::Sym(to_primitive_sym),
             Property {
                 kind: PropertyKind::Data {

--- a/crates/chidori-js/src/builtins/disposable.rs
+++ b/crates/chidori-js/src/builtins/disposable.rs
@@ -24,7 +24,7 @@ fn state_key(vm: &Vm) -> PropertyKey {
 fn stack_state(vm: &mut Vm, this: &Value) -> Result<JsObject, Value> {
     if let Value::Object(o) = this {
         let key = state_key(vm);
-        let found = o.borrow().props.get(&key).and_then(|p| match &p.kind {
+        let found = o.borrow().own_get(&key).and_then(|p| match &p.kind {
             PropertyKind::Data {
                 value: Value::Object(arr),
                 ..
@@ -57,8 +57,7 @@ fn new_stack(vm: &mut Vm, proto: &JsObject) -> JsObject {
     let o = vm.alloc_ordinary(Some(proto.clone()));
     let key = state_key(vm);
     o.borrow_mut()
-        .props
-        .insert(key, Property::builtin(Value::Object(arr)));
+        .own_insert(key, Property::builtin(Value::Object(arr)));
     o
 }
 
@@ -211,8 +210,7 @@ fn install_one(vm: &mut Vm, is_async: bool) {
     let tag = vm.realm.symbol_to_string_tag.clone();
     proto
         .borrow_mut()
-        .props
-        .insert(PropertyKey::Sym(tag), Property::builtin(Value::str(name)));
+        .own_insert(PropertyKey::Sym(tag), Property::builtin(Value::str(name)));
 }
 
 /// Run the disposers in reverse, chaining failures into a SuppressedError.
@@ -264,12 +262,12 @@ fn install_sync_dispose(vm: &mut Vm, proto: &JsObject, dispose_sym: &JsSymbol) {
         run_disposers(vm, disposers)?;
         Ok(Value::Undefined)
     });
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("dispose"),
         Property::builtin(Value::Object(dispose.clone())),
     );
     // `[Symbol.dispose]` is the same function object as `dispose`.
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(dispose_sym.clone()),
         Property::builtin(Value::Object(dispose)),
     );
@@ -380,11 +378,11 @@ fn install_async_dispose(vm: &mut Vm, proto: &JsObject, dispose_sym: &JsSymbol) 
         }
         Ok(Value::Object(result))
     });
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("disposeAsync"),
         Property::builtin(Value::Object(dispose.clone())),
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(dispose_sym.clone()),
         Property::builtin(Value::Object(dispose)),
     );

--- a/crates/chidori-js/src/builtins/fundamental.rs
+++ b/crates/chidori-js/src/builtins/fundamental.rs
@@ -136,8 +136,7 @@ fn array_exotic_current(b: &ObjectData, key: &PropertyKey) -> Option<Property> {
                     value: Value::Number(arr.len() as f64),
                     // length is writable unless the props map records otherwise.
                     writable: b
-                        .props
-                        .get(key)
+                        .own_get(key)
                         .map(
                             |p| matches!(&p.kind, PropertyKind::Data { writable, .. } if *writable),
                         )
@@ -278,7 +277,7 @@ fn define_own_property_inner(
     // Snapshot current state without holding the borrow across vm.* calls.
     let (current, extensible, is_array) = {
         let b = obj.borrow();
-        let cur = match b.props.get(key) {
+        let cur = match b.own_get(key) {
             Some(p) => Some(p.clone()),
             None => array_exotic_current(&b, key),
         };
@@ -306,7 +305,7 @@ fn define_own_property_inner(
                 };
                 (idx as usize) >= len
                     && matches!(
-                        b.props.get(&PropertyKey::str("length")),
+                        b.own_get(&PropertyKey::str("length")),
                         Some(Property {
                             kind: PropertyKind::Data {
                                 writable: false,
@@ -431,7 +430,7 @@ fn define_own_property_inner(
                 };
                 let mut block: Option<usize> = None;
                 if new_len < cur_len {
-                    for (k, p) in b.props.iter() {
+                    for (k, p) in b.own_iter() {
                         if let Some(idx) = k.array_index() {
                             let idx = idx as usize;
                             if idx >= new_len && idx < cur_len && !p.configurable {
@@ -448,19 +447,18 @@ fn define_own_property_inner(
                     arr.resize(k + 1, Value::Hole);
                 }
                 let drop_keys: Vec<PropertyKey> = b
-                    .props
-                    .keys()
+                    .own_keys_iter()
                     .filter(|kk| kk.array_index().is_some_and(|i| (i as usize) > k))
                     .cloned()
                     .collect();
                 for kk in drop_keys {
-                    b.props.shift_remove(&kk);
+                    b.own_remove(&kk);
                 }
                 // A deferred `writable: false` still applies — with the length
                 // where deletion stopped — even though the define FAILS
                 // (ArraySetLength steps 19.d.i-ii).
                 if d.writable == Some(false) {
-                    b.props.insert(
+                    b.own_insert(
                         PropertyKey::str("length"),
                         Property {
                             kind: PropertyKind::Data {
@@ -545,7 +543,7 @@ pub(crate) fn create_data_index(
 ) -> Result<(), Value> {
     {
         let mut b = obj.borrow_mut();
-        if b.extensible && b.props.is_empty() {
+        if b.extensible && b.own_is_empty() {
             if let Internal::Array(arr) = &mut b.internal {
                 let i = idx as usize;
                 match i.cmp(&arr.len()) {
@@ -700,7 +698,7 @@ fn store_property(
                 // Record non-writable length as a marker property so that
                 // freeze/isFrozen and the writable invariant are observable.
                 if !*writable {
-                    obj.borrow_mut().props.insert(
+                    obj.borrow_mut().own_insert(
                         key.clone(),
                         Property {
                             kind: PropertyKind::Data {
@@ -712,7 +710,7 @@ fn store_property(
                         },
                     );
                 } else {
-                    obj.borrow_mut().props.shift_remove(key);
+                    obj.borrow_mut().own_remove(key);
                 }
                 return Ok(());
             }
@@ -739,7 +737,7 @@ fn store_property(
                             }
                             arr[idx] = value.clone();
                         }
-                        b.props.shift_remove(key);
+                        b.own_remove(key);
                         return Ok(());
                     }
                 }
@@ -765,7 +763,7 @@ fn store_property(
             }
         }
     }
-    obj.borrow_mut().props.insert(key.clone(), prop);
+    obj.borrow_mut().own_insert(key.clone(), prop);
     Ok(())
 }
 
@@ -827,7 +825,7 @@ fn install_object(vm: &mut Vm) {
             return Ok(Value::Bool(false));
         }
         let b = o.borrow();
-        let e = match b.props.get(&key) {
+        let e = match b.own_get(&key) {
             Some(p) => p.enumerable,
             None => match &b.internal {
                 Internal::Array(arr) => key
@@ -918,7 +916,7 @@ fn install_object(vm: &mut Vm) {
         }
         Ok(Value::Undefined)
     });
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("__proto__"),
         Property {
             kind: PropertyKind::Accessor {
@@ -1031,8 +1029,7 @@ fn install_object(vm: &mut Vm) {
         for (key, elements) in groups {
             let arr = vm.new_array(elements);
             obj.borrow_mut()
-                .props
-                .insert(key, Property::data(Value::Object(arr)));
+                .own_insert(key, Property::data(Value::Object(arr)));
         }
         Ok(Value::Object(obj))
     });
@@ -1241,7 +1238,7 @@ fn install_object_extra(vm: &mut Vm) {
             let prop = own_property_descriptor(&o, &key);
             if let Some(p) = prop {
                 let desc = descriptor_to_object(vm, &p);
-                result.borrow_mut().props.insert(key, Property::data(desc));
+                result.borrow_mut().own_insert(key, Property::data(desc));
             }
         }
         Ok(Value::Object(result))
@@ -1361,11 +1358,10 @@ pub(crate) fn set_integrity_level(vm: &mut Vm, o: &JsObject, frozen: bool) -> Re
         if let Internal::Array(arr) = &b.internal {
             let len = arr.len() as f64;
             let cur_writable = b
-                .props
-                .get(&PropertyKey::str("length"))
+                .own_get(&PropertyKey::str("length"))
                 .map(|p| matches!(&p.kind, PropertyKind::Data { writable, .. } if *writable))
                 .unwrap_or(true);
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("length"),
                 Property {
                     kind: PropertyKind::Data {
@@ -1464,7 +1460,7 @@ fn lookup_accessor(
         }
         let next = {
             let b = obj.borrow();
-            if let Some(p) = b.props.get(key) {
+            if let Some(p) = b.own_get(key) {
                 return Ok(match &p.kind {
                     PropertyKind::Accessor { get, set } => {
                         let f = if want_get { get } else { set };
@@ -1661,7 +1657,7 @@ fn enumerable_own_strings_dyn(vm: &mut Vm, o: &JsObject) -> Result<Vec<JsString>
 
 fn own_property_exists(o: &JsObject, key: &PropertyKey) -> bool {
     let b = o.borrow();
-    if b.props.contains_key(key) {
+    if b.own_contains_key(key) {
         return true;
     }
     match &b.internal {
@@ -1698,7 +1694,7 @@ fn own_property_exists(o: &JsObject, key: &PropertyKey) -> bool {
 /// index/length slots reified into `Property` values.
 pub(crate) fn own_property_descriptor(o: &JsObject, key: &PropertyKey) -> Option<Property> {
     let b = o.borrow();
-    if let Some(p) = b.props.get(key) {
+    if let Some(p) = b.own_get(key) {
         let mut p = p.clone();
         // Mapped arguments: the descriptor's value reads the parameter cell.
         if let Internal::Arguments(map) = &b.internal {
@@ -1838,7 +1834,7 @@ fn define_properties(vm: &mut Vm, obj: &JsObject, props: &Value) -> Result<(), V
             }
         } else {
             let b = po.borrow();
-            match b.props.get(&k) {
+            match b.own_get(&k) {
                 Some(p) => p.enumerable,
                 None => match &b.internal {
                     Internal::Array(arr) => k
@@ -1873,29 +1869,28 @@ pub(crate) fn descriptor_to_object(vm: &mut Vm, p: &Property) -> Value {
         let mut b = o.borrow_mut();
         match &p.kind {
             PropertyKind::Data { value, writable } => {
-                b.props
-                    .insert(PropertyKey::str("value"), Property::data(value.clone()));
-                b.props.insert(
+                b.own_insert(PropertyKey::str("value"), Property::data(value.clone()));
+                b.own_insert(
                     PropertyKey::str("writable"),
                     Property::data(Value::Bool(*writable)),
                 );
             }
             PropertyKind::Accessor { get, set } => {
-                b.props.insert(
+                b.own_insert(
                     PropertyKey::str("get"),
                     Property::data(get.clone().unwrap_or(Value::Undefined)),
                 );
-                b.props.insert(
+                b.own_insert(
                     PropertyKey::str("set"),
                     Property::data(set.clone().unwrap_or(Value::Undefined)),
                 );
             }
         }
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("enumerable"),
             Property::data(Value::Bool(p.enumerable)),
         );
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("configurable"),
             Property::data(Value::Bool(p.configurable)),
         );
@@ -1972,7 +1967,7 @@ fn install_function(vm: &mut Vm) {
         ));
         {
             let mut b = bound.borrow_mut();
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("length"),
                 Property {
                     kind: PropertyKind::Data {
@@ -1983,7 +1978,7 @@ fn install_function(vm: &mut Vm) {
                     configurable: true,
                 },
             );
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("name"),
                 Property {
                     kind: PropertyKind::Data {
@@ -2022,7 +2017,7 @@ fn install_function(vm: &mut Vm) {
         Ok(Value::Bool(r))
     });
     // @@hasInstance is non-writable, non-enumerable, NON-configurable.
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(has_instance),
         Property {
             kind: PropertyKind::Data {
@@ -2041,7 +2036,7 @@ fn install_function(vm: &mut Vm) {
         } else {
             Value::str("")
         };
-        proto.borrow_mut().props.insert(
+        proto.borrow_mut().own_insert(
             PropertyKey::str(k),
             Property {
                 kind: PropertyKind::Data {
@@ -2115,7 +2110,7 @@ fn install_symbol(vm: &mut Vm) {
     ];
     for (name, sym) in pairs {
         // Well-known symbols are non-writable, non-enumerable, non-configurable.
-        ctor.borrow_mut().props.insert(
+        ctor.borrow_mut().own_insert(
             PropertyKey::str(name),
             Property {
                 kind: PropertyKind::Data {
@@ -2176,7 +2171,7 @@ fn install_symbol(vm: &mut Vm) {
                 _ => Err(vm.throw_type("Symbol.prototype.description requires a symbol")),
             }
         });
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("description"),
         Property {
             kind: PropertyKind::Accessor {
@@ -2198,7 +2193,7 @@ fn install_symbol(vm: &mut Vm) {
             _ => Err(vm.throw_type("Symbol.prototype[Symbol.toPrimitive] requires a symbol")),
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(to_primitive_sym),
         Property {
             kind: PropertyKind::Data {
@@ -2212,7 +2207,7 @@ fn install_symbol(vm: &mut Vm) {
 
     // Symbol.prototype[Symbol.toStringTag] = "Symbol".
     let to_string_tag_sym = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(to_string_tag_sym),
         Property {
             kind: PropertyKind::Data {
@@ -2338,11 +2333,11 @@ fn install_errors(vm: &mut Vm) {
 fn install_suppressed_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
     let proto = vm.alloc_ordinary(Some(vm.realm.error_proto.clone()));
     proto.borrow_mut().internal = Internal::Error;
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("name"),
         Property::builtin(Value::str("SuppressedError")),
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("message"),
         Property::builtin(Value::str("")),
     );
@@ -2358,7 +2353,7 @@ fn install_suppressed_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
         let msg = arg(args, 2);
         if !msg.is_undefined() {
             let s = vm.to_js_string(&msg)?;
-            o.borrow_mut().props.insert(
+            o.borrow_mut().own_insert(
                 PropertyKey::str("message"),
                 Property::builtin(Value::String(s)),
             );
@@ -2366,9 +2361,8 @@ fn install_suppressed_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
         // `error` (1st arg) and `suppressed` (2nd arg) are non-enumerable,
         // writable, configurable own data properties.
         o.borrow_mut()
-            .props
-            .insert(PropertyKey::str("error"), Property::builtin(arg(args, 0)));
-        o.borrow_mut().props.insert(
+            .own_insert(PropertyKey::str("error"), Property::builtin(arg(args, 0)));
+        o.borrow_mut().own_insert(
             PropertyKey::str("suppressed"),
             Property::builtin(arg(args, 1)),
         );
@@ -2393,11 +2387,11 @@ fn install_suppressed_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
 fn install_error_kind(vm: &mut Vm, proto: &JsObject, name: &str) -> JsObject {
     proto.borrow_mut().internal = Internal::Error;
     // name and message are non-enumerable data properties on the prototype.
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("name"),
         Property::builtin(Value::str(name)),
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("message"),
         Property::builtin(Value::str("")),
     );
@@ -2452,7 +2446,7 @@ fn make_error_obj(vm: &mut Vm, proto: &JsObject, args: &[Value]) -> Result<Value
     if !msg.is_undefined() {
         // ToString(message) is observable and throws for e.g. a Symbol.
         let s = vm.to_js_string(&msg)?;
-        o.borrow_mut().props.insert(
+        o.borrow_mut().own_insert(
             PropertyKey::str("message"),
             Property::builtin(Value::String(s)),
         );
@@ -2470,8 +2464,7 @@ fn install_error_options(vm: &mut Vm, o: &JsObject, options: Value) -> Result<()
         if has_cause {
             let cause = vm.get_prop(&Value::Object(opts.clone()), &PropertyKey::str("cause"))?;
             o.borrow_mut()
-                .props
-                .insert(PropertyKey::str("cause"), Property::builtin(cause));
+                .own_insert(PropertyKey::str("cause"), Property::builtin(cause));
         }
     }
     Ok(())
@@ -2485,12 +2478,11 @@ fn install_error_stack(vm: &mut Vm, o: &JsObject) {
         .unwrap_or_else(|_| "Error".into());
     let m = o
         .borrow()
-        .props
-        .get(&PropertyKey::str("message"))
+        .own_get(&PropertyKey::str("message"))
         .and_then(|p| p.value().cloned())
         .map(|v| vm.to_string_lossy(&v))
         .unwrap_or_default();
-    o.borrow_mut().props.insert(
+    o.borrow_mut().own_insert(
         PropertyKey::str("stack"),
         Property::builtin(Value::str(if m.is_empty() {
             name
@@ -2504,11 +2496,11 @@ fn install_error_stack(vm: &mut Vm, o: &JsObject) {
 fn install_aggregate_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
     let proto = vm.alloc_ordinary(Some(vm.realm.error_proto.clone()));
     proto.borrow_mut().internal = Internal::Error;
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("name"),
         Property::builtin(Value::str("AggregateError")),
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("message"),
         Property::builtin(Value::str("")),
     );
@@ -2524,7 +2516,7 @@ fn install_aggregate_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
         let msg = arg(args, 1);
         if !msg.is_undefined() {
             let s = vm.to_js_string(&msg)?;
-            o.borrow_mut().props.insert(
+            o.borrow_mut().own_insert(
                 PropertyKey::str("message"),
                 Property::builtin(Value::String(s)),
             );
@@ -2533,7 +2525,7 @@ fn install_aggregate_error(vm: &mut Vm, error_ctor: Option<&JsObject>) {
         // 1st argument is the iterable of errors.
         let errors = vm.iterate_to_vec(&arg(args, 0))?;
         let arr = vm.new_array(errors);
-        o.borrow_mut().props.insert(
+        o.borrow_mut().own_insert(
             PropertyKey::str("errors"),
             Property::builtin(Value::Object(arr)),
         );

--- a/crates/chidori-js/src/builtins/intl.rs
+++ b/crates/chidori-js/src/builtins/intl.rs
@@ -36,7 +36,7 @@ pub fn install(vm: &mut Vm) {
 
     // Intl[Symbol.toStringTag] = "Intl" (non-writable, non-enumerable, configurable).
     let tag = vm.realm.symbol_to_string_tag.clone();
-    intl.borrow_mut().props.insert(
+    intl.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -127,7 +127,7 @@ fn to_length(vm: &mut Vm, v: &Value) -> Result<u64, Value> {
 /// True when `v` is an object carrying the `[[InitializedLocale]]` brand.
 fn is_locale(vm: &Vm, v: &Value) -> bool {
     matches!(v, Value::Object(o)
-        if o.borrow().props.contains_key(&PropertyKey::Sym(vm.realm.symbol_intl_locale.clone())))
+        if o.borrow().own_contains_key(&PropertyKey::Sym(vm.realm.symbol_intl_locale.clone())))
 }
 
 /// The stored `[[Locale]]` canonical tag of an Intl.Locale, if `v` is one.
@@ -135,8 +135,7 @@ fn locale_internal(vm: &Vm, v: &Value) -> Option<String> {
     let Value::Object(o) = v else { return None };
     match o
         .borrow()
-        .props
-        .get(&PropertyKey::Sym(vm.realm.symbol_intl_locale.clone()))
+        .own_get(&PropertyKey::Sym(vm.realm.symbol_intl_locale.clone()))
     {
         Some(Property {
             kind:
@@ -163,7 +162,7 @@ fn locale_of(vm: &mut Vm, this: &Value) -> Result<Locale, Value> {
 /// canonical `tag` string.
 fn new_locale_object(vm: &Vm, tag: String, proto: &JsObject) -> Value {
     let o = vm.alloc(ObjectData::new(Some(proto.clone()), Internal::Ordinary));
-    o.borrow_mut().props.insert(
+    o.borrow_mut().own_insert(
         PropertyKey::Sym(vm.realm.symbol_intl_locale.clone()),
         Property {
             kind: PropertyKind::Data {
@@ -333,7 +332,7 @@ fn install_locale(vm: &mut Vm, intl: &JsObject) {
 
     // Intl.Locale.prototype (non-writable, non-enumerable, non-configurable) and
     // its back-reference.
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -344,7 +343,7 @@ fn install_locale(vm: &mut Vm, intl: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -425,7 +424,7 @@ fn install_locale(vm: &mut Vm, intl: &JsObject) {
 
     // Intl.Locale.prototype[Symbol.toStringTag] = "Intl.Locale"
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -437,7 +436,7 @@ fn install_locale(vm: &mut Vm, intl: &JsObject) {
         },
     );
 
-    intl.borrow_mut().props.insert(
+    intl.borrow_mut().own_insert(
         PropertyKey::str("Locale"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -485,7 +484,7 @@ fn coerce_options(vm: &mut Vm, options: Value) -> Result<Value, Value> {
 /// Insert an enumerable, writable, configurable data property (the
 /// `CreateDataPropertyOrThrow` used to build a `resolvedOptions` result).
 fn data_prop(target: &JsObject, key: &str, value: Value) {
-    target.borrow_mut().props.insert(
+    target.borrow_mut().own_insert(
         PropertyKey::str(key),
         Property {
             kind: PropertyKind::Data {
@@ -589,7 +588,7 @@ fn set_digit_options(
 
 /// Read a string field of the internal PluralRules record.
 fn rec_str(rec: &JsObject, key: &str) -> String {
-    match rec.borrow().props.get(&PropertyKey::str(key)) {
+    match rec.borrow().own_get(&PropertyKey::str(key)) {
         Some(Property {
             kind:
                 PropertyKind::Data {
@@ -604,7 +603,7 @@ fn rec_str(rec: &JsObject, key: &str) -> String {
 
 /// Read a numeric field of the internal PluralRules record (`None` if absent).
 fn rec_num(rec: &JsObject, key: &str) -> Option<u32> {
-    match rec.borrow().props.get(&PropertyKey::str(key)) {
+    match rec.borrow().own_get(&PropertyKey::str(key)) {
         Some(Property {
             kind:
                 PropertyKind::Data {
@@ -622,8 +621,7 @@ fn plural_record(vm: &Vm, this: &Value) -> Option<JsObject> {
     let Value::Object(o) = this else { return None };
     match o
         .borrow()
-        .props
-        .get(&PropertyKey::Sym(vm.realm.symbol_intl_plural_rules.clone()))
+        .own_get(&PropertyKey::Sym(vm.realm.symbol_intl_plural_rules.clone()))
     {
         Some(Property {
             kind:
@@ -769,7 +767,7 @@ fn construct_plural_rules(vm: &mut Vm, args: &[Value], proto: &JsObject) -> Resu
     {
         let mut b = rec.borrow_mut();
         let mut put = |k: &str, v: Value| {
-            b.props.insert(PropertyKey::str(k), Property::builtin(v));
+            b.own_insert(PropertyKey::str(k), Property::builtin(v));
         };
         put("locale", Value::str(locale));
         put("type", Value::str(typ));
@@ -797,7 +795,7 @@ fn construct_plural_rules(vm: &mut Vm, args: &[Value], proto: &JsObject) -> Resu
     }
 
     let o = vm.alloc(ObjectData::new(Some(proto.clone()), Internal::Ordinary));
-    o.borrow_mut().props.insert(
+    o.borrow_mut().own_insert(
         PropertyKey::Sym(vm.realm.symbol_intl_plural_rules.clone()),
         Property {
             kind: PropertyKind::Data {
@@ -820,7 +818,7 @@ fn install_plural_rules(vm: &mut Vm, intl: &JsObject) {
         |vm, _t, _a| Err(vm.throw_type("Constructor Intl.PluralRules requires 'new'")),
         move |vm, _this, args| construct_plural_rules(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -831,7 +829,7 @@ fn install_plural_rules(vm: &mut Vm, intl: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -950,7 +948,7 @@ fn install_plural_rules(vm: &mut Vm, intl: &JsObject) {
 
     // Intl.PluralRules.prototype[Symbol.toStringTag] = "Intl.PluralRules"
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -962,7 +960,7 @@ fn install_plural_rules(vm: &mut Vm, intl: &JsObject) {
         },
     );
 
-    intl.borrow_mut().props.insert(
+    intl.borrow_mut().own_insert(
         PropertyKey::str("PluralRules"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -978,7 +976,7 @@ use icu_decimal::DecimalFormatter;
 /// The internal record object of an Intl.NumberFormat receiver, if `this` is one.
 fn nf_record(vm: &Vm, this: &Value) -> Option<JsObject> {
     let Value::Object(o) = this else { return None };
-    match o.borrow().props.get(&PropertyKey::Sym(
+    match o.borrow().own_get(&PropertyKey::Sym(
         vm.realm.symbol_intl_number_format.clone(),
     )) {
         Some(Property {
@@ -1415,7 +1413,7 @@ fn construct_number_format(vm: &mut Vm, args: &[Value], proto: &JsObject) -> Res
     {
         let mut b = rec.borrow_mut();
         let mut put = |k: &str, v: Value| {
-            b.props.insert(PropertyKey::str(k), Property::builtin(v));
+            b.own_insert(PropertyKey::str(k), Property::builtin(v));
         };
         put("locale", Value::str(locale));
         if let Some(nu) = &numbering_system {
@@ -1458,7 +1456,7 @@ fn construct_number_format(vm: &mut Vm, args: &[Value], proto: &JsObject) -> Res
     }
 
     let o = vm.alloc(ObjectData::new(Some(proto.clone()), Internal::Ordinary));
-    o.borrow_mut().props.insert(
+    o.borrow_mut().own_insert(
         PropertyKey::Sym(vm.realm.symbol_intl_number_format.clone()),
         Property {
             kind: PropertyKind::Data {
@@ -1510,7 +1508,7 @@ fn install_number_format(vm: &mut Vm, intl: &JsObject) {
         move |vm, _t, args| construct_number_format(vm, args, &call_proto),
         move |vm, _this, args| construct_number_format(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -1521,7 +1519,7 @@ fn install_number_format(vm: &mut Vm, intl: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -1540,8 +1538,7 @@ fn install_number_format(vm: &mut Vm, intl: &JsObject) {
         })?;
         let cached = rec
             .borrow()
-            .props
-            .get(&PropertyKey::str("boundFormat"))
+            .own_get(&PropertyKey::str("boundFormat"))
             .and_then(|p| match &p.kind {
                 PropertyKind::Data { value, .. } => Some(value.clone()),
                 _ => None,
@@ -1554,7 +1551,7 @@ fn install_number_format(vm: &mut Vm, intl: &JsObject) {
             let n = nf_input(vm, &arg(args, 0))?;
             Ok(Value::str(nf_format(&bound_rec, n)))
         });
-        rec.borrow_mut().props.insert(
+        rec.borrow_mut().own_insert(
             PropertyKey::str("boundFormat"),
             Property::builtin(Value::Object(bound.clone())),
         );
@@ -1649,7 +1646,7 @@ fn install_number_format(vm: &mut Vm, intl: &JsObject) {
     // call it as a method, which the data method above satisfies.)
 
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -1661,7 +1658,7 @@ fn install_number_format(vm: &mut Vm, intl: &JsObject) {
         },
     );
 
-    intl.borrow_mut().props.insert(
+    intl.borrow_mut().own_insert(
         PropertyKey::str("NumberFormat"),
         Property::builtin(Value::Object(ctor)),
     );

--- a/crates/chidori-js/src/builtins/mod.rs
+++ b/crates/chidori-js/src/builtins/mod.rs
@@ -88,10 +88,8 @@ fn install_restricted_properties(vm: &mut Vm) {
     ));
     {
         let mut b = tte.borrow_mut();
-        b.props
-            .insert(PropertyKey::str("length"), frozen(Value::Number(0.0)));
-        b.props
-            .insert(PropertyKey::str("name"), frozen(Value::str("")));
+        b.own_insert(PropertyKey::str("length"), frozen(Value::Number(0.0)));
+        b.own_insert(PropertyKey::str("name"), frozen(Value::str("")));
         b.extensible = false;
     }
     vm.realm.throw_type_error = tte.clone();
@@ -106,8 +104,8 @@ fn install_restricted_properties(vm: &mut Vm) {
     };
     let fp = vm.realm.function_proto.clone();
     let mut b = fp.borrow_mut();
-    b.props.insert(PropertyKey::str("caller"), poison.clone());
-    b.props.insert(PropertyKey::str("arguments"), poison);
+    b.own_insert(PropertyKey::str("caller"), poison.clone());
+    b.own_insert(PropertyKey::str("arguments"), poison);
 }
 
 // ---- function-kind intrinsics (%GeneratorFunction% etc.) ----
@@ -169,7 +167,7 @@ fn install_kind_function(
     // [[Prototype]] of the constructor is %Function% (the Function constructor).
     ctor.borrow_mut().proto = Some(function_ctor.clone());
     // Constructor.prototype = func_proto (non-writable, non-enumerable, non-config).
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -182,12 +180,10 @@ fn install_kind_function(
     );
     {
         let mut fp = func_proto.borrow_mut();
-        fp.props
-            .insert(PropertyKey::str("constructor"), ro_c(Value::Object(ctor)));
-        fp.props
-            .insert(tag_key.clone(), ro_c(Value::str(ctor_name)));
+        fp.own_insert(PropertyKey::str("constructor"), ro_c(Value::Object(ctor)));
+        fp.own_insert(tag_key.clone(), ro_c(Value::str(ctor_name)));
         if let Some((ip, _)) = &instance {
-            fp.props.insert(
+            fp.own_insert(
                 PropertyKey::str("prototype"),
                 ro_c(Value::Object(ip.clone())),
             );
@@ -195,11 +191,11 @@ fn install_kind_function(
     }
     if let Some((ip, instance_tag)) = instance {
         let mut ipb = ip.borrow_mut();
-        ipb.props.insert(
+        ipb.own_insert(
             PropertyKey::str("constructor"),
             ro_c(Value::Object(func_proto)),
         );
-        ipb.props.insert(tag_key, ro_c(Value::str(instance_tag)));
+        ipb.own_insert(tag_key, ro_c(Value::str(instance_tag)));
     }
 }
 
@@ -242,8 +238,7 @@ fn inspect_object(vm: &mut Vm, o: &JsObject, depth: usize, seen: &mut Vec<usize>
         let b = o.borrow();
         if b.is_callable() {
             let name = b
-                .props
-                .get(&PropertyKey::str("name"))
+                .own_get(&PropertyKey::str("name"))
                 .and_then(|p| p.value().cloned())
                 .and_then(|v| v.as_str().map(|s| s.to_string()))
                 .unwrap_or_default();
@@ -528,8 +523,7 @@ fn deep_clone(vm: &mut Vm, v: &Value) -> Result<Value, Value> {
                     let val = vm.get_prop(v, &PropertyKey::Str(k.clone()))?;
                     let cloned = deep_clone(vm, &val)?;
                     no.borrow_mut()
-                        .props
-                        .insert(PropertyKey::Str(k), Property::data(cloned));
+                        .own_insert(PropertyKey::Str(k), Property::data(cloned));
                 }
                 Ok(Value::Object(no))
             }

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -894,6 +894,8 @@ fn install_json(vm: &mut Vm) {
             pos: 0,
             src: s.as_str(),
             keys: Default::default(),
+            shape_paths: Vec::new(),
+            depth: 0,
         };
         p.skip_ws();
         let v = p.parse_value(vm)?;
@@ -1130,6 +1132,16 @@ struct JsonParser<'a> {
         PropertyKey,
         std::hash::BuildHasherDefault<crate::fxhash::FxHasher>,
     >,
+    /// Record-shape cursor (docs/js-object-shapes-design.md §3.3): per
+    /// object-nesting depth, the shape chain (first key → leaf) of the last
+    /// COMPLETED object at that depth. The dominant JSON input — an array of
+    /// same-structure records — makes every record after the first advance
+    /// this path with one parent-pointer + key compare per key (interned
+    /// keys hit the `Rc` fast path), skipping the transition-table hash;
+    /// the object is then one slot-vec allocation. Depth-indexed so nested
+    /// records don't clobber their parent's cursor mid-object.
+    shape_paths: Vec<Vec<std::rc::Rc<crate::shape::Shape>>>,
+    depth: usize,
 }
 
 impl<'a> JsonParser<'a> {
@@ -1391,12 +1403,33 @@ impl<'a> JsonParser<'a> {
 
     fn parse_object(&mut self, vm: &mut Vm) -> Result<Value, Value> {
         self.pos += 1;
-        let obj = vm.new_object();
         self.skip_ws();
         if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
             self.pos += 1;
-            return Ok(Value::Object(obj));
+            return Ok(Value::Object(vm.new_object()));
         }
+        self.depth += 1;
+        if self.shape_paths.len() < self.depth {
+            self.shape_paths.push(Vec::new());
+        }
+        let r = self.parse_object_members(vm);
+        self.depth -= 1;
+        r
+    }
+
+    /// The member loop of a NON-EMPTY object, accumulated locally: keys and
+    /// values build a (shape, slots) pair directly — the object materializes
+    /// with ONE allocation (the slot vec) at the closing brace. The
+    /// record-shape cursor (`shape_paths`, see the field docs) makes a
+    /// repeat of the previous record's key sequence advance by pointer
+    /// compares alone; a divergent key falls back to the memoized
+    /// transition tree, and duplicate/index-spam keys take the same
+    /// replace/demote edges as `ObjectData::own_insert`.
+    fn parse_object_members(&mut self, vm: &mut Vm) -> Result<Value, Value> {
+        let mut shape = vm.realm.shape_root.clone();
+        let mut slots: Vec<Property> = Vec::with_capacity(8);
+        let mut dict: Option<crate::fxhash::FxIndexMap<PropertyKey, Property>> = None;
+        let mut on_path = true;
         loop {
             self.skip_ws();
             if self.pos >= self.bytes.len() || self.bytes[self.pos] != b'"' {
@@ -1409,14 +1442,39 @@ impl<'a> JsonParser<'a> {
             }
             self.pos += 1;
             let v = self.parse_value(vm)?;
-            {
-                let mut b = obj.borrow_mut();
-                // One up-front table allocation covers the common ≤8-member
-                // object instead of the 0→3→7 growth (two allocs + a rehash).
-                if b.own_capacity() == 0 {
-                    b.own_reserve(8);
+            let prop = Property::data(v);
+            if let Some(map) = &mut dict {
+                map.insert(key, prop);
+            } else {
+                let cursor_hit = on_path
+                    .then(|| self.shape_paths[self.depth - 1].get(slots.len()))
+                    .flatten()
+                    .filter(|next| next.appends(&shape, &key))
+                    .cloned();
+                if let Some(next) = cursor_hit {
+                    shape = next;
+                    slots.push(prop);
+                } else if let Some(slot) = shape.lookup(&key) {
+                    // Duplicate key: last value wins, first position kept
+                    // (CreateDataProperty on an existing key).
+                    slots[slot as usize] = prop;
+                } else if crate::shape::Shape::can_append(&key, slots.len()) {
+                    on_path = false;
+                    shape = shape.transition(key);
+                    slots.push(prop);
+                } else {
+                    // Integer-key spam: same demotion edge as own_insert.
+                    on_path = false;
+                    let mut map = crate::fxhash::FxIndexMap::with_capacity_and_hasher(
+                        slots.len() + 1,
+                        Default::default(),
+                    );
+                    for (k, p) in shape.keys_in_order().into_iter().zip(slots.drain(..)) {
+                        map.insert(k.clone(), p);
+                    }
+                    map.insert(key, prop);
+                    dict = Some(map);
                 }
-                b.own_insert(key, Property::data(v));
             }
             self.skip_ws();
             if self.pos >= self.bytes.len() {
@@ -1431,6 +1489,21 @@ impl<'a> JsonParser<'a> {
                 _ => return Err(vm.throw_syntax("Expected ',' or '}' in JSON object")),
             }
         }
+        let proto = Some(vm.realm.object_proto.clone());
+        let obj = match dict {
+            Some(map) => {
+                let mut data = ObjectData::new(proto, Internal::Ordinary);
+                data.set_props_map(map);
+                vm.alloc(data)
+            }
+            None => {
+                if !on_path {
+                    // Remember this record's chain for its siblings.
+                    self.shape_paths[self.depth - 1] = shape.path_from_root();
+                }
+                vm.alloc(ObjectData::new_shaped_with(proto, shape, slots))
+            }
+        };
         Ok(Value::Object(obj))
     }
 }

--- a/crates/chidori-js/src/builtins/numbers.rs
+++ b/crates/chidori-js/src/builtins/numbers.rs
@@ -708,7 +708,7 @@ fn install_math(vm: &mut Vm) {
 
     // Math[Symbol.toStringTag] = "Math" (non-writable, non-enumerable, configurable).
     let tag = vm.realm.symbol_to_string_tag.clone();
-    math.borrow_mut().props.insert(
+    math.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -730,8 +730,7 @@ fn install_math(vm: &mut Vm) {
         .map(|k| {
             match math
                 .borrow()
-                .props
-                .get(&PropertyKey::str(k.name()))
+                .own_get(&PropertyKey::str(k.name()))
                 .and_then(|p| p.value().cloned())
             {
                 Some(Value::Object(o)) => o,
@@ -908,8 +907,7 @@ fn install_json(vm: &mut Vm) {
             let holder = vm.new_object();
             holder
                 .borrow_mut()
-                .props
-                .insert(PropertyKey::str(""), Property::data(v));
+                .own_insert(PropertyKey::str(""), Property::data(v));
             return json_revive(vm, &holder, "", &reviver);
         }
         Ok(v)
@@ -932,8 +930,7 @@ fn install_json(vm: &mut Vm) {
         let holder = vm.new_object();
         holder
             .borrow_mut()
-            .props
-            .insert(PropertyKey::str(""), Property::data(value));
+            .own_insert(PropertyKey::str(""), Property::data(value));
         let mut out = String::with_capacity(128);
         let root_key = JsString::from("");
         if json_stringify(
@@ -951,7 +948,7 @@ fn install_json(vm: &mut Vm) {
     });
     // JSON[Symbol.toStringTag] = "JSON" (non-writable, non-enumerable, configurable).
     let tag = vm.realm.symbol_to_string_tag.clone();
-    json.borrow_mut().props.insert(
+    json.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -1416,10 +1413,10 @@ impl<'a> JsonParser<'a> {
                 let mut b = obj.borrow_mut();
                 // One up-front table allocation covers the common ≤8-member
                 // object instead of the 0→3→7 growth (two allocs + a rehash).
-                if b.props.capacity() == 0 {
-                    b.props.reserve(8);
+                if b.own_capacity() == 0 {
+                    b.own_reserve(8);
                 }
-                b.props.insert(key, Property::data(v));
+                b.own_insert(key, Property::data(v));
             }
             self.skip_ws();
             if self.pos >= self.bytes.len() {

--- a/crates/chidori-js/src/builtins/reflect.rs
+++ b/crates/chidori-js/src/builtins/reflect.rs
@@ -267,7 +267,7 @@ fn reflect_get(
                     }
                 }
             }
-            b.props.get(key).cloned()
+            b.own_get(key).cloned()
         };
         match found {
             Some(prop) => match prop.kind {
@@ -352,7 +352,7 @@ pub(crate) fn reflect_set(
         }
         let kind = {
             let b = cur.borrow();
-            b.props.get(key).map(|p| match &p.kind {
+            b.own_get(key).map(|p| match &p.kind {
                 PropertyKind::Accessor { set, .. } => DescKind::Accessor(set.clone()),
                 PropertyKind::Data { writable, .. } => DescKind::Data(*writable),
             })
@@ -476,29 +476,28 @@ fn descriptor_to_object(vm: &mut Vm, p: &Property) -> Value {
         let mut b = o.borrow_mut();
         match &p.kind {
             PropertyKind::Data { value, writable } => {
-                b.props
-                    .insert(PropertyKey::str("value"), Property::data(value.clone()));
-                b.props.insert(
+                b.own_insert(PropertyKey::str("value"), Property::data(value.clone()));
+                b.own_insert(
                     PropertyKey::str("writable"),
                     Property::data(Value::Bool(*writable)),
                 );
             }
             PropertyKind::Accessor { get, set } => {
-                b.props.insert(
+                b.own_insert(
                     PropertyKey::str("get"),
                     Property::data(get.clone().unwrap_or(Value::Undefined)),
                 );
-                b.props.insert(
+                b.own_insert(
                     PropertyKey::str("set"),
                     Property::data(set.clone().unwrap_or(Value::Undefined)),
                 );
             }
         }
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("enumerable"),
             Property::data(Value::Bool(p.enumerable)),
         );
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("configurable"),
             Property::data(Value::Bool(p.configurable)),
         );

--- a/crates/chidori-js/src/builtins/regexp_builtin.rs
+++ b/crates/chidori-js/src/builtins/regexp_builtin.rs
@@ -375,11 +375,7 @@ fn encode_for_regexp_escape(c: char) -> String {
 
 fn regexp_this(vm: &mut Vm, this: &Value) -> Result<JsObject, Value> {
     match this {
-        Value::Object(o)
-            if o.borrow()
-                .props
-                .contains_key(&PropertyKey::str(REGEXP_MARK)) =>
-        {
+        Value::Object(o) if o.borrow().own_contains_key(&PropertyKey::str(REGEXP_MARK)) => {
             Ok(o.clone())
         }
         _ => Err(vm.throw_type("Method RegExp.prototype called on incompatible receiver")),
@@ -467,11 +463,7 @@ fn regexp_exec_abstract(vm: &mut Vm, rx: &Value, s: &JsString) -> Result<Value, 
         return Ok(result);
     }
     let o = match rx {
-        Value::Object(o)
-            if o.borrow()
-                .props
-                .contains_key(&PropertyKey::str(REGEXP_MARK)) =>
-        {
+        Value::Object(o) if o.borrow().own_contains_key(&PropertyKey::str(REGEXP_MARK)) => {
             o.clone()
         }
         _ => return Err(vm.throw_type("Method RegExp.prototype called on incompatible receiver")),
@@ -648,7 +640,7 @@ fn make_regexp_string_iterator(
         }
         Ok(vm.make_iter_result(result, false))
     });
-    iter.borrow_mut().props.insert(
+    iter.borrow_mut().own_insert(
         PropertyKey::str("next"),
         Property::builtin(Value::Object(next)),
     );
@@ -901,7 +893,7 @@ pub fn build_match_array(
                     Some((s, e)) => Value::String(JsString::from_code_units(&units[s..e])),
                     None => Value::Undefined,
                 };
-                gb.props.insert(PropertyKey::str(name), Property::data(val));
+                gb.own_insert(PropertyKey::str(name), Property::data(val));
             }
         }
         Value::Object(obj)
@@ -932,16 +924,14 @@ pub fn build_match_array(
                     None => Value::Undefined,
                 };
                 obj.borrow_mut()
-                    .props
-                    .insert(PropertyKey::str(name), Property::data(val));
+                    .own_insert(PropertyKey::str(name), Property::data(val));
             }
             Value::Object(obj)
         };
         let idx_arr = vm.new_array(idx_elems);
         idx_arr
             .borrow_mut()
-            .props
-            .insert(PropertyKey::str("groups"), Property::data(idx_groups));
+            .own_insert(PropertyKey::str("groups"), Property::data(idx_groups));
         Some(Value::Object(idx_arr))
     } else {
         None
@@ -949,19 +939,17 @@ pub fn build_match_array(
     let arr = vm.new_array(elems);
     {
         let mut b = arr.borrow_mut();
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("index"),
             Property::data(Value::Number(mat.start as f64)),
         );
-        b.props.insert(
+        b.own_insert(
             PropertyKey::str("input"),
             Property::data(Value::String(input.clone())),
         );
-        b.props
-            .insert(PropertyKey::str("groups"), Property::data(groups));
+        b.own_insert(PropertyKey::str("groups"), Property::data(groups));
         if let Some(indices) = indices {
-            b.props
-                .insert(PropertyKey::str("indices"), Property::data(indices));
+            b.own_insert(PropertyKey::str("indices"), Property::data(indices));
         }
     }
     Value::Object(arr)
@@ -982,11 +970,7 @@ fn define_string_getter(
 ) {
     let getter = vm.new_native(&format!("get {name}"), 0, move |vm, this, _a| {
         let o = match &this {
-            Value::Object(o)
-                if o.borrow()
-                    .props
-                    .contains_key(&PropertyKey::str(REGEXP_MARK)) =>
-            {
+            Value::Object(o) if o.borrow().own_contains_key(&PropertyKey::str(REGEXP_MARK)) => {
                 o.clone()
             }
             // RegExp.prototype itself reports the canonical empty source/flags.
@@ -1007,11 +991,7 @@ fn define_string_getter(
 fn define_flag_getter(vm: &mut Vm, proto: &JsObject, name: &str, flag: char) {
     let getter = vm.new_native(&format!("get {name}"), 0, move |vm, this, _a| {
         let o = match &this {
-            Value::Object(o)
-                if o.borrow()
-                    .props
-                    .contains_key(&PropertyKey::str(REGEXP_MARK)) =>
-            {
+            Value::Object(o) if o.borrow().own_contains_key(&PropertyKey::str(REGEXP_MARK)) => {
                 o.clone()
             }
             // RegExp.prototype itself is not a real RegExp: report undefined.
@@ -1029,7 +1009,7 @@ fn define_flag_getter(vm: &mut Vm, proto: &JsObject, name: &str, flag: char) {
 /// Insert a non-enumerable, configurable accessor property with the given
 /// getter and no setter.
 fn install_accessor(proto: &JsObject, name: &str, getter: JsObject) {
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str(name),
         Property {
             kind: PropertyKind::Accessor {

--- a/crates/chidori-js/src/builtins/string.rs
+++ b/crates/chidori-js/src/builtins/string.rs
@@ -349,8 +349,7 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
     // `Array.prototype.push`.
     let ccode = proto
         .borrow()
-        .props
-        .get(&PropertyKey::str("charCodeAt"))
+        .own_get(&PropertyKey::str("charCodeAt"))
         .and_then(|p| p.value().cloned());
     if let Some(Value::Object(o)) = ccode {
         vm.realm.string_char_code_at = Some(o);
@@ -822,8 +821,7 @@ fn install_proto(vm: &mut Vm, proto: &JsObject) {
         .unwrap();
     proto
         .borrow_mut()
-        .props
-        .shift_remove(&PropertyKey::str("[Symbol.iterator]"));
+        .own_remove(&PropertyKey::str("[Symbol.iterator]"));
     vm.define_value_sym(proto, sym, it);
 }
 

--- a/crates/chidori-js/src/builtins/temporal.rs
+++ b/crates/chidori-js/src/builtins/temporal.rs
@@ -156,7 +156,7 @@ pub fn install(vm: &mut Vm) {
 
     // Temporal[Symbol.toStringTag] = "Temporal" (non-writable, non-enumerable, configurable).
     let tag = vm.realm.symbol_to_string_tag.clone();
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -327,7 +327,7 @@ fn install_duration(vm: &mut Vm, temporal: &JsObject) {
         |vm, _t, _a| Err(vm.throw_type("Constructor Temporal.Duration requires 'new'")),
         move |vm, _this, args| construct_duration(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -338,7 +338,7 @@ fn install_duration(vm: &mut Vm, temporal: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -523,7 +523,7 @@ fn install_duration(vm: &mut Vm, temporal: &JsObject) {
 
     // Temporal.Duration.prototype[Symbol.toStringTag] = "Temporal.Duration"
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -535,7 +535,7 @@ fn install_duration(vm: &mut Vm, temporal: &JsObject) {
         },
     );
 
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("Duration"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -772,7 +772,7 @@ fn install_plain_time(vm: &mut Vm, temporal: &JsObject) {
         |vm, _t, _a| Err(vm.throw_type("Constructor Temporal.PlainTime requires 'new'")),
         move |vm, _this, args| construct_plain_time(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -783,7 +783,7 @@ fn install_plain_time(vm: &mut Vm, temporal: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -898,7 +898,7 @@ fn install_plain_time(vm: &mut Vm, temporal: &JsObject) {
     });
 
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -910,7 +910,7 @@ fn install_plain_time(vm: &mut Vm, temporal: &JsObject) {
         },
     );
 
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("PlainTime"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -1065,7 +1065,7 @@ fn install_plain_date(vm: &mut Vm, temporal: &JsObject) {
         |vm, _t, _a| Err(vm.throw_type("Constructor Temporal.PlainDate requires 'new'")),
         move |vm, _this, args| construct_plain_date(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -1076,7 +1076,7 @@ fn install_plain_date(vm: &mut Vm, temporal: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -1230,7 +1230,7 @@ fn install_plain_date(vm: &mut Vm, temporal: &JsObject) {
     });
 
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -1242,7 +1242,7 @@ fn install_plain_date(vm: &mut Vm, temporal: &JsObject) {
         },
     );
 
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("PlainDate"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -1319,7 +1319,7 @@ fn install_instant(vm: &mut Vm, temporal: &JsObject) {
         |vm, _t, _a| Err(vm.throw_type("Constructor Temporal.Instant requires 'new'")),
         move |vm, _this, args| construct_instant(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -1330,7 +1330,7 @@ fn install_instant(vm: &mut Vm, temporal: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -1456,7 +1456,7 @@ fn install_instant(vm: &mut Vm, temporal: &JsObject) {
     });
 
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -1468,7 +1468,7 @@ fn install_instant(vm: &mut Vm, temporal: &JsObject) {
         },
     );
 
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("Instant"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -1583,7 +1583,7 @@ fn install_plain_date_time(vm: &mut Vm, temporal: &JsObject) {
         |vm, _t, _a| Err(vm.throw_type("Constructor Temporal.PlainDateTime requires 'new'")),
         move |vm, _this, args| construct_plain_date_time(vm, args, &ctor_proto),
     );
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -1594,7 +1594,7 @@ fn install_plain_date_time(vm: &mut Vm, temporal: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -1789,7 +1789,7 @@ fn install_plain_date_time(vm: &mut Vm, temporal: &JsObject) {
     });
 
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -1801,7 +1801,7 @@ fn install_plain_date_time(vm: &mut Vm, temporal: &JsObject) {
         },
     );
 
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("PlainDateTime"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -2121,7 +2121,7 @@ fn install_year_month(vm: &mut Vm, temporal: &JsObject) {
         Err(vm.throw_type("Temporal.PlainYearMonth: use compare() instead of relational operators"))
     });
     set_tag(vm, &proto, "Temporal.PlainYearMonth");
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("PlainYearMonth"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -2236,7 +2236,7 @@ fn install_month_day(vm: &mut Vm, temporal: &JsObject) {
         Err(vm.throw_type("Temporal.PlainMonthDay: use equals() instead of relational operators"))
     });
     set_tag(vm, &proto, "Temporal.PlainMonthDay");
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("PlainMonthDay"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -2245,7 +2245,7 @@ fn install_month_day(vm: &mut Vm, temporal: &JsObject) {
 /// Wire `ctor.prototype` / `proto.constructor` (non-enumerable).
 fn install_ctor_proto(vm: &Vm, ctor: &JsObject, proto: &JsObject) {
     let _ = vm;
-    ctor.borrow_mut().props.insert(
+    ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -2256,7 +2256,7 @@ fn install_ctor_proto(vm: &Vm, ctor: &JsObject, proto: &JsObject) {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ctor.clone())),
     );
@@ -2265,7 +2265,7 @@ fn install_ctor_proto(vm: &Vm, ctor: &JsObject, proto: &JsObject) {
 /// Set a prototype's `[Symbol.toStringTag]`.
 fn set_tag(vm: &Vm, proto: &JsObject, tag: &str) {
     let sym = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(sym),
         Property {
             kind: PropertyKind::Data {
@@ -2620,7 +2620,7 @@ fn install_zoned_date_time(vm: &mut Vm, temporal: &JsObject) {
         Err(vm.throw_type("Temporal.ZonedDateTime: use compare() instead of relational operators"))
     });
     set_tag(vm, &proto, "Temporal.ZonedDateTime");
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("ZonedDateTime"),
         Property::builtin(Value::Object(ctor)),
     );
@@ -2710,7 +2710,7 @@ fn install_now(vm: &mut Vm, temporal: &JsObject) {
     });
 
     set_tag(vm, &now, "Temporal.Now");
-    temporal.borrow_mut().props.insert(
+    temporal.borrow_mut().own_insert(
         PropertyKey::str("Now"),
         Property::builtin(Value::Object(now)),
     );

--- a/crates/chidori-js/src/builtins/typedarray.rs
+++ b/crates/chidori-js/src/builtins/typedarray.rs
@@ -85,7 +85,7 @@ use crate::typed_array::ARRAY_BUFFER_MAX_SLOT as AB_MAX;
 
 /// The resizable max for a buffer, or `None` when it is fixed-length.
 fn ab_max_byte_length(o: &JsObject) -> Option<usize> {
-    match o.borrow().props.get(&PropertyKey::str(AB_MAX)) {
+    match o.borrow().own_get(&PropertyKey::str(AB_MAX)) {
         Some(Property {
             kind:
                 PropertyKind::Data {
@@ -130,7 +130,7 @@ fn ab_transfer(
     }
     if preserve_resizable {
         if let Some(m) = max {
-            new_buf.borrow_mut().props.insert(
+            new_buf.borrow_mut().own_insert(
                 PropertyKey::str(AB_MAX),
                 Property {
                     kind: PropertyKind::Data {
@@ -166,7 +166,7 @@ fn install_array_buffer(vm: &mut Vm, species: &JsSymbol) {
                     if len > max {
                         return Err(vm.throw_range("ArrayBuffer length exceeds maxByteLength"));
                     }
-                    buf.borrow_mut().props.insert(
+                    buf.borrow_mut().own_insert(
                         PropertyKey::str(AB_MAX),
                         Property {
                             kind: PropertyKind::Data {
@@ -364,7 +364,7 @@ fn install_array_buffer(vm: &mut Vm, species: &JsSymbol) {
 
     // ArrayBuffer.prototype[Symbol.toStringTag] = "ArrayBuffer"
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -551,7 +551,7 @@ fn install_shared_array_buffer(vm: &mut Vm, species: &JsSymbol) {
 
     // SharedArrayBuffer.prototype[Symbol.toStringTag] = "SharedArrayBuffer"
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -722,7 +722,7 @@ fn ta_species_create(vm: &mut Vm, exemplar: &JsObject, args: &[Value]) -> Result
     // time), not whatever `prototype.constructor` currently holds.
     let base = vm.realm.typed_array_proto.clone();
     let ckey = PropertyKey::str(format!("__ctor_{}", kind.name()));
-    let default_ctor = match base.borrow().props.get(&ckey).and_then(|p| p.value()) {
+    let default_ctor = match base.borrow().own_get(&ckey).and_then(|p| p.value()) {
         Some(v) => v.clone(),
         None => Value::Undefined,
     };
@@ -757,7 +757,7 @@ fn install_typed_array_base(vm: &mut Vm, species: &JsSymbol) -> JsObject {
         |vm, _t, _a| Err(vm.throw_type("Abstract class TypedArray not directly constructable")),
     );
     // Wire %TypedArray%.prototype <-> %TypedArray% without exposing a global.
-    ta_ctor.borrow_mut().props.insert(
+    ta_ctor.borrow_mut().own_insert(
         PropertyKey::str("prototype"),
         Property {
             kind: PropertyKind::Data {
@@ -768,7 +768,7 @@ fn install_typed_array_base(vm: &mut Vm, species: &JsSymbol) -> JsObject {
             configurable: false,
         },
     );
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::str("constructor"),
         Property::builtin(Value::Object(ta_ctor.clone())),
     );
@@ -1627,15 +1627,13 @@ fn install_ta_methods(vm: &mut Vm, proto: &JsObject) {
         .realm
         .array_proto
         .borrow()
-        .props
-        .get(&PropertyKey::str("toString"))
+        .own_get(&PropertyKey::str("toString"))
         .and_then(|p| p.value().cloned());
     match array_to_string {
         Some(f) => {
             proto
                 .borrow_mut()
-                .props
-                .insert(PropertyKey::str("toString"), Property::builtin(f));
+                .own_insert(PropertyKey::str("toString"), Property::builtin(f));
         }
         None => {
             vm.define_method(proto, "toString", 0, |vm, this, _a| {
@@ -1859,7 +1857,7 @@ fn default_numeric_compare(a: f64, b: f64) -> i32 {
 fn per_kind_proto(vm: &mut Vm, kind: TAKind) -> JsObject {
     let key = PropertyKey::str(format!("__proto_{}", kind.name()));
     let base = vm.realm.typed_array_proto.clone();
-    if let Some(p) = base.borrow().props.get(&key) {
+    if let Some(p) = base.borrow().own_get(&key) {
         if let Some(Value::Object(o)) = p.value() {
             return o.clone();
         }
@@ -1867,8 +1865,7 @@ fn per_kind_proto(vm: &mut Vm, kind: TAKind) -> JsObject {
     // Should have been installed by install_kind_ctors; create a bare fallback.
     let proto = vm.alloc_ordinary(Some(base.clone()));
     base.borrow_mut()
-        .props
-        .insert(key, Property::builtin(Value::Object(proto.clone())));
+        .own_insert(key, Property::builtin(Value::Object(proto.clone())));
     proto
 }
 
@@ -1881,8 +1878,7 @@ fn install_kind_ctors(vm: &mut Vm, ta_ctor: &JsObject) {
         let key = PropertyKey::str(format!("__proto_{}", kind.name()));
         ta_proto
             .borrow_mut()
-            .props
-            .insert(key, Property::builtin(Value::Object(proto.clone())));
+            .own_insert(key, Property::builtin(Value::Object(proto.clone())));
 
         let bytes_per = kind.bytes() as f64;
         let name = kind.name();
@@ -1935,13 +1931,12 @@ fn install_kind_ctors(vm: &mut Vm, ta_ctor: &JsObject) {
         let ckey = PropertyKey::str(format!("__ctor_{}", kind.name()));
         ta_proto
             .borrow_mut()
-            .props
-            .insert(ckey, Property::builtin(Value::Object(ctor.clone())));
+            .own_insert(ckey, Property::builtin(Value::Object(ctor.clone())));
 
         // BYTES_PER_ELEMENT on both ctor and prototype (non-writable,
         // non-enumerable, non-configurable).
         for target in [&ctor, &proto] {
-            target.borrow_mut().props.insert(
+            target.borrow_mut().own_insert(
                 PropertyKey::str("BYTES_PER_ELEMENT"),
                 Property {
                     kind: PropertyKind::Data {
@@ -2259,7 +2254,7 @@ fn install_data_view(vm: &mut Vm) {
 
     // [Symbol.toStringTag] = "DataView"
     let tag = vm.realm.symbol_to_string_tag.clone();
-    proto.borrow_mut().props.insert(
+    proto.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {
@@ -3055,7 +3050,7 @@ fn install_atomics(vm: &mut Vm) {
 
     // Atomics[Symbol.toStringTag] = "Atomics" (non-writable, non-enumerable, configurable).
     let tag = vm.realm.symbol_to_string_tag.clone();
-    atomics.borrow_mut().props.insert(
+    atomics.borrow_mut().own_insert(
         PropertyKey::Sym(tag),
         Property {
             kind: PropertyKind::Data {

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -210,6 +210,14 @@ pub struct FuncProto {
 /// evaluated values.
 pub struct ObjTemplate {
     pub map: crate::fxhash::FxIndexMap<crate::value::PropertyKey, crate::value::Property>,
+    /// Memoized (realm root, leaf) shape pair for this literal site: after
+    /// the first instantiation in a realm, building the object is ONE slot
+    /// vec allocation + N value writes under the cached leaf shape — no
+    /// hashing, no transition walk (docs/js-object-shapes-design.md §3.3).
+    /// The root is stored to verify the cache belongs to the CURRENT realm
+    /// (a `FuncProto` may be shared across realms by the source cache);
+    /// a mismatch just recomputes. Never serialized, never observable.
+    pub shape_cache: std::cell::RefCell<Option<(Rc<crate::shape::Shape>, Rc<crate::shape::Shape>)>>,
 }
 
 impl std::fmt::Debug for ObjTemplate {
@@ -229,6 +237,13 @@ pub struct IcEntry {
     pub own_slot: std::cell::Cell<u32>,
     pub proto_slot: std::cell::Cell<u32>,
     pub holder: std::cell::RefCell<Option<crate::value::JsObject>>,
+    /// The receiver's shape when `own_slot` was resolved (`None` when it was
+    /// in dictionary mode). A pointer-identical CURRENT shape upgrades the
+    /// hit check to one `Rc::ptr_eq` — no key compare, no probe. Holds the
+    /// shape strongly: an IC pins at most one small key chain per site.
+    pub own_shape: std::cell::RefCell<Option<Rc<crate::shape::Shape>>>,
+    /// As `own_shape`, for the prototype holder's `proto_slot`.
+    pub proto_shape: std::cell::RefCell<Option<Rc<crate::shape::Shape>>>,
 }
 
 impl FuncProto {

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -1888,6 +1888,8 @@ impl Compiler {
                     own_slot: std::cell::Cell::new(u32::MAX),
                     proto_slot: std::cell::Cell::new(u32::MAX),
                     holder: std::cell::RefCell::new(None),
+                    own_shape: std::cell::RefCell::new(None),
+                    proto_shape: std::cell::RefCell::new(None),
                 })
                 .collect(),
             code,
@@ -3891,7 +3893,10 @@ impl Compiler {
         }
         let fc = self.fns.last_mut().expect("fn ctx");
         fc.obj_tpls
-            .push(std::rc::Rc::new(crate::bytecode::ObjTemplate { map }));
+            .push(std::rc::Rc::new(crate::bytecode::ObjTemplate {
+                map,
+                shape_cache: Default::default(),
+            }));
         Some((fc.obj_tpls.len() - 1) as u32)
     }
 

--- a/crates/chidori-js/src/convert.rs
+++ b/crates/chidori-js/src/convert.rs
@@ -122,8 +122,7 @@ impl Vm {
                 {
                     let mut b = o.borrow_mut();
                     for (k, val) in m {
-                        b.props
-                            .insert(PropertyKey::str(k), Property::data(self.json_to_value(val)));
+                        b.own_insert(PropertyKey::str(k), Property::data(self.json_to_value(val)));
                     }
                 }
                 Value::Object(o)

--- a/crates/chidori-js/src/dom.rs
+++ b/crates/chidori-js/src/dom.rs
@@ -1473,7 +1473,7 @@ fn remove_listener(dom: &Rc<RefCell<Dom>>, node: usize, ty: &str, handler: &Valu
 }
 
 fn define_accessor(target: &JsObject, name: &str, get: Value, set: Option<Value>) {
-    target.borrow_mut().props.insert(
+    target.borrow_mut().own_insert(
         PropertyKey::str(name),
         Property {
             kind: PropertyKind::Accessor {

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -410,7 +410,7 @@ impl Vm {
         let Some(canon) = &self.realm.ta_length_getter else {
             return false;
         };
-        if !o.borrow().props.is_empty() {
+        if !o.borrow().own_is_empty() {
             return false;
         }
         let key = crate::value::StrKeyRef("length");
@@ -421,7 +421,7 @@ impl Vm {
         for _ in 0..4 {
             let Some(p) = cur else { break };
             let b = p.borrow();
-            if let Some(prop) = b.props.get(&key) {
+            if let Some(prop) = b.own_get(&key) {
                 return matches!(
                     &prop.kind,
                     PropertyKind::Accessor { get: Some(Value::Object(g)), .. }
@@ -445,7 +445,7 @@ impl Vm {
         {
             let g = self.realm.global.borrow();
             let math_ok = matches!(
-                g.props.get(&crate::value::StrKeyRef("Math")),
+                g.own_get(&crate::value::StrKeyRef("Math")),
                 Some(Property {
                     kind: PropertyKind::Data { value: Value::Object(o), .. },
                     ..
@@ -458,7 +458,7 @@ impl Vm {
         let mb = canon.borrow();
         used.iter().all(|k| {
             matches!(
-                mb.props.get(&crate::value::StrKeyRef(k.name())),
+                mb.own_get(&crate::value::StrKeyRef(k.name())),
                 Some(Property {
                     kind: PropertyKind::Data { value: Value::Object(o), .. },
                     ..
@@ -479,7 +479,7 @@ impl Vm {
             return false;
         };
         matches!(
-            self.realm.array_proto.borrow().props.get(&crate::value::StrKeyRef(name)),
+            self.realm.array_proto.borrow().own_get(&crate::value::StrKeyRef(name)),
             Some(Property {
                 kind: PropertyKind::Data { value: Value::Object(o), .. },
                 ..
@@ -501,8 +501,7 @@ impl Vm {
             self.realm
                 .string_proto
                 .borrow()
-                .props
-                .get(&crate::value::StrKeyRef("charCodeAt")),
+                .own_get(&crate::value::StrKeyRef("charCodeAt")),
             Some(Property {
                 kind: PropertyKind::Data { value: Value::Object(o), .. },
                 ..
@@ -675,7 +674,7 @@ impl Vm {
                 let ok = if let Value::Object(o) = &frame.locals[k.oslots[obj as usize] as usize] {
                     let b = o.borrow();
                     matches!(b.internal, Internal::Array(_))
-                        && b.props.is_empty()
+                        && b.own_is_empty()
                         && b.extensible
                         && b.proto
                             .as_ref()
@@ -717,7 +716,7 @@ impl Vm {
                             kind: PropertyKind::Data { value, writable },
                             ..
                         },
-                    )) = b.props.get_full(&PropertyKey::str(&p.key))
+                    )) = b.own_get_full(&PropertyKey::str(&p.key))
                     {
                         if matches!(value, Value::Number(_)) && (!p.store || *writable) {
                             let id = (o.ptr_id(), idx as u32);
@@ -792,7 +791,7 @@ impl Vm {
             let prop_base = k.n_regs as usize - k.props_used.len();
             for (i, p) in k.props_used.iter().enumerate() {
                 let b = objs[p.oslot as usize].borrow();
-                match b.props.get_index(prop_slots[i] as usize) {
+                match b.own_get_index(prop_slots[i] as usize) {
                     Some((
                         _,
                         Property {
@@ -1021,7 +1020,7 @@ impl Vm {
                     if let Some(iu) = dense_index(i) {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
-                            Internal::Array(arr) if b.props.is_empty() => {
+                            Internal::Array(arr) if b.own_is_empty() => {
                                 if let Some(Value::Number(n)) = arr.get(iu) {
                                     w[dst as usize & KWIN_MASK] = *n;
                                     ok = true;
@@ -1067,7 +1066,7 @@ impl Vm {
                     let mut ok = false;
                     {
                         let mut b = objs[obj as usize].borrow_mut();
-                        if b.props.is_empty()
+                        if b.own_is_empty()
                             && b.extensible
                             && b.proto
                                 .as_ref()
@@ -1094,7 +1093,7 @@ impl Vm {
                     let mut ok = false;
                     {
                         let mut b = objs[obj as usize].borrow_mut();
-                        if b.props.is_empty() && b.extensible {
+                        if b.own_is_empty() && b.extensible {
                             if let Internal::Array(arr) = &mut b.internal {
                                 if let Some(Value::Number(n)) = arr.last() {
                                     w[dst as usize & KWIN_MASK] = *n;
@@ -1128,7 +1127,7 @@ impl Vm {
                     if let Some(iu) = dense_index(i) {
                         let mut b = objs[obj as usize].borrow_mut();
                         let extensible = b.extensible;
-                        let props_empty = b.props.is_empty();
+                        let props_empty = b.own_is_empty();
                         match &mut b.internal {
                             Internal::Array(arr) if props_empty => {
                                 match arr.get_mut(iu) {
@@ -1219,7 +1218,7 @@ impl Vm {
                     {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
-                            Internal::Array(arr) if b.props.is_empty() => {
+                            Internal::Array(arr) if b.own_is_empty() => {
                                 w[dst as usize & KWIN_MASK] = arr.len() as f64;
                                 ok = true;
                             }
@@ -1304,7 +1303,7 @@ impl Vm {
                     {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
-                            Internal::Array(arr) if b.props.is_empty() => {
+                            Internal::Array(arr) if b.own_is_empty() => {
                                 w[dst as usize & KWIN_MASK] = arr.len() as f64;
                                 ok = true;
                             }
@@ -1342,7 +1341,7 @@ impl Vm {
                     if let Some(iu) = dense_index(i) {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
-                            Internal::Array(arr) if b.props.is_empty() => {
+                            Internal::Array(arr) if b.own_is_empty() => {
                                 if let Some(Value::Number(n)) = arr.get(iu) {
                                     w[dst as usize & KWIN_MASK] = *n;
                                     ok = true;
@@ -1387,7 +1386,7 @@ impl Vm {
                     if let Some(iu) = dense_index(i) {
                         let b = objs[obj as usize].borrow();
                         match &b.internal {
-                            Internal::Array(arr) if b.props.is_empty() => {
+                            Internal::Array(arr) if b.own_is_empty() => {
                                 if let Some(Value::Number(n)) = arr.get(iu) {
                                     w[dst as usize & KWIN_MASK] = *n;
                                     ok = true;
@@ -2021,7 +2020,7 @@ impl Vm {
             let g = self.realm.global.borrow();
             for c in fam.global_checks.iter() {
                 let ok = matches!(
-                    g.props.get_index(c.slot as usize),
+                    g.own_get_index(c.slot as usize),
                     Some((
                         k,
                         Property {
@@ -2124,7 +2123,7 @@ impl Vm {
                     match r {
                         crate::bytecode::SelfRefKind::Global(name) => {
                             let g = self.realm.global.borrow();
-                            match g.props.get_full(&PropertyKey::str(name)) {
+                            match g.own_get_full(&PropertyKey::str(name)) {
                                 Some((
                                     slot,
                                     key,
@@ -2183,7 +2182,7 @@ impl Vm {
                 for name in rec.globals.iter() {
                     let (bf2, slot, key) = {
                         let g = self.realm.global.borrow();
-                        match g.props.get_full(&PropertyKey::str(name)) {
+                        match g.own_get_full(&PropertyKey::str(name)) {
                             Some((
                                 slot,
                                 key,
@@ -2628,7 +2627,7 @@ impl Vm {
         {
             let mut b = o.borrow_mut();
             for (i, v) in frame.args.iter().enumerate() {
-                b.props.insert(
+                b.own_insert(
                     PropertyKey::from_index(i as u32),
                     Property {
                         kind: PropertyKind::Data {
@@ -2640,7 +2639,7 @@ impl Vm {
                     },
                 );
             }
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("length"),
                 Property {
                     kind: PropertyKind::Data {
@@ -2657,12 +2656,11 @@ impl Vm {
             .realm
             .array_proto
             .borrow()
-            .props
-            .get(&PropertyKey::str("values"))
+            .own_get(&PropertyKey::str("values"))
             .and_then(|p| p.value().cloned())
             .unwrap_or(Value::Undefined);
         let iter_key = PropertyKey::Sym(self.realm.symbol_iterator.clone());
-        o.borrow_mut().props.insert(
+        o.borrow_mut().own_insert(
             iter_key,
             Property {
                 kind: PropertyKind::Data {
@@ -2704,8 +2702,7 @@ impl Vm {
             }
         };
         o.borrow_mut()
-            .props
-            .insert(PropertyKey::str("callee"), callee);
+            .own_insert(PropertyKey::str("callee"), callee);
         Value::Object(o)
     }
 
@@ -3347,7 +3344,7 @@ impl Vm {
                     let key = PropertyKey::str(name);
                     let (present, extensible) = {
                         let b = g.borrow();
-                        (b.props.contains_key(&key), b.extensible)
+                        (b.own_contains_key(&key), b.extensible)
                     };
                     if !present {
                         if !extensible {
@@ -3358,8 +3355,7 @@ impl Vm {
                         // global var is deletable (configurable), unlike a
                         // script-level one.
                         g.borrow_mut()
-                            .props
-                            .insert(key, Property::data(Value::Undefined));
+                            .own_insert(key, Property::data(Value::Undefined));
                     }
                 } else {
                     // Function-scope eval var: lives on the caller frame's
@@ -3375,10 +3371,10 @@ impl Vm {
                         }
                     };
                     let key = PropertyKey::str(name);
-                    if !ev.borrow().props.contains_key(&key) {
+                    if !ev.borrow().own_contains_key(&key) {
                         let mut p = Property::data(Value::Undefined);
                         p.enumerable = true;
-                        ev.borrow_mut().props.insert(key, p);
+                        ev.borrow_mut().own_insert(key, p);
                     }
                 }
             }
@@ -3545,7 +3541,7 @@ impl Vm {
                 // answered directly from the dense Vec, mirroring
                 // `get_from_object`'s array arm (a reified `length` can
                 // only live in `props`, which is empty here).
-                if is_arr && b.props.is_empty() && name.as_str() == "length" {
+                if is_arr && b.own_is_empty() && name.as_str() == "length" {
                     if let Internal::Array(a) = &b.internal {
                         return Ok(Value::Number(a.len() as f64));
                     }
@@ -3557,7 +3553,7 @@ impl Vm {
                     // Own-property hit: never touches the holder cell.
                     if is_ord {
                         if let Some((PropertyKey::Str(k), prop)) =
-                            b.props.get_index(ic.own_slot.get() as usize)
+                            b.own_get_index(ic.own_slot.get() as usize)
                         {
                             if let PropertyKind::Data { value, .. } = &prop.kind {
                                 if k == &name {
@@ -3570,13 +3566,13 @@ impl Vm {
                     // Proto hit: valid only when the receiver has no
                     // own props (nothing can shadow) and its CURRENT
                     // direct proto is the cached holder.
-                    if b.props.is_empty() {
+                    if b.own_is_empty() {
                         let holder = ic.holder.borrow();
                         if let Some(h) = &*holder {
                             if b.proto.as_ref().is_some_and(|p| p.ptr_eq(h)) {
                                 let hb = h.borrow();
                                 if let Some((PropertyKey::Str(k), prop)) =
-                                    hb.props.get_index(ic.proto_slot.get() as usize)
+                                    hb.own_get_index(ic.proto_slot.get() as usize)
                                 {
                                     if let PropertyKind::Data { value, .. } = &prop.kind {
                                         if k == &name {
@@ -3593,7 +3589,7 @@ impl Vm {
                     // props can shadow.
                     let key = PropertyKey::Str(name.clone());
                     if is_ord {
-                        if let Some((idx, _, prop)) = b.props.get_full(&key) {
+                        if let Some((idx, _, prop)) = b.own_get_full(&key) {
                             if let PropertyKind::Data { value, .. } = &prop.kind {
                                 ic.own_slot.set(idx as u32);
                                 let v = value.clone();
@@ -3601,13 +3597,13 @@ impl Vm {
                             }
                         }
                     }
-                    if b.props.is_empty() {
+                    if b.own_is_empty() {
                         if let Some(p) = &b.proto {
                             let pb = p.borrow();
                             if matches!(pb.internal, Internal::Ordinary)
                                 || matches!(pb.internal, Internal::Array(_))
                             {
-                                if let Some((idx, _, prop)) = pb.props.get_full(&key) {
+                                if let Some((idx, _, prop)) = pb.own_get_full(&key) {
                                     if let PropertyKind::Data { value, .. } = &prop.kind {
                                         ic.proto_slot.set(idx as u32);
                                         let v = value.clone();
@@ -3651,7 +3647,7 @@ impl Vm {
                 let mut b = o.borrow_mut();
                 if matches!(b.internal, Internal::Ordinary) {
                     if let Some((PropertyKey::Str(k), prop)) =
-                        b.props.get_index_mut(ic.own_slot.get() as usize)
+                        b.own_get_index_mut(ic.own_slot.get() as usize)
                     {
                         if k == &name {
                             if let PropertyKind::Data {
@@ -3665,7 +3661,7 @@ impl Vm {
                         }
                     }
                     let key = PropertyKey::Str(name.clone());
-                    if let Some((idx, _, prop)) = b.props.get_full_mut(&key) {
+                    if let Some((idx, _, prop)) = b.own_get_full_mut(&key) {
                         if let PropertyKind::Data {
                             value: slot,
                             writable: true,
@@ -3699,7 +3695,7 @@ impl Vm {
             if let Some(iu) = dense_index(*n) {
                 let b = o.borrow();
                 if let Internal::Array(arr) = &b.internal {
-                    if b.props.is_empty() {
+                    if b.own_is_empty() {
                         if let Some(v) = arr.get(iu) {
                             if !matches!(v, Value::Hole) {
                                 let v = v.clone();
@@ -3760,7 +3756,7 @@ impl Vm {
                 let mut creates = None;
                 {
                     let mut b = o.borrow_mut();
-                    if b.props.is_empty() {
+                    if b.own_is_empty() {
                         let extensible = b.extensible;
                         if let Internal::Array(arr) = &mut b.internal {
                             match arr.get_mut(i) {
@@ -3822,8 +3818,7 @@ impl Vm {
         // indexed load plus a pointer-equality key check, no hashing.
         if let Some(ic) = ic {
             let b = g.borrow();
-            if let Some((PropertyKey::Str(k), prop)) = b.props.get_index(ic.own_slot.get() as usize)
-            {
+            if let Some((PropertyKey::Str(k), prop)) = b.own_get_index(ic.own_slot.get() as usize) {
                 if let PropertyKind::Data { value, .. } = &prop.kind {
                     if k == &name {
                         let v = value.clone();
@@ -3839,7 +3834,7 @@ impl Vm {
         // the inline cache with the slot it finds.
         let fast = {
             let b = g.borrow();
-            match b.props.get_full(&key) {
+            match b.own_get_full(&key) {
                 Some((
                     idx,
                     _,
@@ -3957,7 +3952,7 @@ impl Vm {
         let key = PropertyKey::Str(name.clone());
         let (present, extensible) = {
             let b = g.borrow();
-            (b.props.contains_key(&key), b.extensible)
+            (b.own_contains_key(&key), b.extensible)
         };
         if !present {
             // CanDeclareGlobalVar/Function: needs an extensible global.
@@ -3966,7 +3961,7 @@ impl Vm {
             }
             // CreateGlobalVarBinding(N, D): writable, enumerable;
             // configurable only for eval-created bindings.
-            g.borrow_mut().props.insert(
+            g.borrow_mut().own_insert(
                 key,
                 Property {
                     kind: PropertyKind::Data {
@@ -3991,7 +3986,7 @@ impl Vm {
         // absent, on a non-extensible global) the declaration fails.
         let definable = {
             let b = g.borrow();
-            match b.props.get(&key) {
+            match b.own_get(&key) {
                 None => b.extensible,
                 Some(p) => {
                     p.configurable
@@ -4022,14 +4017,14 @@ impl Vm {
         // is just assigned the new value.
         let redefine = {
             let b = g.borrow();
-            match b.props.get(&key) {
+            match b.own_get(&key) {
                 None => true,
                 Some(p) => p.configurable,
             }
         };
         let mut b = g.borrow_mut();
         if redefine {
-            b.props.insert(
+            b.own_insert(
                 key,
                 Property {
                     kind: PropertyKind::Data {
@@ -4040,7 +4035,7 @@ impl Vm {
                     configurable: deletable,
                 },
             );
-        } else if let Some(p) = b.props.get_mut(&key) {
+        } else if let Some(p) = b.own_get_mut(&key) {
             if let PropertyKind::Data { value: slot, .. } = &mut p.kind {
                 *slot = value;
             }
@@ -4076,7 +4071,7 @@ impl Vm {
         // template object, which is itself frozen (spec
         // GetTemplateObject / TemplateString integrity).
         crate::builtins::fundamental::set_integrity_level(self, &raw_arr, true)?;
-        arr.borrow_mut().props.insert(
+        arr.borrow_mut().own_insert(
             PropertyKey::str("raw"),
             Property {
                 kind: PropertyKind::Data {
@@ -4128,7 +4123,7 @@ impl Vm {
                 // key — e.g. a computed static "prototype" — is a TypeError).
                 self.check_redefinable(obj, &key)?;
                 if let Value::Object(o) = obj {
-                    o.borrow_mut().props.insert(key, Property::builtin(value));
+                    o.borrow_mut().own_insert(key, Property::builtin(value));
                 }
             }
             DefKind::Getter => {
@@ -4166,11 +4161,11 @@ impl Vm {
             if let Value::Object(s) = src {
                 for k in self.enumerable_own_keys_dyn(s)? {
                     let val = self.get_prop(src, &k)?;
-                    t.borrow_mut().props.insert(k, Property::data(val));
+                    t.borrow_mut().own_insert(k, Property::data(val));
                 }
             } else if let Value::String(st) = src {
                 for (i, c) in st.as_str().chars().enumerate() {
-                    t.borrow_mut().props.insert(
+                    t.borrow_mut().own_insert(
                         PropertyKey::from_index(i as u32),
                         Property::data(Value::str(c.to_string())),
                     );
@@ -4195,7 +4190,7 @@ impl Vm {
                 // not observe a [[GetOwnProperty]]/[[Get]] for them.
                 for k in self.enumerable_own_keys_excluding(s, excluded)? {
                     let val = self.get_prop(src, &k)?;
-                    t.borrow_mut().props.insert(k, Property::data(val));
+                    t.borrow_mut().own_insert(k, Property::data(val));
                 }
             } else if let Value::String(st) = src {
                 // A primitive-string source contributes its index keys.
@@ -4205,8 +4200,7 @@ impl Vm {
                         continue;
                     }
                     t.borrow_mut()
-                        .props
-                        .insert(k, Property::data(Value::str(c.to_string())));
+                        .own_insert(k, Property::data(Value::str(c.to_string())));
                 }
             }
         }
@@ -4234,7 +4228,7 @@ impl Vm {
                 } else {
                     format!("{} {}", prefix.as_str(), base)
                 };
-                f.borrow_mut().props.insert(
+                f.borrow_mut().own_insert(
                     PropertyKey::str("name"),
                     Property {
                         kind: PropertyKind::Data {
@@ -7029,7 +7023,7 @@ impl Vm {
         loop {
             let proto = {
                 let b = cur.borrow();
-                if b.props.contains_key(key) {
+                if b.own_contains_key(key) {
                     return true;
                 }
                 b.proto.clone()
@@ -7083,7 +7077,7 @@ impl Vm {
     /// definitions (`static ['prototype']() {}` must throw, not overwrite).
     fn check_redefinable(&mut self, obj: &Value, key: &PropertyKey) -> Result<(), Value> {
         if let Value::Object(o) = obj {
-            let non_config = o.borrow().props.get(key).is_some_and(|p| !p.configurable);
+            let non_config = o.borrow().own_get(key).is_some_and(|p| !p.configurable);
             if non_config {
                 return Err(self.throw_type(&format!("Cannot redefine property: {key:?}")));
             }
@@ -7132,7 +7126,7 @@ impl Vm {
     ) {
         if let Value::Object(o) = obj {
             let mut b = o.borrow_mut();
-            match b.props.get_mut(&key) {
+            match b.own_get_mut(&key) {
                 Some(Property {
                     kind: PropertyKind::Accessor { get: g, set: s },
                     ..
@@ -7145,7 +7139,7 @@ impl Vm {
                     }
                 }
                 _ => {
-                    b.props.insert(
+                    b.own_insert(
                         key,
                         Property {
                             kind: PropertyKind::Accessor { get, set },
@@ -7197,7 +7191,7 @@ impl Vm {
         ));
         {
             let mut b = obj.borrow_mut();
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("length"),
                 Property {
                     kind: PropertyKind::Data {
@@ -7208,7 +7202,7 @@ impl Vm {
                     configurable: true,
                 },
             );
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("name"),
                 Property {
                     kind: PropertyKind::Data {
@@ -7226,11 +7220,11 @@ impl Vm {
             FuncKind::Normal | FuncKind::ClassCtor | FuncKind::DerivedCtor
         ) {
             let proto_obj = self.new_object();
-            proto_obj.borrow_mut().props.insert(
+            proto_obj.borrow_mut().own_insert(
                 PropertyKey::str("constructor"),
                 Property::builtin(Value::Object(obj.clone())),
             );
-            obj.borrow_mut().props.insert(
+            obj.borrow_mut().own_insert(
                 PropertyKey::str("prototype"),
                 Property {
                     kind: PropertyKind::Data {
@@ -7260,7 +7254,7 @@ impl Vm {
                 self.realm.generator_proto.clone()
             };
             let proto_obj = self.alloc_ordinary(Some(instance_proto));
-            obj.borrow_mut().props.insert(
+            obj.borrow_mut().own_insert(
                 PropertyKey::str("prototype"),
                 Property {
                     kind: PropertyKind::Data {
@@ -7745,7 +7739,7 @@ fn writeback_kernel_props(
             continue;
         }
         let mut b = objs[p.oslot as usize].borrow_mut();
-        match b.props.get_index_mut(prop_slots[i] as usize) {
+        match b.own_get_index_mut(prop_slots[i] as usize) {
             Some((
                 _,
                 Property {

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -3552,13 +3552,32 @@ impl Vm {
                 if (is_ord || is_arr) && plain_key {
                     // Own-property hit: never touches the holder cell.
                     if is_ord {
-                        if let Some((PropertyKey::Str(k), prop)) =
-                            b.own_get_index(ic.own_slot.get() as usize)
-                        {
-                            if let PropertyKind::Data { value, .. } = &prop.kind {
-                                if k == &name {
+                        // Shape-verified hit (docs §3.3): one `Rc::ptr_eq`
+                        // replaces the key compare + probe — shape identity
+                        // pins the key at every slot; only the property KIND
+                        // can differ (attributes live per-object), checked
+                        // as before. Dictionary-mode receivers keep the
+                        // key-verified slot hint unchanged.
+                        let shape_ok = match (b.own_shape(), &*ic.own_shape.borrow()) {
+                            (Some(s), Some(c)) => Rc::ptr_eq(c, s),
+                            _ => false,
+                        };
+                        if shape_ok {
+                            if let Some(prop) = b.own_prop_at(ic.own_slot.get() as usize) {
+                                if let PropertyKind::Data { value, .. } = &prop.kind {
                                     let v = value.clone();
                                     return Ok(v);
+                                }
+                            }
+                        } else if b.own_shape().is_none() {
+                            if let Some((PropertyKey::Str(k), prop)) =
+                                b.own_get_index(ic.own_slot.get() as usize)
+                            {
+                                if let PropertyKind::Data { value, .. } = &prop.kind {
+                                    if k == &name {
+                                        let v = value.clone();
+                                        return Ok(v);
+                                    }
                                 }
                             }
                         }
@@ -3571,13 +3590,30 @@ impl Vm {
                         if let Some(h) = &*holder {
                             if b.proto.as_ref().is_some_and(|p| p.ptr_eq(h)) {
                                 let hb = h.borrow();
-                                if let Some((PropertyKey::Str(k), prop)) =
-                                    hb.own_get_index(ic.proto_slot.get() as usize)
-                                {
-                                    if let PropertyKind::Data { value, .. } = &prop.kind {
-                                        if k == &name {
+                                // Holder identity is already verified; a
+                                // shape-verified slot replaces the key
+                                // compare when the holder is shaped.
+                                let shape_ok = match (hb.own_shape(), &*ic.proto_shape.borrow()) {
+                                    (Some(s), Some(c)) => Rc::ptr_eq(c, s),
+                                    _ => false,
+                                };
+                                if shape_ok {
+                                    if let Some(prop) = hb.own_prop_at(ic.proto_slot.get() as usize)
+                                    {
+                                        if let PropertyKind::Data { value, .. } = &prop.kind {
                                             let v = value.clone();
                                             return Ok(v);
+                                        }
+                                    }
+                                } else if hb.own_shape().is_none() {
+                                    if let Some((PropertyKey::Str(k), prop)) =
+                                        hb.own_get_index(ic.proto_slot.get() as usize)
+                                    {
+                                        if let PropertyKind::Data { value, .. } = &prop.kind {
+                                            if k == &name {
+                                                let v = value.clone();
+                                                return Ok(v);
+                                            }
                                         }
                                     }
                                 }
@@ -3593,6 +3629,7 @@ impl Vm {
                             if let PropertyKind::Data { value, .. } = &prop.kind {
                                 ic.own_slot.set(idx as u32);
                                 let v = value.clone();
+                                *ic.own_shape.borrow_mut() = b.own_shape().cloned();
                                 return Ok(v);
                             }
                         }
@@ -3608,6 +3645,7 @@ impl Vm {
                                         ic.proto_slot.set(idx as u32);
                                         let v = value.clone();
                                         let holder_obj = p.clone();
+                                        *ic.proto_shape.borrow_mut() = pb.own_shape().cloned();
                                         drop(pb);
                                         *ic.holder.borrow_mut() = Some(holder_obj);
                                         return Ok(v);
@@ -3646,10 +3684,14 @@ impl Vm {
             if let Some(ic) = ic {
                 let mut b = o.borrow_mut();
                 if matches!(b.internal, Internal::Ordinary) {
-                    if let Some((PropertyKey::Str(k), prop)) =
-                        b.own_get_index_mut(ic.own_slot.get() as usize)
-                    {
-                        if k == &name {
+                    // Shape-verified write (docs §3.3): pointer compare, then
+                    // the same writable-data-kind check as before.
+                    let shape_ok = match (b.own_shape(), &*ic.own_shape.borrow()) {
+                        (Some(s), Some(c)) => Rc::ptr_eq(c, s),
+                        _ => false,
+                    };
+                    if shape_ok {
+                        if let Some(prop) = b.own_prop_at_mut(ic.own_slot.get() as usize) {
                             if let PropertyKind::Data {
                                 value: slot,
                                 writable: true,
@@ -3659,8 +3701,24 @@ impl Vm {
                                 return Ok(value);
                             }
                         }
+                    } else if b.own_shape().is_none() {
+                        if let Some((PropertyKey::Str(k), prop)) =
+                            b.own_get_index_mut(ic.own_slot.get() as usize)
+                        {
+                            if k == &name {
+                                if let PropertyKind::Data {
+                                    value: slot,
+                                    writable: true,
+                                } = &mut prop.kind
+                                {
+                                    *slot = value.clone();
+                                    return Ok(value);
+                                }
+                            }
+                        }
                     }
                     let key = PropertyKey::Str(name.clone());
+                    let new_shape = b.own_shape().cloned();
                     if let Some((idx, _, prop)) = b.own_get_full_mut(&key) {
                         if let PropertyKind::Data {
                             value: slot,
@@ -3668,6 +3726,7 @@ impl Vm {
                         } = &mut prop.kind
                         {
                             ic.own_slot.set(idx as u32);
+                            *ic.own_shape.borrow_mut() = new_shape;
                             *slot = value.clone();
                             return Ok(value);
                         }

--- a/crates/chidori-js/src/gc.rs
+++ b/crates/chidori-js/src/gc.rs
@@ -203,7 +203,7 @@ impl Vm {
 /// no longer keep anything else alive.
 pub(crate) fn clear_object_edges(o: &JsObject) {
     let mut b = o.borrow_mut();
-    b.props.clear();
+    b.own_clear();
     b.proto = None;
     b.internal = Internal::Ordinary;
     b.privates = None;
@@ -223,7 +223,7 @@ fn trace_object(
     if let Some(p) = &data.proto {
         f(p);
     }
-    for (_k, prop) in &data.props {
+    for (_k, prop) in data.own_iter() {
         trace_property(prop, f);
     }
     if let Some(privs) = &data.privates {

--- a/crates/chidori-js/src/gc.rs
+++ b/crates/chidori-js/src/gc.rs
@@ -62,8 +62,11 @@ impl Vm {
     }
 
     /// Allocate (and register) a plain object with the given prototype.
+    /// Born SHAPED (docs/js-object-shapes-design.md §3): its key layout
+    /// lives in the realm's shared transition tree until a demoting edge
+    /// (delete, integer-key spam) reifies a private dictionary.
     pub fn alloc_ordinary(&self, proto: Option<JsObject>) -> JsObject {
-        self.alloc(ObjectData::new(proto, Internal::Ordinary))
+        self.alloc(ObjectData::new_shaped(proto, self.realm.shape_root.clone()))
     }
 
     /// Register an externally-created object with this VM's collector.

--- a/crates/chidori-js/src/generator.rs
+++ b/crates/chidori-js/src/generator.rs
@@ -29,7 +29,7 @@ impl Vm {
         // itself (spec EvaluateGeneratorBody / OrdinaryCreateFromConstructor).
         let proto = {
             let own = func_obj.borrow();
-            match own.props.get(&PropertyKey::str("prototype")) {
+            match own.own_get(&PropertyKey::str("prototype")) {
                 Some(Property {
                     kind:
                         PropertyKind::Data {

--- a/crates/chidori-js/src/iter.rs
+++ b/crates/chidori-js/src/iter.rs
@@ -105,7 +105,7 @@ impl Vm {
         let sym = self.realm.symbol_iterator.clone();
         let key = PropertyKey::Sym(sym);
         let b = o.borrow();
-        if b.props.contains_key(&key) {
+        if b.own_contains_key(&key) {
             return false;
         }
         match &b.proto {
@@ -126,11 +126,9 @@ impl Vm {
     pub fn make_iter_result(&self, value: Value, done: bool) -> Value {
         let o = self.new_object();
         o.borrow_mut()
-            .props
-            .insert(crate::names::key_value(), Property::data(value));
+            .own_insert(crate::names::key_value(), Property::data(value));
         o.borrow_mut()
-            .props
-            .insert(crate::names::key_done(), Property::data(Value::Bool(done)));
+            .own_insert(crate::names::key_done(), Property::data(Value::Bool(done)));
         Value::Object(o)
     }
 
@@ -497,7 +495,7 @@ impl Vm {
             if !matches!(b.internal, Internal::Ordinary) {
                 return None;
             }
-            for (k, p) in b.props.iter() {
+            for (k, p) in b.own_iter() {
                 if let PropertyKey::Str(s) = k {
                     // Internal-slot keys are non-enumerable by contract, so
                     // `p.enumerable` alone excludes them, as on the generic
@@ -546,7 +544,7 @@ impl Vm {
                 }
                 _ => {}
             }
-            for (k, p) in b.props.iter() {
+            for (k, p) in b.own_iter() {
                 if p.enumerable && matches!(k, PropertyKey::Str(_)) {
                     return None;
                 }

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -34,6 +34,7 @@ pub mod realm;
 pub mod reg;
 pub mod regexp;
 pub mod replay;
+pub mod shape;
 pub mod trace;
 pub mod typed_array;
 mod unicode_tables;

--- a/crates/chidori-js/src/module.rs
+++ b/crates/chidori-js/src/module.rs
@@ -568,7 +568,7 @@ impl Vm {
             // @@toStringTag = "Module" — non-writable, non-enumerable,
             // non-configurable (spec 28.3.1).
             let tag = self.realm.symbol_to_string_tag.clone();
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::Sym(tag),
                 Property {
                     kind: crate::value::PropertyKind::Data {

--- a/crates/chidori-js/src/promise.rs
+++ b/crates/chidori-js/src/promise.rs
@@ -80,8 +80,7 @@ impl Vm {
                 .realm
                 .promise_proto
                 .borrow()
-                .props
-                .get(&StrKeyRef("then"))
+                .own_get(&StrKeyRef("then"))
                 .and_then(|p| p.value().cloned());
             let is_intrinsic_then = matches!(
                 (&then, &builtin_then),

--- a/crates/chidori-js/src/proxy.rs
+++ b/crates/chidori-js/src/proxy.rs
@@ -803,18 +803,17 @@ impl Vm {
                     let d = self.new_object();
                     {
                         let mut b = d.borrow_mut();
-                        b.props
-                            .insert(PropertyKey::str("value"), Property::data(value.clone()));
+                        b.own_insert(PropertyKey::str("value"), Property::data(value.clone()));
                         if existing.is_undefined() {
-                            b.props.insert(
+                            b.own_insert(
                                 PropertyKey::str("writable"),
                                 Property::data(Value::Bool(true)),
                             );
-                            b.props.insert(
+                            b.own_insert(
                                 PropertyKey::str("enumerable"),
                                 Property::data(Value::Bool(true)),
                             );
-                            b.props.insert(
+                            b.own_insert(
                                 PropertyKey::str("configurable"),
                                 Property::data(Value::Bool(true)),
                             );
@@ -961,11 +960,11 @@ pub fn install(vm: &mut Vm) {
         let result = vm.new_object();
         {
             let mut b = result.borrow_mut();
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("proxy"),
                 Property::data(Value::Object(proxy)),
             );
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("revoke"),
                 Property::data(Value::Object(revoke)),
             );

--- a/crates/chidori-js/src/realm.rs
+++ b/crates/chidori-js/src/realm.rs
@@ -129,6 +129,12 @@ pub struct Realm {
 
     /// Registry for `Symbol.for`.
     pub symbol_registry: indexmap::IndexMap<String, JsSymbol>,
+    /// The empty root of this realm's shape transition tree (see
+    /// [`crate::shape::Shape`]): every plain object born in this realm
+    /// starts here, so same-literal / same-record objects share key
+    /// layouts. Per-realm (not global) so shape identity checks stay
+    /// realm-local, mirroring the proto-identity inline caches.
+    pub shape_root: Rc<crate::shape::Shape>,
 }
 
 impl Realm {
@@ -259,6 +265,7 @@ impl Realm {
             symbol_intl_plural_rules: bare_symbol(19, "[[InitializedPluralRules]]"),
             symbol_intl_number_format: bare_symbol(20, "[[InitializedNumberFormat]]"),
             symbol_registry: indexmap::IndexMap::new(),
+            shape_root: crate::shape::Shape::new_root(),
         }
     }
 }

--- a/crates/chidori-js/src/reg.rs
+++ b/crates/chidori-js/src/reg.rs
@@ -1173,6 +1173,8 @@ pub fn regify(code: &[Op], num_locals: u32) -> Option<RegProto> {
             own_slot: std::cell::Cell::new(u32::MAX),
             proto_slot: std::cell::Cell::new(u32::MAX),
             holder: std::cell::RefCell::new(None),
+            own_shape: std::cell::RefCell::new(None),
+            proto_shape: std::cell::RefCell::new(None),
         })
         .collect();
     debug_assert_eq!(e.code.len(), e.costs.len());

--- a/crates/chidori-js/src/regexp.rs
+++ b/crates/chidori-js/src/regexp.rs
@@ -1859,7 +1859,7 @@ impl Vm {
         {
             let mut b = o.borrow_mut();
             // Hidden brand marker.
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str(REGEXP_MARK),
                 Property {
                     kind: PropertyKind::Data {
@@ -1871,7 +1871,7 @@ impl Vm {
                 },
             );
             // Internal source/flags strings used by exec to re-parse per call.
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("[[Source]]"),
                 Property {
                     kind: PropertyKind::Data {
@@ -1882,7 +1882,7 @@ impl Vm {
                     configurable: false,
                 },
             );
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("[[Flags]]"),
                 Property {
                     kind: PropertyKind::Data {
@@ -1894,7 +1894,7 @@ impl Vm {
                 },
             );
             // The writable lastIndex data property.
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("lastIndex"),
                 Property {
                     kind: PropertyKind::Data {
@@ -1913,10 +1913,7 @@ impl Vm {
 /// True if `v` is a RegExp object built by `make_regexp`.
 pub fn is_regexp(v: &Value) -> bool {
     if let Value::Object(o) = v {
-        return o
-            .borrow()
-            .props
-            .contains_key(&PropertyKey::str(REGEXP_MARK));
+        return o.borrow().own_contains_key(&PropertyKey::str(REGEXP_MARK));
     }
     false
 }
@@ -1925,15 +1922,13 @@ pub fn is_regexp(v: &Value) -> bool {
 pub fn regexp_source_flags(o: &JsObject) -> (String, String) {
     let b = o.borrow();
     let source = b
-        .props
-        .get(&PropertyKey::str("[[Source]]"))
+        .own_get(&PropertyKey::str("[[Source]]"))
         .and_then(|p| p.value())
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
     let flags = b
-        .props
-        .get(&PropertyKey::str("[[Flags]]"))
+        .own_get(&PropertyKey::str("[[Flags]]"))
         .and_then(|p| p.value())
         .and_then(|v| v.as_str())
         .unwrap_or("")

--- a/crates/chidori-js/src/shape.rs
+++ b/crates/chidori-js/src/shape.rs
@@ -32,6 +32,17 @@ use crate::value::PropertyKey;
 
 type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 
+/// A shape node's outgoing transition edges (see [`Shape::transitions`]).
+#[derive(Default)]
+enum Transitions {
+    #[default]
+    None,
+    /// The common linear-chain case, inline (no table allocation).
+    One(PropertyKey, Weak<Shape>),
+    /// A branching node (two+ successors seen).
+    Many(FxHashMap<PropertyKey, Weak<Shape>>),
+}
+
 /// Chain length at and above which key lookup goes through the per-shape
 /// [`Shape::index`] table. Below it, walking the parent chain is cheaper
 /// than a hash for the 2–5 key objects that dominate real code.
@@ -53,13 +64,21 @@ pub struct Shape {
     key: PropertyKey,
     /// Slot index of `key` in the owning object's slot vector (== depth-1).
     slot: u32,
-    /// key → child shape for the next appended property. Lazily allocated
-    /// (most shapes have 0 or 1 transition); values are weak — see the
-    /// module docs.
-    transitions: RefCell<FxHashMap<PropertyKey, Weak<Shape>>>,
+    /// key → child shape for the next appended property; weak — see the
+    /// module docs. Inline up to one entry: almost every node sits on a
+    /// linear chain with exactly one successor, and the inline slot spares
+    /// it a heap-allocated table (realm setup alone builds thousands of
+    /// chain nodes).
+    transitions: RefCell<Transitions>,
     /// key → slot over the whole chain, built lazily once the chain is long
     /// enough that walking beats hashing no more (see [`INDEX_THRESHOLD`]).
     index: OnceCell<FxIndexMap<PropertyKey, u32>>,
+    /// Set by the first long-chain lookup on this shape; the index is built
+    /// on the SECOND. An object grown key-by-key visits each intermediate
+    /// shape exactly once (the pre-insert lookup), so eager building there
+    /// is O(n²) index churn for a singleton builder (realm setup measured
+    /// it); a shape that is looked up twice is stable enough to pay for.
+    index_armed: std::cell::Cell<bool>,
 }
 
 impl std::fmt::Debug for Shape {
@@ -75,8 +94,9 @@ impl Shape {
             parent: None,
             key: PropertyKey::Str(crate::value::JsString::new("")),
             slot: 0,
-            transitions: RefCell::new(FxHashMap::default()),
+            transitions: RefCell::new(Transitions::None),
             index: OnceCell::new(),
+            index_armed: std::cell::Cell::new(false),
         })
     }
 
@@ -109,7 +129,7 @@ impl Shape {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        if self.len() >= INDEX_THRESHOLD {
+        if self.len() >= INDEX_THRESHOLD && self.index_armed.replace(true) {
             let index = self.index.get_or_init(|| {
                 let mut m = FxIndexMap::with_capacity_and_hasher(self.len(), Default::default());
                 let mut cur = self;
@@ -169,21 +189,60 @@ impl Shape {
     }
 
     /// The child shape appending `key`, memoized in the transition table.
+    // `PropertyKey` trips clippy's `mutable_key_type` via `JsString`'s
+    // interior length cache — a memoized DERIVED value; `Hash`/`Eq` read
+    // only the string bytes, so the key is stable (the engine's property
+    // maps use the same key type; the lint cannot see through `IndexMap`).
+    #[expect(
+        clippy::mutable_key_type,
+        reason = "JsString's interior Cell caches a derived length; Hash/Eq use the immutable bytes"
+    )]
     pub fn transition(self: &Rc<Self>, key: PropertyKey) -> Rc<Shape> {
         let mut tr = self.transitions.borrow_mut();
-        if let Some(w) = tr.get(&key) {
-            if let Some(child) = w.upgrade() {
-                return child;
+        match &*tr {
+            Transitions::None => {}
+            Transitions::One(k, w) => {
+                if *k == key {
+                    if let Some(child) = w.upgrade() {
+                        return child;
+                    }
+                }
+            }
+            Transitions::Many(m) => {
+                if let Some(w) = m.get(&key) {
+                    if let Some(child) = w.upgrade() {
+                        return child;
+                    }
+                }
             }
         }
         let child = Rc::new(Shape {
             parent: Some(self.clone()),
             key: key.clone(),
             slot: self.len() as u32,
-            transitions: RefCell::new(FxHashMap::default()),
+            transitions: RefCell::new(Transitions::None),
             index: OnceCell::new(),
+            index_armed: std::cell::Cell::new(false),
         });
-        tr.insert(key, Rc::downgrade(&child));
+        let weak = Rc::downgrade(&child);
+        match &mut *tr {
+            Transitions::None => *tr = Transitions::One(key, weak),
+            Transitions::One(k, w) => {
+                if *k == key || w.strong_count() == 0 {
+                    // Same key (dead child re-minted) or a dead sibling:
+                    // reuse the inline slot.
+                    *tr = Transitions::One(key, weak);
+                } else {
+                    let mut m = FxHashMap::default();
+                    m.insert(k.clone(), w.clone());
+                    m.insert(key, weak);
+                    *tr = Transitions::Many(m);
+                }
+            }
+            Transitions::Many(m) => {
+                m.insert(key, weak);
+            }
+        }
         child
     }
 

--- a/crates/chidori-js/src/shape.rs
+++ b/crates/chidori-js/src/shape.rs
@@ -62,6 +62,12 @@ pub struct Shape {
     index: OnceCell<FxIndexMap<PropertyKey, u32>>,
 }
 
+impl std::fmt::Debug for Shape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.keys_in_order()).finish()
+    }
+}
+
 impl Shape {
     /// The empty root of a transition tree (one per realm, held by `Realm`).
     pub fn new_root() -> Rc<Shape> {
@@ -179,6 +185,28 @@ impl Shape {
         });
         tr.insert(key, Rc::downgrade(&child));
         child
+    }
+
+    /// `true` when this shape is exactly `parent` + `key` — the O(1) cursor
+    /// check of the JSON record-shape cache (parent pointer + key equality,
+    /// where interned keys hit the `Rc` fast path).
+    #[inline]
+    pub fn appends(&self, parent: &Rc<Shape>, key: &PropertyKey) -> bool {
+        self.parent.as_ref().is_some_and(|p| Rc::ptr_eq(p, parent)) && self.key == *key
+    }
+
+    /// The chain from the first appended key down to this shape (root
+    /// excluded), i.e. `path[i]` has `i + 1` properties.
+    pub fn path_from_root(self: &Rc<Self>) -> Vec<Rc<Shape>> {
+        let mut path = Vec::with_capacity(self.len());
+        let mut cur = self.clone();
+        while cur.parent.is_some() {
+            path.push(cur.clone());
+            let p = cur.parent.clone().expect("checked");
+            cur = p;
+        }
+        path.reverse();
+        path
     }
 
     /// Whether appending `key` to a shaped object with `len` properties

--- a/crates/chidori-js/src/shape.rs
+++ b/crates/chidori-js/src/shape.rs
@@ -1,0 +1,191 @@
+//! Object shapes (hidden classes): shared own-property KEY layout.
+//!
+//! See docs/js-object-shapes-design.md. A [`Shape`] is one node in a
+//! transition tree: the root describes "no own properties (yet)" and each
+//! child appends exactly one property key to its parent. Every plain object
+//! born shaped holds an `Rc<Shape>` (its current node) plus a flat slot
+//! vector; N same-shape objects share ONE key table (the chain) instead of
+//! owning N `IndexMap`s and N copies of every key string.
+//!
+//! Invariants (docs §3.2):
+//! - A shape encodes ONLY the insertion-ordered key list. Property
+//!   attributes/kinds live in the per-object slots, so attribute mutation
+//!   never forks the tree and never demotes; only key REMOVAL (which would
+//!   shift slot indices) demotes to dictionary mode.
+//! - Shapes derive purely from program behavior (keys in insertion order):
+//!   no addresses, no RNG, nothing serialized — replay determinism is
+//!   untouched. Shape identity (`Rc::ptr_eq`) is a pure cache-verification
+//!   signal, exactly like the proto-identity inline caches.
+//! - Transitions hold `Weak` children (the child holds its parent
+//!   STRONGLY). A parent↔child `Rc` cycle would never be reclaimed by the
+//!   reference-counting GC; with weak transition edges, a shape subtree dies
+//!   with its last object (or literal-site/IC cache entry), and a later
+//!   re-transition simply rebuilds the node.
+
+use std::cell::{OnceCell, RefCell};
+use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
+use std::rc::{Rc, Weak};
+
+use crate::fxhash::{FxHasher, FxIndexMap};
+use crate::value::PropertyKey;
+
+type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// Chain length at and above which key lookup goes through the per-shape
+/// [`Shape::index`] table. Below it, walking the parent chain is cheaper
+/// than a hash for the 2–5 key objects that dominate real code.
+const INDEX_THRESHOLD: usize = 8;
+
+/// Appending an integer-index key once an object already has this many
+/// properties demotes to dictionary mode (docs §3.4): the object is being
+/// used as a sparse array / number-keyed map, where per-object dictionary
+/// storage beats minting a fresh transition chain per object.
+const INDEX_KEY_BOUND: usize = 8;
+
+/// One node in the shape tree. Immutable once created (the interior
+/// mutability is memoization only); shared via `Rc`.
+pub struct Shape {
+    /// Parent shape; `None` for the empty root.
+    parent: Option<Rc<Shape>>,
+    /// The property key this node appends to its parent. For the root this
+    /// is an unused sentinel (never compared: lookups stop above the root).
+    key: PropertyKey,
+    /// Slot index of `key` in the owning object's slot vector (== depth-1).
+    slot: u32,
+    /// key → child shape for the next appended property. Lazily allocated
+    /// (most shapes have 0 or 1 transition); values are weak — see the
+    /// module docs.
+    transitions: RefCell<FxHashMap<PropertyKey, Weak<Shape>>>,
+    /// key → slot over the whole chain, built lazily once the chain is long
+    /// enough that walking beats hashing no more (see [`INDEX_THRESHOLD`]).
+    index: OnceCell<FxIndexMap<PropertyKey, u32>>,
+}
+
+impl Shape {
+    /// The empty root of a transition tree (one per realm, held by `Realm`).
+    pub fn new_root() -> Rc<Shape> {
+        Rc::new(Shape {
+            parent: None,
+            key: PropertyKey::Str(crate::value::JsString::new("")),
+            slot: 0,
+            transitions: RefCell::new(FxHashMap::default()),
+            index: OnceCell::new(),
+        })
+    }
+
+    /// Number of properties an object of this shape has (== its slot count).
+    #[inline]
+    pub fn len(&self) -> usize {
+        if self.parent.is_none() {
+            0
+        } else {
+            self.slot as usize + 1
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.parent.is_none()
+    }
+
+    /// Slot of `key`, if present in this shape.
+    #[inline]
+    pub fn lookup<Q>(&self, key: &Q) -> Option<u32>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.lookup_full(key).map(|(slot, _)| slot)
+    }
+
+    /// Slot and canonical (shape-owned) key for `key`, if present.
+    pub fn lookup_full<Q>(&self, key: &Q) -> Option<(u32, &PropertyKey)>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        if self.len() >= INDEX_THRESHOLD {
+            let index = self.index.get_or_init(|| {
+                let mut m = FxIndexMap::with_capacity_and_hasher(self.len(), Default::default());
+                let mut cur = self;
+                while cur.parent.is_some() {
+                    m.insert(cur.key.clone(), cur.slot);
+                    cur = cur.parent.as_deref().expect("checked");
+                }
+                m
+            });
+            return index.get_full(key).map(|(_, k, slot)| (*slot, k));
+        }
+        let mut cur = self;
+        while cur.parent.is_some() {
+            if key.equivalent(&cur.key) {
+                return Some((cur.slot, &cur.key));
+            }
+            cur = cur.parent.as_deref().expect("checked");
+        }
+        None
+    }
+
+    /// The key stored at slot `i`, if in range. O(len - i) parent hops —
+    /// callers indexing hot (the pre-Phase-3 IC verification) sit on 2–5 key
+    /// objects where this is a couple of pointer chases.
+    pub fn key_at(&self, i: u32) -> Option<&PropertyKey> {
+        let len = self.len() as u32;
+        if i >= len {
+            return None;
+        }
+        let mut cur = self;
+        for _ in 0..(len - 1 - i) {
+            cur = cur.parent.as_deref().expect("depth checked");
+        }
+        Some(&cur.key)
+    }
+
+    /// All keys, insertion order (slot order).
+    pub fn keys_in_order(&self) -> Vec<&PropertyKey> {
+        let mut keys = Vec::with_capacity(self.len());
+        let mut cur = self;
+        while cur.parent.is_some() {
+            keys.push(&cur.key);
+            cur = cur.parent.as_deref().expect("checked");
+        }
+        keys.reverse();
+        keys
+    }
+
+    /// The root of this shape's tree (for resetting an emptied object).
+    pub fn root(self: &Rc<Self>) -> Rc<Shape> {
+        let mut cur = self.clone();
+        while let Some(p) = &cur.parent {
+            let p = p.clone();
+            cur = p;
+        }
+        cur
+    }
+
+    /// The child shape appending `key`, memoized in the transition table.
+    pub fn transition(self: &Rc<Self>, key: PropertyKey) -> Rc<Shape> {
+        let mut tr = self.transitions.borrow_mut();
+        if let Some(w) = tr.get(&key) {
+            if let Some(child) = w.upgrade() {
+                return child;
+            }
+        }
+        let child = Rc::new(Shape {
+            parent: Some(self.clone()),
+            key: key.clone(),
+            slot: self.len() as u32,
+            transitions: RefCell::new(FxHashMap::default()),
+            index: OnceCell::new(),
+        });
+        tr.insert(key, Rc::downgrade(&child));
+        child
+    }
+
+    /// Whether appending `key` to a shaped object with `len` properties
+    /// keeps it shaped (docs §3.4: integer-index spam past a small bound is
+    /// an object used as a sparse array — dictionary mode fits better).
+    #[inline]
+    pub fn can_append(key: &PropertyKey, len: usize) -> bool {
+        len < INDEX_KEY_BOUND || key.array_index().is_none()
+    }
+}

--- a/crates/chidori-js/src/typed_array.rs
+++ b/crates/chidori-js/src/typed_array.rs
@@ -191,7 +191,7 @@ impl Vm {
     /// shared brand. (A SharedArrayBuffer shares the `Internal::ArrayBuffer`
     /// byte storage; only the brand and prototype distinguish it.)
     pub fn is_shared_buffer(&self, o: &JsObject) -> bool {
-        o.borrow().props.contains_key(&PropertyKey::Sym(
+        o.borrow().own_contains_key(&PropertyKey::Sym(
             self.realm.symbol_array_buffer_shared.clone(),
         ))
     }
@@ -214,12 +214,12 @@ impl Vm {
                 enumerable: false,
                 configurable: false,
             };
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::Sym(self.realm.symbol_array_buffer_shared.clone()),
                 slot(Value::Bool(true)),
             );
             if let Some(m) = max {
-                b.props.insert(
+                b.own_insert(
                     PropertyKey::str(ARRAY_BUFFER_MAX_SLOT),
                     slot(Value::Number(m as f64)),
                 );

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -908,11 +908,26 @@ impl Default for PropStorage {
     }
 }
 
+/// Chain length up to which shaped iteration steps positions in place
+/// (`key_at` per step: O(len²) parent hops total, ZERO allocation) rather
+/// than pre-collecting the key list. Stringify/own-keys enumerate every
+/// object per pass, so the per-object `Vec` was a measurable slice of
+/// `json_stringify`; the 2–8 key records that dominate stay alloc-free and
+/// genuinely wide objects pay one collect instead of O(len²) hops.
+const ITER_WALK_MAX: usize = 16;
+
 /// Iterator over own properties in insertion order, across both storage
 /// modes (see [`ObjectData::own_iter`]).
 pub enum OwnIter<'a> {
     Dict(indexmap::map::Iter<'a, PropertyKey, Property>),
+    /// Positional stepping over a short shaped chain (alloc-free).
     Shaped {
+        shape: &'a crate::shape::Shape,
+        slots: &'a [Property],
+        pos: u32,
+    },
+    /// Pre-collected keys for a wide shaped chain.
+    ShapedWide {
         keys: std::vec::IntoIter<&'a PropertyKey>,
         slots: std::slice::Iter<'a, Property>,
     },
@@ -924,13 +939,23 @@ impl<'a> Iterator for OwnIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             OwnIter::Dict(it) => it.next(),
-            OwnIter::Shaped { keys, slots } => Some((keys.next()?, slots.next()?)),
+            OwnIter::Shaped { shape, slots, pos } => {
+                let i = *pos as usize;
+                let prop = slots.get(i)?;
+                *pos += 1;
+                Some((shape.key_at(i as u32).expect("slot in range"), prop))
+            }
+            OwnIter::ShapedWide { keys, slots } => Some((keys.next()?, slots.next()?)),
         }
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
             OwnIter::Dict(it) => it.size_hint(),
-            OwnIter::Shaped { keys, .. } => keys.size_hint(),
+            OwnIter::Shaped { slots, pos, .. } => {
+                let n = slots.len().saturating_sub(*pos as usize);
+                (n, Some(n))
+            }
+            OwnIter::ShapedWide { keys, .. } => keys.size_hint(),
         }
     }
 }
@@ -941,7 +966,14 @@ impl ExactSizeIterator for OwnIter<'_> {}
 /// modes (see [`ObjectData::own_keys_iter`]).
 pub enum OwnKeys<'a> {
     Dict(indexmap::map::Keys<'a, PropertyKey, Property>),
-    Shaped(std::vec::IntoIter<&'a PropertyKey>),
+    /// Positional stepping over a short shaped chain (alloc-free).
+    Shaped {
+        shape: &'a crate::shape::Shape,
+        pos: u32,
+        len: u32,
+    },
+    /// Pre-collected keys for a wide shaped chain.
+    ShapedWide(std::vec::IntoIter<&'a PropertyKey>),
 }
 
 impl<'a> Iterator for OwnKeys<'a> {
@@ -950,13 +982,26 @@ impl<'a> Iterator for OwnKeys<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             OwnKeys::Dict(it) => it.next(),
-            OwnKeys::Shaped(it) => it.next(),
+            OwnKeys::Shaped { shape, pos, len } => {
+                if pos < len {
+                    let k = shape.key_at(*pos).expect("slot in range");
+                    *pos += 1;
+                    Some(k)
+                } else {
+                    None
+                }
+            }
+            OwnKeys::ShapedWide(it) => it.next(),
         }
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
             OwnKeys::Dict(it) => it.size_hint(),
-            OwnKeys::Shaped(it) => it.size_hint(),
+            OwnKeys::Shaped { pos, len, .. } => {
+                let n = (*len - *pos) as usize;
+                (n, Some(n))
+            }
+            OwnKeys::ShapedWide(it) => it.size_hint(),
         }
     }
 }
@@ -1260,7 +1305,14 @@ impl ObjectData {
     pub fn own_iter(&self) -> OwnIter<'_> {
         match &self.props {
             PropStorage::Dict(m) => OwnIter::Dict(m.iter()),
-            PropStorage::Shaped { shape, slots } => OwnIter::Shaped {
+            PropStorage::Shaped { shape, slots } if slots.len() <= ITER_WALK_MAX => {
+                OwnIter::Shaped {
+                    shape,
+                    slots,
+                    pos: 0,
+                }
+            }
+            PropStorage::Shaped { shape, slots } => OwnIter::ShapedWide {
                 keys: shape.keys_in_order().into_iter(),
                 slots: slots.iter(),
             },
@@ -1272,7 +1324,16 @@ impl ObjectData {
     pub fn own_keys_iter(&self) -> OwnKeys<'_> {
         match &self.props {
             PropStorage::Dict(m) => OwnKeys::Dict(m.keys()),
-            PropStorage::Shaped { shape, .. } => OwnKeys::Shaped(shape.keys_in_order().into_iter()),
+            PropStorage::Shaped { shape, slots } if slots.len() <= ITER_WALK_MAX => {
+                OwnKeys::Shaped {
+                    shape,
+                    pos: 0,
+                    len: slots.len() as u32,
+                }
+            }
+            PropStorage::Shaped { shape, .. } => {
+                OwnKeys::ShapedWide(shape.keys_in_order().into_iter())
+            }
         }
     }
 

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -1006,6 +1006,24 @@ impl ObjectData {
         }
     }
 
+    /// A plain object born shaped at a KNOWN shape with its slots pre-built
+    /// (object-literal template instantiation). `slots.len()` must equal
+    /// `shape.len()`.
+    pub fn new_shaped_with(
+        proto: Option<JsObject>,
+        shape: Rc<crate::shape::Shape>,
+        slots: Vec<Property>,
+    ) -> Self {
+        debug_assert_eq!(slots.len(), shape.len());
+        ObjectData {
+            proto,
+            props: PropStorage::Shaped { shape, slots },
+            extensible: true,
+            internal: Internal::Ordinary,
+            privates: None,
+        }
+    }
+
     pub fn private_get(&self, id: u64) -> Option<&PrivateElement> {
         self.privates.as_ref().and_then(|p| p.get(&id))
     }
@@ -1162,6 +1180,37 @@ impl ObjectData {
         match &mut self.props {
             PropStorage::Dict(m) => m.shift_remove(key),
             PropStorage::Shaped { .. } => unreachable!("demoted above"),
+        }
+    }
+
+    /// The current shape, when the storage is shaped (`None` in dictionary
+    /// mode). Shape identity (`Rc::ptr_eq`) pins the whole key layout — the
+    /// basis of the (shape, slot) inline caches (docs §3.3).
+    #[inline]
+    pub fn own_shape(&self) -> Option<&Rc<crate::shape::Shape>> {
+        match &self.props {
+            PropStorage::Shaped { shape, .. } => Some(shape),
+            PropStorage::Dict(_) => None,
+        }
+    }
+
+    /// The property at slot `i` WITHOUT retrieving its key — for
+    /// shape-verified cache hits, where shape identity already pins the key
+    /// at every slot.
+    #[inline]
+    pub fn own_prop_at(&self, i: usize) -> Option<&Property> {
+        match &self.props {
+            PropStorage::Shaped { slots, .. } => slots.get(i),
+            PropStorage::Dict(m) => m.get_index(i).map(|(_, p)| p),
+        }
+    }
+
+    /// Mutable variant of [`Self::own_prop_at`].
+    #[inline]
+    pub fn own_prop_at_mut(&mut self, i: usize) -> Option<&mut Property> {
+        match &mut self.props {
+            PropStorage::Shaped { slots, .. } => slots.get_mut(i),
+            PropStorage::Dict(m) => m.get_index_mut(i).map(|(_, p)| p),
         }
     }
 

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -774,15 +774,13 @@ pub fn protos_allow_index_create(proto: Option<JsObject>, idx: u32, count: u32) 
             // String character slots, mapped Arguments, …) own their [[Set]].
             _ => return false,
         }
-        if !b.props.is_empty() {
-            if b.props.contains_key(&StrKeyRef(first)) {
+        if !b.own_is_empty() {
+            if b.own_contains_key(&StrKeyRef(first)) {
                 return false;
             }
             for j in 1..count {
                 let mut buf = [0u8; 10];
-                if b.props
-                    .contains_key(&StrKeyRef(fmt_index(idx + j, &mut buf)))
-                {
+                if b.own_contains_key(&StrKeyRef(fmt_index(idx + j, &mut buf))) {
                     return false;
                 }
             }
@@ -810,7 +808,7 @@ pub fn protos_allow_any_index_create(start: &JsObject) -> bool {
             Internal::Ordinary | Internal::Array(_) => {}
             _ => return false,
         }
-        if !b.props.is_empty() && b.props.keys().any(|k| k.array_index().is_some()) {
+        if !b.own_is_empty() && b.own_keys_iter().any(|k| k.array_index().is_some()) {
             return false;
         }
         let next = b.proto.clone();
@@ -885,7 +883,11 @@ impl Property {
 
 pub struct ObjectData {
     pub proto: Option<JsObject>,
-    pub props: crate::fxhash::FxIndexMap<PropertyKey, Property>,
+    /// The ordinary own-property storage. Private to this module: every other
+    /// part of the engine goes through the `own_*` accessor API below, so the
+    /// backing representation can change (see `PropStorage`) without touching
+    /// the 300+ call sites again.
+    props: crate::fxhash::FxIndexMap<PropertyKey, Property>,
     pub extensible: bool,
     pub internal: Internal,
     /// The spec `[[PrivateElements]]` list, keyed by [`PrivateName::id`].
@@ -908,16 +910,164 @@ impl ObjectData {
     pub fn private_get(&self, id: u64) -> Option<&PrivateElement> {
         self.privates.as_ref().and_then(|p| p.get(&id))
     }
+
+    // =====================================================================
+    // Own-property accessor API (see docs/js-object-shapes-design.md §4,
+    // Phase 1). This is the ONLY way the rest of the engine touches the
+    // ordinary own-property storage; the map itself is module-private.
+    //
+    // The API mirrors `IndexMap`'s surface deliberately: the inline caches
+    // and the kernel prop machinery depend on stable insertion-order slot
+    // indices (`own_get_full` hands them out, `own_get_index[_mut]` uses
+    // them), and probes are generic over `Equivalent<PropertyKey>` so the
+    // alloc-free `StrKeyRef` guards keep working unchanged.
+    // =====================================================================
+
+    /// The own property for `key`, if present.
+    #[inline]
+    pub fn own_get<Q>(&self, key: &Q) -> Option<&Property>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.props.get(key)
+    }
+
+    /// Mutable access to the own property for `key`, if present.
+    #[inline]
+    pub fn own_get_mut<Q>(&mut self, key: &Q) -> Option<&mut Property>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.props.get_mut(key)
+    }
+
+    /// The own property for `key` with its insertion-order slot index (the
+    /// index the inline caches and kernel prop localization cache; it is
+    /// stable for the property's lifetime).
+    #[inline]
+    pub fn own_get_full<Q>(&self, key: &Q) -> Option<(usize, &PropertyKey, &Property)>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.props.get_full(key)
+    }
+
+    /// Mutable variant of [`Self::own_get_full`].
+    #[inline]
+    pub fn own_get_full_mut<Q>(&mut self, key: &Q) -> Option<(usize, &PropertyKey, &mut Property)>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.props.get_full_mut(key)
+    }
+
+    /// Whether an own property for `key` exists.
+    #[inline]
+    pub fn own_contains_key<Q>(&self, key: &Q) -> bool
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.props.contains_key(key)
+    }
+
+    /// Insert (or replace, preserving insertion order) the own property for
+    /// `key`, returning the previous property if any — `IndexMap::insert`
+    /// semantics. Spec checks (extensibility, writability) are the CALLER's
+    /// job, exactly as with the raw map.
+    #[inline]
+    pub fn own_insert(&mut self, key: PropertyKey, prop: Property) -> Option<Property> {
+        self.props.insert(key, prop)
+    }
+
+    /// Remove the own property for `key`, preserving the insertion order of
+    /// the remaining properties (`shift_remove` semantics — enumeration
+    /// order is observable).
+    #[inline]
+    pub fn own_remove<Q>(&mut self, key: &Q) -> Option<Property>
+    where
+        Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
+    {
+        self.props.shift_remove(key)
+    }
+
+    /// The own property at insertion-order slot `i` (IC/kernel verification:
+    /// callers compare the returned key against the expected one).
+    #[inline]
+    pub fn own_get_index(&self, i: usize) -> Option<(&PropertyKey, &Property)> {
+        self.props.get_index(i)
+    }
+
+    /// Mutable variant of [`Self::own_get_index`].
+    #[inline]
+    pub fn own_get_index_mut(&mut self, i: usize) -> Option<(&PropertyKey, &mut Property)> {
+        self.props.get_index_mut(i)
+    }
+
+    /// Number of own properties in the ordinary storage.
+    #[inline]
+    pub fn own_len(&self) -> usize {
+        self.props.len()
+    }
+
+    /// `true` when the ordinary own-property storage is empty — the guard
+    /// every dense-array/exotic fast path checks ("nothing reified can
+    /// shadow").
+    #[inline]
+    pub fn own_is_empty(&self) -> bool {
+        self.props.is_empty()
+    }
+
+    /// Iterate own properties in insertion order.
+    #[inline]
+    pub fn own_iter(&self) -> indexmap::map::Iter<'_, PropertyKey, Property> {
+        self.props.iter()
+    }
+
+    /// Iterate own property keys in insertion order.
+    #[inline]
+    pub fn own_keys_iter(&self) -> indexmap::map::Keys<'_, PropertyKey, Property> {
+        self.props.keys()
+    }
+
+    /// Pre-size the storage for `n` additional properties.
+    #[inline]
+    pub fn own_reserve(&mut self, n: usize) {
+        self.props.reserve(n);
+    }
+
+    /// Allocated capacity of the storage (0 ⇔ nothing allocated yet).
+    #[inline]
+    pub fn own_capacity(&self) -> usize {
+        self.props.capacity()
+    }
+
+    /// Drop every own property (GC edge-clearing).
+    #[inline]
+    pub fn own_clear(&mut self) {
+        self.props.clear();
+    }
+
+    /// Replace the whole storage with a pre-built map (object-literal
+    /// template instantiation).
+    #[inline]
+    pub fn set_props_map(&mut self, map: crate::fxhash::FxIndexMap<PropertyKey, Property>) {
+        self.props = map;
+    }
+
+    /// Take the whole storage, leaving it empty (teardown / cycle breaking).
+    #[inline]
+    pub fn take_props_map(&mut self) -> crate::fxhash::FxIndexMap<PropertyKey, Property> {
+        std::mem::take(&mut self.props)
+    }
     /// Does `props` hold a (reified) entry for the array index `idx`?
     /// Alloc-free: the index is formatted into a stack buffer and probed via
     /// [`StrKeyRef`], so hot fast-path guards can call this per element.
     pub fn has_index_prop(&self, idx: u32) -> bool {
-        if self.props.is_empty() {
+        if self.own_is_empty() {
             return false;
         }
         let mut buf = [0u8; 10];
-        self.props
-            .contains_key(&StrKeyRef(fmt_index(idx, &mut buf)))
+        self.own_contains_key(&StrKeyRef(fmt_index(idx, &mut buf)))
     }
     /// Append a private element; `false` (no insert) when `id` is already
     /// present — the caller's duplicate-initialization TypeError.

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -1008,6 +1008,24 @@ impl<'a> Iterator for OwnKeys<'a> {
 
 impl ExactSizeIterator for OwnKeys<'_> {}
 
+/// Owning iterator over property values (see
+/// [`ObjectData::take_props_values`]).
+pub enum PropsIntoValues {
+    Dict(indexmap::map::IntoValues<PropertyKey, Property>),
+    Slots(std::vec::IntoIter<Property>),
+}
+
+impl Iterator for PropsIntoValues {
+    type Item = Property;
+    #[inline]
+    fn next(&mut self) -> Option<Property> {
+        match self {
+            PropsIntoValues::Dict(it) => it.next(),
+            PropsIntoValues::Slots(it) => it.next(),
+        }
+    }
+}
+
 pub struct ObjectData {
     pub proto: Option<JsObject>,
     /// The ordinary own-property storage. Private to this module: every other
@@ -1374,13 +1392,15 @@ impl ObjectData {
         self.props = PropStorage::Dict(map);
     }
 
-    /// Take the whole storage, leaving it empty (teardown / cycle breaking).
+    /// Take every own property VALUE, leaving the storage empty (teardown /
+    /// cycle breaking — the keys are not needed to break value edges, and a
+    /// shaped object must not pay a key-cloning dictionary materialization
+    /// just to be dropped).
     #[inline]
-    pub fn take_props_map(&mut self) -> crate::fxhash::FxIndexMap<PropertyKey, Property> {
-        self.demote();
+    pub fn take_props_values(&mut self) -> PropsIntoValues {
         match std::mem::take(&mut self.props) {
-            PropStorage::Dict(m) => m,
-            PropStorage::Shaped { .. } => unreachable!("demoted above"),
+            PropStorage::Dict(m) => PropsIntoValues::Dict(m.into_values()),
+            PropStorage::Shaped { slots, .. } => PropsIntoValues::Slots(slots.into_iter()),
         }
     }
     /// Does `props` hold a (reified) entry for the array index `idx`?

--- a/crates/chidori-js/src/value.rs
+++ b/crates/chidori-js/src/value.rs
@@ -881,13 +881,95 @@ impl Property {
     }
 }
 
+/// Ordinary own-property storage (see docs/js-object-shapes-design.md §3.1).
+///
+/// `Shaped` is the append-only common case: the [`Shape`] holds the shared,
+/// insertion-ordered key list and `slots[i]` holds the full [`Property`] for
+/// the key at chain depth `i`. Keeping whole `Property` values in the slots
+/// (rather than bare values) means attribute mutation and accessor
+/// properties need NO demotion — the shape encodes key ORDER only, so the
+/// only edges that demote are the order-destroying ones (`delete`) and
+/// integer-key spam (see [`Shape::can_append`]). `Dict` is today's map,
+/// verbatim: the battle-tested path every demoted object falls back to
+/// (objects never re-promote), and the birth mode for exotics/intrinsics.
+///
+/// Mode is unobservable: enumeration order is insertion order in both.
+pub(crate) enum PropStorage {
+    Shaped {
+        shape: Rc<crate::shape::Shape>,
+        slots: Vec<Property>,
+    },
+    Dict(crate::fxhash::FxIndexMap<PropertyKey, Property>),
+}
+
+impl Default for PropStorage {
+    fn default() -> Self {
+        PropStorage::Dict(crate::fxhash::FxIndexMap::default())
+    }
+}
+
+/// Iterator over own properties in insertion order, across both storage
+/// modes (see [`ObjectData::own_iter`]).
+pub enum OwnIter<'a> {
+    Dict(indexmap::map::Iter<'a, PropertyKey, Property>),
+    Shaped {
+        keys: std::vec::IntoIter<&'a PropertyKey>,
+        slots: std::slice::Iter<'a, Property>,
+    },
+}
+
+impl<'a> Iterator for OwnIter<'a> {
+    type Item = (&'a PropertyKey, &'a Property);
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            OwnIter::Dict(it) => it.next(),
+            OwnIter::Shaped { keys, slots } => Some((keys.next()?, slots.next()?)),
+        }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            OwnIter::Dict(it) => it.size_hint(),
+            OwnIter::Shaped { keys, .. } => keys.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for OwnIter<'_> {}
+
+/// Iterator over own property keys in insertion order, across both storage
+/// modes (see [`ObjectData::own_keys_iter`]).
+pub enum OwnKeys<'a> {
+    Dict(indexmap::map::Keys<'a, PropertyKey, Property>),
+    Shaped(std::vec::IntoIter<&'a PropertyKey>),
+}
+
+impl<'a> Iterator for OwnKeys<'a> {
+    type Item = &'a PropertyKey;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            OwnKeys::Dict(it) => it.next(),
+            OwnKeys::Shaped(it) => it.next(),
+        }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            OwnKeys::Dict(it) => it.size_hint(),
+            OwnKeys::Shaped(it) => it.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for OwnKeys<'_> {}
+
 pub struct ObjectData {
     pub proto: Option<JsObject>,
     /// The ordinary own-property storage. Private to this module: every other
     /// part of the engine goes through the `own_*` accessor API below, so the
-    /// backing representation can change (see `PropStorage`) without touching
-    /// the 300+ call sites again.
-    props: crate::fxhash::FxIndexMap<PropertyKey, Property>,
+    /// backing representation can vary (shaped vs dictionary) without the
+    /// 300+ call sites knowing.
+    props: PropStorage,
     pub extensible: bool,
     pub internal: Internal,
     /// The spec `[[PrivateElements]]` list, keyed by [`PrivateName::id`].
@@ -901,14 +983,54 @@ impl ObjectData {
     pub fn new(proto: Option<JsObject>, internal: Internal) -> Self {
         ObjectData {
             proto,
-            props: crate::fxhash::FxIndexMap::default(),
+            props: PropStorage::default(),
             extensible: true,
             internal,
             privates: None,
         }
     }
+
+    /// A plain object born in shaped mode: `root` is the realm's empty root
+    /// shape. Costs nothing until the first insert (no table, no slot vec
+    /// allocation).
+    pub fn new_shaped(proto: Option<JsObject>, root: Rc<crate::shape::Shape>) -> Self {
+        ObjectData {
+            proto,
+            props: PropStorage::Shaped {
+                shape: root,
+                slots: Vec::new(),
+            },
+            extensible: true,
+            internal: Internal::Ordinary,
+            privates: None,
+        }
+    }
+
     pub fn private_get(&self, id: u64) -> Option<&PrivateElement> {
         self.privates.as_ref().and_then(|p| p.get(&id))
+    }
+
+    /// Demote to dictionary mode: materialize the map from the shape chain +
+    /// slots, preserving insertion order. One-way — a demoted object never
+    /// re-promotes (docs §3.4). Idempotent; returns the map for follow-up
+    /// mutation.
+    fn demote(&mut self) -> &mut crate::fxhash::FxIndexMap<PropertyKey, Property> {
+        if matches!(self.props, PropStorage::Shaped { .. }) {
+            if let PropStorage::Shaped { shape, slots } = std::mem::take(&mut self.props) {
+                let mut map = crate::fxhash::FxIndexMap::with_capacity_and_hasher(
+                    slots.len() + 1,
+                    Default::default(),
+                );
+                for (k, p) in shape.keys_in_order().into_iter().zip(slots) {
+                    map.insert(k.clone(), p);
+                }
+                self.props = PropStorage::Dict(map);
+            }
+        }
+        match &mut self.props {
+            PropStorage::Dict(m) => m,
+            PropStorage::Shaped { .. } => unreachable!("just demoted"),
+        }
     }
 
     // =====================================================================
@@ -929,7 +1051,12 @@ impl ObjectData {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        self.props.get(key)
+        match &self.props {
+            PropStorage::Dict(m) => m.get(key),
+            PropStorage::Shaped { shape, slots } => {
+                shape.lookup(key).map(|slot| &slots[slot as usize])
+            }
+        }
     }
 
     /// Mutable access to the own property for `key`, if present.
@@ -938,7 +1065,12 @@ impl ObjectData {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        self.props.get_mut(key)
+        match &mut self.props {
+            PropStorage::Dict(m) => m.get_mut(key),
+            PropStorage::Shaped { shape, slots } => {
+                shape.lookup(key).map(|slot| &mut slots[slot as usize])
+            }
+        }
     }
 
     /// The own property for `key` with its insertion-order slot index (the
@@ -949,7 +1081,13 @@ impl ObjectData {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        self.props.get_full(key)
+        match &self.props {
+            PropStorage::Dict(m) => m.get_full(key),
+            PropStorage::Shaped { shape, slots } => {
+                let (slot, k) = shape.lookup_full(key)?;
+                Some((slot as usize, k, &slots[slot as usize]))
+            }
+        }
     }
 
     /// Mutable variant of [`Self::own_get_full`].
@@ -958,7 +1096,13 @@ impl ObjectData {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        self.props.get_full_mut(key)
+        match &mut self.props {
+            PropStorage::Dict(m) => m.get_full_mut(key),
+            PropStorage::Shaped { shape, slots } => {
+                let (slot, k) = shape.lookup_full(key)?;
+                Some((slot as usize, k, &mut slots[slot as usize]))
+            }
+        }
     }
 
     /// Whether an own property for `key` exists.
@@ -967,7 +1111,10 @@ impl ObjectData {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        self.props.contains_key(key)
+        match &self.props {
+            PropStorage::Dict(m) => m.contains_key(key),
+            PropStorage::Shaped { shape, .. } => shape.lookup(key).is_some(),
+        }
     }
 
     /// Insert (or replace, preserving insertion order) the own property for
@@ -976,7 +1123,25 @@ impl ObjectData {
     /// job, exactly as with the raw map.
     #[inline]
     pub fn own_insert(&mut self, key: PropertyKey, prop: Property) -> Option<Property> {
-        self.props.insert(key, prop)
+        match &mut self.props {
+            PropStorage::Dict(m) => return m.insert(key, prop),
+            PropStorage::Shaped { shape, slots } => {
+                if let Some(slot) = shape.lookup(&key) {
+                    // Replacing at an existing key keeps slot order in both
+                    // modes; the shape is unchanged.
+                    return Some(std::mem::replace(&mut slots[slot as usize], prop));
+                }
+                if crate::shape::Shape::can_append(&key, slots.len()) {
+                    let next = shape.transition(key);
+                    *shape = next;
+                    slots.push(prop);
+                    return None;
+                }
+            }
+        }
+        // Shaped, but the key must not join the transition tree
+        // (integer-index spam): fall to dictionary mode.
+        self.demote().insert(key, prop)
     }
 
     /// Remove the own property for `key`, preserving the insertion order of
@@ -987,26 +1152,47 @@ impl ObjectData {
     where
         Q: ?Sized + std::hash::Hash + indexmap::Equivalent<PropertyKey>,
     {
-        self.props.shift_remove(key)
+        if let PropStorage::Shaped { shape, .. } = &self.props {
+            // Deleting an absent key changes nothing: stay shaped. A hit
+            // shifts the slot indices of everything after it — the one edge
+            // shapes cannot represent — so demote first (docs §3.4).
+            shape.lookup(key)?;
+            self.demote();
+        }
+        match &mut self.props {
+            PropStorage::Dict(m) => m.shift_remove(key),
+            PropStorage::Shaped { .. } => unreachable!("demoted above"),
+        }
     }
 
     /// The own property at insertion-order slot `i` (IC/kernel verification:
     /// callers compare the returned key against the expected one).
     #[inline]
     pub fn own_get_index(&self, i: usize) -> Option<(&PropertyKey, &Property)> {
-        self.props.get_index(i)
+        match &self.props {
+            PropStorage::Dict(m) => m.get_index(i),
+            PropStorage::Shaped { shape, slots } => Some((shape.key_at(i as u32)?, slots.get(i)?)),
+        }
     }
 
     /// Mutable variant of [`Self::own_get_index`].
     #[inline]
     pub fn own_get_index_mut(&mut self, i: usize) -> Option<(&PropertyKey, &mut Property)> {
-        self.props.get_index_mut(i)
+        match &mut self.props {
+            PropStorage::Dict(m) => m.get_index_mut(i),
+            PropStorage::Shaped { shape, slots } => {
+                Some((shape.key_at(i as u32)?, slots.get_mut(i)?))
+            }
+        }
     }
 
     /// Number of own properties in the ordinary storage.
     #[inline]
     pub fn own_len(&self) -> usize {
-        self.props.len()
+        match &self.props {
+            PropStorage::Dict(m) => m.len(),
+            PropStorage::Shaped { slots, .. } => slots.len(),
+        }
     }
 
     /// `true` when the ordinary own-property storage is empty — the guard
@@ -1014,50 +1200,78 @@ impl ObjectData {
     /// shadow").
     #[inline]
     pub fn own_is_empty(&self) -> bool {
-        self.props.is_empty()
+        match &self.props {
+            PropStorage::Dict(m) => m.is_empty(),
+            PropStorage::Shaped { slots, .. } => slots.is_empty(),
+        }
     }
 
     /// Iterate own properties in insertion order.
     #[inline]
-    pub fn own_iter(&self) -> indexmap::map::Iter<'_, PropertyKey, Property> {
-        self.props.iter()
+    pub fn own_iter(&self) -> OwnIter<'_> {
+        match &self.props {
+            PropStorage::Dict(m) => OwnIter::Dict(m.iter()),
+            PropStorage::Shaped { shape, slots } => OwnIter::Shaped {
+                keys: shape.keys_in_order().into_iter(),
+                slots: slots.iter(),
+            },
+        }
     }
 
     /// Iterate own property keys in insertion order.
     #[inline]
-    pub fn own_keys_iter(&self) -> indexmap::map::Keys<'_, PropertyKey, Property> {
-        self.props.keys()
+    pub fn own_keys_iter(&self) -> OwnKeys<'_> {
+        match &self.props {
+            PropStorage::Dict(m) => OwnKeys::Dict(m.keys()),
+            PropStorage::Shaped { shape, .. } => OwnKeys::Shaped(shape.keys_in_order().into_iter()),
+        }
     }
 
     /// Pre-size the storage for `n` additional properties.
     #[inline]
     pub fn own_reserve(&mut self, n: usize) {
-        self.props.reserve(n);
+        match &mut self.props {
+            PropStorage::Dict(m) => m.reserve(n),
+            PropStorage::Shaped { slots, .. } => slots.reserve(n),
+        }
     }
 
     /// Allocated capacity of the storage (0 ⇔ nothing allocated yet).
     #[inline]
     pub fn own_capacity(&self) -> usize {
-        self.props.capacity()
+        match &self.props {
+            PropStorage::Dict(m) => m.capacity(),
+            PropStorage::Shaped { slots, .. } => slots.capacity(),
+        }
     }
 
     /// Drop every own property (GC edge-clearing).
     #[inline]
     pub fn own_clear(&mut self) {
-        self.props.clear();
+        match &mut self.props {
+            PropStorage::Dict(m) => m.clear(),
+            PropStorage::Shaped { shape, slots } => {
+                slots.clear();
+                *shape = shape.root();
+            }
+        }
     }
 
     /// Replace the whole storage with a pre-built map (object-literal
     /// template instantiation).
     #[inline]
     pub fn set_props_map(&mut self, map: crate::fxhash::FxIndexMap<PropertyKey, Property>) {
-        self.props = map;
+        self.props = PropStorage::Dict(map);
     }
 
     /// Take the whole storage, leaving it empty (teardown / cycle breaking).
     #[inline]
     pub fn take_props_map(&mut self) -> crate::fxhash::FxIndexMap<PropertyKey, Property> {
-        std::mem::take(&mut self.props)
+        self.demote();
+        match std::mem::take(&mut self.props) {
+            PropStorage::Dict(m) => m,
+            PropStorage::Shaped { .. } => unreachable!("demoted above"),
+        }
     }
     /// Does `props` hold a (reified) entry for the array index `idx`?
     /// Alloc-free: the index is formatted into a stack buffer and probed via

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -1986,7 +1986,7 @@ impl Vm {
             if let Some(p) = b.proto.take() {
                 stack.push(p);
             }
-            for (_k, prop) in b.take_props_map() {
+            for prop in b.take_props_values() {
                 match prop.kind {
                     PropertyKind::Data { value, .. } => push_dispose_obj(value, &mut stack),
                     PropertyKind::Accessor { get, set } => {

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -489,17 +489,31 @@ impl Vm {
         tpl: &crate::bytecode::ObjTemplate,
         values: impl Iterator<Item = Value>,
     ) -> JsObject {
-        let mut map = tpl.map.clone();
-        for (i, v) in values.enumerate() {
-            let (_, p) = map.get_index_mut(i).expect("template arity");
-            p.kind = PropertyKind::Data {
-                value: v,
-                writable: true,
-            };
-        }
-        let mut data = ObjectData::new(Some(self.realm.object_proto.clone()), Internal::Ordinary);
-        data.set_props_map(map);
-        self.alloc(data)
+        // Resolve (and memoize) this literal site's leaf shape in the
+        // current realm: after warm-up, instantiation is one slot-vec
+        // allocation + N value writes — no hashing, no per-key inserts.
+        let shape = {
+            let mut cache = tpl.shape_cache.borrow_mut();
+            match &*cache {
+                Some((root, leaf)) if Rc::ptr_eq(root, &self.realm.shape_root) => leaf.clone(),
+                _ => {
+                    let mut leaf = self.realm.shape_root.clone();
+                    for k in tpl.map.keys() {
+                        leaf = leaf.transition(k.clone());
+                    }
+                    *cache = Some((self.realm.shape_root.clone(), leaf.clone()));
+                    leaf
+                }
+            }
+        };
+        let mut slots = Vec::with_capacity(tpl.map.len());
+        slots.extend(values.map(Property::data));
+        debug_assert_eq!(slots.len(), tpl.map.len(), "template arity");
+        self.alloc(ObjectData::new_shaped_with(
+            Some(self.realm.object_proto.clone()),
+            shape,
+            slots,
+        ))
     }
 
     pub fn new_object_proto(&self, proto: Option<JsObject>) -> JsObject {

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -498,7 +498,7 @@ impl Vm {
             };
         }
         let mut data = ObjectData::new(Some(self.realm.object_proto.clone()), Internal::Ordinary);
-        data.props = map;
+        data.set_props_map(map);
         self.alloc(data)
     }
 
@@ -519,7 +519,7 @@ impl Vm {
             Some(self.realm.string_proto.clone()),
             Internal::StringObj(s),
         ));
-        o.borrow_mut().props.insert(
+        o.borrow_mut().own_insert(
             PropertyKey::str("length"),
             Property {
                 kind: PropertyKind::Data {
@@ -552,7 +552,7 @@ impl Vm {
         ));
         {
             let mut b = obj.borrow_mut();
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("length"),
                 Property {
                     kind: PropertyKind::Data {
@@ -563,7 +563,7 @@ impl Vm {
                     configurable: true,
                 },
             );
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("name"),
                 Property {
                     kind: PropertyKind::Data {
@@ -598,7 +598,7 @@ impl Vm {
         ));
         {
             let mut b = obj.borrow_mut();
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("length"),
                 Property {
                     kind: PropertyKind::Data {
@@ -609,7 +609,7 @@ impl Vm {
                     configurable: true,
                 },
             );
-            b.props.insert(
+            b.own_insert(
                 PropertyKey::str("name"),
                 Property {
                     kind: PropertyKind::Data {
@@ -627,7 +627,7 @@ impl Vm {
     /// Wire `ctor.prototype = proto` (non-enumerable) and `proto.constructor =
     /// ctor` (non-enumerable), then bind `ctor` as a global of the given name.
     pub fn install_ctor(&self, name: &str, ctor: &JsObject, proto: &JsObject) {
-        ctor.borrow_mut().props.insert(
+        ctor.borrow_mut().own_insert(
             PropertyKey::str("prototype"),
             Property {
                 kind: PropertyKind::Data {
@@ -638,7 +638,7 @@ impl Vm {
                 configurable: false,
             },
         );
-        proto.borrow_mut().props.insert(
+        proto.borrow_mut().own_insert(
             PropertyKey::str("constructor"),
             Property::builtin(Value::Object(ctor.clone())),
         );
@@ -656,30 +656,26 @@ impl Vm {
         let f = self.new_native(name, length, func);
         target
             .borrow_mut()
-            .props
-            .insert(PropertyKey::str(name), Property::builtin(Value::Object(f)));
+            .own_insert(PropertyKey::str(name), Property::builtin(Value::Object(f)));
     }
 
     pub fn define_value(&self, target: &JsObject, name: &str, value: Value) {
         target
             .borrow_mut()
-            .props
-            .insert(PropertyKey::str(name), Property::builtin(value));
+            .own_insert(PropertyKey::str(name), Property::builtin(value));
     }
 
     /// Define a frozen constant (non-writable, non-enumerable, non-configurable).
     pub fn define_constant(&self, target: &JsObject, name: &str, value: Value) {
         target
             .borrow_mut()
-            .props
-            .insert(PropertyKey::str(name), Property::frozen(value));
+            .own_insert(PropertyKey::str(name), Property::frozen(value));
     }
 
     pub fn define_value_sym(&self, target: &JsObject, key: JsSymbol, value: Value) {
         target
             .borrow_mut()
-            .props
-            .insert(PropertyKey::Sym(key), Property::builtin(value));
+            .own_insert(PropertyKey::Sym(key), Property::builtin(value));
     }
 
     // ---------------------------------------------------------------------
@@ -696,11 +692,11 @@ impl Vm {
             ErrorKind::Uri => &self.realm.uri_error_proto,
         };
         let obj = self.alloc(ObjectData::new(Some(proto.clone()), Internal::Error));
-        obj.borrow_mut().props.insert(
+        obj.borrow_mut().own_insert(
             PropertyKey::str("message"),
             Property::builtin(Value::str(message)),
         );
-        obj.borrow_mut().props.insert(
+        obj.borrow_mut().own_insert(
             PropertyKey::str("stack"),
             Property::builtin(Value::str(format!("{}: {}", kind.name(), message))),
         );
@@ -981,7 +977,7 @@ impl Vm {
         if let Value::Object(o) = base {
             let b = o.borrow();
             if let Internal::Array(arr) = &b.internal {
-                if b.props.is_empty() {
+                if b.own_is_empty() {
                     if let Some(v) = arr.get(idx as usize) {
                         if !matches!(v, Value::Hole) {
                             return Ok(v.clone());
@@ -1084,7 +1080,7 @@ impl Vm {
         // Ordinary own-property resolution shared by every (non-exotic) level.
         // A reified `props` entry shadows any dense array/string element.
         let ordinary = |b: &ObjectData| -> Step {
-            match b.props.get(key) {
+            match b.own_get(key) {
                 Some(prop) => match &prop.kind {
                     PropertyKind::Data { value, .. } => Step::Value(value.clone()),
                     PropertyKind::Accessor { get, .. } => match get {
@@ -1124,7 +1120,7 @@ impl Vm {
                     // parameter CELL, not the stale `props` value.
                     Internal::Arguments(map) => {
                         let aliased = key.array_index().and_then(|idx| {
-                            if b.props.contains_key(key) {
+                            if b.own_contains_key(key) {
                                 map.get(idx as usize).and_then(|c| c.clone())
                             } else {
                                 None
@@ -1140,13 +1136,13 @@ impl Vm {
                     // an absent index (climb the chain → undefined).
                     Internal::Array(arr) => {
                         if let Some("length") = key.as_str() {
-                            if b.props.contains_key(key) {
+                            if b.own_contains_key(key) {
                                 ordinary(&b)
                             } else {
                                 Step::Value(Value::Number(arr.len() as f64))
                             }
                         } else if let Some(idx) = key.array_index() {
-                            if b.props.contains_key(key) {
+                            if b.own_contains_key(key) {
                                 ordinary(&b)
                             } else {
                                 match arr.get(idx as usize) {
@@ -1327,7 +1323,7 @@ impl Vm {
             }
             let accessor = {
                 let b = cur.borrow();
-                match b.props.get(key) {
+                match b.own_get(key) {
                     Some(Property {
                         kind: PropertyKind::Accessor { set, .. },
                         ..
@@ -1430,7 +1426,7 @@ impl Vm {
         // CELL too (the ordinary props entry below stays in sync).
         if let Internal::Arguments(map) = &b.internal {
             if let Some(idx) = key.array_index() {
-                if b.props.contains_key(key) {
+                if b.own_contains_key(key) {
                     if let Some(Some(cell)) = map.get(idx as usize) {
                         *cell.borrow_mut() = value.clone();
                     }
@@ -1440,11 +1436,11 @@ impl Vm {
         // Array exotic write. A reified `props` entry for an index/length shadows
         // the dense store, so route the write through the ordinary props path
         // below (which honours its writable flag) when such an entry exists.
-        let has_props_entry = b.props.contains_key(key);
+        let has_props_entry = b.own_contains_key(key);
         let extensible = b.extensible;
         // A non-writable `length` marker blocks index writes past the end.
         let len_not_writable = matches!(
-            b.props.get(&PropertyKey::str("length")),
+            b.own_get(&PropertyKey::str("length")),
             Some(Property {
                 kind: PropertyKind::Data {
                     writable: false,
@@ -1512,7 +1508,7 @@ impl Vm {
                 }
             }
         }
-        match b.props.get_mut(key) {
+        match b.own_get_mut(key) {
             Some(p) => match &mut p.kind {
                 PropertyKind::Data {
                     value: slot,
@@ -1537,7 +1533,7 @@ impl Vm {
                     }
                     return Ok(());
                 }
-                b.props.insert(key.clone(), Property::data(value));
+                b.own_insert(key.clone(), Property::data(value));
             }
         }
         Ok(())
@@ -1570,7 +1566,7 @@ impl Vm {
         let mut b = obj.borrow_mut();
         // A reified `props` entry for an index shadows the dense slot; honour its
         // configurable flag and fall through to the ordinary delete below.
-        let has_props_entry = b.props.contains_key(key);
+        let has_props_entry = b.own_contains_key(key);
         if !has_props_entry {
             if let Internal::Array(arr) = &mut b.internal {
                 if let Some(idx) = key.array_index() {
@@ -1601,10 +1597,10 @@ impl Vm {
                 _ => {}
             }
         }
-        match b.props.get(key) {
+        match b.own_get(key) {
             Some(p) if !p.configurable => Ok(false),
             Some(_) => {
-                b.props.shift_remove(key);
+                b.own_remove(key);
                 // Removing a reified array-index override exposes the stale dense
                 // slot it shadowed; clear it so the deleted index reads as a hole.
                 if let Internal::Array(arr) = &mut b.internal {
@@ -1649,7 +1645,7 @@ impl Vm {
             }
             let (has, proto) = {
                 let b = cur.borrow();
-                let mut has = b.props.contains_key(key);
+                let mut has = b.own_contains_key(key);
                 // Module Namespace exotic [[HasProperty]]: export names are
                 // present (symbols consult the ordinary props above).
                 if let Internal::ModuleNamespace(ns) = &b.internal {
@@ -1751,7 +1747,7 @@ impl Vm {
         // before the other string keys — unless it has already been reified
         // into `props` (e.g. by freeze/seal, where the props loop emits it).
         if matches!(b.internal, Internal::Array(_) | Internal::StringObj(_))
-            && !b.props.contains_key(&PropertyKey::str("length"))
+            && !b.own_contains_key(&PropertyKey::str("length"))
         {
             str_keys.push(PropertyKey::str("length"));
         }
@@ -1762,7 +1758,7 @@ impl Vm {
                 str_keys.push(PropertyKey::Str(name.clone()));
             }
         }
-        for k in b.props.keys() {
+        for k in b.own_keys_iter() {
             // Engine-internal slots (a buffer's `[[ArrayBufferMaxByteLength]]`,
             // the SharedArrayBuffer brand) are not real properties: they never
             // surface through `[[OwnPropertyKeys]]`.
@@ -1835,7 +1831,7 @@ impl Vm {
                 }
             } else {
                 let b = o.borrow();
-                match b.props.get(&k) {
+                match b.own_get(&k) {
                     Some(p) => p.enumerable,
                     None => match &b.internal {
                         Internal::Array(arr) => k
@@ -1874,7 +1870,7 @@ impl Vm {
             });
         }
         let b = obj.borrow();
-        Ok(match b.props.get(key) {
+        Ok(match b.own_get(key) {
             Some(p) => p.enumerable,
             None => match &b.internal {
                 Internal::Array(arr) => key
@@ -1900,7 +1896,7 @@ impl Vm {
             if let PropertyKey::Str(s) = &k {
                 // A reified `props` entry shadows the exotic index slot, so its
                 // enumerable flag wins over the implicit dense-element default.
-                let enumerable = match b.props.get(&k) {
+                let enumerable = match b.own_get(&k) {
                     Some(p) => p.enumerable,
                     None => match &b.internal {
                         Internal::Array(_) if k.array_index().is_some() => true,
@@ -1976,7 +1972,7 @@ impl Vm {
             if let Some(p) = b.proto.take() {
                 stack.push(p);
             }
-            for (_k, prop) in std::mem::take(&mut b.props) {
+            for (_k, prop) in b.take_props_map() {
                 match prop.kind {
                     PropertyKind::Data { value, .. } => push_dispose_obj(value, &mut stack),
                     PropertyKind::Accessor { get, set } => {

--- a/crates/chidori-js/tests/shapes.rs
+++ b/crates/chidori-js/tests/shapes.rs
@@ -1,0 +1,317 @@
+//! Shapes-focused corpus (docs/js-object-shapes-design.md §4, Phase 2).
+//!
+//! Plain objects are born SHAPED (shared key layout in the realm's
+//! transition tree) and demote to dictionary mode on the destructive edges.
+//! Storage mode must be unobservable: these tests pin the observable
+//! surfaces — enumeration order, delete/defineProperty/freeze mid-loop,
+//! accessors, proxies over shaped targets, JSON round-trips — across the
+//! shaped path, the demotion boundary, and dictionary mode.
+
+use chidori_js::Engine;
+
+fn run(src: &str) -> String {
+    let mut e = Engine::new();
+    match e.eval(src) {
+        Ok(v) => e.vm.to_string_lossy(&v),
+        Err(err) => format!("ERR: {err}"),
+    }
+}
+
+#[test]
+fn literal_enumeration_order_is_insertion_order() {
+    assert_eq!(run("Object.keys({b: 1, a: 2, c: 3}).join()"), "b,a,c");
+    // Same keys, different insertion order: distinct shapes, distinct orders.
+    assert_eq!(run("Object.keys({a: 2, b: 1, c: 3}).join()"), "a,b,c");
+}
+
+#[test]
+fn integer_keys_enumerate_first_ascending() {
+    // Spec ordering applies at enumeration time in both storage modes.
+    assert_eq!(
+        run("Object.keys({b: 0, 2: 0, a: 0, 0: 0}).join()"),
+        "0,2,b,a"
+    );
+    assert_eq!(
+        run(r#"
+            let o = {x: 1};
+            o[1] = 'i'; o.y = 2; o[0] = 'j';
+            Object.keys(o).join()
+        "#),
+        "0,1,x,y"
+    );
+}
+
+#[test]
+fn same_shape_objects_do_not_alias_values() {
+    // N same-shape objects share ONE key layout but never values.
+    assert_eq!(
+        run(r#"
+            const mk = (i) => ({x: i, y: i * 2});
+            const a = [];
+            for (let i = 0; i < 100; i++) a.push(mk(i));
+            a[7].x = -1;
+            [a[7].x, a[7].y, a[8].x, a[8].y].join()
+        "#),
+        "-1,14,8,16"
+    );
+}
+
+#[test]
+fn delete_mid_loop_preserves_order_and_semantics() {
+    assert_eq!(
+        run(r#"
+            const out = [];
+            for (let i = 0; i < 3; i++) {
+                const o = {a: 1, b: 2, c: 3};
+                if (i === 1) delete o.b;
+                o.d = 4; // append AFTER the demoting delete
+                out.push(Object.keys(o).join(''));
+            }
+            out.join('|')
+        "#),
+        "abcd|acd|abcd"
+    );
+    // Delete then re-add: the key moves to the END (insertion order).
+    assert_eq!(
+        run("const o = {a:1, b:2, c:3}; delete o.b; o.b = 9; Object.keys(o).join()"),
+        "a,c,b"
+    );
+    // Deleting an ABSENT key is not a demoting edge and changes nothing.
+    assert_eq!(
+        run("const o = {a:1, b:2}; delete o.zzz; Object.keys(o).join() + '=' + o.a"),
+        "a,b=1"
+    );
+}
+
+#[test]
+fn define_property_mid_loop() {
+    // Attribute changes (non-enumerable, non-writable, accessors) on shaped
+    // objects — mid-loop so shaped siblings of the mutated object coexist.
+    assert_eq!(
+        run(r#"
+            const out = [];
+            for (let i = 0; i < 3; i++) {
+                const o = {a: 1, b: 2};
+                if (i === 1) {
+                    Object.defineProperty(o, 'b', {enumerable: false});
+                    Object.defineProperty(o, 'c', {value: 3, writable: false,
+                                                   enumerable: true, configurable: true});
+                    o.c = 99; // silently ignored (sloppy): non-writable
+                } else {
+                    o.c = 3;
+                }
+                out.push(Object.keys(o).join('') + ':' + o.a + o.b + o.c);
+            }
+            out.join('|')
+        "#),
+        "abc:123|ac:123|abc:123"
+    );
+}
+
+#[test]
+fn accessors_on_shaped_objects() {
+    assert_eq!(
+        run(r#"
+            const o = {x: 1};
+            let backing = 10;
+            Object.defineProperty(o, 'y', {
+                get() { return backing; },
+                set(v) { backing = v * 2; },
+                enumerable: true, configurable: true,
+            });
+            o.z = 3;               // append after an accessor was defined
+            o.y = 21;
+            [o.x, o.y, o.z, Object.keys(o).join('')].join('|')
+        "#),
+        "1|42|3|xyz"
+    );
+}
+
+#[test]
+fn freeze_and_seal_mid_loop() {
+    assert_eq!(
+        run(r#"
+            const out = [];
+            for (let i = 0; i < 3; i++) {
+                const o = {a: 1, b: 2};
+                if (i === 1) Object.freeze(o);
+                o.a = 5;    // ignored when frozen (sloppy)
+                o.c = 3;    // ignored when frozen
+                out.push(Object.keys(o).join('') + ':' + o.a + ':' + (o.c ?? '-')
+                         + ':' + Object.isFrozen(o));
+            }
+            out.join('|')
+        "#),
+        "abc:5:3:false|ab:1:-:true|abc:5:3:false"
+    );
+    assert_eq!(
+        run(r#"
+            const o = {a: 1, b: 2};
+            Object.seal(o);
+            o.a = 7;          // sealed: existing props stay writable
+            delete o.b;       // refused
+            o.c = 1;          // refused
+            [Object.keys(o).join(''), o.a, o.b, Object.isSealed(o)].join('|')
+        "#),
+        "ab|7|2|true"
+    );
+}
+
+#[test]
+fn for_in_over_shaped_and_demoted() {
+    assert_eq!(
+        run(r#"
+            const proto = {p: 0};
+            const o = Object.create(proto);
+            o.a = 1; o.b = 2;
+            const seen = [];
+            for (const k in o) seen.push(k);
+            delete o.a;
+            for (const k in o) seen.push(k);
+            seen.join()
+        "#),
+        "a,b,p,b,p"
+    );
+}
+
+#[test]
+fn json_roundtrip_shaped_records() {
+    assert_eq!(
+        run(r#"
+            const src = JSON.stringify(
+                Array.from({length: 50}, (_, i) => ({id: i, name: 'n' + i,
+                    tags: [i, i + 1], meta: {ok: i % 2 === 0}})));
+            const arr = JSON.parse(src);
+            JSON.stringify(arr) === src
+                ? arr[49].id + ':' + arr[49].meta.ok + ':' + Object.keys(arr[0]).join('')
+                : 'MISMATCH'
+        "#),
+        "49:false:idnametagsmeta"
+    );
+}
+
+#[test]
+fn spread_rest_and_assign_preserve_order() {
+    assert_eq!(run("Object.keys({...{b: 1, a: 2}, c: 3}).join()"), "b,a,c");
+    assert_eq!(
+        run("const {b, ...rest} = {b: 1, a: 2, c: 3}; Object.keys(rest).join()"),
+        "a,c"
+    );
+    assert_eq!(
+        run("Object.keys(Object.assign({z: 0}, {b: 1, a: 2})).join()"),
+        "z,b,a"
+    );
+}
+
+#[test]
+fn proxy_over_shaped_target() {
+    assert_eq!(
+        run(r#"
+            const target = {a: 1, b: 2};
+            const log = [];
+            const p = new Proxy(target, {
+                get(t, k, r) { if (typeof k === 'string') log.push('g' + k); return Reflect.get(t, k, r); },
+                deleteProperty(t, k) { log.push('d' + k); return Reflect.deleteProperty(t, k); },
+            });
+            p.a; delete p.b; p.c = 3;
+            [Object.keys(target).join(''), log.join('')].join('|')
+        "#),
+        "ac|gadb"
+    );
+}
+
+#[test]
+fn getownpropertydescriptor_across_modes() {
+    assert_eq!(
+        run(r#"
+            const o = {a: 1, b: 2};
+            const d1 = Object.getOwnPropertyDescriptor(o, 'a');
+            delete o.b; // demote
+            const d2 = Object.getOwnPropertyDescriptor(o, 'a');
+            [d1.value, d1.writable, d1.enumerable, d1.configurable,
+             d2.value, d2.writable, d2.enumerable, d2.configurable].join()
+        "#),
+        "1,true,true,true,1,true,true,true"
+    );
+}
+
+#[test]
+fn many_index_keys_demote_but_stay_correct() {
+    // Integer-key spam on a non-array crosses the shaped→dictionary bound;
+    // ordering (indices ascending first) and values must be unaffected.
+    assert_eq!(
+        run(r#"
+            const o = {name: 'grid'};
+            for (let i = 0; i < 20; i++) o[i] = i * i;
+            Object.keys(o).length + ':' + o[19] + ':' + Object.keys(o)[0]
+              + ':' + Object.keys(o)[20]
+        "#),
+        "21:361:0:name"
+    );
+}
+
+#[test]
+fn wide_objects_use_index_lookup() {
+    // Cross the chain-walk → per-shape index threshold (8) and keep going.
+    assert_eq!(
+        run(r#"
+            const o = {};
+            for (let i = 0; i < 40; i++) o['k' + i] = i;
+            let sum = 0;
+            for (let i = 0; i < 40; i++) sum += o['k' + i];
+            sum + ':' + Object.keys(o).length + ':' + o.k39
+        "#),
+        "780:40:39"
+    );
+}
+
+#[test]
+fn shaped_objects_in_maps_and_stringify_of_demoted() {
+    assert_eq!(
+        run(r#"
+            const o = {a: 1, b: 2, c: 3};
+            delete o.b;
+            o.d = 4;
+            JSON.stringify(o)
+        "#),
+        r#"{"a":1,"c":3,"d":4}"#
+    );
+}
+
+#[test]
+fn prototype_mutation_does_not_disturb_shapes() {
+    // Proto changes do NOT demote (the shape holds no proto); lookups after
+    // a proto swap must see the new chain.
+    assert_eq!(
+        run(r#"
+            const o = {a: 1};
+            const proto1 = {p: 'one'}, proto2 = {p: 'two'};
+            Object.setPrototypeOf(o, proto1);
+            const before = o.p;
+            Object.setPrototypeOf(o, proto2);
+            o.b = 2; // still appendable (still shaped or dict — unobservable)
+            [before, o.p, Object.keys(o).join('')].join('|')
+        "#),
+        "one|two|ab"
+    );
+}
+
+#[test]
+fn replay_identical_across_engines() {
+    // Two fresh engines running the same shape-heavy program must produce
+    // identical output (shapes are derived from program behavior only).
+    let src = r#"
+        const rows = [];
+        for (let i = 0; i < 25; i++) {
+            const r = {i, sq: i * i, label: 'r' + i};
+            if (i % 5 === 0) delete r.sq;
+            if (i % 7 === 0) Object.defineProperty(r, 'hidden', {value: i, enumerable: false});
+            rows.push(r);
+        }
+        JSON.stringify(rows)
+    "#;
+    let a = run(src);
+    let b = run(src);
+    assert_eq!(a, b);
+    assert!(a.contains("\"label\":\"r24\""), "unexpected output: {a}");
+}

--- a/docs/js-object-shapes-design.md
+++ b/docs/js-object-shapes-design.md
@@ -252,11 +252,27 @@ to shrink the correctness surface rather than to chase speed:
    per-nesting-depth path (`Vec<Rc<Shape>>` per depth) so nested records
    don't clobber their parent's cursor mid-object.
 
-Phase-4 items still open: re-profile with callgrind to re-rank the
-remaining cost centers, and consider stringify-from-shape (serializing
-slots directly for all-plain-data records — deliberately skipped because
-the spec's per-key re-lookup during serialization is observable under
-mutating `toJSON`).
+**Measured (callgrind instruction counts, examples/shapebench, vs the
+fork point efb16a0):** `object_literals` −19%, `mixed_helpers` −5.8%,
+`for-in` over per-iteration records −3.8%, `JSON.parse` −1.9%,
+`json_roundtrip` −0.8%, `JSON.stringify` +1.7% — of which ~+0.5M
+instructions in every workload is one-time realm setup (intrinsic
+container objects now mint shape chains; ≈0.15 ms per `Engine::new`, and
+two rounds of tuning already halved it twice: an inline single-entry
+transition slot, and two-touch arming of the per-shape key index so
+grow-by-insert singletons never pay O(n²) index builds). The §4 1.3–1.6×
+json estimate did NOT materialize on this corpus: with Phase-0 interning
+and the pre-reserved parse maps already landed, per-record construction
+was a smaller slice of `json_roundtrip` than the 2026-07-06 table
+suggested, and stringify/parse inherent work dominates. The structural
+wins concentrate where construction actually dominates (object literals
+in loops, record-processing helpers).
+
+Phase-4 items still open: stringify-from-shape (serializing slots
+directly for all-plain-data records — deliberately skipped because the
+spec's per-key re-lookup during serialization is observable under
+mutating `toJSON`), and shrinking the residual realm-setup delta if
+`Engine::new` latency ever matters.
 
 ## 6. Relationship to register bytecode (§3.5 of the roadmap)
 

--- a/docs/js-object-shapes-design.md
+++ b/docs/js-object-shapes-design.md
@@ -1,6 +1,13 @@
 # Object shapes (hidden classes): design + phased migration plan
 
-> **Status:** design (2026-07-06). This answers the question
+> **Status:** IMPLEMENTED (2026-07-12) — Phases 0–3 landed on this branch;
+> every phase gated on the full test262 language+built-ins baseline with
+> zero regressions (47,291 tests). See §6.5 for the deltas between this design
+> and what actually landed (slots hold whole `Property` values so attribute
+> edges never demote; transition edges are `Weak`; the per-shape `index` is
+> an `FxIndexMap` for `Equivalent`-probe parity).
+>
+> Original design note (2026-07-06): this answers the question
 > [`js-performance-roadmap.md`](./js-performance-roadmap.md) §3.7 deferred —
 > "revisit with fresh callgrind data; if `get_index_of` still dominates
 > property-heavy code, shapes are the next step" — with fresh data, and it
@@ -210,6 +217,46 @@ workload allocates a record per iteration) and colder property access.
   shapes hold no `Value`s, only keys.
 - **`u128` liveness / slot bounds**: slot vecs cap at the same bound as
   dictionary properties today (no new limit).
+
+## 6.5 Implementation deltas (what actually landed, 2026-07-12)
+
+The landed implementation follows §3–§4 with four refinements, each chosen
+to shrink the correctness surface rather than to chase speed:
+
+1. **Slots hold whole `Property` values** (`Shaped { shape, slots:
+   Vec<Property> }`), not bare `Value`s, and the shape does NOT carry an
+   `enumerable` bit. The shape therefore encodes exactly one thing — the
+   insertion-ordered key list — and every attribute/kind mutation
+   (`defineProperty` with any attributes, accessors, `seal`/`freeze`) works
+   identically in both modes with NO demotion. The §3.4 demotion set
+   shrinks to the order-destroying edges only: `delete` of a present key,
+   and integer-index keys past a small bound (8). This also let the
+   Phase-1 accessor API keep `IndexMap`-shaped signatures
+   (`&Property`/`&mut Property`, 3-tuple `get_full`), which is what made
+   the ~340-site refactor mechanical. The cost is `size_of::<Property>()`
+   per slot instead of `size_of::<Value>()` — the allocation-count win
+   (one slot vec vs. a per-object `IndexMap` + key strings) is unchanged.
+2. **Transition edges are `Weak`** (`transitions:
+   RefCell<FxHashMap<PropertyKey, Weak<Shape>>>`); the child holds its
+   parent strongly. The §3.1 sketch's strong child edges would form
+   parent↔child `Rc` cycles that the reference-counting GC can never
+   reclaim. With weak edges a shape subtree dies with its last object /
+   cache entry, and a later transition simply rebuilds the node — no
+   registry, no §5 quiescence sweep needed.
+3. **The per-shape `index` is an `FxIndexMap<PropertyKey, u32>`** (not a
+   plain `FxHashMap`) so it accepts the same `Equivalent<PropertyKey>`
+   probes (`StrKeyRef`) as the dictionary path.
+4. **ICs hold `Rc<Shape>` strongly** in the new `IcEntry::{own_shape,
+   proto_shape}` fields — one small key chain pinned per monomorphic site,
+   in exchange for upgrade-free verification. The JSON.parse cursor is a
+   per-nesting-depth path (`Vec<Rc<Shape>>` per depth) so nested records
+   don't clobber their parent's cursor mid-object.
+
+Phase-4 items still open: re-profile with callgrind to re-rank the
+remaining cost centers, and consider stringify-from-shape (serializing
+slots directly for all-plain-data records — deliberately skipped because
+the spec's per-key re-lookup during serialization is observable under
+mutating `toJSON`).
 
 ## 6. Relationship to register bytecode (§3.5 of the roadmap)
 


### PR DESCRIPTION
Implements [`docs/js-object-shapes-design.md`](docs/js-object-shapes-design.md) — Phases 1–4 (Phase 0, parse-key interning, was already on the branch). Every phase was gated on the full test262 language+built-ins baseline: **47,291 tests, 99.11% of executed, zero regressions**, with pass/fail counts identical to the committed baseline at each step.

## What this does

Plain objects stop owning a private `IndexMap` (hash table + key strings). They are born **shaped**: an `Rc<Shape>` into a per-realm transition tree holds the shared, insertion-ordered key layout, and each object owns just a flat `Vec<Property>` of slots. N same-shape objects (JSON records, per-iteration literals) share one key table and pay one allocation each. Destructive edges (`delete` of a present key, integer-key spam) demote to today's dictionary storage, which remains verbatim as the fallback and the birth mode for exotics/intrinsics. Mode is unobservable: enumeration order is insertion order in both.

## Commits (each independently test262-gated)

1. **Accessor extraction** — every direct `.props` access (~340 sites, 29 files) replaced with a narrow `own_*` API on `ObjectData`; the storage field is module-private. The API mirrors `IndexMap` (stable slot indices for IC/kernel paths, `Equivalent`-generic probes for the alloc-free `StrKeyRef` guards), so the refactor is semantically inert.
2. **`PropStorage` + shape tree** — `shape.rs` (parent-linked nodes, weak transition edges, lazily-built per-shape key index) and `PropStorage {Shaped, Dict}` behind the accessors; `alloc_ordinary` births shaped from the realm root. New `tests/shapes.rs` corpus pins delete/defineProperty/freeze mid-loop, enumeration order, proxies over shaped targets, JSON round-trips, and cross-engine replay identity.
3. **Consumers** — GetProp/SetProp ICs upgrade to (shape, slot): a hit is one `Rc::ptr_eq` + a property-kind check, no key compare, same verify-on-every-use discipline (a stale hint is a miss, never a wrong answer). Object-literal templates memoize their leaf shape per realm (instantiation = one slot-vec allocation + N value writes). `JSON.parse` builds `(shape, slots)` directly with a per-nesting-depth record-shape cursor: sibling records advance the previous record's chain by one pointer + interned-key compare per key. Kernel prop localization needed no changes — it inherits shape awareness through the accessors.
4. **Measurement + tuning** — wall-clock was container-noise-bound, so a callgrind runner (`examples/shapebench`) drove tuning on deterministic instruction counts: alloc-free positional iteration for short chains, an inline single-entry transition slot, and two-touch arming of the per-shape index (grow-by-insert singletons like `Math` were paying O(n²) index rebuilds during realm setup). Plus a teardown path that drops values without materializing a dictionary.

## Measured (callgrind instruction counts vs the fork point)

| workload | Δ instructions |
| --- | ---: |
| object_literals | **−19%** |
| mixed_helpers | −5.8% |
| for-in over per-iteration records | −3.8% |
| JSON.parse | −1.9% |
| json_roundtrip | −0.8% |
| JSON.stringify | +1.7% |

The stringify delta is mostly a one-time realm-setup constant (~0.5M instructions ≈ 0.15 ms per `Engine::new`; intrinsic containers now mint shape chains). The design doc's 1.3–1.6× json estimate did **not** materialize on this corpus — with Phase-0 interning already landed, construction was a smaller slice of `json_roundtrip` than the doc's 2026-07-06 profile suggested; the wins concentrate where construction dominates. Recorded honestly in the doc's new §6.5.

## Deviations from the design doc (all recorded in §6.5)

- **Slots hold whole `Property` values**, so the shape encodes key *order* only: attribute changes, accessors, and seal/freeze never demote — only `delete` and integer-key spam do. This is also what kept the Phase-1 API `IndexMap`-shaped and the 340-site refactor mechanical.
- **Transition edges are `Weak`** (child→parent stays strong): the doc's strong edges would form parent↔child `Rc` cycles the refcounting GC can never reclaim; weak edges make dead shape subtrees self-reclaiming.
- The per-shape `index` is an `FxIndexMap` for `Equivalent`-probe parity; ICs hold `Rc<Shape>` strongly (one small chain pinned per monomorphic site).

Invariants preserved: zero `unsafe`, no new dependencies, shapes derived from program behavior only (never serialized, never observable) — byte-identical deterministic replay, covered by the existing replay tests plus a new cross-engine identity test.

Open follow-ups (doc §6.5): stringify-from-shape (skipped: per-key re-lookup during serialization is spec-observable under mutating `toJSON`), and the residual realm-setup delta if `Engine::new` latency ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmVMnjbfjii4guSKkg4aTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmVMnjbfjii4guSKkg4aTJ)_