### PR TITLE
Fix example typechecking and standardize on the run() authoring convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,8 @@ jobs:
       - name: Build chidori binary
         run: cargo build
 
+      - name: Run Python SDK client unit tests
+        run: python -m unittest sdk/python/tests/test_client_http.py
+
       - name: Run Python SDK integration tests
         run: python -m unittest sdk/python/tests/test_session_api.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Typecheck examples against the SDK types
+        run: |
+          npx tsc -p ../../examples
+          npx tsc -p ../../examples/record-replay
+
       - name: Build package
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -182,18 +182,19 @@ assistant) and `--template worker` (an autonomous tool-using loop); omit
 
 ### 2. Write your own agent
 
-An agent is just an exported `agent` function. Every model call is a recorded
-host call:
+An agent is a plain TypeScript file: import the `chidori` host object and the
+`run` definer from the virtual `chidori:agent` module and register your handler.
+Every model call is a recorded host call:
 
 ```ts
 // summarizer.ts
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { document: string }, chidori: Chidori) {
+run(async (input: { document: string }) => {
   const summary = await chidori.prompt("Summarize in 3 bullets:\n" + input.document);
   const actionItems = await chidori.prompt("Extract action items:\n" + summary);
   return { summary, actionItems };
-}
+});
 ```
 
 That's a complete, durable agent. Both prompts are recorded; replay returns them

--- a/README.md
+++ b/README.md
@@ -287,8 +287,10 @@ human-in-the-loop pause/resume loop — see
 - **npm packages without Node** — `chidori add zod` installs straight from the
   npm registry into a content-addressed cache (SHA-512 verified, hardlinked
   `node_modules`, merge-friendly JSONL lockfile, no install scripts ever), and
-  agents just `import { z } from "zod"`. See [package
-  management](./docs/package-management.md).
+  agents just `import { z } from "zod"`. The engine is not Node, so the
+  compatible set is pure-ESM, native-free packages using only the shimmed
+  builtins — `chidori add` warns when a package falls outside it. See
+  [package management](./docs/package-management.md#compatibility).
 
 Agents reach all of this through a fixed set of host functions on the `chidori`
 object — see [**Core concepts**](./docs/core-concepts.md) for the full list and

--- a/crates/chidori/src/init.rs
+++ b/crates/chidori/src/init.rs
@@ -13,12 +13,9 @@ use anyhow::{bail, Context, Result};
 /// (written to `agent.ts`) and the fileless `chidori chat` (written to a temp
 /// file). Driven mode (a fixed `messages` list) is how `chidori chat` feeds each
 /// turn; with no messages it reads the terminal interactively.
-pub const CHAT_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
+pub const CHAT_AGENT_SRC: &str = r#"import { chidori, run } from "chidori:agent";
 
-export async function agent(
-  input: { messages?: string[]; system?: string; model?: string; tools?: string[] },
-  chidori: Chidori,
-) {
+run(async (input: { messages?: string[]; system?: string; model?: string; tools?: string[] }) => {
   const chat = chidori.conversation({
     system: input.system ?? "You are a helpful, concise assistant.",
     model: input.model || undefined,
@@ -38,7 +35,7 @@ export async function agent(
   // Interactive mode: read each turn from the terminal. Type "exit" to end.
   const transcript = await chat.loop({ prompt: "you>" });
   return { transcript };
-}
+});
 "#;
 
 const CHAT_README: &str = r#"# Chidori chat agent
@@ -83,7 +80,7 @@ skip the env var entirely.
 /// (scoped to this project — the agent can only see files placed here) plus the
 /// conversation + replay model. The only thing sent to the model is the user's
 /// question and these scaffolded docs; nothing else on the machine is touched.
-const DOCS_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
+const DOCS_AGENT_SRC: &str = r#"import { chidori, run } from "chidori:agent";
 
 /**
  * Chat with the Chidori docs.
@@ -93,10 +90,7 @@ const DOCS_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
  * agent can only ever read files you put here — and the only data sent to the
  * model is your question plus these docs.
  */
-export async function agent(
-  input: { messages?: string[]; model?: string },
-  chidori: Chidori,
-) {
+run(async (input: { messages?: string[]; model?: string }) => {
   // Load the local docs corpus. workspace.list/read are recorded host calls,
   // so re-running this agent replays them for free (no disk re-read on replay).
   const entries = await chidori.workspace.list();
@@ -132,7 +126,7 @@ export async function agent(
   // Interactive mode: ask the docs anything. Type "exit" to quit.
   const transcript = await chat.loop({ prompt: "ask the docs>" });
   return { transcript };
-}
+});
 "#;
 
 const DOCS_README: &str = r#"# Chat with the Chidori docs
@@ -206,18 +200,20 @@ Either way the `chidori` binary lands on your PATH. Check it with
 
 ## Writing an agent
 
-An agent is a TypeScript file that exports an `agent` function taking the run
-input and the `chidori` host object:
+An agent is a TypeScript file that imports the `chidori` host object and the
+`run` definer from the virtual `chidori:agent` module, then registers its
+handler with `run(...)`:
 
-    import type { Chidori } from "chidori:agent";
+    import { chidori, run } from "chidori:agent";
 
-    export async function agent(input: { document: string }, chidori: Chidori) {
+    run(async (input: { document: string }) => {
       const summary = await chidori.prompt("Summarize:\n" + input.document);
       return { summary };
-    }
+    });
 
 That is a complete, durable agent. The prompt is recorded; replay returns it for
-free.
+free. (The older style — `export async function agent(input, chidori)` — is
+still accepted for existing files.)
 
 ## What a host call is
 
@@ -386,7 +382,7 @@ const CHAT: Template = Template {
 // Inlined rather than include_str!'d from examples/ so the crate packages
 // self-contained for crates.io (examples/ lives outside the package root).
 // Mirrors examples/agents/worker.ts and examples/tools/reverse.ts.
-const WORKER_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
+const WORKER_AGENT_SRC: &str = r#"import { chidori, run, type AgentJson, type JsonObject } from "chidori:agent";
 
 /**
  * An autonomous "worker" agent: it loops — think, call a tool, observe the
@@ -403,10 +399,7 @@ const WORKER_AGENT_SRC: &str = r#"import type { Chidori } from "chidori:agent";
  *     --input task="Reverse the word 'chidori' and tell me the result." \
  *     --tools examples/tools
  */
-export async function agent(
-  input: { task: string; maxSteps?: number },
-  chidori: Chidori,
-) {
+run(async (input: { task: string; maxSteps?: number }) => {
   const maxSteps = input.maxSteps ?? 8;
 
   let ctx = chidori
@@ -419,7 +412,7 @@ export async function agent(
     .tools(["reverse"]) // tool names discovered from the --tools directory
     .user(input.task);
 
-  const steps: { tool: string; input: unknown; result: unknown }[] = [];
+  const steps: { tool: string; input: JsonObject; result: AgentJson }[] = [];
 
   for (let step = 0; step < maxSteps; step++) {
     const { response, context } = await ctx.respond({ type: "final" });
@@ -439,7 +432,7 @@ export async function agent(
   }
 
   return { answer: "(stopped: reached maxSteps without finishing)", steps };
-}
+});
 "#;
 
 const REVERSE_TOOL_SRC: &str = r#"import type { ToolDefinition } from "chidori:agent";

--- a/crates/chidori/src/pkg/compat.rs
+++ b/crates/chidori/src/pkg/compat.rs
@@ -1,0 +1,398 @@
+//! Post-install compatibility scan for `chidori add`.
+//!
+//! Chidori's embedded engine is not Node: CommonJS `require()` only works for
+//! leaf modules, `node:` builtins are a small allowlisted set of shims, and
+//! native addons can never load. None of that is visible at install time —
+//! `chidori add somepkg` succeeds as pure data movement and the failure only
+//! surfaces when the agent imports the package. This module closes that gap:
+//! after materializing `node_modules`, the freshly added root packages are
+//! scanned for the three known cliffs and a warning is printed for each, so
+//! the author learns about an incompatible package at `add` time instead of
+//! at first import.
+//!
+//! The scan is heuristic and bounded (metadata plus a capped source sweep);
+//! it can miss dynamically-built specifiers, so it warns — it never fails the
+//! install.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::runtime::typescript::transpile::NODE_BUILTIN_ALLOWLIST;
+
+/// Every Node builtin module base name (the part before any `/` subpath).
+/// Used to tell a builtin specifier apart from a package import; the subset
+/// chidori actually provides is `NODE_BUILTIN_ALLOWLIST`.
+const NODE_BUILTIN_BASES: &[&str] = &[
+    "assert",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "domain",
+    "events",
+    "fs",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "module",
+    "net",
+    "os",
+    "path",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "repl",
+    "stream",
+    "string_decoder",
+    "sys",
+    "timers",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib",
+];
+
+/// Bounds for the source sweep, so `chidori add` stays fast on huge packages.
+const MAX_SCANNED_FILES: usize = 400;
+const MAX_FILE_BYTES: u64 = 512 * 1024;
+
+/// Scan one installed package directory and return human-readable warnings
+/// for anything that will not work under chidori's embedded engine.
+pub fn check_package_compat(name: &str, pkg_dir: &Path) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let manifest: serde_json::Value = std::fs::read_to_string(pkg_dir.join("package.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or(serde_json::Value::Null);
+
+    if let Some(reason) = native_addon_marker(pkg_dir, &manifest) {
+        warnings.push(format!(
+            "`{name}` {reason} — native addons cannot load in chidori's embedded \
+             engine, so importing its native parts will fail at runtime"
+        ));
+    }
+
+    if !has_esm_entry(pkg_dir, &manifest) {
+        warnings.push(format!(
+            "`{name}` ships no ES module build (no `type: \"module\"`, `exports` \
+             import condition, `module` field, or `.mjs` entry). CommonJS support \
+             is leaf-only: it will load ONLY if its entry never calls require() at \
+             runtime. Prefer a package that ships ESM \
+             (docs/package-management.md#compatibility)"
+        ));
+    }
+
+    let missing = unsupported_builtin_imports(pkg_dir);
+    if !missing.is_empty() {
+        let list: Vec<&str> = missing.iter().map(String::as_str).collect();
+        warnings.push(format!(
+            "`{name}` references Node builtins the chidori runtime does not provide \
+             ({}); imports of those modules will fail at runtime \
+             (provided: {})",
+            list.join(", "),
+            NODE_BUILTIN_ALLOWLIST.join(", "),
+        ));
+    }
+
+    warnings
+}
+
+/// Native-addon markers: a `binding.gyp`, `gypfile: true`, a dependency on the
+/// usual prebuild loaders, or a shipped `.node` binary.
+fn native_addon_marker(pkg_dir: &Path, manifest: &serde_json::Value) -> Option<String> {
+    if pkg_dir.join("binding.gyp").exists() {
+        return Some("contains a binding.gyp (node-gyp native build)".to_string());
+    }
+    if manifest.get("gypfile").and_then(|v| v.as_bool()) == Some(true) {
+        return Some("declares `gypfile: true` (node-gyp native build)".to_string());
+    }
+    const NATIVE_LOADERS: &[&str] = &[
+        "node-gyp",
+        "node-gyp-build",
+        "prebuild-install",
+        "node-addon-api",
+        "bindings",
+        "node-pre-gyp",
+        "@mapbox/node-pre-gyp",
+    ];
+    for section in ["dependencies", "peerDependencies", "optionalDependencies"] {
+        if let Some(deps) = manifest.get(section).and_then(|v| v.as_object()) {
+            for loader in NATIVE_LOADERS {
+                if deps.contains_key(*loader) {
+                    return Some(format!("depends on `{loader}` (native addon loader)"));
+                }
+            }
+        }
+    }
+    if let Some(file) = find_file_with_extension(pkg_dir, "node", 0) {
+        return Some(format!("ships a compiled `.node` binary ({file})"));
+    }
+    None
+}
+
+/// Does the package advertise any ES-module entry the resolver can prefer?
+fn has_esm_entry(pkg_dir: &Path, manifest: &serde_json::Value) -> bool {
+    if manifest.get("type").and_then(|v| v.as_str()) == Some("module") {
+        return true;
+    }
+    if manifest.get("module").and_then(|v| v.as_str()).is_some() {
+        return true;
+    }
+    if let Some(main) = manifest.get("main").and_then(|v| v.as_str()) {
+        if main.ends_with(".mjs") {
+            return true;
+        }
+    }
+    if let Some(exports) = manifest.get("exports") {
+        if exports_has_import_condition(exports) {
+            return true;
+        }
+    }
+    // A package with no manifest hints may still be import-only via .mjs files.
+    find_file_with_extension(pkg_dir, "mjs", 0).is_some()
+}
+
+/// Recursively look for an `import` (or `module`) condition key, or any `.mjs`
+/// target, inside an `exports` map.
+fn exports_has_import_condition(exports: &serde_json::Value) -> bool {
+    match exports {
+        serde_json::Value::String(target) => target.ends_with(".mjs"),
+        serde_json::Value::Object(map) => map.iter().any(|(key, value)| {
+            key == "import" || key == "module" || exports_has_import_condition(value)
+        }),
+        serde_json::Value::Array(items) => items.iter().any(exports_has_import_condition),
+        _ => false,
+    }
+}
+
+/// Bounded sweep of the package's JS sources for imports/requires of Node
+/// builtins outside the shim allowlist. Returns the sorted set of offending
+/// specifiers (with any `node:` prefix stripped).
+fn unsupported_builtin_imports(pkg_dir: &Path) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let mut scanned = 0usize;
+    scan_dir(pkg_dir, &mut found, &mut scanned);
+    found
+}
+
+fn scan_dir(dir: &Path, found: &mut BTreeSet<String>, scanned: &mut usize) {
+    if *scanned >= MAX_SCANNED_FILES {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if *scanned >= MAX_SCANNED_FILES {
+            return;
+        }
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            // A nested node_modules belongs to a transitive dependency; it
+            // gets its own scan when it is itself `add`ed.
+            if path.file_name().and_then(|n| n.to_str()) != Some("node_modules") {
+                scan_dir(&path, found, scanned);
+            }
+            continue;
+        }
+        let is_js = matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("js" | "mjs" | "cjs")
+        );
+        if !is_js {
+            continue;
+        }
+        if entry
+            .metadata()
+            .map(|m| m.len() > MAX_FILE_BYTES)
+            .unwrap_or(true)
+        {
+            continue;
+        }
+        *scanned += 1;
+        if let Ok(source) = std::fs::read_to_string(&path) {
+            collect_unsupported_specifiers(&source, found);
+        }
+    }
+}
+
+/// Extract module specifiers from `require(...)`, `import ... from ...`, and
+/// dynamic `import(...)` and record the Node builtins chidori doesn't shim.
+fn collect_unsupported_specifiers(source: &str, found: &mut BTreeSet<String>) {
+    const OPENERS: &[&str] = &[
+        "require(\"",
+        "require('",
+        "from \"",
+        "from '",
+        "import(\"",
+        "import('",
+        "import \"",
+        "import '",
+    ];
+    for opener in OPENERS {
+        let quote = opener.as_bytes()[opener.len() - 1] as char;
+        let mut rest = source;
+        while let Some(idx) = rest.find(opener) {
+            rest = &rest[idx + opener.len()..];
+            let Some(end) = rest.find(quote) else { break };
+            let spec = &rest[..end];
+            rest = &rest[end..];
+            let bare = spec.strip_prefix("node:").unwrap_or(spec);
+            let base = bare.split('/').next().unwrap_or(bare);
+            if NODE_BUILTIN_BASES.contains(&base) && !NODE_BUILTIN_ALLOWLIST.contains(&bare) {
+                found.insert(bare.to_string());
+            }
+        }
+    }
+}
+
+/// Find one file with the given extension anywhere under `dir` (bounded walk).
+fn find_file_with_extension(dir: &Path, ext: &str, depth: usize) -> Option<String> {
+    if depth > 4 {
+        return None;
+    }
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        let file_type = entry.file_type().ok()?;
+        if file_type.is_file() && path.extension().and_then(|e| e.to_str()) == Some(ext) {
+            return Some(path.file_name()?.to_string_lossy().into_owned());
+        }
+        if file_type.is_dir() && path.file_name().and_then(|n| n.to_str()) != Some("node_modules") {
+            if let Some(hit) = find_file_with_extension(&path, ext, depth + 1) {
+                return Some(hit);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_pkg(tag: &str, manifest: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("chidori-compat-{tag}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("package.json"), manifest).unwrap();
+        dir
+    }
+
+    #[test]
+    fn clean_esm_package_yields_no_warnings() {
+        let dir = temp_pkg(
+            "esm",
+            r#"{"name":"zed","version":"1.0.0","type":"module","main":"index.js"}"#,
+        );
+        std::fs::write(
+            dir.join("index.js"),
+            "import path from 'node:path';\nexport const x = 1;\n",
+        )
+        .unwrap();
+        assert!(check_package_compat("zed", &dir).is_empty());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn exports_import_condition_counts_as_esm() {
+        let dir = temp_pkg(
+            "exports",
+            r#"{"name":"dualpkg","version":"1.0.0","exports":{".":{"import":"./index.mjs","require":"./index.cjs"}}}"#,
+        );
+        std::fs::write(dir.join("index.mjs"), "export const x = 1;\n").unwrap();
+        std::fs::write(dir.join("index.cjs"), "module.exports = { x: 1 };\n").unwrap();
+        assert!(check_package_compat("dualpkg", &dir).is_empty());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn cjs_only_package_warns() {
+        let dir = temp_pkg(
+            "cjs",
+            r#"{"name":"oldpkg","version":"1.0.0","main":"index.js"}"#,
+        );
+        std::fs::write(dir.join("index.js"), "module.exports = 42;\n").unwrap();
+        let warnings = check_package_compat("oldpkg", &dir);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("no ES module build"), "{warnings:?}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn unsupported_builtin_imports_warn() {
+        let dir = temp_pkg(
+            "builtins",
+            r#"{"name":"netpkg","version":"1.0.0","type":"module","main":"index.js"}"#,
+        );
+        std::fs::write(
+            dir.join("index.js"),
+            "import net from 'node:net';\nimport { Readable } from \"stream\";\nimport path from 'node:path';\nexport {};\n",
+        )
+        .unwrap();
+        let warnings = check_package_compat("netpkg", &dir);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("net"), "{warnings:?}");
+        assert!(warnings[0].contains("stream"), "{warnings:?}");
+        // path IS allowlisted — it must not be flagged.
+        assert!(!warnings[0].contains("(path"), "{warnings:?}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn native_addon_markers_warn() {
+        let dir = temp_pkg(
+            "native",
+            r#"{"name":"fastlib","version":"1.0.0","type":"module","dependencies":{"node-gyp-build":"^4.0.0"}}"#,
+        );
+        let warnings = check_package_compat("fastlib", &dir);
+        assert!(
+            warnings.iter().any(|w| w.contains("node-gyp-build")),
+            "{warnings:?}"
+        );
+
+        let dir2 = temp_pkg(
+            "gyp",
+            r#"{"name":"gyplib","version":"1.0.0","type":"module"}"#,
+        );
+        std::fs::write(dir2.join("binding.gyp"), "{}").unwrap();
+        let warnings2 = check_package_compat("gyplib", &dir2);
+        assert!(
+            warnings2.iter().any(|w| w.contains("binding.gyp")),
+            "{warnings2:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+        let _ = std::fs::remove_dir_all(dir2);
+    }
+
+    #[test]
+    fn shipped_node_binary_warns() {
+        let dir = temp_pkg(
+            "prebuilt",
+            r#"{"name":"prebuilt","version":"1.0.0","type":"module"}"#,
+        );
+        std::fs::create_dir_all(dir.join("prebuilds/linux-x64")).unwrap();
+        std::fs::write(dir.join("prebuilds/linux-x64/lib.node"), b"\x7fELF").unwrap();
+        let warnings = check_package_compat("prebuilt", &dir);
+        assert!(warnings.iter().any(|w| w.contains(".node")), "{warnings:?}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/chidori/src/pkg/install.rs
+++ b/crates/chidori/src/pkg/install.rs
@@ -82,6 +82,16 @@ pub fn cmd_add(dir: &Path, specs: &[String], dev: bool) -> Result<()> {
         println!("+ {name}@{version}");
     }
     report(&resolution, &stats, started);
+
+    // The install itself is pure data movement, so an incompatible package
+    // (CJS-only, native addon, non-allowlisted builtins) "succeeds" here and
+    // only explodes on first import. Surface that now instead.
+    for (name, _) in &requested {
+        let pkg_dir = dir.join("node_modules").join(name);
+        for warning in super::compat::check_package_compat(name, &pkg_dir) {
+            eprintln!("warning: {warning}");
+        }
+    }
     Ok(())
 }
 

--- a/crates/chidori/src/pkg/mod.rs
+++ b/crates/chidori/src/pkg/mod.rs
@@ -24,6 +24,7 @@
 //!   attack vector. Packages needing native builds don't apply here — agent
 //!   code runs on chidori's embedded engine.
 
+pub mod compat;
 pub mod install;
 pub mod layout;
 pub mod lockfile;

--- a/crates/chidori/src/runtime/typescript/check.rs
+++ b/crates/chidori/src/runtime/typescript/check.rs
@@ -53,14 +53,25 @@ fn check_agent_source(
         },
     )?;
 
-    if !exports_async_function(&javascript, "agent") {
+    if !declares_run_entrypoint(&javascript) && !exports_async_function(&javascript, "agent") {
         anyhow::bail!(
-            "No `export async function agent(input, chidori)` found in {}",
+            "No agent entrypoint found in {}: call `run(handler)` at the top level \
+             (import it from \"chidori:agent\"), or export the legacy \
+             `export async function agent(input, chidori)`",
             path.display()
         );
     }
 
     Ok(TypeScriptCheck { javascript })
+}
+
+/// Does the transpiled module register its entrypoint with `run(handler)`?
+/// The `chidori:agent` import is stripped by transpilation, so a top-level
+/// `run(...)` call is what remains of the canonical authoring style.
+fn declares_run_entrypoint(source: &str) -> bool {
+    source
+        .lines()
+        .any(|line| line.trim_start().starts_with("run("))
 }
 
 fn exports_async_function(source: &str, name: &str) -> bool {
@@ -92,6 +103,30 @@ mod tests {
 
         let result = check_agent_file(&path, &policy).unwrap();
         assert!(result.javascript.contains("export async function agent"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn check_agent_accepts_run_entrypoint() {
+        let policy = RuntimePolicy::durable_default("run");
+        let dir = std::env::temp_dir().join(format!("chidori-ts-check-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        std::fs::write(
+            &path,
+            r#"
+                import { chidori, run } from "chidori:agent";
+                run(async (input: { name: string }) => {
+                    await chidori.log("hello", { name: input.name });
+                    return { hello: input.name };
+                });
+            "#,
+        )
+        .unwrap();
+
+        let result = check_agent_file(&path, &policy).unwrap();
+        assert!(result.javascript.contains("run("));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/docs/actors.md
+++ b/docs/actors.md
@@ -177,7 +177,9 @@ policy:
 
 ```ts
 // supervisor.ts — spawned by the run, supervises its own worker pool.
-export async function agent(input: { shards: string[] }) {
+import { chidori, run } from "chidori:agent";
+
+run(async (input: { shards: string[] }) => {
   const workers = [];
   for (const shard of input.shards) {
     workers.push(await chidori.actors.spawn("worker.ts", { shard }, {
@@ -191,7 +193,7 @@ export async function agent(input: { shards: string[] }) {
     results.push(outcome.output);
   }
   return { results };
-}
+});
 ```
 
 The tree rules:

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -360,12 +360,9 @@ laid out once as a cache-marked prefix; only the question and the growing Q&A
 tail change. Source: `examples/agents/context_qa.ts`.
 
 ```ts
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(
-  input: { corpus: string; questions: string[] },
-  chidori: Chidori,
-) {
+run(async (input: { corpus: string; questions: string[] }) => {
   // The stable head, built ONCE and frozen as a cacheable prefix.
   const base = chidori
     .context()
@@ -393,7 +390,7 @@ export async function agent(
   }
 
   return { answers };
-}
+});
 ```
 
 Run it:

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,10 +1,12 @@
 # Core concepts: agents & host functions
 
-An agent is a `.ts` file that exports an async `agent(input, chidori)` function.
-The runtime provides a fixed set of **host functions** for side effects through
-the `chidori` object — agents never touch the outside world directly, so the
-runtime sees and records everything. See [`llm.txt`](../llm.txt) for the full
-API reference.
+An agent is a `.ts` file that imports `{ chidori, run }` from the virtual
+`chidori:agent` module and registers its handler with `run(async (input) => …)`.
+(The legacy form — an exported async `agent(input, chidori)` function — is still
+accepted.) The runtime provides a fixed set of **host functions** for side
+effects through the `chidori` object — agents never touch the outside world
+directly, so the runtime sees and records everything. See
+[`llm.txt`](../llm.txt) for the full API reference.
 
 ## Host functions
 

--- a/docs/detached-agents.md
+++ b/docs/detached-agents.md
@@ -29,14 +29,16 @@ run(async () => {
 ```ts
 // services/inbox-triager.ts — hibernates between emails, holding no thread
 // and no VM; an alarm compacts state daily even with no traffic.
-export async function agent() {
+import { chidori, run } from "chidori:agent";
+
+run(async () => {
   const triaged = [];
   while (true) {
     const msg = await chidori.signal("email");     // hibernate point
     const result = await chidori.prompt(`Triage: ${JSON.stringify(msg.payload)}`);
     triaged.push({ email: msg.payload, result });
   }
-}
+});
 ```
 
 ## The model

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,8 @@ Expected output:
 
 What this demonstrates:
 
-- `examples/agents/hello.ts` exports `agent(input, chidori)`.
+- `examples/agents/hello.ts` imports `{ chidori, run }` from `chidori:agent`
+  and registers its handler with `run(async (input) => …)`.
 - The agent calls `chidori.log(...)`, so the runtime records a host call.
 - The agent returns plain JSON, which is what CLI, server, and SDK users receive.
 - A checkpoint is written under `examples/agents/.chidori/runs/<run_id>/` for

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -99,6 +99,38 @@ that calls `require()` throws with a clear message; prefer packages that ship
 an ESM build (most modern ones do). JSON subpath imports resolve to a default
 export.
 
+## Compatibility
+
+Chidori's embedded engine is **not Node**, and "no Node required" cuts both
+ways: a package that works under `node` is not automatically compatible. The
+three cliffs, concretely:
+
+1. **CommonJS is leaf-only.** ESM builds load fully. A CommonJS file loads
+   only if it never calls `require()` at runtime (the wrapper turns its
+   `module.exports` into the default export). Any runtime `require()` throws —
+   at *import time*, not install time.
+2. **Node builtins are a small allowlist.** The runtime shims exactly:
+   `process`, `buffer`, `util`, `fs`, `fs/promises`, `crypto`, `http`,
+   `https`, `path`, `path/posix`, `events`, `url`, `assert`,
+   `assert/strict`, `os`. Anything else — `net`, `stream`, `child_process`,
+   `worker_threads`, `zlib`, `tls`, `vm`, … — is not provided, and importing
+   it fails with an allowlist error. (Networking is `fetch` plus the
+   `node:http`/`node:https` client shims, all captured for replay.)
+3. **No native addons.** There is no node-gyp build step (lifecycle scripts
+   never run) and no way to load a `.node` binary. Packages that depend on
+   `node-gyp-build`, `prebuild-install`, `bindings`, etc. cannot work, even
+   when the install "succeeds".
+
+In short: **pure-ESM, native-free, allowlist-respecting packages work**; the
+rest fail at first import. Because installs are pure data movement, `chidori
+add` can't make an incompatible package fail to install — instead it scans
+each added package for these three cliffs and prints a `warning:` when it
+finds one (no ESM build, native-addon markers, imports of unprovided
+builtins). The scan is a bounded heuristic: it can miss dynamically computed
+specifiers, so a quiet `add` is strong — not perfect — evidence of
+compatibility. `chidori check agent.ts` (or just running the agent) gives the
+definitive answer, since the module graph resolves eagerly.
+
 ## Out of scope (v1) and why
 
 - **Lifecycle scripts** — by design, see above. Not "not yet": running

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -77,13 +77,14 @@ hashes, so the tree rebuilds from the store alone.
 Installed packages import the way they would under node or bun:
 
 ```ts
+import { run } from "chidori:agent";
 import { z } from "zod";
 import ms from "ms";
 
-export default async function agent(input: { minutes: number }) {
+run(async (input: { minutes: number }) => {
   const schema = z.object({ minutes: z.number() });
   return { human: ms(schema.parse(input).minutes * 60_000, { long: true }) };
-}
+});
 ```
 
 The module loader resolves bare specifiers through the full Node ESM

--- a/docs/running-modes.md
+++ b/docs/running-modes.md
@@ -65,12 +65,9 @@ An agent can handle incoming HTTP events:
 
 ```ts
 // agents/webhook.ts
-import type { Chidori } from "chidori:agent";
+import { run, type JsonObject } from "chidori:agent";
 
-export async function agent(
-  input: { url: string; payload?: Record<string, unknown> },
-  chidori: Chidori,
-) {
+run(async (input: { url: string; payload?: JsonObject }) => {
   // `fetch` is the runtime's captured networking surface — policy-gated,
   // pausable for approval, and recorded for replay.
   const response = await fetch(input.url, {
@@ -79,7 +76,7 @@ export async function agent(
     body: JSON.stringify(input.payload ?? { source: "chidori" }),
   });
   return { status: response.status, body: await response.json() };
-}
+});
 ```
 
 ```bash

--- a/examples/agents/actor_pipeline.ts
+++ b/examples/agents/actor_pipeline.ts
@@ -33,7 +33,7 @@ run(async () => {
   for (const worker of workers) {
     await worker.send("finish", null);
     const outcome = await worker.join();
-    summaries.push(outcome.output);
+    summaries.push(outcome.output ?? null);
   }
 
   results.sort((a, b) => a.n - b.n);

--- a/examples/agents/actor_tree.ts
+++ b/examples/agents/actor_tree.ts
@@ -18,6 +18,6 @@ run(async () => {
   }
   return {
     statuses: outcomes.map((o) => o.status),
-    shards: outcomes.map((o) => o.output),
+    shards: outcomes.map((o) => o.output ?? null),
   };
 });

--- a/examples/agents/actors/supervisor.ts
+++ b/examples/agents/actors/supervisor.ts
@@ -29,7 +29,7 @@ run(async (input: { tasks: number[]; workers: number }) => {
   const summaries = [];
   for (const worker of pool) {
     await worker.send("finish", null);
-    summaries.push((await worker.join()).output);
+    summaries.push((await worker.join()).output ?? null);
   }
   results.sort((a, b) => a.n - b.n);
   return { results, summaries };

--- a/examples/agents/context_qa.ts
+++ b/examples/agents/context_qa.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Cache-aware multi-turn Q&A over a fixed corpus, using `chidori.context`.
@@ -14,10 +14,7 @@ import type { Chidori } from "chidori:agent";
  *   chidori run examples/agents/context_qa.ts \
  *     --input '{"corpus": "Section 1: All deploys require review. Section 2: Rollbacks are automatic.", "questions": ["Who approves deploys?", "What happens on a bad deploy?"]}'
  */
-export async function agent(
-  input: { corpus: string; questions: string[] },
-  chidori: Chidori,
-) {
+run(async (input: { corpus: string; questions: string[] }) => {
   // The stable head, built ONCE and frozen as a cacheable prefix.
   const base = chidori
     .context()
@@ -47,4 +44,4 @@ export async function agent(
   }
 
   return { answers };
-}
+});

--- a/examples/agents/conversation.ts
+++ b/examples/agents/conversation.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * A multi-turn conversational agent — the "chat assistant" shape — built on
@@ -20,10 +20,7 @@ import type { Chidori } from "chidori:agent";
  *   under `chidori serve`; type "exit" or "quit" to end):
  *     chidori run examples/agents/conversation.ts
  */
-export async function agent(
-  input: { system?: string; messages?: string[] },
-  chidori: Chidori,
-) {
+run(async (input: { system?: string; messages?: string[] }) => {
   const chat = chidori.conversation({
     system:
       input.system ??
@@ -52,4 +49,4 @@ export async function agent(
   });
 
   return { turns: chat.length, transcript };
-}
+});

--- a/examples/agents/hello.ts
+++ b/examples/agents/hello.ts
@@ -1,7 +1,7 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { name?: string }, chidori: Chidori) {
+run(async (input: { name?: string }) => {
   const name = input.name ?? "world";
   await chidori.log("Saying hello", { name });
   return { greeting: `Hello, ${name}!` };
-}
+});

--- a/examples/agents/input_pause.ts
+++ b/examples/agents/input_pause.ts
@@ -1,6 +1,6 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { request: string }, chidori: Chidori) {
+run(async (input: { request: string }) => {
   const approval = await chidori.input("Approve this request?", {
     type: "approval",
     choices: ["yes", "no"],
@@ -9,4 +9,4 @@ export async function agent(input: { request: string }, chidori: Chidori) {
     request: input.request,
     approved: approval.toLowerCase() === "yes",
   };
-}
+});

--- a/examples/agents/parallel.ts
+++ b/examples/agents/parallel.ts
@@ -1,6 +1,6 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { topic: string }, chidori: Chidori) {
+run(async (input: { topic: string }) => {
   const drafts = await chidori.util.parallel(
     [
       async () =>
@@ -18,4 +18,4 @@ export async function agent(input: { topic: string }, chidori: Chidori) {
   );
 
   return { drafts };
-}
+});

--- a/examples/agents/streaming_progress.ts
+++ b/examples/agents/streaming_progress.ts
@@ -1,6 +1,6 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { topic: string }, chidori: Chidori) {
+run(async (input: { topic: string }) => {
   const progress = await chidori.prompt(
     "In one sentence, say what work is starting for: " + input.topic,
     { type: "progress", maxTokens: 80 },
@@ -37,4 +37,4 @@ export async function agent(input: { topic: string }, chidori: Chidori) {
   );
 
   return { progress, drafts, subagent, final };
-}
+});

--- a/examples/agents/streaming_progress_child.ts
+++ b/examples/agents/streaming_progress_child.ts
@@ -1,10 +1,10 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { topic: string }, chidori: Chidori) {
+run(async (input: { topic: string }) => {
   const note = await chidori.prompt(
     "As a nested sub-agent, explain why labelled prompt streams matter for: " +
       input.topic,
     { type: "subagent", maxTokens: 120 },
   );
   return { note };
-}
+});

--- a/examples/agents/summarizer.ts
+++ b/examples/agents/summarizer.ts
@@ -1,9 +1,9 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { document: string }, chidori: Chidori) {
+run(async (input: { document: string }) => {
   const summary = await chidori.prompt(
     "Summarize this document in three concise bullets:\n\n" + input.document,
     { type: "final", maxTokens: 220 },
   );
   return { summary };
-}
+});

--- a/examples/agents/tool_use.ts
+++ b/examples/agents/tool_use.ts
@@ -1,6 +1,6 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { query: string }, chidori: Chidori) {
+run(async (input: { query: string }) => {
   const result = await chidori.tool("web_search", { query: input.query });
   return { result };
-}
+});

--- a/examples/agents/value_checkpoint.ts
+++ b/examples/agents/value_checkpoint.ts
@@ -9,9 +9,9 @@
 //
 // The run pauses on `input()`; resume it and the "index" step is served from
 // the journal instead of being recomputed. See docs/value-checkpoints.md.
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { docs?: number }, chidori: Chidori) {
+run(async (input: { docs?: number }) => {
   const docs = input.docs ?? 1000;
 
   // Expensive, deterministic, effect-free — exactly what a step is for.
@@ -33,4 +33,4 @@ export async function agent(input: { docs?: number }, chidori: Chidori) {
   const answer = await chidori.input("Publish the index?");
 
   return { published: answer === "yes", docs: index.docs, shards: index.shards };
-}
+});

--- a/examples/agents/webhook.ts
+++ b/examples/agents/webhook.ts
@@ -1,4 +1,6 @@
-export async function agent(input: { url: string; payload?: { [key: string]: unknown } }, _chidori: unknown) {
+import { run, type JsonObject } from "chidori:agent";
+
+run(async (input: { url: string; payload?: JsonObject }) => {
   // `fetch` is the runtime's captured networking surface: this POST is
   // policy-gated, pausable for approval, and recorded for deterministic replay,
   // exactly like any network call a dependency would make under the hood.
@@ -11,4 +13,4 @@ export async function agent(input: { url: string; payload?: { [key: string]: unk
     status: response.status,
     body: await response.json(),
   };
-}
+});

--- a/examples/agents/worker.ts
+++ b/examples/agents/worker.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run, type AgentJson, type JsonObject } from "chidori:agent";
 
 /**
  * An autonomous "worker" agent: it loops — think, call a tool, observe the
@@ -15,10 +15,7 @@ import type { Chidori } from "chidori:agent";
  *     --input task="Reverse the word 'chidori' and tell me the result." \
  *     --tools examples/tools
  */
-export async function agent(
-  input: { task: string; maxSteps?: number },
-  chidori: Chidori,
-) {
+run(async (input: { task: string; maxSteps?: number }) => {
   const maxSteps = input.maxSteps ?? 8;
 
   let ctx = chidori
@@ -31,7 +28,7 @@ export async function agent(
     .tools(["reverse"]) // tool names discovered from the --tools directory
     .user(input.task);
 
-  const steps: { tool: string; input: unknown; result: unknown }[] = [];
+  const steps: { tool: string; input: JsonObject; result: AgentJson }[] = [];
 
   for (let step = 0; step < maxSteps; step++) {
     const { response, context } = await ctx.respond({ type: "final" });
@@ -51,4 +48,4 @@ export async function agent(
   }
 
   return { answer: "(stopped: reached maxSteps without finishing)", steps };
-}
+});

--- a/examples/branching/agent.ts
+++ b/examples/branching/agent.ts
@@ -1,4 +1,4 @@
-import type { BranchOutcome, Chidori } from "chidori:agent";
+import { chidori, run, type BranchOutcome } from "chidori:agent";
 
 /**
  * Branching example (docs/branching-execution.md).
@@ -22,7 +22,7 @@ import type { BranchOutcome, Chidori } from "chidori:agent";
 
 type Brief = { topic?: string };
 
-export async function agent(input: Brief, chidori: Chidori) {
+run(async (input: Brief) => {
   const topic = input.topic ?? "incident postmortem";
 
   // Shared prefix: paid once, handed to every branch as state.
@@ -55,7 +55,7 @@ export async function agent(input: Brief, chidori: Chidori) {
   await chidori.log(`picked: ${best.label}`);
 
   return { picked: best.label, draft: best.output, outcomes };
-}
+});
 
 function score(outcome: BranchOutcome): number {
   const draft = (outcome.output as { draft?: string } | undefined)?.draft ?? "";

--- a/examples/branching/strategies/draft_direct.ts
+++ b/examples/branching/strategies/draft_direct.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Strategy B: write a flowing draft straight from the research, no outline.
@@ -8,8 +8,8 @@ import type { Chidori } from "chidori:agent";
 
 type BranchInput = { topic: string; research: string };
 
-export async function agent(input: BranchInput, chidori: Chidori) {
+run(async (input: BranchInput) => {
   await chidori.log("draft-direct: writing straight through");
   const draft = `# ${input.topic}\n\nIn short: ${input.research}. Told as one continuous narrative.`;
   return { strategy: "draft-direct", draft };
-}
+});

--- a/examples/branching/strategies/outline_first.ts
+++ b/examples/branching/strategies/outline_first.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Strategy A: build an outline from the handed-over research, then expand each
@@ -8,10 +8,10 @@ import type { Chidori } from "chidori:agent";
 
 type BranchInput = { topic: string; research: string };
 
-export async function agent(input: BranchInput, chidori: Chidori) {
+run(async (input: BranchInput) => {
   await chidori.log("outline-first: structuring before writing");
   const points = input.research.split(";").map((p) => p.trim());
   const outline = points.map((p, i) => `${i + 1}. ${p}`).join("\n");
   const draft = `# ${input.topic}\n\n${outline}\n\nEach point expanded in order, building on the last.`;
   return { strategy: "outline-first", draft };
-}
+});

--- a/examples/interactive-pipeline/interactive_pipeline.ts
+++ b/examples/interactive-pipeline/interactive_pipeline.ts
@@ -82,7 +82,7 @@ run(async (input: Input) => {
   }
 
   await chidori.log(`pipeline '${pipeline}' complete`, { stages, totalReviewed });
-  return { pipeline, status: "completed", totalReviewed, journal };
+  return { pipeline, status: "completed", stoppedAt: null, totalReviewed, journal };
 });
 
 function clampInt(value: unknown, fallback: number, min: number, max: number): number {

--- a/examples/multiplayer-review/policy_doc.ts
+++ b/examples/multiplayer-review/policy_doc.ts
@@ -1,4 +1,4 @@
-import type { Chidori, Signal } from "chidori:agent";
+import { chidori, run, type Signal } from "chidori:agent";
 
 /**
  * Multiplayer policy-doc drafting agent (the worked example in docs/signals.md).
@@ -36,13 +36,13 @@ type Brief = { topic?: string; audience?: string; priority?: string; scope?: str
 type Review = { decision: "approve" | "changes"; notes: string };
 type Steer = { priority?: string; scope?: string };
 
-export async function agent(input: Brief, chidori: Chidori) {
+run(async (input: Brief) => {
   let brief: Brief = {
     topic: input.topic ?? "data-retention policy",
     audience: input.audience ?? "all staff",
   };
 
-  let draft = await writeDraft(chidori, brief); // "expensive": stands in for LLM + retrieval
+  let draft = await writeDraft(brief); // "expensive": stands in for LLM + retrieval
   let round = 0;
 
   while (true) {
@@ -76,23 +76,18 @@ export async function agent(input: Brief, chidori: Chidori) {
       brief = { ...brief, ...steer.payload }; // re-scope without restarting
     }
 
-    draft = await revise(chidori, draft, review.payload.notes, brief);
+    draft = await revise(draft, review.payload.notes, brief);
   }
-}
+});
 
 /** Stand-in for the expensive drafting step (LLM + retrieval). Local + offline. */
-async function writeDraft(chidori: Chidori, brief: Brief): Promise<string> {
+async function writeDraft(brief: Brief): Promise<string> {
   await chidori.log("writing draft", { topic: brief.topic, scope: brief.scope });
   return `# ${brief.topic} (for ${brief.audience})\n\nInitial draft body.`;
 }
 
 /** Stand-in for the revision step. Appends the reviewer's notes to the draft. */
-async function revise(
-  chidori: Chidori,
-  draft: string,
-  notes: string,
-  brief: Brief,
-): Promise<string> {
+async function revise(draft: string, notes: string, brief: Brief): Promise<string> {
   await chidori.log("revising draft", { notes, scope: brief.scope });
   return `${draft}\n\n## Revision\nAddressed: ${notes}`;
 }

--- a/examples/record-replay/README.md
+++ b/examples/record-replay/README.md
@@ -102,7 +102,7 @@ Point the driver elsewhere with `--url`, or override the input with
 ### (optional) Typecheck the agents against the SDK types
 
 ```bash
-npx -y typescript@5.4 tsc -p examples/record-replay
+npx -y -p typescript@5.4 tsc -p examples/record-replay
 ```
 
 The detailed walkthroughs for each layer — including the modify-and-resume and

--- a/examples/record-replay/deterministic_identity.ts
+++ b/examples/record-replay/deterministic_identity.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Deterministic non-determinism — reproducible ids, clocks, and choices.
@@ -14,7 +14,7 @@ import type { Chidori } from "chidori:agent";
  * a tool. This example uses an explicit tool so the recorded value is obvious in
  * the call log.)
  */
-export async function agent(input: { prefix?: string }, chidori: Chidori) {
+run(async (input: { prefix?: string }) => {
   const minted = await chidori.tool<{ prefix: string }, { id: string; epochMs: number }>("mint_id", {
     prefix: input.prefix ?? "run",
   });
@@ -25,4 +25,4 @@ export async function agent(input: { prefix?: string }, chidori: Chidori) {
   await chidori.memory.set("identity", { id: minted.id, lane });
 
   return { runId: minted.id, startedAt: minted.epochMs, lane };
-}
+});

--- a/examples/record-replay/exactly_once.ts
+++ b/examples/record-replay/exactly_once.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Exactly-once side effects — the core durability guarantee for agents.
@@ -13,7 +13,7 @@ import type { Chidori } from "chidori:agent";
  *   chidori trace <run-id>            # see the recorded tool calls
  *   chidori resume examples/record-replay/exactly_once.ts <run-id>   # no re-send
  */
-export async function agent(input: { name?: string }, chidori: Chidori) {
+run(async (input: { name?: string }) => {
   const name = input.name ?? "Ada";
 
   const ticket = await chidori.tool<{ subject: string }, { id: string }>("open_ticket", {
@@ -29,4 +29,4 @@ export async function agent(input: { name?: string }, chidori: Chidori) {
   await chidori.memory.set("onboarding", { ticket: ticket.id, email: email.id });
 
   return { ticket: ticket.id, emailId: email.id, delivered: email.delivered };
-}
+});

--- a/examples/record-replay/human_approval.ts
+++ b/examples/record-replay/human_approval.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Durable pause / resume — human-in-the-loop across process restarts.
@@ -14,7 +14,7 @@ import type { Chidori } from "chidori:agent";
  *   const s = await client.run({ order: "A-1007" });   // -> status "paused"
  *   const done = await client.resume(s.id, "approve");  // -> status "completed"
  */
-export async function agent(input: { order?: string }, chidori: Chidori) {
+run(async (input: { order?: string }) => {
   const order = input.order ?? "A-1007";
 
   // Pretend this came from an orders service; kept inline to stay offline.
@@ -33,4 +33,4 @@ export async function agent(input: { order?: string }, chidori: Chidori) {
   }
 
   return { order, status: "denied" };
-}
+});

--- a/examples/record-replay/retry_flaky_tool.ts
+++ b/examples/record-replay/retry_flaky_tool.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Resilient retries with a reproducible history.
@@ -16,7 +16,7 @@ type FetchResult = {
   value?: { flag: boolean };
 };
 
-export async function agent(input: { maxAttempts?: number }, chidori: Chidori) {
+run(async (input: { maxAttempts?: number }) => {
   const maxAttempts = input.maxAttempts ?? 5;
   const attempts: string[] = [];
   let value: FetchResult["value"] | null = null;
@@ -35,4 +35,4 @@ export async function agent(input: { maxAttempts?: number }, chidori: Chidori) {
   }
 
   return { attempts, value, succeeded: value !== null };
-}
+});

--- a/examples/record-replay/tool_pipeline.ts
+++ b/examples/record-replay/tool_pipeline.ts
@@ -1,4 +1,4 @@
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
 /**
  * Deterministic fan-out + a durable artifact.
@@ -13,10 +13,7 @@ import type { Chidori } from "chidori:agent";
  * `chidori.workspace.write(...)` and run with CHIDORI_WORKSPACE_ROOT set to a
  * directory — see the README.)
  */
-export async function agent(
-  input: { city?: string; currency?: string },
-  chidori: Chidori,
-) {
+run(async (input: { city?: string; currency?: string }) => {
   const city = input.city ?? "Berlin";
   const currency = input.currency ?? "EUR";
 
@@ -45,4 +42,4 @@ export async function agent(
   await chidori.memory.set(`briefing:${city}`, { city, currency, briefing });
 
   return { city, currency, briefing };
-}
+});

--- a/examples/record-replay/tsconfig.json
+++ b/examples/record-replay/tsconfig.json
@@ -10,8 +10,8 @@
     "types": [],
     "baseUrl": ".",
     "paths": {
-      "chidori": ["../../sdk/typescript/src/index.ts"],
-      "chidori/agent": ["../../sdk/typescript/src/agent.ts"]
+      "chidori:agent": ["../../sdk/typescript/src/agent.ts"],
+      "@1kbirds/chidori": ["../../sdk/typescript/src/index.ts"]
     }
   },
   "include": ["*.ts", "tools/*.ts"]

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "//": "Typecheck every example agent/tool against the in-repo SDK types. Run: npx tsc -p examples",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "chidori:agent": ["../sdk/typescript/src/agent.ts"],
+      "@1kbirds/chidori": ["../sdk/typescript/src/index.ts"]
+    }
+  },
+  "include": [
+    "agents/**/*.ts",
+    "branching/**/*.ts",
+    "interactive-pipeline/**/*.ts",
+    "multiplayer-review/**/*.ts",
+    "tools/**/*.ts"
+  ]
+}

--- a/llm.txt
+++ b/llm.txt
@@ -10,25 +10,26 @@ and tools.
 
 ## Agent Shape
 
-An agent is a `.ts` file that exports `agent(input, chidori)`:
+An agent is a `.ts` file that imports `{ chidori, run }` from the virtual
+`chidori:agent` module and registers its handler with `run(...)`:
 
 ```ts
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(input: { document: string }, chidori: Chidori) {
+run(async (input: { document: string }) => {
   const summary = await chidori.prompt(
     "Summarize in three bullets:\n\n" + input.document,
     { type: "final" },
   );
   return { summary };
-}
+});
 ```
 
 Rules:
 
-- Export `async function agent(input, chidori)`, or import `{ run }` from
-  `chidori:agent` and call `run(handler)` — the `agent` export is the fallback
-  entrypoint when `run(...)` wasn't called.
+- Import `{ chidori, run }` from `chidori:agent` and call `run(handler)` at the
+  top level. (Legacy fallback: `export async function agent(input, chidori)`
+  is still accepted when `run(...)` wasn't called.)
 - Return JSON-compatible values only.
 - Use `chidori.*` for LLMs, tools, input, signals, memory, templates, workspace
   files, and logging. HTTP goes through the standard `fetch`, which the runtime

--- a/scripts/pgo-train/train.ts
+++ b/scripts/pgo-train/train.ts
@@ -7,9 +7,9 @@
 // host-effect boundary). Deterministic and fully offline: no LLM calls, no
 // tools, no timers. Sizes are scaled so the whole run stays around a second —
 // PGO needs branch *frequencies*, not a long benchmark.
-import type { Chidori } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
 
-export async function agent(_input: Record<string, never>, chidori: Chidori) {
+run(async () => {
   const checksums: Record<string, number> = {};
 
   // arith_loop: integer/double mix in a tight loop.
@@ -97,4 +97,4 @@ export async function agent(_input: Record<string, never>, chidori: Chidori) {
   // One host-effect round trip so the journal/effect boundary is in profile.
   await chidori.log("pgo training checksums", checksums);
   return checksums;
-}
+});

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -94,9 +94,49 @@ Mirrors the TypeScript SDK (`sdk/typescript/`) method-for-method. See the
 top-level `examples/sdk_demo.py` for a longer walkthrough and
 `docs/running-modes.md` for the HTTP session API this client wraps.
 
+## Timeouts, retries, and errors
+
+Every request is bounded by `timeout_seconds` (default 300 — generous because
+`run()` executes the whole agent before responding; pass `0` to disable).
+Idempotent GETs are retried `retries` times (default 2, exponential backoff
+from `retry_delay_seconds`) on connection errors, timeouts, and 429/502/503/504
+responses. POSTs are **never** retried — `run`/`resume`/`signal` are not
+idempotent. For `stream()` the timeout covers connection establishment only.
+
+```python
+client = AgentClient("http://localhost:8080", timeout_seconds=60, retries=3)
+```
+
+Failures raise typed exceptions, all subclassing `AgentClientError` (itself a
+`RuntimeError`, so existing handlers keep working):
+
+```python
+from chidori import AgentClientError, ConnectionError, HttpError, TimeoutError
+
+try:
+    client.signal(session_id, "review", payload={"decision": "approve"})
+except HttpError as e:
+    if e.status == 404:   # unknown session
+        ...
+    elif e.status == 409:  # run already terminal
+        ...
+    else:
+        raise
+except TimeoutError:
+    ...  # server hung past timeout_seconds
+except ConnectionError:
+    ...  # nothing listening / connection refused
+```
+
+`HttpError` carries `.status`, the raw `.body`, and `.detail` (the server's
+`error` field when the body was JSON), so the documented 400/404/409 semantics
+are distinguishable without string-matching messages.
+
 ## Testing
 
 ```bash
+python3 -m unittest sdk/python/tests/test_client_http.py -v   # HTTP layer: errors/timeout/retry (no binary needed)
+
 cargo build                     # make sure target/debug/chidori is up to date
 python3 -m unittest sdk/python/tests/test_session_api.py -v
 ```

--- a/sdk/python/chidori/__init__.py
+++ b/sdk/python/chidori/__init__.py
@@ -17,6 +17,24 @@ Usage:
     replayed = client.replay(checkpoint)
 """
 
-from chidori.client import AgentClient, Session, Checkpoint, SignalQueued
+from chidori.client import (
+    AgentClient,
+    AgentClientError,
+    Checkpoint,
+    ConnectionError,
+    HttpError,
+    Session,
+    SignalQueued,
+    TimeoutError,
+)
 
-__all__ = ["AgentClient", "Session", "Checkpoint", "SignalQueued"]
+__all__ = [
+    "AgentClient",
+    "AgentClientError",
+    "Checkpoint",
+    "ConnectionError",
+    "HttpError",
+    "Session",
+    "SignalQueued",
+    "TimeoutError",
+]

--- a/sdk/python/chidori/client.py
+++ b/sdk/python/chidori/client.py
@@ -3,12 +3,85 @@
 from __future__ import annotations
 
 import json
+import socket
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
 import urllib.request
 import urllib.error
+
+
+class AgentClientError(RuntimeError):
+    """Base class for every error the SDK raises.
+
+    Subclasses ``RuntimeError`` so existing ``except RuntimeError`` handlers
+    keep working.
+    """
+
+
+class HttpError(AgentClientError):
+    """A non-2xx HTTP response.
+
+    Carries the parsed ``status`` so callers can distinguish the server's
+    documented semantics — e.g. for ``AgentClient.signal``: 400 (empty name),
+    404 (unknown session), 409 (terminal run) — instead of string-matching
+    the message.
+    """
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        status: int,
+        body: str,
+        detail: str | None = None,
+    ) -> None:
+        self.method = method
+        self.path = path
+        self.status = status
+        self.body = body
+        #: The server's ``error`` field, when the body was ``{"error": ...}``.
+        self.detail = detail
+        suffix = f": {detail if detail is not None else body}" if (detail or body) else ""
+        super().__init__(f"{method} {path} failed: HTTP {status}{suffix}")
+
+    @classmethod
+    def from_http_error(cls, method: str, path: str, e: urllib.error.HTTPError) -> "HttpError":
+        body = e.read().decode(errors="replace") if e.fp else ""
+        detail: str | None = None
+        try:
+            parsed = json.loads(body)
+            if isinstance(parsed, dict) and isinstance(parsed.get("error"), str):
+                detail = parsed["error"]
+        except json.JSONDecodeError:
+            pass
+        return cls(method, path, e.code, body, detail)
+
+
+class TimeoutError(AgentClientError):  # noqa: A001 - deliberate, scoped to this package
+    """The request exceeded the client's ``timeout_seconds`` without completing."""
+
+    def __init__(self, method: str, path: str, timeout_seconds: float) -> None:
+        self.method = method
+        self.path = path
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"{method} {path} timed out after {timeout_seconds}s")
+
+
+class ConnectionError(AgentClientError):  # noqa: A001 - deliberate, scoped to this package
+    """The request never produced an HTTP response (refused, reset, DNS, ...)."""
+
+    def __init__(self, method: str, path: str, reason: object) -> None:
+        self.method = method
+        self.path = path
+        self.reason = reason
+        super().__init__(f"{method} {path} failed: {reason}")
+
+
+#: Response statuses worth retrying on idempotent requests.
+_RETRYABLE_STATUS = frozenset({429, 502, 503, 504})
 
 
 @dataclass
@@ -150,8 +223,36 @@ class AgentClient:
         assert s1.output == s2.output  # same result, zero LLM calls
     """
 
-    def __init__(self, base_url: str = "http://localhost:8080"):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8080",
+        *,
+        timeout_seconds: float = 300.0,
+        retries: int = 2,
+        retry_delay_seconds: float = 0.25,
+    ):
+        """Create a client.
+
+        ``timeout_seconds`` bounds each request (0 disables it). The default is
+        generous — 5 minutes — because ``run()`` executes the whole agent
+        before responding, but finite so a hung server raises ``TimeoutError``
+        instead of blocking forever. For ``stream()`` it covers connection
+        establishment, not the open event stream.
+
+        ``retries`` applies to idempotent GET requests only, retried on
+        connection errors, timeouts, and 429/502/503/504 responses with
+        exponential backoff starting at ``retry_delay_seconds``. POSTs are
+        never retried — ``run``/``resume``/``signal`` are not idempotent, and
+        a blind retry could execute an agent twice.
+
+        Failures raise typed errors (all subclassing ``AgentClientError``,
+        itself a ``RuntimeError``): ``HttpError`` with a ``.status`` for
+        non-2xx responses, ``TimeoutError``, or ``ConnectionError``.
+        """
         self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.retries = retries
+        self.retry_delay_seconds = retry_delay_seconds
 
     def health(self) -> dict:
         """Check server health."""
@@ -374,11 +475,24 @@ class AgentClient:
             },
             method="POST",
         )
+        # The timeout covers connection establishment; once the stream is
+        # open the socket timeout is cleared so a healthy run may idle
+        # between events indefinitely.
         try:
-            resp = urllib.request.urlopen(req)
+            resp = urllib.request.urlopen(req, timeout=self._urlopen_timeout())
         except urllib.error.HTTPError as e:
-            err_body = e.read().decode() if e.fp else ""
-            raise RuntimeError(f"HTTP {e.code}: {err_body}") from e
+            raise HttpError.from_http_error("POST", "/sessions/stream", e) from e
+        except socket.timeout as e:
+            raise TimeoutError("POST", "/sessions/stream", self.timeout_seconds) from e
+        except urllib.error.URLError as e:
+            if isinstance(e.reason, socket.timeout):
+                raise TimeoutError("POST", "/sessions/stream", self.timeout_seconds) from e
+            raise ConnectionError("POST", "/sessions/stream", e.reason) from e
+        try:
+            sock = resp.fp.raw._sock  # noqa: SLF001 - stdlib http response internals
+            sock.settimeout(None)
+        except AttributeError:
+            pass  # non-CPython layout; keep the connect timeout for reads too
 
         # Minimal SSE parser: accumulate `event:` and `data:` lines until a
         # blank line, then yield the decoded frame. Good enough for the
@@ -423,27 +537,56 @@ class AgentClient:
     # -- HTTP helpers --
 
     def _get(self, path: str) -> dict:
-        url = self.base_url + path
-        req = urllib.request.Request(url)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read())
-        except urllib.error.HTTPError as e:
-            body = e.read().decode()
-            raise RuntimeError(f"HTTP {e.code}: {body}") from e
+        # GETs are idempotent: retry connection failures, timeouts, and
+        # retryable statuses with exponential backoff.
+        return self._request("GET", path, retries=self.retries)[1]
 
     def _post(self, path: str, body: dict) -> dict:
         return self._post_with_status(path, body)[1]
 
     def _post_with_status(self, path: str, body: dict) -> tuple[int, dict]:
+        # POSTs are never retried: run/resume/signal are not idempotent.
+        return self._request("POST", path, body=body, retries=0)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict | None = None,
+        retries: int = 0,
+    ) -> tuple[int, dict]:
+        """One HTTP exchange with timeout and (for idempotent requests) retries.
+
+        Returns ``(status, parsed_json)``; raises ``HttpError``,
+        ``TimeoutError``, or ``ConnectionError`` otherwise.
+        """
         url = self.base_url + path
-        data = json.dumps(body).encode()
-        req = urllib.request.Request(
-            url, data=data, headers={"Content-Type": "application/json"}
-        )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return resp.status, json.loads(resp.read())
-        except urllib.error.HTTPError as e:
-            body = e.read().decode()
-            raise RuntimeError(f"HTTP {e.code}: {body}") from e
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {"Content-Type": "application/json"} if body is not None else {}
+        for attempt in range(retries + 1):
+            if attempt:
+                time.sleep(self.retry_delay_seconds * 2 ** (attempt - 1))
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req, timeout=self._urlopen_timeout()) as resp:
+                    return resp.status, json.loads(resp.read())
+            except urllib.error.HTTPError as e:
+                err: AgentClientError = HttpError.from_http_error(method, path, e)
+                if err.status not in _RETRYABLE_STATUS or attempt == retries:
+                    raise err from e
+            except socket.timeout as e:
+                err = TimeoutError(method, path, self.timeout_seconds)
+                if attempt == retries:
+                    raise err from e
+            except urllib.error.URLError as e:
+                if isinstance(e.reason, socket.timeout):
+                    err = TimeoutError(method, path, self.timeout_seconds)
+                else:
+                    err = ConnectionError(method, path, e.reason)
+                if attempt == retries:
+                    raise err from e
+        raise AssertionError("unreachable: the retry loop returns or raises")
+
+    def _urlopen_timeout(self) -> float | None:
+        """`urlopen`'s socket timeout; `timeout_seconds == 0` disables it."""
+        return self.timeout_seconds if self.timeout_seconds > 0 else None

--- a/sdk/python/tests/test_client_http.py
+++ b/sdk/python/tests/test_client_http.py
@@ -1,0 +1,146 @@
+"""Unit tests for the AgentClient HTTP layer: typed errors, timeout, retry.
+
+These run against in-process stdlib servers — no chidori binary needed —
+so they complement the end-to-end coverage in test_session_api.py.
+
+Run:  python -m unittest sdk/python/tests/test_client_http.py
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import socketserver
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chidori import (  # noqa: E402
+    AgentClient,
+    AgentClientError,
+    ConnectionError,
+    HttpError,
+    TimeoutError,
+)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    """Scriptable handler: the test case sets `script`, a list of
+    (status, body_dict) responses consumed in order (the last repeats)."""
+
+    script: list[tuple[int, dict]] = [(200, {"status": "ok"})]
+    calls: int = 0
+
+    def _respond(self) -> None:
+        idx = min(_Handler.calls, len(_Handler.script) - 1)
+        _Handler.calls += 1
+        status, payload = _Handler.script[idx]
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib naming
+        self._respond()
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib naming
+        self._respond()
+
+    def log_message(self, *args: object) -> None:
+        pass
+
+
+class HttpLayerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+        cls.base_url = f"http://127.0.0.1:{cls.server.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def setUp(self) -> None:
+        _Handler.script = [(200, {"status": "ok"})]
+        _Handler.calls = 0
+        self.client = AgentClient(self.base_url, retries=2, retry_delay_seconds=0.01)
+
+    def test_http_error_carries_status_and_detail(self) -> None:
+        _Handler.script = [(409, {"error": "run is terminal"})]
+        with self.assertRaises(HttpError) as ctx:
+            self.client.resume("x", "yes")
+        err = ctx.exception
+        self.assertEqual(err.status, 409)
+        self.assertEqual(err.detail, "run is terminal")
+        self.assertIn("409", str(err))
+        # Still a RuntimeError, for pre-existing handlers.
+        self.assertIsInstance(err, AgentClientError)
+        self.assertIsInstance(err, RuntimeError)
+
+    def test_distinct_statuses_are_distinguishable(self) -> None:
+        for status in (400, 404, 409):
+            _Handler.script = [(status, {"error": f"status {status}"})]
+            _Handler.calls = 0
+            with self.assertRaises(HttpError) as ctx:
+                self.client.signal("x", "review")
+            self.assertEqual(ctx.exception.status, status)
+
+    def test_get_retries_on_retryable_status(self) -> None:
+        _Handler.script = [(503, {"error": "warming up"}), (503, {"error": "warming up"}), (200, {"status": "ok"})]
+        self.assertEqual(self.client.health(), {"status": "ok"})
+        self.assertEqual(_Handler.calls, 3)
+
+    def test_get_gives_up_after_retries(self) -> None:
+        _Handler.script = [(503, {"error": "down"})]
+        client = AgentClient(self.base_url, retries=1, retry_delay_seconds=0.01)
+        with self.assertRaises(HttpError) as ctx:
+            client.health()
+        self.assertEqual(ctx.exception.status, 503)
+        self.assertEqual(_Handler.calls, 2)
+
+    def test_get_does_not_retry_non_retryable_status(self) -> None:
+        _Handler.script = [(404, {"error": "no such session"})]
+        with self.assertRaises(HttpError) as ctx:
+            self.client.get_session("nope")
+        self.assertEqual(ctx.exception.status, 404)
+        self.assertEqual(_Handler.calls, 1)
+
+    def test_post_is_never_retried(self) -> None:
+        _Handler.script = [(503, {"error": "overloaded"})]
+        with self.assertRaises(HttpError) as ctx:
+            self.client.run({"q": 1})
+        self.assertEqual(ctx.exception.status, 503)
+        self.assertEqual(_Handler.calls, 1)
+
+    def test_connection_error_when_nothing_listens(self) -> None:
+        client = AgentClient("http://127.0.0.1:1", retries=0, timeout_seconds=2)
+        with self.assertRaises(ConnectionError):
+            client.health()
+
+    def test_timeout_on_silent_server(self) -> None:
+        class Silent(socketserver.BaseRequestHandler):
+            def handle(self) -> None:
+                time.sleep(5)
+
+        silent = socketserver.TCPServer(("127.0.0.1", 0), Silent)
+        threading.Thread(target=silent.serve_forever, daemon=True).start()
+        try:
+            port = silent.server_address[1]
+            client = AgentClient(f"http://127.0.0.1:{port}", retries=0, timeout_seconds=0.3)
+            with self.assertRaises(TimeoutError):
+                client.run({"q": 1})
+        finally:
+            silent.shutdown()
+            silent.server_close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -36,13 +36,29 @@ npm run build
 ### Authoring agents and tools
 
 Agent and tool files run *inside* the Chidori runtime, not as a normal Node
-program. They get their authoring types — and the `chidori`/`run` globals — from
-the **virtual** module `chidori:agent`:
+program. They import their authoring surface — the `chidori` host object, the
+`run` definer, and every authoring type — from the **virtual** module
+`chidori:agent`:
 
 ```ts
 /// <reference types="@1kbirds/chidori/agent-env" />
-import type { Chidori, ToolDefinition } from "chidori:agent";
+import { chidori, run } from "chidori:agent";
+
+run(async (input: { document: string }) => {
+  const summary = await chidori.prompt("Summarize:\n" + input.document);
+  return { summary };
+});
 ```
+
+(Tool files import `type { ToolDefinition }` from the same module. The legacy
+agent form — `export async function agent(input, chidori)` — is still accepted.)
+
+So there are exactly **two** specifiers, with different jobs:
+
+| Specifier | What it is | Where it's used |
+|---|---|---|
+| `chidori:agent` | Virtual module the runtime injects | Inside agent/tool files |
+| `@1kbirds/chidori` | This npm package (HTTP client + the ambient types for `chidori:agent`) | In your Node/browser app |
 
 There is no installable package behind `chidori:agent`; it is a URL-style scheme
 (like `node:fs`) that the runtime strips and injects at execution time, so the

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -125,6 +125,44 @@ if (isSignalQueued(result)) {
 
 See the top-level `sdk/python/chidori` for the Python equivalent.
 
+## Timeouts, retries, and errors
+
+Every request is bounded by `timeoutMs` (default 300 000 — generous because
+`run()` executes the whole agent before responding; pass `0` to disable).
+Idempotent GETs are retried `retries` times (default 2, exponential backoff
+from `retryDelayMs`) on connection errors, timeouts, and 429/502/503/504
+responses. POSTs are **never** retried — `run`/`resume`/`signal` are not
+idempotent. For `stream()` the timeout covers connection establishment only,
+never the open event stream.
+
+```ts
+const client = new AgentClient("http://localhost:8080", { timeoutMs: 60_000, retries: 3 });
+```
+
+Failures throw typed errors, all extending `AgentClientError`:
+
+```ts
+import { AgentClientError, ConnectionError, HttpError, TimeoutError } from "@1kbirds/chidori";
+
+try {
+  await client.signal(sessionId, { name: "review", payload: { decision: "approve" } });
+} catch (err) {
+  if (err instanceof HttpError) {
+    // err.status distinguishes the documented semantics:
+    // 400 empty name, 404 unknown session, 409 terminal run
+    if (err.status === 409) console.log("run already finished:", err.detail);
+  } else if (err instanceof TimeoutError) {
+    // server hung past timeoutMs
+  } else if (err instanceof ConnectionError) {
+    // nothing listening / connection refused
+  }
+}
+```
+
+`HttpError` carries `.status`, the raw `.body`, and `.detail` (the server's
+`error` field when the body was JSON), so status handling never string-matches
+messages.
+
 ## Snapshot-aware checkpoints
 
 `Checkpoint` contains the replay call log plus optional `snapshotManifest`

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -15,6 +15,27 @@ export type AgentJson =
 
 export type JsonObject = { [key: string]: AgentJson };
 
+/**
+ * Structured fields for `chidori.log`. Values are JSON; `undefined` entries are
+ * accepted (and simply dropped on serialization) so optional data can be logged
+ * without `?? null` dances.
+ */
+export type LogFields = { [key: string]: AgentJson | undefined };
+
+/**
+ * What an agent handler may return: JSON, except object members may be
+ * `undefined` (they are dropped when the output is serialized). This is what
+ * lets outcome shapes with optional fields — {@link BranchOutcome},
+ * {@link ActorOutcome} — be returned from an agent without `?? null` dances.
+ */
+export type AgentOutput =
+  | null
+  | boolean
+  | number
+  | string
+  | AgentOutput[]
+  | { [key: string]: AgentOutput | undefined };
+
 export interface JsonSchema {
   type?: "object" | "array" | "string" | "number" | "integer" | "boolean" | "null";
   description?: string;
@@ -62,7 +83,9 @@ export interface PromptOptions {
 export interface LlmResponseJson {
   content: string;
   blocks: AgentJson[];
-  toolCalls: { id: string; name: string; input: AgentJson }[];
+  /** Tool-use requests from the model. `input` is always a JSON object, so it
+   * can be passed straight to `chidori.tool(call.name, call.input)`. */
+  toolCalls: { id: string; name: string; input: JsonObject }[];
   stopReason: string;
   inputTokens: number;
   outputTokens: number;
@@ -148,11 +171,13 @@ export interface Context {
   estimateTokens(): number;
 }
 
-/** One recorded exchange in a {@link Conversation} transcript. */
-export interface ConversationTurn {
+/** One recorded exchange in a {@link Conversation} transcript. A type alias
+ * (not an interface) so transcripts stay assignable to {@link AgentJson} and
+ * can be returned as agent output directly. */
+export type ConversationTurn = {
   role: "user" | "assistant";
   text: string;
-}
+};
 
 /** Options for `chidori.conversation()`. */
 export interface ConversationOptions {
@@ -250,12 +275,15 @@ export interface InputOptions {
  * Who delivered a signal. `kind` distinguishes a human participant from a peer
  * agent; `id` is the participant identity; `runId` is set when an agent sends
  * (its own run id), so agent-to-agent coordination is attributable in the trace.
+ *
+ * A type alias (not an interface) so it stays assignable to {@link AgentJson} —
+ * senders routinely flow into `chidori.log` fields and agent outputs.
  */
-export interface SignalSender {
+export type SignalSender = {
   kind: "human" | "agent";
   id: string;
   runId?: string;
-}
+};
 
 /**
  * A named message delivered into a run mid-flight (`docs/signals.md`). The
@@ -263,13 +291,13 @@ export interface SignalSender {
  * `{ name, payload, from }` at an agent-declared listen point. Every signal is
  * recorded in the call log, so the multiplayer session replays deterministically.
  */
-export interface Signal<T = AgentJson> {
+export type Signal<T = AgentJson> = {
   name: string;
   payload: T;
   from: SignalSender;
   /** Never set on a delivered signal — the discriminant against {@link SignalTimeout}, so `if (result.timedOut)` narrows. */
   timedOut?: undefined;
-}
+};
 
 export interface SignalOptions {
   /**
@@ -287,12 +315,12 @@ export interface SignalOptions {
  * rejecting (`docs/signals.md`). `name` is the single awaited name, or `null`
  * for a multi-name fan-in listen.
  */
-export interface SignalTimeout {
+export type SignalTimeout = {
   name: string | null;
   payload: null;
   from: null;
   timedOut: true;
-}
+};
 
 export interface ParallelOptions {
   concurrency?: number;
@@ -314,8 +342,9 @@ export interface BranchVariant {
 
 export type BranchStatus = "completed" | "paused" | "failed";
 
-/** The result of one branch sub-run, returned for comparison (not merged). */
-export interface BranchOutcome<T extends AgentJson = AgentJson> {
+/** The result of one branch sub-run, returned for comparison (not merged).
+ * A type alias so outcomes can flow straight into agent output. */
+export type BranchOutcome<T extends AgentJson = AgentJson> = {
   label: string;
   /**
    * `<parent run id>-op<branch seq>-branch-<k>` — identifies the branch
@@ -330,7 +359,7 @@ export interface BranchOutcome<T extends AgentJson = AgentJson> {
   pendingPrompt?: string;
   /** The failure message, when `status` is `"failed"`. */
   error?: string;
-}
+};
 
 export interface BranchOptions {
   /**
@@ -378,8 +407,9 @@ export interface SpawnActorOptions {
 /** How an actor's supervision loop settled. */
 export type ActorOutcomeStatus = "completed" | "failed" | "paused" | "stopped";
 
-/** The settlement `actors.join()`/`actors.stop()` resolve to. */
-export interface ActorOutcome<T extends AgentJson = AgentJson> {
+/** The settlement `actors.join()`/`actors.stop()` resolve to.
+ * A type alias so outcomes can flow straight into agent output. */
+export type ActorOutcome<T extends AgentJson = AgentJson> = {
   pid: string;
   status: ActorOutcomeStatus;
   /** The actor's return value, when `status` is `"completed"`. */
@@ -390,20 +420,20 @@ export interface ActorOutcome<T extends AgentJson = AgentJson> {
   pendingPrompt?: string;
   /** How many supervised restarts the actor consumed. */
   restarts: number;
-}
+};
 
 /**
  * What a `join`/`stop` with `timeoutMs` resolves to when the deadline passes
  * before the actor settles: a snapshot, not a settlement — nothing merged,
  * join again later. Discriminate with `outcome.status === "running"`.
  */
-export interface ActorStillRunning {
+export type ActorStillRunning = {
   pid: string;
   status: "running";
   restarts: number;
-}
+};
 
-export interface ActorStatus {
+export type ActorStatus = {
   pid: string;
   status: ActorOutcomeStatus | "running" | "waiting" | "unknown";
   restarts?: number;
@@ -411,17 +441,17 @@ export interface ActorStatus {
   mailbox?: number;
   /** The listen-point names a `"waiting"` actor is parked on. */
   waitingFor?: string[];
-}
+};
 
 /** A message consumed from a mailbox. */
-export interface ActorMessage<T = AgentJson> {
+export type ActorMessage<T = AgentJson> = {
   name: string;
   payload: T;
   /** Sender identity: `id` is the sending actor's pid, or `"run"`. */
   from: SignalSender;
   /** Never set on a delivered message — the discriminant against {@link SignalTimeout}. */
   timedOut?: undefined;
-}
+};
 
 export interface ReceiveOptions {
   /** Resolve to the `{ timedOut: true }` sentinel after this many ms. */
@@ -530,8 +560,9 @@ export type DetachedAgentStatus =
   | "failed"
   | "stopped";
 
-/** The snapshot `agents.status()`/`agents.join()` resolve to. */
-export interface DetachedAgentOutcome<T extends AgentJson = AgentJson> {
+/** The snapshot `agents.status()`/`agents.join()` resolve to.
+ * A type alias so outcomes can flow straight into agent output. */
+export type DetachedAgentOutcome<T extends AgentJson = AgentJson> = {
   name: string;
   runId: string;
   status: DetachedAgentStatus;
@@ -542,7 +573,7 @@ export interface DetachedAgentOutcome<T extends AgentJson = AgentJson> {
   waitingFor?: string[] | null;
   /** The alarm deadline, when the current wait carries one (ISO timestamp). */
   deadline?: string | null;
-}
+};
 
 /**
  * A detached agent's handle — same sugar as {@link ActorHandle}, addressed by
@@ -793,7 +824,7 @@ export interface Chidori {
   /** In-VM control-flow helpers (`parallel`, `retry`, `tryCall`) — pure JS, never recorded. */
   util: ChidoriUtil;
   template(pathOrText: string, vars?: JsonObject, options?: TemplateOptions): Promise<string>;
-  log(message: string, fields?: JsonObject): Promise<void>;
+  log(message: string, fields?: LogFields): Promise<void>;
   /** The persistent, namespaced key-value store. */
   memory: MemoryStore;
   /** The journaled agent-run application-data store (generative-UI runs). */
@@ -805,7 +836,7 @@ export interface Chidori {
   mark(label?: string, data?: AgentJson): Promise<void>;
 }
 
-export type AgentFunction<TInput extends AgentJson = JsonObject, TOutput extends AgentJson = AgentJson> = (
+export type AgentFunction<TInput extends AgentJson = JsonObject, TOutput extends AgentOutput = AgentOutput> = (
   input: TInput,
 ) => TOutput | Promise<TOutput>;
 
@@ -851,7 +882,7 @@ export const chidori: Chidori = new Proxy({} as Chidori, {
  * run(async (input) => ({ greeting: `hello ${input.name}` }));
  * ```
  */
-export function run<TInput extends AgentJson = JsonObject, TOutput extends AgentJson = AgentJson>(
+export function run<TInput extends AgentJson = JsonObject, TOutput extends AgentOutput = AgentOutput>(
   handler: AgentFunction<TInput, TOutput>,
 ): void {
   void handler;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -17,6 +17,7 @@ export type {
   ActorStillRunning,
   AgentFunction,
   AgentJson,
+  AgentOutput,
   AppData,
   BranchOptions,
   BranchOutcome,
@@ -41,6 +42,7 @@ export type {
   JsonObject,
   JsonSchema,
   LlmResponseJson,
+  LogFields,
   MapSetSnapshotPolicy,
   MemoryStore,
   ParallelOptions,
@@ -358,6 +360,96 @@ export type StreamEvent =
     }
   | { type: "done"; id: string; status: SessionStatus; output?: Json; error?: string };
 
+/** Base class for every error the SDK throws. `catch (e) { if (e instanceof
+ * AgentClientError) ... }` covers HTTP failures, timeouts, and connection
+ * errors alike. */
+export class AgentClientError extends Error {}
+
+/**
+ * A non-2xx HTTP response. Carries the parsed `status` so callers can
+ * distinguish the server's documented semantics — e.g. for `client.signal`:
+ * 400 (empty name), 404 (unknown session), 409 (terminal run) — instead of
+ * string-matching the message.
+ */
+export class HttpError extends AgentClientError {
+  constructor(
+    /** HTTP method of the failed request. */
+    readonly method: string,
+    /** Request path relative to the base URL. */
+    readonly path: string,
+    /** HTTP status code (400, 404, 409, 500, ...). */
+    readonly status: number,
+    /** Raw response body text (may be empty). */
+    readonly body: string,
+    /** The server's `error` field, when the body was `{ "error": ... }`. */
+    readonly detail: string | null = null,
+  ) {
+    super(`${method} ${path} failed: HTTP ${status}${detail || body ? `: ${detail ?? body}` : ""}`);
+    this.name = "HttpError";
+  }
+
+  static async fromResponse(method: string, path: string, resp: Response): Promise<HttpError> {
+    const body = await resp.text().catch(() => "");
+    let detail: string | null = null;
+    try {
+      const parsed = JSON.parse(body) as { error?: unknown };
+      if (typeof parsed.error === "string") detail = parsed.error;
+    } catch {
+      // not JSON — leave detail null
+    }
+    return new HttpError(method, path, resp.status, body, detail);
+  }
+}
+
+/** The request exceeded the client's `timeoutMs` without completing. */
+export class TimeoutError extends AgentClientError {
+  constructor(
+    readonly method: string,
+    readonly path: string,
+    readonly timeoutMs: number,
+  ) {
+    super(`${method} ${path} timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+  }
+}
+
+/** The request never produced an HTTP response (refused, reset, DNS, ...). */
+export class ConnectionError extends AgentClientError {
+  constructor(
+    readonly method: string,
+    readonly path: string,
+    cause: unknown,
+  ) {
+    super(`${method} ${path} failed: ${cause instanceof Error ? cause.message : String(cause)}`, {
+      cause,
+    });
+    this.name = "ConnectionError";
+  }
+}
+
+/** Response statuses worth retrying on idempotent requests. */
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+
+export interface AgentClientOptions {
+  /**
+   * Per-request timeout in milliseconds; `0` disables it. Defaults to
+   * 300 000 (5 minutes) — generous because `run()` executes the whole agent
+   * before responding, but finite so a hung server surfaces as a
+   * `TimeoutError` instead of blocking forever. For `stream()` the timeout
+   * covers connection establishment only, never an open event stream.
+   */
+  timeoutMs?: number;
+  /**
+   * How many times to retry **idempotent GET requests** after a connection
+   * error, timeout, or retryable status (429/502/503/504). Defaults to 2.
+   * POST requests are never retried — `run`/`resume`/`signal` are not
+   * idempotent, and a blind retry could execute an agent twice.
+   */
+  retries?: number;
+  /** Base delay between retries in milliseconds, doubling per attempt (default 250). */
+  retryDelayMs?: number;
+}
+
 /**
  * HTTP client for an `chidori serve` instance.
  *
@@ -369,12 +461,23 @@ export type StreamEvent =
  * const cp = await session.checkpoint();
  * const replayed = await client.replay(cp);  // zero LLM calls
  * ```
+ *
+ * Failures throw typed errors (all extending {@link AgentClientError}):
+ * {@link HttpError} with a `.status` for non-2xx responses,
+ * {@link TimeoutError} after `timeoutMs`, {@link ConnectionError} when no
+ * response arrived at all.
  */
 export class AgentClient {
   readonly baseUrl: string;
+  readonly timeoutMs: number;
+  readonly retries: number;
+  readonly retryDelayMs: number;
 
-  constructor(baseUrl: string = "http://localhost:8080") {
+  constructor(baseUrl: string = "http://localhost:8080", options: AgentClientOptions = {}) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.timeoutMs = options.timeoutMs ?? 300_000;
+    this.retries = options.retries ?? 2;
+    this.retryDelayMs = options.retryDelayMs ?? 250;
   }
 
   async health(): Promise<Json> {
@@ -496,13 +599,29 @@ export class AgentClient {
    * progress streams separately from final-answer streams.
    */
   async *stream(input: Json): AsyncGenerator<StreamEvent, void, void> {
-    const resp = await fetch(`${this.baseUrl}/sessions/stream`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
-      body: JSON.stringify({ input }),
-    });
+    // The timeout covers connection establishment (until response headers
+    // arrive), not the open event stream — a healthy run may stream for a
+    // long time between events.
+    const controller = new AbortController();
+    const timer =
+      this.timeoutMs > 0 ? setTimeout(() => controller.abort(), this.timeoutMs) : null;
+    let resp: Response;
+    try {
+      resp = await fetch(`${this.baseUrl}/sessions/stream`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
+        body: JSON.stringify({ input }),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      throw controller.signal.aborted
+        ? new TimeoutError("POST", "/sessions/stream", this.timeoutMs)
+        : new ConnectionError("POST", "/sessions/stream", err);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
     if (!resp.ok || !resp.body) {
-      throw new Error(`stream request failed: ${resp.status}`);
+      throw await HttpError.fromResponse("POST", "/sessions/stream", resp);
     }
 
     // Minimal SSE parser — just enough for the events our server emits.
@@ -543,8 +662,9 @@ export class AgentClient {
   }
 
   private async getJSON(path: string): Promise<unknown> {
-    const resp = await fetch(this.baseUrl + path);
-    if (!resp.ok) throw await httpError(resp);
+    // GETs are idempotent: retry connection failures, timeouts, and
+    // retryable statuses with exponential backoff.
+    const resp = await this.request("GET", path, undefined, this.retries);
     return await resp.json();
   }
 
@@ -556,19 +676,68 @@ export class AgentClient {
     path: string,
     body: unknown,
   ): Promise<{ status: number; data: Record<string, unknown> }> {
-    const resp = await fetch(this.baseUrl + path, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw await httpError(resp);
+    // POSTs are never retried: run/resume/signal are not idempotent.
+    const resp = await this.request("POST", path, body, 0);
     return { status: resp.status, data: (await resp.json()) as Record<string, unknown> };
+  }
+
+  /**
+   * One HTTP exchange with timeout and (for idempotent requests) retries.
+   * Resolves with a 2xx `Response`; throws {@link HttpError},
+   * {@link TimeoutError}, or {@link ConnectionError} otherwise.
+   */
+  private async request(
+    method: "GET" | "POST",
+    path: string,
+    body: unknown,
+    retries: number,
+  ): Promise<Response> {
+    let lastError: AgentClientError | null = null;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      if (attempt > 0) {
+        await sleep(this.retryDelayMs * 2 ** (attempt - 1));
+      }
+      const controller = new AbortController();
+      const timer =
+        this.timeoutMs > 0 ? setTimeout(() => controller.abort(), this.timeoutMs) : null;
+      try {
+        let resp: Response;
+        try {
+          resp = await fetch(this.baseUrl + path, {
+            method,
+            signal: controller.signal,
+            ...(body !== undefined
+              ? {
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify(body),
+                }
+              : {}),
+          });
+        } catch (err) {
+          throw controller.signal.aborted
+            ? new TimeoutError(method, path, this.timeoutMs)
+            : new ConnectionError(method, path, err);
+        }
+        if (!resp.ok) throw await HttpError.fromResponse(method, path, resp);
+        return resp;
+      } catch (err) {
+        const retryable =
+          err instanceof TimeoutError ||
+          err instanceof ConnectionError ||
+          (err instanceof HttpError && RETRYABLE_STATUS.has(err.status));
+        if (!retryable || attempt === retries) throw err;
+        lastError = err as AgentClientError;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    }
+    // Unreachable: the loop either returns or throws on the last attempt.
+    throw lastError ?? new ConnectionError(method, path, "retries exhausted");
   }
 }
 
-async function httpError(resp: Response): Promise<Error> {
-  const text = await resp.text().catch(() => "");
-  return new Error(`HTTP ${resp.status}: ${text}`);
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function parseSseFrame(frame: string): StreamEvent | null {

--- a/sdk/typescript/test/client.test.mjs
+++ b/sdk/typescript/test/client.test.mjs
@@ -9,8 +9,12 @@ import { after, before, beforeEach, describe, it } from "node:test";
 
 import {
   AgentClient,
+  AgentClientError,
   Checkpoint,
+  ConnectionError,
+  HttpError,
   Session,
+  TimeoutError,
   isSignalQueued,
 } from "../dist/index.js";
 
@@ -332,11 +336,93 @@ describe("Checkpoint serialization", () => {
 });
 
 describe("error handling", () => {
-  it("throws HTTP <status>: <body> on a non-2xx response", async () => {
-    server.on((_req, res) => sendJson(res, 500, { error: "kaboom" }));
+  it("throws a typed HttpError carrying status, body, and detail", async () => {
+    // 400 is not retryable, so a single handler suffices.
+    server.on((_req, res) => sendJson(res, 400, { error: "kaboom" }));
     await assert.rejects(() => client.health(), (err) => {
-      assert.match(err.message, /HTTP 500/);
+      assert.ok(err instanceof HttpError);
+      assert.ok(err instanceof AgentClientError);
+      assert.equal(err.status, 400);
+      assert.equal(err.detail, "kaboom");
+      assert.match(err.body, /kaboom/);
+      assert.match(err.message, /HTTP 400/);
       assert.match(err.message, /kaboom/);
+      return true;
+    });
+  });
+
+  it("distinguishes 400/404/409 via err.status", async () => {
+    for (const status of [400, 404, 409]) {
+      server.reset();
+      server.on((_req, res) => sendJson(res, status, { error: `status ${status}` }));
+      await assert.rejects(
+        () => client.signal("run-x", { name: "review" }),
+        (err) => err instanceof HttpError && err.status === status,
+      );
+    }
+  });
+
+  it("does not retry POSTs on a retryable status", async () => {
+    server.on((_req, res) => sendJson(res, 503, { error: "overloaded" }));
+    await assert.rejects(() => client.run({ q: 1 }), (err) => {
+      assert.ok(err instanceof HttpError);
+      assert.equal(err.status, 503);
+      return true;
+    });
+    assert.equal(server.requestsFor("/sessions").length, 1);
+  });
+
+  it("retries GETs on a retryable status and succeeds", async () => {
+    const fastClient = new AgentClient(server.baseUrl, { retries: 2, retryDelayMs: 1 });
+    let calls = 0;
+    server.on((_req, res) => {
+      calls += 1;
+      if (calls < 3) return sendJson(res, 503, { error: "warming up" });
+      sendJson(res, 200, { status: "ok" });
+    });
+    assert.deepEqual(await fastClient.health(), { status: "ok" });
+    assert.equal(calls, 3);
+  });
+
+  it("gives up retrying GETs after `retries` attempts", async () => {
+    const fastClient = new AgentClient(server.baseUrl, { retries: 1, retryDelayMs: 1 });
+    server.on((_req, res) => sendJson(res, 503, { error: "still down" }));
+    await assert.rejects(() => fastClient.health(), (err) => {
+      assert.ok(err instanceof HttpError);
+      assert.equal(err.status, 503);
+      return true;
+    });
+    assert.equal(server.requestsFor("/health").length, 2);
+  });
+
+  it("does not retry GETs on a non-retryable status", async () => {
+    server.on((_req, res) => sendJson(res, 404, { error: "no such session" }));
+    await assert.rejects(() => client.getSession("nope"), (err) => {
+      assert.ok(err instanceof HttpError);
+      assert.equal(err.status, 404);
+      return true;
+    });
+    assert.equal(server.requestsFor("/sessions/nope").length, 1);
+  });
+
+  it("throws a TimeoutError when the server never responds", async () => {
+    const impatient = new AgentClient(server.baseUrl, { timeoutMs: 50, retries: 0 });
+    server.on(() => {
+      // Never respond; the client should abort.
+    });
+    await assert.rejects(() => impatient.run({ q: 1 }), (err) => {
+      assert.ok(err instanceof TimeoutError);
+      assert.ok(err instanceof AgentClientError);
+      assert.equal(err.timeoutMs, 50);
+      return true;
+    });
+  });
+
+  it("throws a ConnectionError when nothing is listening", async () => {
+    const nowhere = new AgentClient("http://127.0.0.1:1", { retries: 0, timeoutMs: 1000 });
+    await assert.rejects(() => nowhere.health(), (err) => {
+      assert.ok(err instanceof ConnectionError);
+      assert.ok(err instanceof AgentClientError);
       return true;
     });
   });
@@ -395,13 +481,17 @@ describe("stream", () => {
     assert.deepEqual(events[0].output, { v: 1 });
   });
 
-  it("throws when the stream request fails", async () => {
+  it("throws an HttpError when the stream request fails", async () => {
     server.on((_req, res) => res.writeHead(500).end());
     await assert.rejects(async () => {
       // eslint-disable-next-line no-unused-vars
       for await (const _ of client.stream({})) {
         // no-op
       }
-    }, /stream request failed: 500/);
+    }, (err) => {
+      assert.ok(err instanceof HttpError);
+      assert.equal(err.status, 500);
+      return true;
+    });
   });
 });


### PR DESCRIPTION
- Map the real `chidori:agent` specifier in example tsconfigs (was aliasing
  `chidori`/`chidori/agent`, which no source imports), add an umbrella
  examples/tsconfig.json, and typecheck both in CI. `npx tsc -p examples`
  and `npx tsc -p examples/record-replay` now pass.
- Convert every example agent (and scripts/pgo-train) from the legacy
  `export async function agent(input, chidori)` form to the canonical
  `import { chidori, run } from "chidori:agent"` + `run(handler)` form.
- SDK types: make data shapes (SignalSender, Signal, SignalTimeout,
  ActorOutcome, ActorMessage, ActorStatus, ActorStillRunning, BranchOutcome,
  DetachedAgentOutcome, ConversationTurn) type aliases so they stay
  assignable to AgentJson; add LogFields (log fields may be undefined) and
  AgentOutput (agent returns may carry undefined members, dropped on
  serialization); type LlmResponseJson.toolCalls[].input as JsonObject so it
  feeds chidori.tool() directly.
- Add typed AgentClient errors (HttpError with .status/.detail, TimeoutError,
  ConnectionError, base AgentClientError), a configurable request timeout
  (default 5 min, 0 disables), and retries with exponential backoff for
  idempotent GETs (429/502/503/504, connection errors, timeouts). POSTs are
  never retried. stream() applies the timeout to connection establishment
  only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKsRyF9ybYeVbMVTpuz2yL