### PR TITLE
Fix E0616 in global-callee fast path after props privatization

### DIFF
--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -842,7 +842,7 @@ impl Vm {
                         // the spec says.
                         crate::bytecode::KCalleeSrc::Global(name) => {
                             let g = self.realm.global.borrow();
-                            match g.props.get(&PropertyKey::str(name)) {
+                            match g.own_get(&PropertyKey::str(name)) {
                                 Some(Property {
                                     kind:
                                         PropertyKind::Data {


### PR DESCRIPTION
The object-shapes change (#108) made ObjectData.props private behind
own_* accessors, while the kernel callee-pinning fast path (#106) still
read the field directly for KCalleeSrc::Global lookups. The two merged
independently, leaving main failing to compile. Use own_get, the direct
equivalent lookup.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017u7jc1m9UzKzQ8tLTgkq6Y