### PR TITLE
Harden default server posture and fix root README type-resolution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Every model call is a recorded host call:
 
 ```ts
 // summarizer.ts
+/// <reference types="@1kbirds/chidori/agent-env" />
 import { chidori, run } from "chidori:agent";
 
 run(async (input: { document: string }) => {
@@ -199,6 +200,15 @@ run(async (input: { document: string }) => {
 
 That's a complete, durable agent. Both prompts are recorded; replay returns them
 for free.
+
+`chidori:agent` is a **virtual** module the runtime injects at execution time —
+there is no npm package behind it, so the runtime needs nothing installed. The
+`/// <reference …>` line is what gives your editor and `tsc` its types: they
+ship in the [`@1kbirds/chidori`](https://www.npmjs.com/package/@1kbirds/chidori)
+npm package (`npm install -D @1kbirds/chidori`, or add
+`"types": ["@1kbirds/chidori/agent-env"]` to your `tsconfig.json` instead of
+the per-file directive). See the
+[TypeScript SDK README](./sdk/typescript/README.md) for the full story.
 
 ### 3. Run it
 

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -304,6 +304,15 @@ enum Commands {
         #[arg(short, long, default_value = "8080")]
         port: u16,
 
+        /// Address to bind. Defaults to loopback (127.0.0.1) so the server —
+        /// which executes agent code — is not reachable from the network
+        /// unless you opt in. Pass `--host 0.0.0.0` (or set CHIDORI_HOST) to
+        /// expose it; a non-loopback bind requires CHIDORI_API_KEY to be set
+        /// unless CHIDORI_ALLOW_UNAUTHENTICATED=1 explicitly opts out. The
+        /// server speaks plain HTTP either way — terminate TLS in front of it.
+        #[arg(long)]
+        host: Option<String>,
+
         /// Print host function calls to stderr during execution
         #[arg(short, long)]
         verbose: bool,
@@ -436,6 +445,7 @@ fn main() {
         Commands::Serve {
             file,
             port,
+            host,
             verbose,
             untrusted,
             trusted,
@@ -444,7 +454,10 @@ fn main() {
             if isolate {
                 crate::runtime::isolate::enable();
             }
-            (cmd_serve(&file, port, verbose, untrusted, trusted), false)
+            (
+                cmd_serve(&file, host.as_deref(), port, verbose, untrusted, trusted),
+                false,
+            )
         }
     };
 
@@ -624,8 +637,9 @@ fn cmd_demo() -> Result<()> {
                 return Ok(());
             }
             // The demo serves the developer's own example agent on their own
-            // machine — the trusted posture, like `chidori run`.
-            cmd_serve(&PathBuf::from(file), *port, false, false, true)
+            // machine — the trusted posture, like `chidori run`, on the
+            // default loopback bind.
+            cmd_serve(&PathBuf::from(file), None, *port, false, false, true)
         }
     }
 }
@@ -1537,7 +1551,14 @@ fn cmd_stats(dir: Option<&std::path::Path>) -> Result<()> {
     Ok(())
 }
 
-fn cmd_serve(file: &Path, port: u16, verbose: bool, untrusted: bool, trusted: bool) -> Result<()> {
+fn cmd_serve(
+    file: &Path,
+    host: Option<&str>,
+    port: u16,
+    verbose: bool,
+    untrusted: bool,
+    trusted: bool,
+) -> Result<()> {
     if verbose {
         tracing_subscriber::fmt()
             .with_env_filter("info")
@@ -1569,12 +1590,21 @@ fn cmd_serve(file: &Path, port: u16, verbose: bool, untrusted: bool, trusted: bo
     // callers by policy but not by process, point at --isolate.
     crate::runtime::isolate::warn_if_untrusted_without_isolation(!trusted);
 
+    // Bind-address precedence: --host flag, then CHIDORI_HOST, then the safe
+    // loopback default (the server refuses non-loopback binds without auth —
+    // see server::serve).
+    let host = host
+        .map(str::to_owned)
+        .or_else(|| std::env::var("CHIDORI_HOST").ok())
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+
     let (policy, policy_posture) = serve_policy(untrusted, trusted);
     let tokio_rt = scheduler::new_tokio_runtime().context("Failed to create server runtime")?;
     tokio_rt.block_on(server::serve(
         providers,
         template_engine,
         file.to_path_buf(),
+        host,
         port,
         policy,
         policy_posture,

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -574,6 +574,7 @@ pub async fn serve(
     providers: Arc<ProviderRegistry>,
     template_engine: Arc<TemplateEngine>,
     agent_path: PathBuf,
+    host: String,
     port: u16,
     policy: Arc<PolicyConfig>,
     policy_posture: String,
@@ -692,6 +693,21 @@ pub async fn serve(
     }
 
     let auth_required = std::env::var("CHIDORI_API_KEY").is_ok();
+    let loopback = is_loopback_host(&host);
+    // Fail closed on the dangerous combination: a network-reachable bind with
+    // no authentication means anyone who can route to the port can execute
+    // agent code. The default bind is loopback, so this only trips when the
+    // operator explicitly asked for a wider bind without setting a key.
+    if !loopback && !auth_required && !allow_unauthenticated_from_env() {
+        anyhow::bail!(
+            "refusing to bind {host}:{port} without authentication: a non-loopback bind \
+             exposes this server — which executes agent code — to the network with no \
+             access control. Either set CHIDORI_API_KEY to require bearer auth, keep the \
+             default loopback bind (drop --host / CHIDORI_HOST), or set \
+             CHIDORI_ALLOW_UNAUTHENTICATED=1 if a reverse proxy or firewall in front of \
+             this server already controls access."
+        );
+    }
     let cors_layer = build_cors_layer();
 
     // ACP router owns its own state so session lookups go through the same
@@ -740,8 +756,14 @@ pub async fn serve(
         .layer(middleware::from_fn(auth_middleware))
         .layer(cors_layer);
 
-    let addr = format!("0.0.0.0:{port}");
+    let addr = format!("{host}:{port}");
     eprintln!("Listening on http://{addr}");
+    if !loopback {
+        eprintln!(
+            "WARNING: non-loopback bind speaks plain HTTP (no TLS). Terminate TLS at a \
+             reverse proxy or platform ingress and firewall the port (docs/deployment.md)."
+        );
+    }
     eprintln!();
     eprintln!(
         "  Concurrency: max {} sessions, {}ms acquire timeout",
@@ -751,8 +773,11 @@ pub async fn serve(
         "  Auth:        {}",
         if auth_required {
             "REQUIRED (Authorization: Bearer $CHIDORI_API_KEY)"
+        } else if loopback {
+            "disabled (loopback bind; set CHIDORI_API_KEY to enable)"
         } else {
-            "disabled (set CHIDORI_API_KEY to enable)"
+            "DISABLED on a network-reachable bind (CHIDORI_ALLOW_UNAUTHENTICATED) — \
+             anyone who can reach the port can execute agents"
         }
     );
     eprintln!("  Policy:      {}", policy_posture);
@@ -850,6 +875,28 @@ fn bearer_token_matches(header_value: &str, raw_keys: &str) -> bool {
         ok |= bool::from(expected.as_bytes().ct_eq(header_value.as_bytes()));
     }
     ok
+}
+
+/// A bind host counts as loopback when it is the literal name `localhost` or
+/// parses to a loopback IP (`127.0.0.0/8`, `::1`). Anything else — including
+/// unresolvable hostnames — is treated as network-reachable, so the
+/// no-auth-on-a-reachable-bind refusal fails closed.
+fn is_loopback_host(host: &str) -> bool {
+    host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false)
+}
+
+/// Explicit operator opt-out of the "non-loopback bind requires
+/// CHIDORI_API_KEY" refusal, for deployments where something in front of the
+/// server (reverse proxy auth, network policy, firewall) controls access.
+fn allow_unauthenticated_from_env() -> bool {
+    matches!(
+        std::env::var("CHIDORI_ALLOW_UNAUTHENTICATED").as_deref(),
+        Ok("1") | Ok("true") | Ok("on")
+    )
 }
 
 /// Build a CORS layer from `CHIDORI_CORS_ORIGINS`:
@@ -3021,6 +3068,22 @@ mod tests {
         assert!(bearer_token_matches("Bearer k2", " k1 , k2 ,"));
         // An empty list entry never matches an empty credential.
         assert!(!bearer_token_matches("Bearer ", ","));
+    }
+
+    #[test]
+    fn loopback_host_classification() {
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("127.0.0.2")); // whole 127.0.0.0/8 block
+        assert!(is_loopback_host("::1"));
+        assert!(is_loopback_host("localhost"));
+        // Network-reachable binds — these require auth (or the explicit
+        // CHIDORI_ALLOW_UNAUTHENTICATED opt-out) at startup.
+        assert!(!is_loopback_host("0.0.0.0"));
+        assert!(!is_loopback_host("::"));
+        assert!(!is_loopback_host("10.0.0.5"));
+        // Unparseable hostnames fail closed: treated as network-reachable.
+        assert!(!is_loopback_host("my-host.internal"));
+        assert!(!is_loopback_host(""));
     }
 
     fn test_run_base(name: &str) -> PathBuf {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,7 +83,14 @@ CHIDORI_DURABILITY=strict           # refuse side effects the journal hasn't rec
   `CHIDORI_HTTP_ALLOW_HOSTS` (comma-separated hostnames, IPs, or CIDRs, e.g.
   `localhost,10.2.0.0/16`); the single value `*` disables the guard.
 
-- **TLS:** the server speaks plain HTTP on `0.0.0.0:<port>`. Put a reverse
+- **Bind address:** the server binds loopback (`127.0.0.1:<port>`) by
+  default, so a fresh `chidori serve` is not reachable from the network. To
+  expose it — in a container, or to a proxy on another machine — pass
+  `--host 0.0.0.0` (or set `CHIDORI_HOST`). A non-loopback bind **requires
+  `CHIDORI_API_KEY`**; the server refuses to start otherwise. If access is
+  genuinely controlled in front of the server (reverse-proxy auth, network
+  policy), `CHIDORI_ALLOW_UNAUTHENTICATED=1` overrides the refusal.
+- **TLS:** the server speaks plain HTTP on whatever it binds. Put a reverse
   proxy or the platform's TLS in front, and firewall the port.
 - **Policy:** `chidori serve` is **deny-by-default** — gated effects (`fetch`,
   workspace mutations) are refused until you configure `CHIDORI_POLICY_FILE`
@@ -156,7 +163,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 WORKDIR /app
 COPY . .
 EXPOSE 8080
-CMD ["chidori", "serve", "agent.ts", "--port", "8080"]
+# --host 0.0.0.0 makes the port reachable from outside the container; the
+# server then requires CHIDORI_API_KEY at startup (set it in the env block).
+CMD ["chidori", "serve", "agent.ts", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
 Pair it with an `s3://` mirror instead of a volume — hydration makes the
@@ -396,6 +405,9 @@ sequenceDiagram
 ## Production checklist
 
 - [ ] `CHIDORI_API_KEY` set; port reachable only through a TLS proxy
+- [ ] Bind address deliberate: loopback default for a same-host proxy, or
+      `--host 0.0.0.0` when the proxy/ingress is elsewhere (auth then
+      enforced at startup)
 - [ ] Policy configured (`CHIDORI_POLICY_FILE`, or a deliberate `--trusted`)
 - [ ] `CHIDORI_HTTP_ALLOW_HOSTS` limited to the internal hosts agents truly
       need (never `*` in production)

--- a/docs/running-modes.md
+++ b/docs/running-modes.md
@@ -44,6 +44,12 @@ requests via `fetch`/`node:http`, workspace mutations) are refused — sessions
 arrive from callers you may not control. Local `chidori run` keeps the
 permissive default. See [`docs/sandbox-model.md`](./sandbox-model.md).
 
+It also binds **loopback only** (`127.0.0.1`) by default. To make it reachable
+from the network, pass `--host 0.0.0.0` (or set `CHIDORI_HOST`) — which
+requires `CHIDORI_API_KEY` to be set, since an exposed unauthenticated server
+would let anyone on the network execute agents. See
+[`docs/deployment.md`](./deployment.md).
+
 Exposes:
 - `GET  /health` — health check
 - `ANY  /*` — any request is passed to `agent(event)` as an event dict


### PR DESCRIPTION
The server now binds loopback (127.0.0.1) by default instead of 0.0.0.0,
so a fresh `chidori serve` is no longer reachable from the network. A new
--host flag (or CHIDORI_HOST) opts into a wider bind, and a non-loopback
bind without CHIDORI_API_KEY refuses to start — fail closed — unless
CHIDORI_ALLOW_UNAUTHENTICATED=1 explicitly acknowledges that access is
controlled in front of the server. Non-loopback startup also warns that
the server speaks plain HTTP and needs TLS terminated in front.

The root README quickstart now carries the
/// <reference types="@1kbirds/chidori/agent-env" /> directive and
explains how the virtual chidori:agent module resolves, matching the
TypeScript SDK README, so the front-page snippet typechecks after
npm install @1kbirds/chidori.

Docs updated: deployment (bind-address section, Dockerfile CMD,
production checklist) and running-modes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NZjh6FPAP2WvkpRpvC8nry