### PR TITLE
Security hardening: SSRF guard, constant-time auth, mandatory checksums, dependency scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Automated dependency update PRs. Security updates always open immediately;
+# routine version bumps arrive weekly and grouped, so the noise stays low.
+version: 2
+updates:
+  # Rust workspace (448 transitive crates — the main supply-chain surface).
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # CI workflow actions (checkout, setup-node, publish actions, ...).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # TypeScript SDK (published to npm as @1kbirds/chidori).
+  - package-ecosystem: npm
+    directory: /sdk/typescript
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Python SDK (published to PyPI as chidori).
+  - package-ecosystem: pip
+    directory: /sdk/python
+    schedule:
+      interval: weekly

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,50 @@
+name: Security
+
+# Dependency scanning for the Rust workspace via cargo-deny (RustSec
+# advisories, license allowlist, duplicate/wildcard bans, crates.io-only
+# sources — see deny.toml). Runs on pushes and PRs that touch the dependency
+# graph, plus a weekly schedule so new advisories surface even when the tree
+# is quiet. Dependabot (.github/dependabot.yml) handles the update PRs;
+# npm audit covers the TypeScript SDK's lockfile.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (advisories, bans, licenses, sources)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: stable
+          command: check advisories bans licenses sources
+
+  npm-audit:
+    name: npm audit (TypeScript SDK)
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-channel"
@@ -565,6 +565,7 @@ dependencies = [
  "serde_yaml",
  "sha1 0.10.6",
  "sha2",
+ "subtle",
  "tar",
  "tempfile",
  "tokio",
@@ -878,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -65,6 +65,8 @@ tokio-stream = "0.1"
 async-stream = "0.3"
 sha2 = "0.10"
 sha1 = "0.10"
+# Constant-time comparison for API-key checks (already in-tree via `digest`).
+subtle = "2"
 hmac = "0.12"
 base64 = "0.22"
 hex = "0.4"

--- a/crates/chidori/src/pkg/mod.rs
+++ b/crates/chidori/src/pkg/mod.rs
@@ -13,9 +13,10 @@
 //!   `node_modules` by hardlinking (copy fallback). Warm installs touch no
 //!   network and duplicate no file contents.
 //! - **Integrity verification**: every tarball is verified against the
-//!   registry's `sha512` integrity (or legacy `sha1` shasum) before it enters
-//!   the store. Hashing runs on blocking worker threads, off the async
-//!   download path.
+//!   registry's `sha512` integrity before it enters the store. The legacy
+//!   `sha1` shasum (pre-2017 publishes) is collision-broken and refused
+//!   unless `CHIDORI_PKG_ALLOW_SHA1=1` opts in. Hashing runs on blocking
+//!   worker threads, off the async download path.
 //! - **Sorted JSONL lockfile** (`chidori.lock.jsonl`): one JSON object per
 //!   line, strictly sorted, so concurrent dependency changes merge in git
 //!   without conflict churn.

--- a/crates/chidori/src/pkg/store.rs
+++ b/crates/chidori/src/pkg/store.rs
@@ -30,9 +30,29 @@ pub enum Integrity {
     Sha1(Vec<u8>),
 }
 
+/// Env var opting in to the collision-broken SHA-1 `shasum` fallback for
+/// packages that publish no `sha512` integrity (pre-2017 publishes).
+pub const ALLOW_SHA1_ENV: &str = "CHIDORI_PKG_ALLOW_SHA1";
+
 impl Integrity {
     /// Prefer the SRI `integrity` field, fall back to the legacy shasum.
+    ///
+    /// SHA-1 has had practical collision attacks since 2017 (SHAttered), so
+    /// the shasum fallback is refused unless `CHIDORI_PKG_ALLOW_SHA1=1`
+    /// explicitly opts in — installing a legacy package then still verifies
+    /// against the shasum rather than nothing at all.
     pub fn from_dist(integrity: Option<&str>, shasum: Option<&str>) -> Result<Self> {
+        let allow_sha1 = std::env::var(ALLOW_SHA1_ENV).is_ok_and(|v| v.trim() == "1");
+        Self::from_dist_with_options(integrity, shasum, allow_sha1)
+    }
+
+    /// [`Integrity::from_dist`] with the SHA-1 opt-in as an explicit argument,
+    /// so tests can exercise both modes without racing on process env.
+    pub fn from_dist_with_options(
+        integrity: Option<&str>,
+        shasum: Option<&str>,
+        allow_sha1: bool,
+    ) -> Result<Self> {
         if let Some(sri) = integrity {
             // SRI allows space-separated alternatives; take the strongest
             // sha512 entry if present.
@@ -49,6 +69,13 @@ impl Integrity {
             }
         }
         if let Some(hex_sum) = shasum {
+            if !allow_sha1 {
+                bail!(
+                    "registry entry publishes only a SHA-1 shasum, which is \
+                     collision-broken and refused by default; set {ALLOW_SHA1_ENV}=1 \
+                     to install this legacy package anyway"
+                );
+            }
             let digest = hex::decode(hex_sum.trim()).context("decoding sha1 shasum")?;
             if digest.len() != 20 {
                 bail!("sha1 shasum has wrong digest length");
@@ -331,19 +358,42 @@ mod tests {
     }
 
     #[test]
-    fn integrity_prefers_sha512_and_falls_back_to_shasum() {
+    fn integrity_prefers_sha512_and_falls_back_to_shasum_when_opted_in() {
         let sri = format!(
             "sha512-{}",
             base64::engine::general_purpose::STANDARD.encode([7u8; 64])
         );
-        match Integrity::from_dist(Some(&sri), Some("aa".repeat(20).as_str())).unwrap() {
+        match Integrity::from_dist_with_options(Some(&sri), Some("aa".repeat(20).as_str()), false)
+            .unwrap()
+        {
             Integrity::Sha512(d) => assert_eq!(d, vec![7u8; 64]),
             other => panic!("expected sha512, got {other:?}"),
         }
-        match Integrity::from_dist(None, Some("ab".repeat(20).as_str())).unwrap() {
+        match Integrity::from_dist_with_options(None, Some("ab".repeat(20).as_str()), true).unwrap()
+        {
             Integrity::Sha1(d) => assert_eq!(d.len(), 20),
             other => panic!("expected sha1, got {other:?}"),
         }
-        assert!(Integrity::from_dist(None, None).is_err());
+        assert!(Integrity::from_dist_with_options(None, None, true).is_err());
+    }
+
+    #[test]
+    fn integrity_refuses_sha1_only_dist_by_default() {
+        let err = Integrity::from_dist_with_options(None, Some("ab".repeat(20).as_str()), false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("SHA-1"), "{err}");
+        assert!(err.contains(ALLOW_SHA1_ENV), "{err}");
+        // A dist with a usable sha512 entry is unaffected by the gate.
+        let sri = format!(
+            "sha512-{}",
+            base64::engine::general_purpose::STANDARD.encode([9u8; 64])
+        );
+        assert!(Integrity::from_dist_with_options(
+            Some(&sri),
+            Some("ab".repeat(20).as_str()),
+            false
+        )
+        .is_ok());
     }
 }

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -1328,7 +1328,17 @@ fn http_client() -> Result<reqwest::Client> {
     // `gzip(true)` (with the reqwest `gzip` feature) sends Accept-Encoding
     // and transparently decompresses gzipped response bodies, so tools get
     // readable text instead of a binary blob.
-    let built = reqwest::Client::builder().gzip(true).build()?;
+    //
+    // The SSRF guard is baked into the client: the guarded DNS resolver
+    // filters non-public addresses at resolution time (so DNS rebinding and
+    // redirect hops are covered by the same check the connector dials from),
+    // and the redirect policy re-validates each hop's scheme and IP-literal
+    // host. See `runtime::ssrf`.
+    let built = reqwest::Client::builder()
+        .gzip(true)
+        .dns_resolver(crate::runtime::ssrf::dns_resolver())
+        .redirect(crate::runtime::ssrf::redirect_policy())
+        .build()?;
     Ok(CLIENT.get_or_init(|| built).clone())
 }
 
@@ -1370,6 +1380,24 @@ fn rewrite_to_override(
         parsed.path(),
         query
     ))
+}
+
+/// Render an error with its full source chain. reqwest's `Display` truncates
+/// the chain (a blocked destination shows up as just "error sending request"),
+/// but the guest needs the root cause — e.g. the SSRF guard's policy message —
+/// to act on the failure.
+fn error_chain_string(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut rendered = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        let text = cause.to_string();
+        if !rendered.contains(&text) {
+            rendered.push_str(": ");
+            rendered.push_str(&text);
+        }
+        source = cause.source();
+    }
+    rendered
 }
 
 pub fn execute_http(tokio_rt: &tokio::runtime::Runtime, args: &Value) -> Result<Value> {
@@ -1426,6 +1454,15 @@ fn execute_app_data_with_config(
         .filter(|value| !value.is_null())
         .cloned()
         .unwrap_or_else(|| json!([]));
+
+    // The endpoint is host-injected config (typically loopback agent-builder),
+    // so exempt its host from the SSRF guard before issuing the request.
+    if let Some(host) = url::Url::parse(&cfg.endpoint)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_owned))
+    {
+        crate::runtime::ssrf::trust_host(&host);
+    }
 
     // The bearer is a placeholder; the secret broker substitutes the real
     // per-run token inside `execute_http`, locked to the endpoint's host.
@@ -1504,6 +1541,14 @@ fn execute_http_with_secrets(
     // substitute into a mock request (and in test mode none are injected
     // anyway). See app-agent-builder docs/design/mock-integrations-test-mode.md.
     if let Some(rewritten) = apply_base_url_override(&url) {
+        // The rewrite target is host-injected config (the loopback mock
+        // gateway), so exempt it from the SSRF guard before requesting.
+        if let Some(host) = url::Url::parse(&rewritten)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_owned))
+        {
+            crate::runtime::ssrf::trust_host(&host);
+        }
         url = rewritten;
     }
 
@@ -1547,6 +1592,15 @@ fn execute_http_with_secrets(
                 }
             }
         }
+    }
+
+    // SSRF pre-flight: reject non-http(s) schemes and blocked IP-literal
+    // destinations up front with a policy error (hostname destinations are
+    // checked by the guarded resolver at connect time, against the exact
+    // addresses the connector dials — see `runtime::ssrf`). An unparseable
+    // URL is left for reqwest to reject with its usual builder error.
+    if let Ok(parsed) = url::Url::parse(&url) {
+        crate::runtime::ssrf::preflight(&parsed).map_err(|message| anyhow::anyhow!(message))?;
     }
 
     let caller_set_user_agent = headers
@@ -1612,13 +1666,13 @@ fn execute_http_with_secrets(
             Ok(resp) => resp,
             Err(err) => {
                 if err.is_builder() {
-                    return Err(anyhow::anyhow!(secrets.redact(&err.to_string())));
+                    return Err(anyhow::anyhow!(secrets.redact(&error_chain_string(&err))));
                 }
                 return Ok(json!({
                     "status": 0,
                     "headers": {},
                     "body": null,
-                    "error": secrets.redact(&err.to_string()),
+                    "error": secrets.redact(&error_chain_string(&err)),
                 }));
             }
         };
@@ -1671,6 +1725,9 @@ mod tests {
     /// address so the test can point `AppDataConfig::endpoint` at it.
     fn canned_http_endpoint(status: &'static str, body: &'static str) -> std::net::SocketAddr {
         use std::io::{Read, Write};
+        // Tests exercise the real http effect against loopback fixtures, which
+        // the SSRF guard would otherwise block.
+        crate::runtime::ssrf::trust_host("127.0.0.1");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         std::thread::spawn(move || {
@@ -2142,6 +2199,7 @@ mod tests {
 
     #[test]
     fn execute_http_returns_status_zero_for_transport_error() {
+        crate::runtime::ssrf::trust_host("127.0.0.1");
         let tokio_rt = tokio::runtime::Runtime::new().unwrap();
         let result = execute_http(
             &tokio_rt,
@@ -2165,6 +2223,9 @@ mod tests {
     /// surface a transport error.
     async fn one_shot_http_capture() -> (String, tokio::task::JoinHandle<String>) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        // Tests exercise the real http effect against loopback fixtures, which
+        // the SSRF guard would otherwise block.
+        crate::runtime::ssrf::trust_host("127.0.0.1");
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let url = format!("http://{addr}/ua-check");
@@ -2356,6 +2417,7 @@ mod tests {
     #[test]
     fn execute_http_redacts_echoed_secret_from_response() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        crate::runtime::ssrf::trust_host("127.0.0.1");
         let tokio_rt = tokio::runtime::Runtime::new().unwrap();
         let (url, server) = tokio_rt.block_on(async {
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2392,6 +2454,74 @@ mod tests {
             json!("[REDACTED:LOCAL_API_KEY]"),
             "response headers must be redacted"
         );
+    }
+
+    #[test]
+    fn execute_http_blocks_metadata_ip_literal() {
+        let tokio_rt = tokio::runtime::Runtime::new().unwrap();
+        let err = execute_http(
+            &tokio_rt,
+            &json!({ "url": "http://169.254.169.254/latest/meta-data/", "method": "GET" }),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("SSRF protection"), "{err}");
+        assert!(err.contains("CHIDORI_HTTP_ALLOW_HOSTS"), "{err}");
+    }
+
+    #[test]
+    fn execute_http_blocks_hostname_resolving_to_loopback() {
+        // `localhost` resolves to a loopback address; the guarded resolver
+        // must refuse it even though `127.0.0.1` is trusted by other tests
+        // under its own (distinct) host key.
+        let tokio_rt = tokio::runtime::Runtime::new().unwrap();
+        let result = execute_http(
+            &tokio_rt,
+            &json!({ "url": "http://localhost:9/ssrf-check", "method": "GET" }),
+        )
+        .unwrap();
+        assert_eq!(result["status"], json!(0));
+        let err = result["error"].as_str().unwrap_or_default();
+        assert!(err.contains("SSRF protection"), "{err}");
+    }
+
+    #[test]
+    fn execute_http_blocks_redirect_to_private_address() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        crate::runtime::ssrf::trust_host("127.0.0.1");
+        let tokio_rt = tokio::runtime::Runtime::new().unwrap();
+        let url = tokio_rt.block_on(async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut buf = vec![0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let _ = stream
+                    .write_all(
+                        b"HTTP/1.1 302 Found\r\nLocation: http://10.0.0.1/internal\r\nContent-Length: 0\r\n\r\n",
+                    )
+                    .await;
+                let _ = stream.shutdown().await;
+            });
+            format!("http://{addr}/redirect")
+        });
+        let result = execute_http(&tokio_rt, &json!({ "url": url, "method": "GET" })).unwrap();
+        assert_eq!(result["status"], json!(0));
+        let err = result["error"].as_str().unwrap_or_default();
+        assert!(err.contains("SSRF protection"), "{err}");
+    }
+
+    #[test]
+    fn execute_http_rejects_non_http_scheme() {
+        let tokio_rt = tokio::runtime::Runtime::new().unwrap();
+        let err = execute_http(
+            &tokio_rt,
+            &json!({ "url": "file:///etc/passwd", "method": "GET" }),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("scheme"), "{err}");
     }
 
     #[test]

--- a/crates/chidori/src/runtime/mod.rs
+++ b/crates/chidori/src/runtime/mod.rs
@@ -21,6 +21,8 @@ pub mod prompt_cache;
 pub mod rust_engine;
 pub mod secret_env;
 pub mod snapshot;
+/// SSRF guard for the guest-facing `http`/`fetch` host effect.
+pub mod ssrf;
 /// Pluggable persistence for the durable run artifact (journal + blobs).
 pub mod store;
 /// S3-compatible blob backend for the run store (S3 / R2 / GCS / MinIO).

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -2254,7 +2254,9 @@ mod tests {
         use std::io::{Read, Write};
 
         // A one-shot local HTTP server so the request goes through the real
-        // captured networking host op (`__chidori_http`) end to end.
+        // captured networking host op (`__chidori_http`) end to end. Loopback
+        // must be trusted explicitly — the SSRF guard blocks it by default.
+        crate::runtime::ssrf::trust_host("127.0.0.1");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let server = std::thread::spawn(move || {

--- a/crates/chidori/src/runtime/ssrf.rs
+++ b/crates/chidori/src/runtime/ssrf.rs
@@ -1,0 +1,412 @@
+//! SSRF guard for the guest-facing `http`/`fetch` host effect.
+//!
+//! Guest agents hand `execute_http` arbitrary URLs, and under OS isolation the
+//! request is brokered by the parent process — which has the host's full
+//! network reach — so without a guard an agent can pivot into cloud metadata
+//! services (169.254.169.254), loopback daemons, and RFC 1918 internal
+//! networks. This module blocks requests whose destination resolves to a
+//! non-public address, and it does so at the right layer:
+//!
+//!  * **DNS resolution time.** The guard is installed as the reqwest client's
+//!    DNS resolver ([`dns_resolver`]), so the addresses that get filtered are
+//!    the exact addresses the connector would dial. That closes the classic
+//!    DNS-rebinding TOCTOU (resolve-check-resolve-connect) — there is no
+//!    second resolution to rebind.
+//!  * **Every redirect hop.** [`redirect_policy`] re-checks each hop's scheme
+//!    and IP-literal host, and hostname hops go back through the guarded
+//!    resolver when the connector dials them, so a public server can't 302 the
+//!    client into a private address.
+//!  * **Pre-flight** ([`preflight`]) for the initial URL, so IP-literal
+//!    requests fail with a clear policy error instead of a transport error.
+//!
+//! Escape hatches, because loopback is legitimately used by host-injected
+//! endpoints and local development:
+//!
+//!  * `CHIDORI_HTTP_ALLOW_HOSTS` — comma-separated hostnames, IPs, or CIDRs
+//!    that may resolve to otherwise-blocked addresses
+//!    (e.g. `localhost,10.0.0.0/8`). The single value `*` disables the guard.
+//!  * [`trust_host`] — host code registers endpoints it injected itself (the
+//!    mock-integration gateway rewrite target, the app-data plane endpoint,
+//!    test fixtures). Guest code never reaches this function.
+
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::{Arc, LazyLock, RwLock};
+
+/// Env var listing extra allowed destinations (hostnames, IPs, CIDRs, or `*`).
+pub const ALLOW_HOSTS_ENV: &str = "CHIDORI_HTTP_ALLOW_HOSTS";
+
+/// Hosts registered at runtime by host code ([`trust_host`]): the mock-gateway
+/// rewrite target, the app-data endpoint, and test fixtures. Add-only, keyed
+/// by lowercase hostname (no port).
+static TRUSTED_HOSTS: LazyLock<RwLock<HashSet<String>>> =
+    LazyLock::new(|| RwLock::new(HashSet::new()));
+
+/// Rules parsed from `CHIDORI_HTTP_ALLOW_HOSTS`, once per process — the same
+/// process-global env assumption `apply_base_url_override` documents (each
+/// agent run is its own subprocess with its own env).
+static ENV_RULES: LazyLock<AllowRules> = LazyLock::new(|| {
+    AllowRules::parse(std::env::var(ALLOW_HOSTS_ENV).unwrap_or_default().as_str())
+});
+
+/// Parsed form of the allowlist env var.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct AllowRules {
+    /// `*` was present: the guard is disabled entirely.
+    allow_all: bool,
+    /// Lowercase hostnames (and IP literals in their canonical string form).
+    hosts: HashSet<String>,
+    /// CIDR ranges, as (network address, prefix length).
+    cidrs: Vec<(IpAddr, u8)>,
+}
+
+impl AllowRules {
+    fn parse(raw: &str) -> Self {
+        let mut rules = AllowRules::default();
+        for item in raw.split(',') {
+            let item = item.trim();
+            if item.is_empty() {
+                continue;
+            }
+            if item == "*" {
+                rules.allow_all = true;
+            } else if let Some((net, prefix)) = parse_cidr(item) {
+                rules.cidrs.push((net, prefix));
+            } else if let Ok(ip) = item.parse::<IpAddr>() {
+                // Store the canonical form so `[::1]`-style URL hosts and
+                // differently-written literals still match.
+                rules.hosts.insert(ip.to_string());
+            } else {
+                rules.hosts.insert(item.to_ascii_lowercase());
+            }
+        }
+        rules
+    }
+
+    fn host_allowed(&self, host: &str) -> bool {
+        if self.allow_all {
+            return true;
+        }
+        let host = canonical_host(host);
+        self.hosts.contains(&host)
+    }
+
+    fn ip_allowed(&self, ip: IpAddr) -> bool {
+        if self.allow_all {
+            return true;
+        }
+        self.cidrs
+            .iter()
+            .any(|(net, prefix)| cidr_contains(*net, *prefix, ip))
+    }
+}
+
+/// Lowercase and canonicalize a URL host for allowlist lookups: strip IPv6
+/// brackets and normalize IP literals to their canonical string form.
+fn canonical_host(host: &str) -> String {
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = trimmed.parse::<IpAddr>() {
+        return ip.to_string();
+    }
+    host.to_ascii_lowercase()
+}
+
+fn parse_cidr(item: &str) -> Option<(IpAddr, u8)> {
+    let (addr, prefix) = item.split_once('/')?;
+    let addr = addr.trim().parse::<IpAddr>().ok()?;
+    let prefix = prefix.trim().parse::<u8>().ok()?;
+    let max = match addr {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+    (prefix <= max).then_some((addr, prefix))
+}
+
+fn cidr_contains(net: IpAddr, prefix: u8, ip: IpAddr) -> bool {
+    match (net, ip) {
+        (IpAddr::V4(net), IpAddr::V4(ip)) => {
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u32::MAX << (32 - u32::from(prefix))
+            };
+            (u32::from(net) & mask) == (u32::from(ip) & mask)
+        }
+        (IpAddr::V6(net), IpAddr::V6(ip)) => {
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u128::MAX << (128 - u32::from(prefix))
+            };
+            (u128::from(net) & mask) == (u128::from(ip) & mask)
+        }
+        _ => false,
+    }
+}
+
+/// Register a host-injected endpoint (by URL host, no port) as trusted, so the
+/// guard lets requests through to it even when it lives on loopback. Only host
+/// code calls this — with hosts it configured itself — never with anything a
+/// guest supplied.
+pub fn trust_host(host: &str) {
+    TRUSTED_HOSTS
+        .write()
+        .expect("SSRF trusted-host lock poisoned")
+        .insert(canonical_host(host));
+}
+
+fn host_is_trusted(host: &str) -> bool {
+    TRUSTED_HOSTS
+        .read()
+        .expect("SSRF trusted-host lock poisoned")
+        .contains(&canonical_host(host))
+}
+
+/// True when `host` may reach otherwise-blocked addresses: allowlisted via the
+/// env var or registered through [`trust_host`].
+fn host_exempt(host: &str) -> bool {
+    ENV_RULES.host_allowed(host) || host_is_trusted(host)
+}
+
+/// Should the guard refuse to connect to `ip`? Everything that is not
+/// unambiguously a public unicast address is blocked: loopback, RFC 1918
+/// private, link-local (the cloud-metadata range), CGNAT, benchmarking,
+/// documentation, multicast, reserved, and their IPv6 counterparts
+/// (including IPv4-mapped/compatible forms, which unwrap to the IPv4 rules).
+fn ip_blocked(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => ipv4_blocked(v4),
+        IpAddr::V6(v6) => ipv6_blocked(v6),
+    }
+}
+
+fn ipv4_blocked(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local() // 169.254.0.0/16 — cloud metadata lives here
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || octets[0] == 0 // 0.0.0.0/8 "this network"
+        || (octets[0] == 100 && (octets[1] & 0xc0) == 64) // 100.64.0.0/10 CGNAT
+        || (octets[0] == 198 && (octets[1] & 0xfe) == 18) // 198.18.0.0/15 benchmarking
+        || octets[0] >= 224 // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+}
+
+fn ipv6_blocked(ip: Ipv6Addr) -> bool {
+    // IPv4-mapped (::ffff:a.b.c.d) and the deprecated IPv4-compatible form
+    // both smuggle an IPv4 destination; judge them by the IPv4 rules.
+    if let Some(v4) = ip.to_ipv4() {
+        return ipv4_blocked(v4);
+    }
+    let segments = ip.segments();
+    ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_multicast()
+        || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7 unique-local
+        || (segments[0] == 0x2001 && segments[1] == 0xdb8) // 2001:db8::/32 documentation
+        || (segments[0] == 0x64 && segments[1] == 0xff9b) // 64:ff9b::/96 NAT64 → IPv4
+}
+
+fn blocked_message(host: &str, ip: IpAddr) -> String {
+    format!(
+        "SSRF protection: '{host}' resolves to non-public address {ip}, which the http effect \
+         refuses to reach; set {ALLOW_HOSTS_ENV} (comma-separated hostnames, IPs, or CIDRs; \
+         '*' disables the guard) to allow it"
+    )
+}
+
+/// Check a URL before the request (and on every redirect hop): scheme must be
+/// http(s), and an IP-literal host must not be a blocked address. Hostname
+/// destinations are checked later, by the guarded resolver, against the exact
+/// addresses the connector will dial.
+pub fn preflight(url: &url::Url) -> Result<(), String> {
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "SSRF protection: scheme '{other}' is not allowed for the http effect (use http or https)"
+            ));
+        }
+    }
+    let Some(host) = url.host_str() else {
+        return Err("SSRF protection: url has no host".to_string());
+    };
+    if host_exempt(host) {
+        return Ok(());
+    }
+    if let Ok(ip) = canonical_host(host).parse::<IpAddr>() {
+        if ip_blocked(ip) && !ENV_RULES.ip_allowed(ip) {
+            return Err(blocked_message(host, ip));
+        }
+    }
+    Ok(())
+}
+
+/// Filter the addresses `host` resolved to, dropping blocked ones. Errors when
+/// every address is blocked (so the caller gets the policy message instead of
+/// an empty-lookup error).
+fn filter_resolved(host: &str, addrs: Vec<SocketAddr>) -> Result<Vec<SocketAddr>, String> {
+    if host_exempt(host) {
+        return Ok(addrs);
+    }
+    let mut blocked: Option<IpAddr> = None;
+    let allowed: Vec<SocketAddr> = addrs
+        .into_iter()
+        .filter(|addr| {
+            let ip = addr.ip();
+            if !ip_blocked(ip) || ENV_RULES.ip_allowed(ip) {
+                true
+            } else {
+                blocked = Some(ip);
+                false
+            }
+        })
+        .collect();
+    match (allowed.is_empty(), blocked) {
+        (true, Some(ip)) => Err(blocked_message(host, ip)),
+        _ => Ok(allowed),
+    }
+}
+
+/// DNS resolver for the http-effect reqwest client: resolves via the system
+/// resolver, then applies [`filter_resolved`] so blocked addresses never reach
+/// the connector — including on redirect hops and DNS-rebinding flips.
+pub struct GuardedDns;
+
+impl reqwest::dns::Resolve for GuardedDns {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            // Port 0 placeholder: the connector swaps in the URL's port.
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?
+                .collect();
+            match filter_resolved(&host, addrs) {
+                Ok(allowed) => {
+                    Ok(Box::new(allowed.into_iter())
+                        as Box<dyn Iterator<Item = SocketAddr> + Send>)
+                }
+                Err(message) => Err(Box::new(std::io::Error::other(message))
+                    as Box<dyn std::error::Error + Send + Sync>),
+            }
+        })
+    }
+}
+
+/// The guarded resolver, shared by the process-wide http-effect client.
+pub fn dns_resolver() -> Arc<GuardedDns> {
+    Arc::new(GuardedDns)
+}
+
+/// Redirect policy for the http-effect client: keep reqwest's 10-hop cap, and
+/// re-run [`preflight`] on every hop so redirects can't step outside the
+/// policy (IP-literal hops are rejected here; hostname hops are checked by the
+/// guarded resolver when dialed).
+pub fn redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() > 10 {
+            return attempt.error("too many redirects");
+        }
+        match preflight(attempt.url()) {
+            Ok(()) => attempt.follow(),
+            Err(message) => attempt.error(message),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn blocks_metadata_loopback_private_and_v6_equivalents() {
+        for addr in [
+            "169.254.169.254", // cloud metadata
+            "127.0.0.1",
+            "127.8.9.1",
+            "10.1.2.3",
+            "172.16.0.1",
+            "192.168.1.1",
+            "100.64.0.1", // CGNAT
+            "198.18.0.1", // benchmarking
+            "0.0.0.0",
+            "255.255.255.255",
+            "224.0.0.251", // multicast
+            "::1",
+            "fe80::1",
+            "fd00::1",
+            "::ffff:169.254.169.254", // v4-mapped metadata
+            "64:ff9b::a9fe:a9fe",     // NAT64-embedded metadata
+        ] {
+            assert!(ip_blocked(ip(addr)), "{addr} should be blocked");
+        }
+    }
+
+    #[test]
+    fn allows_public_addresses() {
+        for addr in ["93.184.216.34", "1.1.1.1", "2606:4700:4700::1111"] {
+            assert!(!ip_blocked(ip(addr)), "{addr} should be allowed");
+        }
+    }
+
+    #[test]
+    fn allow_rules_parse_hosts_ips_cidrs_and_star() {
+        let rules = AllowRules::parse(" localhost , 10.0.0.0/8, ::1 , internal.corp ");
+        assert!(!rules.allow_all);
+        assert!(rules.host_allowed("LOCALHOST"));
+        assert!(rules.host_allowed("internal.corp"));
+        assert!(rules.host_allowed("[::1]"));
+        assert!(rules.ip_allowed(ip("10.20.30.40")));
+        assert!(!rules.ip_allowed(ip("192.168.0.1")));
+
+        let star = AllowRules::parse("*");
+        assert!(star.allow_all);
+        assert!(star.host_allowed("anything"));
+        assert!(star.ip_allowed(ip("169.254.169.254")));
+    }
+
+    #[test]
+    fn preflight_rejects_blocked_ip_literals_and_bad_schemes() {
+        let err = preflight(&url::Url::parse("http://169.254.169.254/latest/meta-data").unwrap())
+            .unwrap_err();
+        assert!(err.contains("SSRF protection"), "{err}");
+        assert!(err.contains(ALLOW_HOSTS_ENV), "{err}");
+
+        let err = preflight(&url::Url::parse("ftp://example.com/x").unwrap()).unwrap_err();
+        assert!(err.contains("scheme"), "{err}");
+
+        preflight(&url::Url::parse("https://example.com/").unwrap()).unwrap();
+    }
+
+    #[test]
+    fn preflight_honors_trust_host_registration() {
+        let target = url::Url::parse("http://[::1]:9999/internal").unwrap();
+        assert!(preflight(&target).is_err());
+        trust_host("[::1]");
+        preflight(&target).unwrap();
+    }
+
+    #[test]
+    fn filter_resolved_drops_blocked_addrs_and_errors_when_none_survive() {
+        let public: SocketAddr = "93.184.216.34:443".parse().unwrap();
+        let private: SocketAddr = "10.0.0.1:443".parse().unwrap();
+        let kept = filter_resolved("example.com", vec![public, private]).unwrap();
+        assert_eq!(kept, vec![public]);
+
+        let err = filter_resolved("rebind.example", vec![private]).unwrap_err();
+        assert!(err.contains("SSRF protection"), "{err}");
+
+        // A trusted host keeps its blocked addresses.
+        trust_host("app-data.internal");
+        let kept = filter_resolved("app-data.internal", vec![private]).unwrap();
+        assert_eq!(kept, vec![private]);
+    }
+}

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -796,6 +796,10 @@ pub async fn serve(
 /// request to carry a matching `Authorization: Bearer …` header. Health
 /// stays open so container orchestrators can probe without a key.
 ///
+/// `CHIDORI_API_KEY` accepts a comma-separated list of keys so a key can be
+/// rotated without a hard cutover: set `new-key,old-key`, roll every client
+/// to the new key, then drop the old one from the list.
+///
 /// When the env var is unset the middleware is a no-op, so the default
 /// local-dev experience is unchanged.
 async fn auth_middleware(req: Request<axum::body::Body>, next: Next) -> Response {
@@ -809,7 +813,7 @@ async fn auth_middleware(req: Request<axum::body::Body>, next: Next) -> Response
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .map(|v| v == format!("Bearer {}", expected))
+        .map(|v| bearer_token_matches(v, &expected))
         .unwrap_or(false);
     if ok {
         next.run(req).await
@@ -821,6 +825,31 @@ async fn auth_middleware(req: Request<axum::body::Body>, next: Next) -> Response
         )
             .into_response()
     }
+}
+
+/// Compare the `Authorization` header value against every configured API key
+/// in constant time. A plain `==` short-circuits on the first differing byte,
+/// which turns the comparison into a timing oracle an attacker can use to
+/// recover the key byte-by-byte; `subtle::ConstantTimeEq` examines every byte
+/// regardless of where the mismatch is. (Equal-length inputs are required for
+/// `ct_eq`; a length mismatch only reveals the key's length, not its bytes.)
+///
+/// `raw_keys` is the comma-separated `CHIDORI_API_KEY` value; every key is
+/// checked — never early-returned — so accepted and rejected requests do the
+/// same amount of comparison work.
+fn bearer_token_matches(header_value: &str, raw_keys: &str) -> bool {
+    use subtle::ConstantTimeEq as _;
+
+    let mut ok = false;
+    for key in raw_keys.split(',') {
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        let expected = format!("Bearer {key}");
+        ok |= bool::from(expected.as_bytes().ct_eq(header_value.as_bytes()));
+    }
+    ok
 }
 
 /// Build a CORS layer from `CHIDORI_CORS_ORIGINS`:
@@ -2971,6 +3000,28 @@ mod tests {
     use super::*;
     use crate::runtime::snapshot::HOST_PROMISE_TABLE_FILE;
     use axum::body;
+
+    #[test]
+    fn bearer_token_matches_single_key() {
+        assert!(bearer_token_matches("Bearer sekrit", "sekrit"));
+        assert!(!bearer_token_matches("Bearer wrong", "sekrit"));
+        assert!(!bearer_token_matches("Bearer sekrit-longer", "sekrit"));
+        assert!(!bearer_token_matches("Bearer sekri", "sekrit"));
+        assert!(!bearer_token_matches("sekrit", "sekrit")); // missing scheme
+        assert!(!bearer_token_matches("bearer sekrit", "sekrit")); // scheme is case-sensitive
+    }
+
+    #[test]
+    fn bearer_token_matches_rotating_key_list() {
+        // During rotation both the new and the old key are accepted.
+        assert!(bearer_token_matches("Bearer new-key", "new-key,old-key"));
+        assert!(bearer_token_matches("Bearer old-key", "new-key,old-key"));
+        assert!(!bearer_token_matches("Bearer other", "new-key,old-key"));
+        // Whitespace around entries and empty entries are tolerated.
+        assert!(bearer_token_matches("Bearer k2", " k1 , k2 ,"));
+        // An empty list entry never matches an empty credential.
+        assert!(!bearer_token_matches("Bearer ", ","));
+    }
 
     fn test_run_base(name: &str) -> PathBuf {
         let path = std::env::temp_dir().join(format!("{name}-{}", uuid::Uuid::new_v4()));

--- a/crates/test262-runner/Cargo.toml
+++ b/crates/test262-runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "test262-runner"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license.workspace = true
 # oxc 0.133 relies on `if let` guards, stabilized in Rust 1.95.
 rust-version = "1.95"
 description = "Run the official Test262 ECMAScript conformance suite against chidori's pure-Rust JS engine, the same suite Bun and Node measure language conformance with."

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,54 @@
+# cargo-deny configuration — dependency scanning for the Rust workspace.
+# Run locally with `cargo deny check`; CI runs it on every PR and on a weekly
+# schedule (.github/workflows/security.yml) so new RustSec advisories surface
+# even when the tree is quiet.
+
+[graph]
+all-features = true
+
+# RustSec advisory database: vulnerabilities, unmaintained crates, yanked
+# versions. A finding here fails CI; put a temporary, dated `ignore` entry
+# here (with a reason) if a fix genuinely can't land yet.
+[advisories]
+yanked = "deny"
+ignore = [
+    # async-std is discontinued but still a transitive dependency of the
+    # pinned opentelemetry_sdk 0.27 (via its rt-tokio feature graph). Drops
+    # out when the opentelemetry stack is upgraded past 0.27.
+    { id = "RUSTSEC-2025-0052", reason = "async-std via opentelemetry_sdk 0.27; revisit on otel upgrade" },
+]
+
+[bans]
+# Duplicate crate versions bloat builds and multiply audit surface, but the
+# ecosystem makes some duplication unavoidable — warn, don't fail.
+multiple-versions = "warn"
+wildcards = "deny"
+# Workspace-internal `path = "..."` dependencies of unpublished crates (e.g.
+# test262-runner → chidori-js) carry no version and are fine; the wildcard
+# ban is about registry dependencies.
+allow-wildcard-paths = true
+
+# Everything must come from crates.io — no git dependencies, no alternate
+# registries. This is already true today; deny keeps it that way.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []
+
+[licenses]
+# The workspace itself is Apache-2.0. This allowlist covers the licenses of
+# the current dependency tree; extend it deliberately when a new dependency
+# brings a new (compatible) license in.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "BSL-1.0",
+    "Unicode-3.0",
+    "Unlicense",
+]
+confidence-threshold = 0.8

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,6 +72,17 @@ CHIDORI_RUN_STORE=sqlite            # journal mirror — see table below
 CHIDORI_DURABILITY=strict           # refuse side effects the journal hasn't recorded
 ```
 
+- **API-key rotation:** `CHIDORI_API_KEY` accepts a comma-separated list, so
+  a key rotates without a hard cutover — set `new-key,old-key`, roll every
+  client to the new key, then drop the old one. Comparison is constant-time.
+- **SSRF guard:** the `http`/`fetch` effect refuses destinations that resolve
+  to non-public addresses (loopback, RFC 1918, link-local/cloud-metadata,
+  CGNAT, and their IPv6 equivalents), checked at DNS-resolution time and on
+  every redirect hop, so agents can't pivot into `169.254.169.254` or
+  internal services. To let agents reach specific internal hosts, set
+  `CHIDORI_HTTP_ALLOW_HOSTS` (comma-separated hostnames, IPs, or CIDRs, e.g.
+  `localhost,10.2.0.0/16`); the single value `*` disables the guard.
+
 - **TLS:** the server speaks plain HTTP on `0.0.0.0:<port>`. Put a reverse
   proxy or the platform's TLS in front, and firewall the port.
 - **Policy:** `chidori serve` is **deny-by-default** — gated effects (`fetch`,
@@ -386,6 +397,8 @@ sequenceDiagram
 
 - [ ] `CHIDORI_API_KEY` set; port reachable only through a TLS proxy
 - [ ] Policy configured (`CHIDORI_POLICY_FILE`, or a deliberate `--trusted`)
+- [ ] `CHIDORI_HTTP_ALLOW_HOSTS` limited to the internal hosts agents truly
+      need (never `*` in production)
 - [ ] `CHIDORI_DB_PATH` set so sessions survive restarts
 - [ ] `CHIDORI_RUN_STORE` chosen; `s3://` if the machine is ephemeral
 - [ ] `CHIDORI_DURABILITY=strict`

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -14,9 +14,11 @@ package managers like bun and pnpm fast:
   filesystems). Warm installs are offline and take milliseconds — the smoke
   benchmark installs a 3-package tree in ~1ms warm vs ~250ms cold.
 - **SHA-512 verification.** Every tarball is checked against the registry's
-  `sha512` subresource integrity (legacy `sha1` shasum for pre-2017 publishes)
-  before it can enter the store. Hashing and extraction run on blocking worker
-  threads, off the download path.
+  `sha512` subresource integrity before it can enter the store. Packages that
+  publish only a legacy `sha1` shasum (pre-2017 publishes) are refused by
+  default — SHA-1 is collision-broken — unless `CHIDORI_PKG_ALLOW_SHA1=1`
+  explicitly opts in. Hashing and extraction run on blocking worker threads,
+  off the download path.
 - **Sorted JSONL lockfile.** `chidori.lock.jsonl` holds one JSON object per
   line, strictly sorted (name, then semver). Two branches adding different
   dependencies touch disjoint lines, so git merges apply cleanly instead of

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -284,7 +284,14 @@ in-engine `CHIDORI_JS_DEADLINE_MS`.
 
 Because brokering means the child needs *no* outward capability on any platform,
 even a coarse per-OS sandbox is meaningfully strong — there is nothing wired for
-it to abuse. Each layer is **best-effort**: a layer that cannot be applied (older
+it to abuse. Note the flip side: brokered `http` executes in the *parent*, with
+the parent's network reach, so the OS sandbox alone is no defense against
+server-side request forgery. That is the SSRF guard's job (`runtime::ssrf`):
+the parent refuses `http` destinations that resolve to non-public addresses
+(loopback, RFC 1918, the 169.254.169.254 cloud-metadata range, and their IPv6
+equivalents), checked at DNS-resolution time and on every redirect hop, with
+`CHIDORI_HTTP_ALLOW_HOSTS` as the deliberate allowlist.
+Each layer is **best-effort**: a layer that cannot be applied (older
 kernel, rootless container) logs a skip note and degrades rather than breaking
 the run. Set `CHIDORI_ISOLATE_REQUIRE_SANDBOX=1` to **fail closed** if the
 platform's core layer (seccomp on Linux, Seatbelt on macOS) cannot be applied.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,8 +5,10 @@
 #   curl -fsSL https://raw.githubusercontent.com/ThousandBirdsInc/chidori/main/scripts/install.sh | sh
 #
 # Environment overrides:
-#   CHIDORI_VERSION       tag to install (e.g. v3.3.0); default: latest release
-#   CHIDORI_INSTALL_DIR   install directory; default: $HOME/.chidori/bin
+#   CHIDORI_VERSION        tag to install (e.g. v3.3.0); default: latest release
+#   CHIDORI_INSTALL_DIR    install directory; default: $HOME/.chidori/bin
+#   CHIDORI_SKIP_CHECKSUM  set to 1 to skip the (otherwise mandatory) sha256
+#                          verification of the downloaded tarball
 #
 # Prebuilt binaries cover macOS (arm64/x86_64) and Linux (x86_64/arm64). On any
 # other platform — or if you'd rather build from source — use `cargo install
@@ -85,19 +87,34 @@ fetch "$url" "$tmp/$asset" ||
 	err "download failed: $url
 No prebuilt binary for ${target} at ${version}. Build from source instead: cargo install chidori"
 
-# Verify the checksum when the .sha256 sidecar is published alongside the asset.
-if fetch "${url}.sha256" "$tmp/${asset}.sha256" 2>/dev/null; then
-	expected="$(cut -d' ' -f1 <"$tmp/${asset}.sha256")"
-	if command -v shasum >/dev/null 2>&1; then
-		actual="$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)"
-	elif command -v sha256sum >/dev/null 2>&1; then
+# Verify the release checksum. Verification is mandatory: a missing sidecar,
+# a malformed sidecar, or a machine with no SHA-256 tool aborts the install
+# instead of silently skipping the check. CHIDORI_SKIP_CHECKSUM=1 is the
+# explicit escape hatch (e.g. for pre-sidecar releases pinned via
+# CHIDORI_VERSION).
+if [ "${CHIDORI_SKIP_CHECKSUM:-}" = "1" ]; then
+	printf 'WARNING: skipping checksum verification (CHIDORI_SKIP_CHECKSUM=1)\n' >&2
+else
+	fetch "${url}.sha256" "$tmp/${asset}.sha256" 2>/dev/null ||
+		err "could not download the checksum file ${url}.sha256
+Refusing to install an unverified binary. If this release predates checksum
+sidecars, re-run with CHIDORI_SKIP_CHECKSUM=1 to skip verification explicitly."
+	expected="$(cut -d' ' -f1 <"$tmp/${asset}.sha256" | tr -d '[:space:]')"
+	case "$expected" in
+	*[!0-9a-fA-F]* | "") err "malformed checksum file for ${asset} (got '${expected}')" ;;
+	esac
+	[ "${#expected}" -eq 64 ] || err "malformed checksum file for ${asset} (expected 64 hex chars, got ${#expected})"
+	if command -v sha256sum >/dev/null 2>&1; then
 		actual="$(sha256sum "$tmp/$asset" | cut -d' ' -f1)"
+	elif command -v shasum >/dev/null 2>&1; then
+		actual="$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)"
 	else
-		actual=""
+		err "checksum verification requires sha256sum or shasum; install one, or set CHIDORI_SKIP_CHECKSUM=1 to skip verification explicitly"
 	fi
-	if [ -n "$actual" ] && [ "$expected" != "$actual" ]; then
+	if [ "$expected" != "$actual" ]; then
 		err "checksum mismatch for ${asset} (expected ${expected}, got ${actual})"
 	fi
+	printf 'Checksum verified (sha256: %s)\n' "$actual"
 fi
 
 tar -C "$tmp" -xzf "$tmp/$asset"


### PR DESCRIPTION
Four fixes for the security/supply-chain findings:

- SSRF guard on the http/fetch host effect (new runtime::ssrf). The guest
  URL previously went straight to reqwest, so an agent could reach
  169.254.169.254, loopback daemons, and RFC 1918 internal services — and
  under OS isolation the brokered request runs in the parent with full
  network reach, routing around the sandbox. The guard blocks destinations
  that resolve to non-public addresses, enforced in the reqwest DNS
  resolver (so the filtered addresses are the exact ones dialed — no
  rebinding TOCTOU) and re-checked on every redirect hop, with an http(s)
  scheme + IP-literal preflight. CHIDORI_HTTP_ALLOW_HOSTS
  (hosts/IPs/CIDRs, or *) is the deliberate allowlist; host-injected
  endpoints (mock gateway, app-data plane) are exempted where they are
  configured, never from guest input.

- Constant-time API-key comparison in the serve auth middleware
  (subtle::ConstantTimeEq, already in-tree transitively), replacing a ==
  compare that leaked key bytes through timing. CHIDORI_API_KEY now
  accepts a comma-separated key list so keys rotate without a cutover.

- install.sh checksum verification is mandatory: a missing .sha256
  sidecar, malformed sidecar, or missing sha256 tool now aborts the
  install instead of silently skipping verification; the sidecar contents
  are validated as 64 hex chars. CHIDORI_SKIP_CHECKSUM=1 is the explicit,
  loudly-warned escape hatch.

- Dependency scanning: cargo-deny in CI (RustSec advisories, license
  allowlist, wildcard bans, crates.io-only sources; weekly schedule so new
  advisories surface on a quiet tree), npm audit for the TypeScript SDK,
  and Dependabot for cargo/github-actions/npm/pip. The first scan already
  paid for itself: crossbeam-epoch (RUSTSEC-2026-0204) and anyhow
  (RUSTSEC-2026-0190) updated past their advisories.

- The npm package installer refuses collision-broken SHA-1 shasum-only
  packages by default; CHIDORI_PKG_ALLOW_SHA1=1 opts legacy (pre-2017)
  packages back in, still verified against the shasum.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jk5gE6LfDqqi9sJAkqRtcv