### PR TITLE
Safe defaults and guarded replay: ask-by-default CLI policy, default-on isolation, durable sessions, arg-checked divergence

### DIFF
--- a/crates/chidori-js/src/gc.rs
+++ b/crates/chidori-js/src/gc.rs
@@ -259,7 +259,106 @@ impl Vm {
                 break;
             }
         }
-        let marked: Vec<bool> = live.iter().map(|o| visited.contains(&o.ptr_id())).collect();
+        // The ephemeron worklist still holds strong `Value` clones of dead-key
+        // entry values; drop them so the verification pass below sees each
+        // candidate's true strong count. (The entries themselves are pruned
+        // from their WeakMaps by the sweep.)
+        drop(ephemerons);
+        let mut marked: Vec<bool> = live.iter().map(|o| visited.contains(&o.ptr_id())).collect();
+
+        // Pass 3.5: verify before destroying anything. The accounting above is
+        // only sound if every strong `Rc` edge between registered objects was
+        // subtracted exactly once — a shared interior container (binding cell,
+        // async frame slot, mapped-arguments slot) traced once per holder
+        // instead of once globally would over-subtract and can make a LIVE
+        // object look like garbage (a use-after-free-equivalent sweep; see the
+        // module doc). That invariant is maintained by hand, so check it here
+        // structurally: every sweep candidate's strong count must be exactly
+        // our snapshot handle plus the edges that can legitimately keep
+        // garbage alive — edges from other candidates, and weak-collection
+        // entries of surviving objects (subtracted in pass 2, deliberately
+        // never traversed in pass 3). Any other total means an unexplained (or
+        // over-explained) reference: sweeping would corrupt a live object, so
+        // rescue it — and everything reachable from it — instead. Rescue turns
+        // a memory-corruption bug into a bounded leak, and debug builds assert
+        // so the regression is caught in tests. Cost is one trace over the
+        // candidates only (plus live weak-collection entries), not the heap.
+        let mut in_edges: Vec<isize> = vec![0; live.len()];
+        {
+            let mut vseen_cells: HashSet<usize> = HashSet::new();
+            let mut vseen_frames: HashSet<usize> = HashSet::new();
+            let marked_view = &marked;
+            let index_view = &index;
+            let mut count_edge = |t: &JsObject| {
+                if let Some(&j) = index_view.get(&t.ptr_id()) {
+                    if !marked_view[j] {
+                        in_edges[j] += 1;
+                    }
+                }
+            };
+            for (i, o) in live.iter().enumerate() {
+                if !marked[i] {
+                    trace_object(
+                        &o.borrow(),
+                        &mut vseen_cells,
+                        &mut vseen_frames,
+                        true,
+                        &mut count_edge,
+                    );
+                } else {
+                    let b = o.borrow();
+                    match &b.internal {
+                        Internal::WeakMap(m) => {
+                            for (k, v) in m {
+                                trace_value(&k.0, &mut count_edge);
+                                trace_value(v, &mut count_edge);
+                            }
+                        }
+                        Internal::WeakSet(s) => {
+                            for (k, _) in s {
+                                trace_value(&k.0, &mut count_edge);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        let mut rescue: Vec<JsObject> = live
+            .iter()
+            .enumerate()
+            .filter(|(i, o)| !marked[*i] && (Rc::strong_count(&o.0) as isize - 1) != in_edges[*i])
+            .map(|(_, o)| o.clone())
+            .collect();
+        if !rescue.is_empty() {
+            debug_assert!(
+                false,
+                "GC accounting mismatch: {} sweep candidate(s) have strong references the trace \
+                 did not explain (a shared interior Rc traced once per holder?); rescuing them \
+                 instead of sweeping",
+                rescue.len()
+            );
+            // Conservatively keep the mismatched objects and everything they
+            // reach — including through weak entries, since rescued weak
+            // collections never went through the ephemeron pass.
+            while let Some(o) = rescue.pop() {
+                if !visited.insert(o.ptr_id()) {
+                    continue;
+                }
+                let mut found: Vec<JsObject> = Vec::new();
+                trace_object(
+                    &o.borrow(),
+                    &mut mark_cells,
+                    &mut mark_frames,
+                    true,
+                    &mut |t: &JsObject| found.push(t.clone()),
+                );
+                rescue.extend(found);
+            }
+            for (i, o) in live.iter().enumerate() {
+                marked[i] = visited.contains(&o.ptr_id());
+            }
+        }
 
         // Pass 4: sweep — clear every unmarked object's outgoing edges so the
         // cycle collapses and Rc reclamation frees the subgraph. Surviving

--- a/crates/chidori-js/src/journal.rs
+++ b/crates/chidori-js/src/journal.rs
@@ -23,6 +23,13 @@ pub struct JournalEntry {
     pub site: String,
     /// Per-site invocation index.
     pub seq: u64,
+    /// The call's JSON arguments as recorded, so replay can detect an edit
+    /// that kept the effect order but changed what an already-executed call
+    /// asked for. `Null` for entries that carry no comparable args
+    /// (`durableStep` memoization, journals written before args were
+    /// recorded) — those skip the comparison.
+    #[serde(default)]
+    pub args: Json,
     pub outcome: EffectOutcome,
 }
 
@@ -50,10 +57,11 @@ impl Journal {
             .map(|e| &e.outcome)
     }
 
-    pub fn append(&mut self, key: &HostKey, outcome: EffectOutcome) {
+    pub fn append(&mut self, key: &HostKey, args: Json, outcome: EffectOutcome) {
         self.entries.push(JournalEntry {
             site: key.site.clone(),
             seq: key.seq,
+            args,
             outcome,
         });
     }

--- a/crates/chidori-js/src/replay.rs
+++ b/crates/chidori-js/src/replay.rs
@@ -50,6 +50,11 @@ struct JournalState {
     cursor: usize,
     /// Divergence detected during replay (edit touched already-journaled code).
     divergence: Option<String>,
+    /// True when `restore` was given a bundle whose content hash differs from
+    /// the one the journal was recorded against (modify-and-resume). Legal,
+    /// but recorded so divergence errors can say *why* replay drifted and
+    /// callers can surface it.
+    bundle_changed: bool,
 }
 
 /// Outcome of driving the runtime.
@@ -85,6 +90,7 @@ impl ReplayRuntime {
             pending: HashMap::new(),
             cursor: 0,
             divergence: None,
+            bundle_changed: false,
         }));
         let mut rt = ReplayRuntime {
             vm: Vm::new(),
@@ -108,6 +114,10 @@ impl ReplayRuntime {
     ) -> Result<ReplayRuntime, String> {
         let journal = Journal::from_bytes(journal_bytes)?;
         let bundle_hash = Journal::hash_bundle(bundle);
+        // The journal pins the bundle it was recorded against; actually
+        // compare the pin. A changed bundle is legal (modify-and-resume is
+        // the feature) but must be *detectable*, not silently absorbed.
+        let bundle_changed = !journal.bundle_hash.is_empty() && journal.bundle_hash != bundle_hash;
         let state = Rc::new(RefCell::new(JournalState {
             journal,
             mode: Mode::Replay,
@@ -115,6 +125,7 @@ impl ReplayRuntime {
             pending: HashMap::new(),
             cursor: 0,
             divergence: None,
+            bundle_changed,
         }));
         let mut rt = ReplayRuntime {
             vm: Vm::new(),
@@ -139,6 +150,14 @@ impl ReplayRuntime {
     /// Whether replay detected an edit that diverged from the journal.
     pub fn divergence(&self) -> Option<String> {
         self.state.borrow().divergence.clone()
+    }
+
+    /// Whether this runtime was restored with a bundle whose content hash
+    /// differs from the one the journal was recorded against
+    /// (modify-and-resume). The journal has always stored the hash; this is
+    /// where it is actually checked.
+    pub fn bundle_changed(&self) -> bool {
+        self.state.borrow().bundle_changed
     }
 
     /// Install each named effect as a global async function backed by the
@@ -173,20 +192,34 @@ impl ReplayRuntime {
                         let cursor = s.cursor;
                         if cursor < s.journal.entries.len() {
                             let entry = s.journal.entries[cursor].clone();
-                            if entry.site == site && entry.seq == seq {
+                            if entry.site != site || entry.seq != seq {
+                                let msg = format!(
+                                "expected effect '{}'#{} from journal but program called '{}'#{} \
+                                 (an edit changed already-executed code before the resume point{})",
+                                entry.site, entry.seq, site, seq,
+                                if s.bundle_changed { "; the code bundle differs from the recorded one" } else { "" }
+                            );
+                                s.divergence = Some(msg.clone());
+                                Decision::Diverged(msg)
+                            } else if entry.args != Json::Null && entry.args != args_json {
+                                // Same effect, same position, different request:
+                                // replaying the recorded result would answer a
+                                // question the program no longer asks.
+                                let msg = format!(
+                                    "effect '{}'#{} was recorded with args {} but the program now \
+                                     calls it with {} (an edit changed an already-executed call's \
+                                     arguments before the resume point{})",
+                                    site, seq, entry.args, args_json,
+                                    if s.bundle_changed { "; the code bundle differs from the recorded one" } else { "" }
+                                );
+                                s.divergence = Some(msg.clone());
+                                Decision::Diverged(msg)
+                            } else {
                                 s.cursor += 1;
                                 match entry.outcome {
                                     EffectOutcome::Resolved(j) => Decision::Resolve(j),
                                     EffectOutcome::Rejected(m) => Decision::Reject(m),
                                 }
-                            } else {
-                                let msg = format!(
-                                "expected effect '{}'#{} from journal but program called '{}'#{} \
-                                 (an edit changed already-executed code before the resume point)",
-                                entry.site, entry.seq, site, seq
-                            );
-                                s.divergence = Some(msg.clone());
-                                Decision::Diverged(msg)
                             }
                         } else {
                             Decision::Frontier
@@ -291,7 +324,11 @@ impl ReplayRuntime {
                             let j = vm.value_to_json(&v);
                             {
                                 let mut s = state.borrow_mut();
-                                s.journal.append(&key, EffectOutcome::Resolved(j.clone()));
+                                s.journal.append(
+                                    &key,
+                                    Json::Null,
+                                    EffectOutcome::Resolved(j.clone()),
+                                );
                                 s.cursor = s.journal.entries.len();
                             }
                             let rv = vm.json_to_value(&j);
@@ -301,7 +338,11 @@ impl ReplayRuntime {
                             let msg = vm.error_to_string(&e);
                             {
                                 let mut s = state.borrow_mut();
-                                s.journal.append(&key, EffectOutcome::Rejected(msg.clone()));
+                                s.journal.append(
+                                    &key,
+                                    Json::Null,
+                                    EffectOutcome::Rejected(msg.clone()),
+                                );
                                 s.cursor = s.journal.entries.len();
                             }
                             let err = vm.make_error(ErrorKind::Error, &msg);
@@ -372,8 +413,11 @@ impl ReplayRuntime {
                                 Ok(json) => {
                                     {
                                         let mut s = self.state.borrow_mut();
-                                        s.journal
-                                            .append(&key, EffectOutcome::Resolved(json.clone()));
+                                        s.journal.append(
+                                            &key,
+                                            op.args.clone(),
+                                            EffectOutcome::Resolved(json.clone()),
+                                        );
                                         s.cursor = s.journal.entries.len();
                                     }
                                     let v = self.vm.json_to_value(&json);
@@ -382,8 +426,11 @@ impl ReplayRuntime {
                                 Err(msg) => {
                                     {
                                         let mut s = self.state.borrow_mut();
-                                        s.journal
-                                            .append(&key, EffectOutcome::Rejected(msg.clone()));
+                                        s.journal.append(
+                                            &key,
+                                            op.args.clone(),
+                                            EffectOutcome::Rejected(msg.clone()),
+                                        );
                                         s.cursor = s.journal.entries.len();
                                     }
                                     let e = self.vm.make_error(ErrorKind::Error, &msg);
@@ -421,7 +468,7 @@ impl ReplayRuntime {
                 {
                     let mut s = self.state.borrow_mut();
                     s.journal
-                        .append(&key, EffectOutcome::Resolved(json.clone()));
+                        .append(&key, op.args.clone(), EffectOutcome::Resolved(json.clone()));
                     s.cursor = s.journal.entries.len();
                 }
                 let v = self.vm.json_to_value(&json);
@@ -430,7 +477,8 @@ impl ReplayRuntime {
             Err(msg) => {
                 {
                     let mut s = self.state.borrow_mut();
-                    s.journal.append(&key, EffectOutcome::Rejected(msg.clone()));
+                    s.journal
+                        .append(&key, op.args.clone(), EffectOutcome::Rejected(msg.clone()));
                     s.cursor = s.journal.entries.len();
                 }
                 let e = self.vm.make_error(ErrorKind::Error, &msg);
@@ -488,7 +536,7 @@ impl ReplayRuntime {
                 {
                     let mut s = self.state.borrow_mut();
                     s.journal
-                        .append(&key, EffectOutcome::Resolved(json.clone()));
+                        .append(&key, op.args.clone(), EffectOutcome::Resolved(json.clone()));
                     s.cursor = s.journal.entries.len();
                 }
                 let v = self.vm.json_to_value(&json);
@@ -497,7 +545,8 @@ impl ReplayRuntime {
             Err(msg) => {
                 {
                     let mut s = self.state.borrow_mut();
-                    s.journal.append(&key, EffectOutcome::Rejected(msg.clone()));
+                    s.journal
+                        .append(&key, op.args.clone(), EffectOutcome::Rejected(msg.clone()));
                     s.cursor = s.journal.entries.len();
                 }
                 let e = self.vm.make_error(ErrorKind::Error, &msg);

--- a/crates/chidori-js/tests/limits.rs
+++ b/crates/chidori-js/tests/limits.rs
@@ -1,0 +1,100 @@
+//! Boundary tests for the engine allocation caps (`MAX_DENSE_ARRAY`,
+//! `MAX_STRING_LEN` in `src/value.rs`). The caps guarantee no single opcode
+//! can allocate without bound (docs/sandbox-model.md "Memory ceiling"); each
+//! guard raises a *catchable* `RangeError` before allocating, so agent code
+//! can recover. These tests pin the current values (2^25 elements / 2^28 code
+//! units) so a future change to either constant is a deliberate, test-visible
+//! decision — the previous bump (1M -> 2^25, 2^24 -> 2^28) landed with no test
+//! pinning either boundary.
+
+use chidori_js::value::{Value, MAX_DENSE_ARRAY, MAX_STRING_LEN};
+use chidori_js::Engine;
+
+fn eval_str(e: &mut Engine, src: &str) -> String {
+    match e.eval(src).unwrap() {
+        Value::String(s) => s.as_str().to_string(),
+        other => panic!("expected string result, got {other:?}"),
+    }
+}
+
+#[test]
+fn dense_array_cap_is_a_catchable_range_error() {
+    let mut e = Engine::new();
+    // The constructor guard fires before allocating, so probing one past the
+    // cap is cheap. The error must be a catchable RangeError.
+    let src = format!(
+        r#"
+        (function () {{
+          try {{
+            new Array({over});
+            return "allocated";
+          }} catch (err) {{
+            return err instanceof RangeError ? "range-error" : "wrong-error: " + err;
+          }}
+        }})();
+        "#,
+        over = MAX_DENSE_ARRAY + 1
+    );
+    assert_eq!(eval_str(&mut e, &src), "range-error");
+
+    // Setting `.length` past the cap is guarded the same way.
+    let src = format!(
+        r#"
+        (function () {{
+          const a = [];
+          try {{
+            a.length = {over};
+            return "grew";
+          }} catch (err) {{
+            return err instanceof RangeError ? "range-error" : "wrong-error: " + err;
+          }}
+        }})();
+        "#,
+        over = MAX_DENSE_ARRAY + 1
+    );
+    assert_eq!(eval_str(&mut e, &src), "range-error");
+
+    // Ordinary allocation below the cap is unaffected.
+    let v = e.eval("new Array(4096).length").unwrap();
+    assert!(matches!(v, Value::Number(n) if n == 4096.0));
+}
+
+#[test]
+fn string_cap_is_a_catchable_range_error() {
+    let mut e = Engine::new();
+    // `repeat` guards before allocating; one past the cap must throw a
+    // catchable RangeError.
+    let src = format!(
+        r#"
+        (function () {{
+          try {{
+            "ab".repeat({half} + 1);
+            return "allocated";
+          }} catch (err) {{
+            return err instanceof RangeError ? "range-error" : "wrong-error: " + err;
+          }}
+        }})();
+        "#,
+        half = MAX_STRING_LEN / 2
+    );
+    assert_eq!(eval_str(&mut e, &src), "range-error");
+
+    // The exponential `s += s` OOM pattern terminates in a catchable
+    // RangeError from the concat guard instead of exhausting memory.
+    let src = r#"
+        (function () {
+          let s = "x".repeat(1 << 20); // 1M, far below the cap
+          try {
+            for (let i = 0; i < 40; i++) s += s;
+            return "unbounded";
+          } catch (err) {
+            return err instanceof RangeError ? "range-error" : "wrong-error: " + err;
+          }
+        })();
+    "#;
+    assert_eq!(eval_str(&mut e, src), "range-error");
+
+    // Normal string work below the cap is unaffected.
+    let v = e.eval(r#""ab".repeat(1024).length"#).unwrap();
+    assert!(matches!(v, Value::Number(n) if n == 2048.0));
+}

--- a/crates/chidori-js/tests/replay.rs
+++ b/crates/chidori-js/tests/replay.rs
@@ -319,3 +319,77 @@ fn shared_cached_proto_replays_are_independent_and_identical() {
     );
     assert_eq!(r1.journal_bytes(), journal);
 }
+
+// The journal has always pinned the bundle it was recorded against by content
+// hash; `restore` must actually check the pin so a changed bundle is
+// detectable (modify-and-resume stays legal — it is reported, not refused).
+#[test]
+fn restore_detects_changed_bundle() {
+    let mut rt = ReplayRuntime::record(BUNDLE, &["fetchValue", "report"]);
+    let mut handler =
+        |name: &str, _args: &serde_json::Value| -> Option<Result<serde_json::Value, String>> {
+            match name {
+                "fetchValue" => Some(Ok(json!(1))),
+                _ => Some(Ok(json!(null))),
+            }
+        };
+    rt.drive(&mut handler).unwrap();
+    let journal = rt.journal_bytes();
+
+    // Same bundle: no change reported.
+    let same = ReplayRuntime::restore(BUNDLE, &journal, &["fetchValue", "report"]).unwrap();
+    assert!(!same.bundle_changed());
+
+    // Edited bundle: reported, even before any drive.
+    let edited = format!("{BUNDLE}\n// edited");
+    let changed = ReplayRuntime::restore(&edited, &journal, &["fetchValue", "report"]).unwrap();
+    assert!(changed.bundle_changed());
+}
+
+// An edit that keeps the effect ORDER but changes an already-executed call's
+// arguments used to replay silently (the positional check compared site+seq
+// only). The recorded result would answer a question the program no longer
+// asks — it must surface as a divergence.
+#[test]
+fn pre_frontier_arg_edit_diverges() {
+    let original = r#"
+        async function main() {
+            const a = await fetchValue('a');
+            report(a);
+        }
+        main();
+    "#;
+    let mut rt = ReplayRuntime::record(original, &["fetchValue", "report"]);
+    let mut handler =
+        |name: &str, _args: &serde_json::Value| -> Option<Result<serde_json::Value, String>> {
+            match name {
+                "fetchValue" => Some(Ok(json!(10))),
+                _ => Some(Ok(json!(null))),
+            }
+        };
+    rt.drive(&mut handler).unwrap();
+    let journal = rt.journal_bytes();
+
+    // Pre-frontier edit: same effect at the same position, different argument.
+    let edited = r#"
+        async function main() {
+            const a = await fetchValue('DIFFERENT');
+            report(a);
+        }
+        main();
+    "#;
+    let mut rt2 = ReplayRuntime::restore(edited, &journal, &["fetchValue", "report"]).unwrap();
+    let mut replay_handler =
+        |_name: &str, _args: &serde_json::Value| -> Option<Result<serde_json::Value, String>> {
+            Some(Ok(json!(null)))
+        };
+    let err = rt2.drive(&mut replay_handler).unwrap_err();
+    assert!(
+        err.contains("arguments") || err.contains("args"),
+        "expected an argument-divergence error, got: {err}"
+    );
+    assert!(
+        err.contains("bundle differs"),
+        "divergence should note the changed bundle, got: {err}"
+    );
+}

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -89,15 +89,27 @@ enum Commands {
         /// gated effects (http, workspace mutations) are refused unless
         /// allowlisted. Equivalent to CHIDORI_POLICY_PROFILE=untrusted, but
         /// takes precedence over all CHIDORI_POLICY* env vars.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "trusted")]
         untrusted: bool,
+
+        /// Opt out of the ask-before-powerful-effects default: with no
+        /// CHIDORI_POLICY* configuration, gated effects (http, workspace
+        /// mutations, tools) run without prompts. Explicit CHIDORI_POLICY*
+        /// configuration still applies. Use for agents you wrote yourself.
+        #[arg(long)]
+        trusted: bool,
 
         /// Run the agent in an isolated child process, brokering its host
         /// effects back over a pipe (see docs/os-isolation-plan.md). Equivalent
-        /// to CHIDORI_ISOLATE=process. Phase 1: process separation + brokering;
-        /// per-OS syscall sandboxing lands in a later phase.
-        #[arg(long)]
+        /// to CHIDORI_ISOLATE=process. This is the default on Unix; the flag
+        /// remains as an explicit override of CHIDORI_ISOLATE=off.
+        #[arg(long, conflicts_with = "no_isolate")]
         isolate: bool,
+
+        /// Run the agent in-process, without the isolated worker sandbox.
+        /// Equivalent to CHIDORI_ISOLATE=off.
+        #[arg(long)]
+        no_isolate: bool,
     },
 
     /// Internal: the isolate worker. Runs one agent over a stdin/stdout frame
@@ -189,8 +201,12 @@ enum Commands {
         tools: Vec<PathBuf>,
 
         /// Run under the built-in deny-by-default `untrusted` policy profile.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "trusted")]
         untrusted: bool,
+
+        /// Opt out of the ask-before-powerful-effects default (see `run --trusted`).
+        #[arg(long)]
+        trusted: bool,
     },
 
     /// List all available tools
@@ -321,16 +337,23 @@ enum Commands {
 
         /// Opt out of the server's deny-by-default posture: with no
         /// CHIDORI_POLICY* configuration, gated effects (http, workspace
-        /// mutations) run without restriction, as `chidori run` does.
-        /// Explicit CHIDORI_POLICY* configuration still applies.
+        /// mutations) run without restriction. Explicit CHIDORI_POLICY*
+        /// configuration still applies.
         #[arg(long)]
         trusted: bool,
 
         /// Run each request in an isolated child process, brokering its host
         /// effects back over a pipe (see docs/os-isolation-plan.md). Equivalent
-        /// to CHIDORI_ISOLATE=process. Composes with --untrusted.
-        #[arg(long)]
+        /// to CHIDORI_ISOLATE=process. This is the default on Unix; the flag
+        /// remains as an explicit override of CHIDORI_ISOLATE=off. Composes
+        /// with --untrusted.
+        #[arg(long, conflicts_with = "no_isolate")]
         isolate: bool,
+
+        /// Serve requests in-process, without the isolated worker sandbox.
+        /// Equivalent to CHIDORI_ISOLATE=off.
+        #[arg(long)]
+        no_isolate: bool,
     },
 }
 
@@ -349,6 +372,12 @@ fn main() {
         });
     }
 
+    // OS isolation is default-on for the CLI on platforms with a worker
+    // sandbox: when CHIDORI_ISOLATE is unset, agent-running commands spawn a
+    // confined child process per run. Explicit env values and the
+    // --isolate/--no-isolate flags (handled per command below) always win.
+    crate::runtime::isolate::default_on_if_unset();
+
     // Commands that only do parsing/validation return exit code 2 on failure;
     // everything else returns 1. Success is 0.
     let (result, parse_only) = match cli.command {
@@ -360,18 +389,22 @@ fn main() {
             tools,
             stream,
             untrusted,
+            trusted,
             isolate,
+            no_isolate,
         } => {
             // `run_agent` reads this env var to decide whether to spawn a worker;
             // setting it here keeps the isolation decision in one place.
             if isolate {
                 crate::runtime::isolate::enable();
+            } else if no_isolate {
+                crate::runtime::isolate::disable();
             }
             crate::runtime::isolate::warn_if_untrusted_without_isolation(untrusted);
             let result = if stream {
-                cmd_run_stream(&file, &input, verbose, &tools, untrusted)
+                cmd_run_stream(&file, &input, verbose, &tools, untrusted, trusted)
             } else {
-                cmd_run(&file, &input, trace, verbose, &tools, untrusted)
+                cmd_run(&file, &input, trace, verbose, &tools, untrusted, trusted)
             };
             (result, false)
         }
@@ -403,8 +436,9 @@ fn main() {
             model,
             tools,
             untrusted,
+            trusted,
         } => (
-            cmd_chat(agent.as_deref(), system, model, &tools, untrusted),
+            cmd_chat(agent.as_deref(), system, model, &tools, untrusted, trusted),
             false,
         ),
         Commands::Check { file } => (cmd_check(&file), true),
@@ -440,9 +474,12 @@ fn main() {
             untrusted,
             trusted,
             isolate,
+            no_isolate,
         } => {
             if isolate {
                 crate::runtime::isolate::enable();
+            } else if no_isolate {
+                crate::runtime::isolate::disable();
             }
             (cmd_serve(&file, port, verbose, untrusted, trusted), false)
         }
@@ -613,10 +650,12 @@ fn cmd_demo() -> Result<()> {
                 .map(|value| value.to_string())
                 .collect::<Vec<_>>();
             let tool_dirs = tools.iter().map(PathBuf::from).collect::<Vec<_>>();
+            // The demo runs the repo's own example agents on the developer's
+            // machine — the trusted posture, like `run --trusted`.
             if *stream {
-                cmd_run_stream(&file, &inputs, false, &tool_dirs, false)
+                cmd_run_stream(&file, &inputs, false, &tool_dirs, false, true)
             } else {
-                cmd_run(&file, &inputs, *trace, false, &tool_dirs, false)
+                cmd_run(&file, &inputs, *trace, false, &tool_dirs, false, true)
             }
         }
         DemoAction::Serve { file, port } => {
@@ -737,16 +776,27 @@ fn ensure_llm_provider_interactive() -> bool {
     }
 }
 
-/// Resolve the permission policy for a CLI invocation. `--untrusted` selects
-/// the built-in deny-by-default profile and wins over every CHIDORI_POLICY*
-/// env var (an explicit flag beats ambient configuration); otherwise the
-/// usual env-driven resolution applies.
-fn cli_policy(untrusted: bool) -> Arc<policy::PolicyConfig> {
+/// Resolve the permission policy for a CLI invocation. Precedence:
+///   1. `--untrusted` — deny-by-default, wins over all CHIDORI_POLICY* env
+///      (an explicit flag beats ambient configuration).
+///   2. `--trusted` — the historical permissive resolution: env-driven,
+///      allow-all when nothing is configured.
+///   3. Explicit, valid CHIDORI_POLICY* configuration — as configured.
+///   4. Nothing configured — ask-before-powerful-effects
+///      ([`policy::run_default_profile`]): the operator approves gated
+///      effects at a terminal prompt, and non-interactive runs fail closed
+///      with a reason naming `--trusted` and the env knobs.
+fn cli_policy(untrusted: bool, trusted: bool) -> Arc<policy::PolicyConfig> {
     if untrusted {
-        Arc::new(policy::builtin_profile("untrusted").expect("built-in untrusted profile exists"))
-    } else {
-        policy::PolicyConfig::from_env()
+        return Arc::new(
+            policy::builtin_profile("untrusted").expect("built-in untrusted profile exists"),
+        );
     }
+    if trusted {
+        return policy::PolicyConfig::from_env();
+    }
+    policy::PolicyConfig::from_env_configured()
+        .unwrap_or_else(|| Arc::new(policy::run_default_profile()))
 }
 
 /// Resolve the permission policy for `chidori serve`. Unlike `chidori run`
@@ -805,6 +855,7 @@ fn cmd_run(
     verbose: bool,
     extra_tool_dirs: &[PathBuf],
     untrusted: bool,
+    trusted: bool,
 ) -> Result<()> {
     // Set up tracing.
     if verbose {
@@ -838,7 +889,7 @@ fn cmd_run(
 
     let engine = Engine::new(providers, template_engine, tokio_rt)
         .with_tools(tools)
-        .with_policy(cli_policy(untrusted))
+        .with_policy(cli_policy(untrusted, trusted))
         .with_persist_base(base_dir.join(".chidori").join("runs"))
         .with_workspace_root(abs_dir(&base_dir));
 
@@ -905,6 +956,7 @@ fn cmd_run_stream(
     verbose: bool,
     extra_tool_dirs: &[PathBuf],
     untrusted: bool,
+    trusted: bool,
 ) -> Result<()> {
     use tokio::sync::mpsc;
 
@@ -934,7 +986,7 @@ fn cmd_run_stream(
 
     let engine = Engine::new(providers, template_engine, tokio_rt)
         .with_tools(tools)
-        .with_policy(cli_policy(untrusted));
+        .with_policy(cli_policy(untrusted, trusted));
 
     let (event_tx, event_rx) = mpsc::unbounded_channel::<crate::runtime::context::RuntimeEvent>();
 
@@ -1033,6 +1085,7 @@ fn cmd_chat(
     model: Option<String>,
     extra_tool_dirs: &[PathBuf],
     untrusted: bool,
+    trusted: bool,
 ) -> Result<()> {
     use crate::runtime::context::RuntimeEvent;
     use std::io::Write;
@@ -1077,7 +1130,7 @@ fn cmd_chat(
 
     let engine = Engine::new(providers, template_engine, tokio_rt)
         .with_tools(tools)
-        .with_policy(cli_policy(untrusted))
+        .with_policy(cli_policy(untrusted, trusted))
         .with_workspace_root(abs_dir(&base_dir));
 
     eprintln!("chidori chat — type a message and press enter. Type 'exit' or Ctrl-D to quit.");
@@ -1276,6 +1329,14 @@ fn cmd_resume(
     } else {
         Value::Object(Default::default())
     };
+
+    // Replay is positional: verify the agent code on disk still matches the
+    // source fingerprints recorded in the run's snapshot manifest, exactly as
+    // the server resume routes do, so cached results are never paired with
+    // changed code. (Runs persisted before manifests existed skip with a
+    // warning.)
+    crate::runtime::snapshot::validate_manifest_for_resume(&run_base, Some(run_id), file)
+        .context("resume refused: the agent source no longer matches this run's checkpoint")?;
 
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));

--- a/crates/chidori/src/policy.rs
+++ b/crates/chidori/src/policy.rs
@@ -10,8 +10,11 @@
 //!   1. CHIDORI_POLICY_FILE — path to a JSON file
 //!   2. CHIDORI_POLICY — inline JSON string
 //!   3. CHIDORI_POLICY_PROFILE — name of a built-in profile (e.g. "untrusted")
-//!   4. default (AlwaysAllow for everything except shell, which keeps the
-//!      existing CHIDORI_SHELL_ALLOW semantics)
+//!   4. a per-surface default when nothing is configured: `chidori run` asks
+//!      before powerful effects ([`run_default_profile`], relaxed with
+//!      `--trusted`), `chidori serve` denies them ([`serve_default_profile`],
+//!      relaxed with `--trusted`). Shell keeps the existing
+//!      CHIDORI_SHELL_ALLOW semantics in every posture.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -230,11 +233,29 @@ pub fn serve_default_profile() -> PolicyConfig {
     cfg
 }
 
+/// The policy `chidori run` uses when the operator has not configured one and
+/// has not passed `--trusted`. Agents pulled from a registry or a repo are
+/// third-party code, so the out-of-the-box posture asks before every powerful
+/// effect (the `supervised` profile) instead of running fully trusted: on an
+/// interactive terminal the run pauses at a y/N prompt, and without a terminal
+/// the call fails closed with this reason telling the operator how to relax it.
+pub fn run_default_profile() -> PolicyConfig {
+    let mut cfg = supervised_profile();
+    cfg.default_reason = Some(
+        "chidori run asks before powerful effects by default: approve at the prompt, pass \
+         --trusted for the historical allow-all behavior, or configure CHIDORI_POLICY / \
+         CHIDORI_POLICY_FILE / CHIDORI_POLICY_PROFILE"
+            .to_string(),
+    );
+    cfg
+}
+
 /// Ask-by-default profile: identical allowlist to `untrusted`, but unmatched
 /// gated effects resolve to `AskBefore` — under the server's pause flow the
 /// run suspends as `awaiting_approval` and the operator decides per call
 /// (approvals are remembered per (target, args) for the session). On the bare
-/// CLI, where nothing can answer the prompt, the call errors instead.
+/// CLI the operator is prompted on the controlling terminal when one exists;
+/// otherwise the call errors.
 fn supervised_profile() -> PolicyConfig {
     PolicyConfig {
         rules: read_only_workspace_allowlist(),
@@ -256,6 +277,79 @@ fn read_only_workspace_allowlist() -> Vec<PolicyRule> {
         allow_read_only("workspace:read"),
         allow_read_only("workspace:manifest"),
     ]
+}
+
+/// Ask the operator on the controlling terminal whether an `AskBefore` call
+/// may proceed. Returns `Some(true/false)` when a terminal answered, `None`
+/// when no terminal is available — non-interactive runs must fail closed
+/// instead of assuming consent.
+///
+/// On Unix the prompt goes through `/dev/tty`, so it works even when stdin is
+/// piped input and stdout is a JSON stream (`run --stream`). When `/dev/tty`
+/// is unavailable (or off-Unix) it falls back to stderr + stdin, but only when
+/// both are terminals.
+pub fn prompt_operator_approval(target: &str, args: &Value, reason: Option<&str>) -> Option<bool> {
+    use std::io::Write;
+
+    let args_short: String = {
+        let s = serde_json::to_string(args).unwrap_or_default();
+        if s.chars().count() > 200 {
+            let mut t: String = s.chars().take(200).collect();
+            t.push('…');
+            t
+        } else {
+            s
+        }
+    };
+    let prompt = format!(
+        "chidori policy: agent requests `{}`{}\n  args: {}\nAllow (remembered for this run)? [y/N] ",
+        target,
+        reason.map(|r| format!(" — {r}")).unwrap_or_default(),
+        args_short
+    );
+
+    let parse_answer =
+        |line: &str| matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes");
+
+    #[cfg(unix)]
+    {
+        use std::io::BufRead;
+        if let Ok(tty) = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+        {
+            let mut out = &tty;
+            if out
+                .write_all(prompt.as_bytes())
+                .and_then(|_| out.flush())
+                .is_ok()
+            {
+                let mut line = String::new();
+                if std::io::BufReader::new(&tty).read_line(&mut line).is_ok() {
+                    return Some(parse_answer(&line));
+                }
+            }
+        }
+    }
+
+    {
+        use std::io::IsTerminal;
+        if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() {
+            let mut err = std::io::stderr();
+            if err
+                .write_all(prompt.as_bytes())
+                .and_then(|_| err.flush())
+                .is_ok()
+            {
+                let mut line = String::new();
+                if std::io::stdin().read_line(&mut line).is_ok() {
+                    return Some(parse_answer(&line));
+                }
+            }
+        }
+    }
+    None
 }
 
 /// True when `args` contains all keys/values in `pattern` (shallow for scalars,
@@ -449,8 +543,38 @@ mod tests {
     }
 
     #[test]
+    fn run_default_profile_asks_with_actionable_reason() {
+        let cfg = run_default_profile();
+        assert_eq!(cfg.default, Decision::AskBefore);
+
+        let (decision, reason) = cfg.decide("http", &json!({ "url": "https://example.com" }));
+        assert_eq!(decision, Decision::AskBefore);
+        let reason = reason.expect("run default carries a how-to-relax reason");
+        assert!(
+            reason.contains("--trusted"),
+            "reason should name the opt-out: {reason}"
+        );
+        assert!(
+            reason.contains("CHIDORI_POLICY"),
+            "reason should name the env config: {reason}"
+        );
+
+        // The read-only workspace allowlist stays open so agents can still
+        // introspect their sandbox without a prompt.
+        for target in ["workspace:list", "workspace:read", "workspace:manifest"] {
+            let (decision, _) = cfg.decide(target, &json!({}));
+            assert_eq!(
+                decision,
+                Decision::AlwaysAllow,
+                "{target} should be allowed"
+            );
+        }
+    }
+
+    #[test]
     fn default_profile_allows_everything() {
-        // The historical default must stay unchanged: no rules, AlwaysAllow fallback.
+        // The permissive posture (`--trusted`, or an explicit empty policy)
+        // must stay unchanged: no rules, AlwaysAllow fallback.
         let cfg = PolicyConfig::default();
         assert_eq!(cfg.default, Decision::AlwaysAllow);
         let (decision, _) = cfg.decide("http", &json!({ "url": "https://example.com" }));

--- a/crates/chidori/src/runtime/context.rs
+++ b/crates/chidori/src/runtime/context.rs
@@ -451,6 +451,28 @@ pub struct PendingApproval {
 /// distinguish it from a genuine failure.
 pub const PAUSE_MARKER: &str = "__CHIDORI_PAUSED_FOR_INPUT__";
 
+/// True when `CHIDORI_REPLAY_LAX=1`: argument-level replay divergences are
+/// downgraded to warnings that restore the historical best-effort behavior
+/// (serve the cached result on the sync path, silently re-execute live on the
+/// async host-operation path). Function-name and operation-kind mismatches
+/// remain fatal regardless.
+pub(crate) fn replay_lax() -> bool {
+    std::env::var("CHIDORI_REPLAY_LAX").ok().as_deref() == Some("1")
+}
+
+/// Render call args for a divergence message without flooding the error with
+/// a multi-kilobyte prompt payload.
+pub(crate) fn truncate_json_for_error(value: &serde_json::Value) -> String {
+    let s = serde_json::to_string(value).unwrap_or_else(|_| "<unserializable>".to_string());
+    if s.chars().count() > 300 {
+        let mut t: String = s.chars().take(300).collect();
+        t.push('…');
+        t
+    } else {
+        s
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
     pub model: String,
@@ -1005,27 +1027,59 @@ impl RuntimeContext {
     }
 
     /// Replay-cache lookup with divergence check. Returns:
-    ///   Ok(Some(record)) — cached and the cached record's function name
-    ///                      matches `expected_fn`. Safe to use.
+    ///   Ok(Some(record)) — cached, and the cached record's function name AND
+    ///                      arguments match the call the agent is making now.
+    ///                      Safe to use.
     ///   Ok(None)         — no cache hit; caller should execute live.
-    ///   Err(msg)         — cached, but the recorded function differs from
-    ///                      what the agent is calling now. The agent code
-    ///                      changed since the checkpoint was saved. The
-    ///                      engine should abort the replay with a clear error.
+    ///   Err(msg)         — cached, but the recorded call differs from what
+    ///                      the agent is calling now. The agent code (or its
+    ///                      inputs) changed since the checkpoint was saved.
+    ///                      The engine should abort the replay with a clear
+    ///                      error rather than pair cached results with
+    ///                      different code.
+    ///
+    /// A name mismatch is always fatal. An argument mismatch (same function,
+    /// different args — compared with the derived `request_digest` field
+    /// stripped, like the async host-operation path) is fatal by default and
+    /// downgraded to a warning under `CHIDORI_REPLAY_LAX=1`, which restores
+    /// the historical best-effort behavior of serving the cached result.
     pub fn try_replay_checked(
         &self,
         seq: u64,
         expected_fn: &str,
+        expected_args: &serde_json::Value,
     ) -> Result<Option<CallRecord>, String> {
         match self.try_replay(seq) {
             None => Ok(None),
-            Some(record) if record.function == expected_fn => Ok(Some(record)),
-            Some(record) => Err(format!(
+            Some(record) if record.function != expected_fn => Err(format!(
                 "Replay divergence at seq {}: checkpoint has `{}` but agent called `{}`. \
                  The agent code changed since the checkpoint was saved — \
                  re-run without replay to regenerate.",
                 seq, record.function, expected_fn
             )),
+            Some(record)
+                if !crate::runtime::snapshot::completed_args_match(&record.args, expected_args) =>
+            {
+                if replay_lax() {
+                    tracing::warn!(
+                        "replay divergence at seq {seq} tolerated (CHIDORI_REPLAY_LAX=1): \
+                         `{expected_fn}` was recorded with different arguments; \
+                         serving the cached result"
+                    );
+                    return Ok(Some(record));
+                }
+                Err(format!(
+                    "Replay divergence at seq {}: `{}` was recorded with arguments {} but the \
+                     agent now calls it with {}. The agent code (or its inputs) changed since \
+                     the checkpoint was saved — re-run without replay to regenerate, or set \
+                     CHIDORI_REPLAY_LAX=1 to tolerate argument drift and serve cached results.",
+                    seq,
+                    expected_fn,
+                    truncate_json_for_error(&record.args),
+                    truncate_json_for_error(expected_args)
+                ))
+            }
+            Some(record) => Ok(Some(record)),
         }
     }
 
@@ -1717,13 +1771,12 @@ impl RuntimeContext {
         &self,
         seq: u64,
         kind: PendingHostOperationKind,
-        args: &serde_json::Value,
     ) -> Option<HostPromiseRecord> {
         self.inner
             .lock()
             .unwrap()
             .host_promises
-            .completed_operation(seq, kind, args)
+            .completed_operation(seq, kind)
     }
 
     #[allow(dead_code)]

--- a/crates/chidori/src/runtime/host_core.rs
+++ b/crates/chidori/src/runtime/host_core.rs
@@ -34,7 +34,7 @@ pub fn execute_durable_json_call_at_seq(
     live: impl FnOnce() -> Result<Value>,
 ) -> Result<Value> {
     if let Some(record) = ctx
-        .try_replay_checked(seq, function)
+        .try_replay_checked(seq, function, &args)
         .map_err(|err| anyhow::anyhow!(err))?
     {
         // A replayed call's `live()` is skipped. If it was a container (a tool
@@ -135,9 +135,34 @@ fn replay_completed_host_operation(
     kind: PendingHostOperationKind,
     args: &Value,
 ) -> Result<Option<Value>> {
-    let Some(record) = ctx.completed_host_operation(seq, kind, args) else {
+    let Some(record) = ctx.completed_host_operation(seq, kind) else {
         return Ok(None);
     };
+
+    // A completed operation exists at this (seq, kind) but was recorded with
+    // different arguments: the agent code (or its inputs) changed since the
+    // recording. Historically this silently fell through to a live
+    // re-execution of the side effect — surface it as a divergence instead,
+    // unless the operator explicitly opted into the lax behavior.
+    if !crate::runtime::snapshot::completed_args_match(&record.operation.args, args) {
+        if crate::runtime::context::replay_lax() {
+            tracing::warn!(
+                "replay divergence at seq {seq} tolerated (CHIDORI_REPLAY_LAX=1): completed \
+                 `{function}` was recorded with different arguments; re-executing live"
+            );
+            return Ok(None);
+        }
+        anyhow::bail!(
+            "Replay divergence at seq {}: completed `{}` was recorded with arguments {} but the \
+             agent now calls it with {}. The agent code (or its inputs) changed since the \
+             checkpoint was saved — re-run without replay to regenerate, or set \
+             CHIDORI_REPLAY_LAX=1 to tolerate argument drift and re-execute the effect live.",
+            seq,
+            function,
+            crate::runtime::context::truncate_json_for_error(&record.operation.args),
+            crate::runtime::context::truncate_json_for_error(args)
+        );
+    }
 
     match record.state {
         HostPromiseState::Resolved {
@@ -219,8 +244,10 @@ pub fn execute_input(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
         .ok_or_else(|| anyhow::anyhow!("input requires string prompt"))?
         .to_string();
     let seq = ctx.next_seq();
+    // Both the live paths and the server's synthetic resume record store the
+    // normalized `{"prompt"}` shape, so that is what divergence compares.
     if let Some(record) = ctx
-        .try_replay_checked(seq, "input")
+        .try_replay_checked(seq, "input", &json!({ "prompt": prompt }))
         .map_err(|err| anyhow::anyhow!(err))?
     {
         return Ok(record.result);
@@ -475,7 +502,7 @@ pub fn execute_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
     let seq = ctx.next_seq();
 
     if let Some(record) = ctx
-        .try_replay_checked(seq, "signal")
+        .try_replay_checked(seq, "signal", &match_args)
         .map_err(|err| anyhow::anyhow!(err))?
     {
         return Ok(record.result);
@@ -557,7 +584,7 @@ pub fn execute_signal_any(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
     let seq = ctx.next_seq();
 
     if let Some(record) = ctx
-        .try_replay_checked(seq, "signal_any")
+        .try_replay_checked(seq, "signal_any", &match_args)
         .map_err(|err| anyhow::anyhow!(err))?
     {
         return Ok(record.result);
@@ -639,7 +666,7 @@ pub fn execute_poll_signal(ctx: &RuntimeContext, args: &Value) -> Result<Value> 
     let seq = ctx.next_seq();
 
     if let Some(record) = ctx
-        .try_replay_checked(seq, "poll_signal")
+        .try_replay_checked(seq, "poll_signal", &match_args)
         .map_err(|err| anyhow::anyhow!(err))?
     {
         return Ok(record.result);
@@ -720,7 +747,7 @@ pub fn execute_step_begin(ctx: &RuntimeContext, args: &Value) -> Result<Value> {
     let seq = ctx.next_seq();
 
     if let Some(record) = ctx
-        .try_replay_checked(seq, "step")
+        .try_replay_checked(seq, "step", &json!({ "name": name }))
         .map_err(|err| anyhow::anyhow!(err))?
     {
         let recorded_name = record
@@ -953,7 +980,7 @@ pub fn execute_prompt_text(
     apply_model_override(ctx, &mut request);
     let seq = ctx.next_seq();
     if let Some(record) = ctx
-        .try_replay_checked(seq, "prompt")
+        .try_replay_checked(seq, "prompt", &args)
         .map_err(|err| anyhow::anyhow!(err))?
     {
         return Ok(record.result);
@@ -1044,7 +1071,7 @@ pub fn execute_prompt_response(
     apply_model_override(ctx, &mut request);
     let seq = ctx.next_seq();
     if let Some(record) = ctx
-        .try_replay_checked(seq, "prompt")
+        .try_replay_checked(seq, "prompt", &args)
         .map_err(|err| anyhow::anyhow!(err))?
     {
         return llm_response_from_json(&record.result).ok_or_else(|| {
@@ -1850,7 +1877,7 @@ mod tests {
             seq: 1,
             parent_seq: None,
             function: "template".to_string(),
-            args: json!({ "template": "ignored", "vars": {} }),
+            args: json!({ "template": "{{ value }}", "vars": {} }),
             result: json!("cached"),
             duration_ms: 1,
             token_usage: None,
@@ -1862,13 +1889,51 @@ mod tests {
         let result = execute_durable_json_call(
             &ctx,
             "template",
-            json!({ "template": "{{ broken", "vars": {} }),
+            json!({ "template": "{{ value }}", "vars": {} }),
             || anyhow::bail!("live path should not run"),
         )
         .unwrap();
 
         assert_eq!(result, json!("cached"));
         assert_eq!(ctx.call_log().into_records().len(), 1);
+    }
+
+    #[test]
+    fn durable_json_call_arg_mismatch_is_a_divergence_error() {
+        // Same function name, different args: historically the cached result
+        // was served anyway (the divergence check compared name only). That
+        // silently paired cached results with changed code — it must now be a
+        // hard replay-divergence error.
+        let replay = vec![CallRecord {
+            seq: 1,
+            parent_seq: None,
+            function: "template".to_string(),
+            args: json!({ "template": "recorded", "vars": {} }),
+            result: json!("cached"),
+            duration_ms: 1,
+            token_usage: None,
+            timestamp: Utc::now(),
+            error: None,
+        }];
+        let ctx = RuntimeContext::with_replay(replay);
+
+        let err = execute_durable_json_call(
+            &ctx,
+            "template",
+            json!({ "template": "changed", "vars": {} }),
+            || anyhow::bail!("live path should not run on divergence"),
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(
+            message.contains("Replay divergence"),
+            "expected divergence error, got: {message}"
+        );
+        assert!(
+            message.contains("CHIDORI_REPLAY_LAX"),
+            "error should name the escape hatch, got: {message}"
+        );
     }
 
     #[test]
@@ -1959,17 +2024,61 @@ mod tests {
         );
 
         let replay_ctx = RuntimeContext::with_replay(records);
-        let replayed = execute_native_tool_call(
-            &replay_ctx,
-            &registry,
-            "echo",
-            json!({ "value": "different live args" }),
-        )
-        .unwrap();
+        let replayed =
+            execute_native_tool_call(&replay_ctx, &registry, "echo", json!({ "value": 42 }))
+                .unwrap();
 
         assert_eq!(replayed, json!({ "value": 42 }));
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(replay_ctx.call_log().into_records().len(), 1);
+    }
+
+    #[test]
+    fn completed_host_operation_arg_mismatch_is_a_divergence_error() {
+        // A completed host operation exists at (seq, kind) but was recorded
+        // with different arguments. Historically this silently fell through to
+        // a live re-execution of the side effect — it must now surface as a
+        // replay-divergence error naming the escape hatch.
+        let recorded_args = json!({ "name": "echo", "kwargs": { "value": 42 } });
+        let records = vec![HostPromiseRecord {
+            operation: PendingHostOperation::new(
+                HostOperationId(1),
+                1,
+                PendingHostOperationKind::Tool,
+                recorded_args,
+            ),
+            state: HostPromiseState::Resolved {
+                value: json!({ "value": 42 }),
+                completed_at: Utc::now(),
+            },
+        }];
+        let ctx = RuntimeContext::with_replay_and_host_promises(Vec::new(), records);
+
+        let live_ran = std::cell::Cell::new(false);
+        let err = execute_durable_json_call(
+            &ctx,
+            "tool",
+            json!({ "name": "echo", "kwargs": { "value": 43 } }),
+            || {
+                live_ran.set(true);
+                Ok(json!({ "value": 43 }))
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            !live_ran.get(),
+            "the side effect must not silently re-execute live on arg mismatch"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("Replay divergence"),
+            "expected divergence error, got: {message}"
+        );
+        assert!(
+            message.contains("CHIDORI_REPLAY_LAX"),
+            "error should name the escape hatch, got: {message}"
+        );
     }
 
     #[test]

--- a/crates/chidori/src/runtime/isolate/mod.rs
+++ b/crates/chidori/src/runtime/isolate/mod.rs
@@ -22,8 +22,15 @@ pub(crate) use supervisor::run_agent_isolated;
 /// Whether OS isolation is enabled for this process, controlled by the
 /// `CHIDORI_ISOLATE` environment variable. Any value other than the unset /
 /// empty / explicitly-falsey forms (`0`, `off`, `false`, `no`) turns it on;
-/// `process` is the canonical value. The worker child always has this unset (the
-/// supervisor strips it), so a worker never recursively re-isolates.
+/// `process` is the canonical value. The worker child always has this
+/// explicitly off (the supervisor sets `off`), so a worker never recursively
+/// re-isolates.
+///
+/// Embedders (and the test harness) see the historical opt-in behavior: unset
+/// means off. The `chidori` CLI flips the default at startup via
+/// [`default_on_if_unset`], so `run`/`serve` isolate out of the box on
+/// platforms with a worker sandbox and `--no-isolate` / `CHIDORI_ISOLATE=off`
+/// are the opt-outs.
 pub fn enabled() -> bool {
     match std::env::var("CHIDORI_ISOLATE") {
         Ok(v) => {
@@ -41,12 +48,31 @@ pub fn enable() {
     std::env::set_var("CHIDORI_ISOLATE", "process");
 }
 
+/// Explicitly turn OS isolation off (`--no-isolate`). Sets the falsey value
+/// rather than unsetting so the choice survives [`default_on_if_unset`] and is
+/// inherited by child processes.
+pub fn disable() {
+    std::env::set_var("CHIDORI_ISOLATE", "off");
+}
+
+/// Default-on isolation for the CLI: when the operator has expressed no
+/// preference (`CHIDORI_ISOLATE` unset), turn isolation on wherever the
+/// process-worker mechanism is supported (Unix; Linux and macOS additionally
+/// get an OS sandbox layer). Called once at `chidori` startup — an explicit
+/// env value, `--isolate`, or `--no-isolate` always wins.
+pub fn default_on_if_unset() {
+    if cfg!(unix) && std::env::var_os("CHIDORI_ISOLATE").is_none() {
+        enable();
+    }
+}
+
 /// A one-line, human-readable description of the isolation posture, for startup
 /// banners. Describes *intent*: the worker applies each layer best-effort and
 /// logs to stderr what actually stuck on this host.
 pub fn describe() -> String {
     if !enabled() {
-        return "off (agents run in-process)".to_string();
+        return "off (agents run in-process; pass --isolate or unset CHIDORI_ISOLATE to sandbox)"
+            .to_string();
     }
     let layers = if cfg!(target_os = "linux") {
         "Linux: network namespace + Landlock + seccomp"

--- a/crates/chidori/src/runtime/isolate/supervisor.rs
+++ b/crates/chidori/src/runtime/isolate/supervisor.rs
@@ -60,7 +60,9 @@ pub(crate) fn run_agent_isolated(
         .stderr(Stdio::inherit())
         // The child must not re-enter isolation (it runs the agent directly); make
         // that impossible regardless of how this process's env was configured.
-        .env_remove("CHIDORI_ISOLATE")
+        // Explicitly `off` (not unset) so nothing downstream can re-apply a
+        // default-on posture to the worker or its descendants.
+        .env("CHIDORI_ISOLATE", "off")
         .spawn()
         .with_context(|| format!("spawning isolate worker `{} __run-worker`", exe.display()))?;
 

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -679,7 +679,7 @@ fn execute_captured_random(
 ) -> std::result::Result<Vec<u8>, String> {
     use crate::runtime::capability::Capability;
     let seq = ctx.next_seq();
-    match ctx.try_replay_checked(seq, "crypto.random") {
+    match ctx.try_replay_checked(seq, "crypto.random", &serde_json::json!({ "n": n })) {
         Ok(Some(record)) => {
             ctx.note_capability(Capability::CryptoRandom, seq);
             let b64 = record

--- a/crates/chidori/src/runtime/snapshot.rs
+++ b/crates/chidori/src/runtime/snapshot.rs
@@ -439,16 +439,18 @@ impl HostPromiseTable {
             })
     }
 
+    /// The completed record at (seq, kind), if any. Args are NOT matched here:
+    /// the caller compares them via [`completed_args_match`] so a mismatch can
+    /// be surfaced as a replay divergence instead of silently discarding the
+    /// recorded completion (and re-executing the side effect live).
     pub fn completed_operation(
         &self,
         seq: u64,
         kind: PendingHostOperationKind,
-        args: &Value,
     ) -> Option<HostPromiseRecord> {
         self.records.values().find_map(|record| {
             if record.operation.seq == seq
                 && record.operation.kind == kind
-                && completed_args_match(&record.operation.args, args)
                 && !matches!(record.state, HostPromiseState::Pending)
             {
                 Some(record.clone())
@@ -514,7 +516,7 @@ pub fn load_host_promise_records(
 /// from the same inputs on resume) rather than identifying the operation, so a
 /// digest-scheme change between record and resume must not force a completed
 /// side effect to re-execute.
-fn completed_args_match(recorded: &Value, rebuilt: &Value) -> bool {
+pub(crate) fn completed_args_match(recorded: &Value, rebuilt: &Value) -> bool {
     if recorded == rebuilt {
         return true;
     }
@@ -955,6 +957,72 @@ impl SnapshotManifest {
         self.ensure_module_graph_matches(current_module_graph)?;
         Ok(())
     }
+}
+
+/// Verify the agent code on disk against the snapshot manifest recorded for
+/// `run_id` before a resume replays its journal. Replay is positional — a
+/// changed source file could silently pair cached results with different code
+/// — so every resume surface (the server's resume/approve routes AND the
+/// `chidori resume` CLI) must call this first. Runs persisted before manifests
+/// existed (no readable manifest) are tolerated with a warning; every other
+/// mismatch is an error the caller should surface.
+pub fn validate_manifest_for_resume(
+    run_base: &Path,
+    run_id: Option<&str>,
+    agent_path: &Path,
+) -> Result<()> {
+    let Some(run_id) = run_id else {
+        return Ok(());
+    };
+    let store = SnapshotStore::new(run_base.join(run_id));
+    let manifest = match store.load_manifest() {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            tracing::warn!(
+                "resume: no readable snapshot manifest for run {run_id} ({err}); \
+                 skipping source verification"
+            );
+            return Ok(());
+        }
+    };
+    let entry_source = std::fs::read_to_string(agent_path).map_err(|err| {
+        anyhow::anyhow!("reading resume source {}: {}", agent_path.display(), err)
+    })?;
+    let current_entry = SourceFingerprint::from_source(agent_path, &entry_source);
+    let expected_abi = SnapshotAbi::current("chidori-quickjs");
+    let expected_policy = RuntimePolicy::from_env_for_durable_run(run_id)?;
+    // One module walk yields both manifest views (fingerprints + graph), so
+    // each imported module is read from disk once per resume instead of twice
+    // (once for its fingerprint, again inside the graph walk). Manifests
+    // written before the graph existed fall back to fingerprinting exactly
+    // the paths they list.
+    let (current_modules, current_module_graph) = if manifest.module_graph.is_empty() {
+        let mut current_modules = Vec::with_capacity(manifest.modules.len());
+        for module in &manifest.modules {
+            let source = std::fs::read_to_string(&module.path).map_err(|err| {
+                anyhow::anyhow!(
+                    "reading resume module source {}: {}",
+                    module.path.display(),
+                    err
+                )
+            })?;
+            current_modules.push(SourceFingerprint::from_source(&module.path, &source));
+        }
+        (current_modules, Vec::new())
+    } else {
+        crate::runtime::typescript::module_graph::snapshot_modules(
+            agent_path,
+            &entry_source,
+            &expected_policy,
+        )?
+    };
+    manifest.ensure_resume_compatible(
+        &expected_abi,
+        &expected_policy,
+        &current_entry,
+        &current_modules,
+        &current_module_graph,
+    )
 }
 
 #[derive(Debug, Clone)]

--- a/crates/chidori/src/runtime/typescript/bindings.rs
+++ b/crates/chidori/src/runtime/typescript/bindings.rs
@@ -613,12 +613,32 @@ impl HostBindingBackend {
                     });
                     return Err(PAUSE_MARKER.to_string());
                 }
-                Err(format!(
-                    "policy: `{}` requires approval{}. Set CHIDORI_POLICY_AUTO_APPROVE=1 to \
-                     auto-approve, or run through the server so the approval flow can pause.",
-                    target,
-                    reason.map(|r| format!(" - {}", r)).unwrap_or_default()
-                ))
+                // Bare CLI: ask the operator on the controlling terminal.
+                // Approvals are remembered per (target, args) for this run.
+                if let Some(approved) =
+                    crate::policy::prompt_operator_approval(target, args, reason.as_deref())
+                {
+                    if approved {
+                        policy_cache.lock().unwrap().approve(target, args);
+                        return Ok(());
+                    }
+                    return Err(format!(
+                        "policy: `{}` denied at the operator prompt",
+                        target
+                    ));
+                }
+                // Non-interactive and nothing to answer the prompt: fail closed.
+                // A policy-supplied reason already tells the operator how to
+                // relax the posture; otherwise fall back to the generic help.
+                Err(match reason {
+                    Some(r) => format!("policy: `{}` requires approval - {}", target, r),
+                    None => format!(
+                        "policy: `{}` requires approval. Approve interactively at a terminal, \
+                         set CHIDORI_POLICY_AUTO_APPROVE=1 to auto-approve, or run through the \
+                         server so the approval flow can pause.",
+                        target
+                    ),
+                })
             }
         }
     }

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -27,8 +27,7 @@ use crate::runtime::engine::{Engine, RunResult};
 use crate::runtime::host_core::signal_timeout_sentinel;
 use crate::runtime::snapshot::{
     HostOperationId, HostPromiseRecord, HostPromiseState, PendingHostOperation,
-    PendingHostOperationKind, RuntimePolicy, SnapshotAbi, SnapshotStore, SourceFingerprint,
-    PENDING_HOST_OPERATION_FILE,
+    PendingHostOperationKind, SnapshotStore, PENDING_HOST_OPERATION_FILE,
 };
 use crate::runtime::template::TemplateEngine;
 use crate::scheduler::{self, SchedulerDeps};
@@ -306,52 +305,7 @@ fn validate_snapshot_manifest_for_resume(
     run_id: Option<&str>,
     agent_path: &FsPath,
 ) -> anyhow::Result<()> {
-    let Some(run_id) = run_id else {
-        return Ok(());
-    };
-    let store = SnapshotStore::new(run_base.join(run_id));
-    let manifest = match store.load_manifest() {
-        Ok(manifest) => manifest,
-        Err(_) => return Ok(()),
-    };
-    let entry_source = std::fs::read_to_string(agent_path).map_err(|err| {
-        anyhow::anyhow!("reading resume source {}: {}", agent_path.display(), err)
-    })?;
-    let current_entry = SourceFingerprint::from_source(agent_path, &entry_source);
-    let expected_abi = SnapshotAbi::current("chidori-quickjs");
-    let expected_policy = RuntimePolicy::from_env_for_durable_run(run_id)?;
-    // One module walk yields both manifest views (fingerprints + graph), so
-    // each imported module is read from disk once per resume instead of twice
-    // (once for its fingerprint, again inside the graph walk). Manifests
-    // written before the graph existed fall back to fingerprinting exactly
-    // the paths they list.
-    let (current_modules, current_module_graph) = if manifest.module_graph.is_empty() {
-        let mut current_modules = Vec::with_capacity(manifest.modules.len());
-        for module in &manifest.modules {
-            let source = std::fs::read_to_string(&module.path).map_err(|err| {
-                anyhow::anyhow!(
-                    "reading resume module source {}: {}",
-                    module.path.display(),
-                    err
-                )
-            })?;
-            current_modules.push(SourceFingerprint::from_source(&module.path, &source));
-        }
-        (current_modules, Vec::new())
-    } else {
-        crate::runtime::typescript::module_graph::snapshot_modules(
-            agent_path,
-            &entry_source,
-            &expected_policy,
-        )?
-    };
-    manifest.ensure_resume_compatible(
-        &expected_abi,
-        &expected_policy,
-        &current_entry,
-        &current_modules,
-        &current_module_graph,
-    )
+    crate::runtime::snapshot::validate_manifest_for_resume(run_base, run_id, agent_path)
 }
 
 enum HostPromiseCompletion {
@@ -603,12 +557,12 @@ pub async fn serve(
     });
     let mcp_tools = Arc::new(mcp_tools);
 
-    let session_store = build_session_store();
-    let run_base = agent_path
+    let base_dir = agent_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
-        .join(".chidori")
-        .join("runs");
+        .to_path_buf();
+    let session_store = build_session_store(&base_dir)?;
+    let run_base = base_dir.join(".chidori").join("runs");
 
     let recipe_dir = std::env::var("CHIDORI_RECIPE_DIR").ok().map(PathBuf::from);
     let recipes = recipe_dir
@@ -2998,7 +2952,9 @@ async fn handle_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::snapshot::HOST_PROMISE_TABLE_FILE;
+    use crate::runtime::snapshot::{
+        RuntimePolicy, SnapshotAbi, SourceFingerprint, HOST_PROMISE_TABLE_FILE,
+    };
     use axum::body;
 
     #[test]

--- a/crates/chidori/src/storage.rs
+++ b/crates/chidori/src/storage.rs
@@ -1,8 +1,10 @@
 //! Session and memory persistence.
 //!
 //! Provides two backends:
-//!   * JSON files (default; same layout the framework has used since v0)
-//!   * SQLite (enabled via CHIDORI_DB_PATH)
+//!   * SQLite (default: `.chidori/sessions.sqlite3` next to the agent's
+//!     `.chidori/runs/`; override the path with CHIDORI_DB_PATH)
+//!   * in-memory (opt-in via CHIDORI_DB_PATH=:memory:, for dev loops that
+//!     should leave no state behind)
 //!
 //! The server holds a `SessionStore` trait object so it can switch backends
 //! without touching the HTTP handlers. Sessions are serialized as a JSON blob
@@ -89,8 +91,8 @@ pub trait SessionStore: Send + Sync {
     fn delete(&self, id: &str) -> Result<()>;
 }
 
-/// In-memory store. Default when no persistence is configured; keeps the
-/// pre-v1 behavior for dev loops.
+/// In-memory store. Opt-in via `CHIDORI_DB_PATH=:memory:`, for dev loops that
+/// should leave no state behind.
 pub struct MemoryStore {
     inner: Mutex<std::collections::HashMap<String, StoredSession>>,
 }
@@ -225,24 +227,31 @@ impl SessionStore for SqliteStore {
     }
 }
 
-/// Build the SessionStore configured by env. CHIDORI_DB_PATH picks SQLite;
-/// otherwise an in-memory store is returned.
-pub fn build_session_store() -> std::sync::Arc<dyn SessionStore> {
-    if let Ok(path) = std::env::var("CHIDORI_DB_PATH") {
-        match SqliteStore::open(PathBuf::from(&path)) {
-            Ok(store) => {
-                tracing::info!("session store: sqlite at {}", path);
-                return std::sync::Arc::new(store);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "sqlite session store failed ({}), falling back to memory",
-                    e
-                );
-            }
+/// Build the SessionStore configured by env. Durable by default: sessions go
+/// to SQLite at `CHIDORI_DB_PATH`, or `<base_dir>/.chidori/sessions.sqlite3`
+/// when unset. `CHIDORI_DB_PATH=:memory:` (or `memory`) opts into the
+/// non-durable in-memory store. A SQLite store that fails to open is a hard
+/// startup error — a durability framework must not silently downgrade to a
+/// store that loses every session on restart.
+pub fn build_session_store(base_dir: &std::path::Path) -> Result<std::sync::Arc<dyn SessionStore>> {
+    let path = match std::env::var("CHIDORI_DB_PATH") {
+        Ok(v) if matches!(v.trim(), ":memory:" | "memory") => {
+            tracing::info!("session store: in-memory (CHIDORI_DB_PATH=:memory:)");
+            return Ok(std::sync::Arc::new(MemoryStore::new()));
         }
-    }
-    std::sync::Arc::new(MemoryStore::new())
+        Ok(v) => PathBuf::from(v),
+        Err(_) => base_dir.join(".chidori").join("sessions.sqlite3"),
+    };
+    let store = SqliteStore::open(path.clone()).with_context(|| {
+        format!(
+            "opening the session store at {} — fix the path/permissions, point CHIDORI_DB_PATH \
+             somewhere writable, or set CHIDORI_DB_PATH=:memory: to explicitly opt out of \
+             durable sessions",
+            path.display()
+        )
+    })?;
+    tracing::info!("session store: sqlite at {}", path.display());
+    Ok(std::sync::Arc::new(store))
 }
 
 #[cfg(test)]
@@ -268,5 +277,56 @@ mod tests {
         let session: StoredSession = serde_json::from_value(raw).unwrap();
         assert_eq!(session.status, SessionStatus::Completed);
         assert_eq!(session.run_id, None);
+    }
+
+    fn sample_session(id: &str) -> StoredSession {
+        StoredSession {
+            id: id.to_string(),
+            run_id: None,
+            status: SessionStatus::Completed,
+            input: serde_json::json!({}),
+            output: Some(serde_json::json!({"ok": true})),
+            call_log: Vec::new(),
+            error: None,
+            pending_seq: None,
+            pending_prompt: None,
+            pending_signal_name: None,
+            pending_signal_names: Vec::new(),
+            pending_signal_deadline: None,
+            pending_approval: None,
+            approvals: Vec::new(),
+            policy_profile: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn sqlite_store_persists_across_reopen() {
+        // The durable default must actually be durable: a session written
+        // through one handle is visible through a fresh one on the same path.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".chidori").join("sessions.sqlite3");
+
+        let store = SqliteStore::open(path.clone()).unwrap();
+        store.put(&sample_session("s-1")).unwrap();
+        drop(store);
+
+        let reopened = SqliteStore::open(path).unwrap();
+        let got = reopened
+            .get("s-1")
+            .unwrap()
+            .expect("session survives reopen");
+        assert_eq!(got.status, SessionStatus::Completed);
+    }
+
+    #[test]
+    fn sqlite_store_open_fails_loudly_on_unusable_path() {
+        // The old behavior silently fell back to the in-memory store when
+        // SQLite could not open. Failure must now surface to the caller.
+        let dir = tempfile::tempdir().unwrap();
+        let clash = dir.path().join("not-a-directory");
+        std::fs::write(&clash, b"file, not dir").unwrap();
+        let err = SqliteStore::open(clash.join("sessions.sqlite3"));
+        assert!(err.is_err(), "opening under a file path must error");
     }
 }

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -202,6 +202,7 @@ fn cli_run_discovers_local_typescript_tool_directory_for_direct_tool_calls() {
         &[
             "run",
             agent.to_str().unwrap(),
+            "--trusted",
             "--input",
             r#"{"topic":"chidori"}"#,
         ],
@@ -289,6 +290,7 @@ fn cli_stream_workspace_binding_writes_real_disk_manifest() {
         &[
             "run",
             agent.to_str().unwrap(),
+            "--trusted",
             "--stream",
             "--input",
             r#"{}"#,
@@ -767,12 +769,125 @@ fn cli_run_typescript_agent_invokes_typescript_tool() {
     .unwrap();
 
     let output = run_chidori(
-        &["run", agent.to_str().unwrap(), "--input", r#"{"value": 7}"#],
+        &[
+            "run",
+            agent.to_str().unwrap(),
+            "--trusted",
+            "--input",
+            r#"{"value": 7}"#,
+        ],
         &dir,
     );
     assert_success(&output);
     let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(stdout["echoed"], 7);
+
+    fs::remove_dir_all(dir).ok();
+}
+
+#[test]
+fn cli_run_default_posture_fails_closed_on_gated_effects_without_terminal() {
+    // With no policy configured, no --trusted, and no terminal to answer the
+    // approval prompt, a gated effect (tool call) must fail closed with an
+    // actionable message instead of running fully trusted.
+    let dir = temp_project("default-posture");
+    let tools_dir = dir.join("tools");
+    fs::create_dir_all(&tools_dir).unwrap();
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                return await chidori.tool("echo", { value: 1 });
+            }
+        "#,
+    )
+    .unwrap();
+    fs::write(
+        tools_dir.join("echo.ts"),
+        r#"
+            export const tool = {
+                name: "echo",
+                description: "Echo a value.",
+                parameters: { type: "object", properties: {}, required: [] },
+            };
+            export async function run(args, chidori) {
+                return { echoed: args.value };
+            }
+        "#,
+    )
+    .unwrap();
+
+    let output = run_chidori(&["run", agent.to_str().unwrap()], &dir);
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("requires approval"),
+        "default posture should ask/deny, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--trusted"),
+        "denial should name the opt-out, got:\n{stderr}"
+    );
+
+    // The read-only workspace surface stays open without prompts.
+    fs::remove_dir_all(dir).ok();
+}
+
+#[test]
+fn cli_resume_refuses_changed_agent_source() {
+    // `chidori resume` must verify the stored source fingerprints before
+    // replaying the journal, exactly like the server resume routes: replay is
+    // positional, so pairing cached results with changed code is a silent
+    // correctness hazard.
+    let dir = temp_project("resume-source-check");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.log("original", {});
+                return { version: 1 };
+            }
+        "#,
+    )
+    .unwrap();
+
+    let output = run_chidori(&["run", agent.to_str().unwrap()], &dir);
+    assert_success(&output);
+
+    let runs_dir = dir.join(".chidori").join("runs");
+    let run_id = fs::read_dir(&runs_dir)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .file_name()
+        .into_string()
+        .unwrap();
+
+    // Unchanged source resumes fine.
+    let output = run_chidori(&["resume", agent.to_str().unwrap(), &run_id], &dir);
+    assert_success(&output);
+
+    // Changed source is refused with a source-mismatch error.
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.log("edited", {});
+                return { version: 2 };
+            }
+        "#,
+    )
+    .unwrap();
+    let output = run_chidori(&["resume", agent.to_str().unwrap(), &run_id], &dir);
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("source") && stderr.contains("mismatch"),
+        "expected a source mismatch refusal, got:\n{stderr}"
+    );
 
     fs::remove_dir_all(dir).ok();
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ the three rules below encode.
 ```bash
 ANTHROPIC_API_KEY=sk-ant-...        # or OPENAI_API_KEY / LITELLM_API_URL
 CHIDORI_API_KEY=<long random>       # bearer auth on everything except GET /health
-CHIDORI_DB_PATH=.chidori/sessions.sqlite3   # session index; in-memory without it
+CHIDORI_DB_PATH=.chidori/sessions.sqlite3   # session index; this path is the default (`:memory:` opts out)
 CHIDORI_RUN_STORE=sqlite            # journal mirror — see table below
 CHIDORI_DURABILITY=strict           # refuse side effects the journal hasn't recorded
 ```
@@ -93,9 +93,10 @@ CHIDORI_DURABILITY=strict           # refuse side effects the journal hasn't rec
 - **Optional:** `CHIDORI_CORS_ORIGINS` for browser callers;
   `CHIDORI_MAX_CONCURRENT_SESSIONS` (default 8) to cap parallel runs;
   `CHIDORI_SECRET_ENV` to pass secrets as placeholder tokens the journal
-  never sees; `CHIDORI_ISOLATE=process` to sandbox untrusted agent code (in
-  containers, set `CHIDORI_ISOLATE_REQUIRE_SANDBOX=1` to fail closed — the
-  network-namespace layer needs `CAP_SYS_ADMIN` and is skipped without it).
+  never sees. OS isolation (`CHIDORI_ISOLATE=process`) is the **default on
+  Unix**; opt out with `--no-isolate` / `CHIDORI_ISOLATE=off`. In containers,
+  set `CHIDORI_ISOLATE_REQUIRE_SANDBOX=1` to fail closed — the
+  network-namespace layer needs `CAP_SYS_ADMIN` and is skipped without it.
 
 ## Decision 1: where the journal lives
 
@@ -399,7 +400,7 @@ sequenceDiagram
 - [ ] Policy configured (`CHIDORI_POLICY_FILE`, or a deliberate `--trusted`)
 - [ ] `CHIDORI_HTTP_ALLOW_HOSTS` limited to the internal hosts agents truly
       need (never `*` in production)
-- [ ] `CHIDORI_DB_PATH` set so sessions survive restarts
+- [ ] `CHIDORI_DB_PATH` left at (or set to) a durable path — never `:memory:` in production
 - [ ] `CHIDORI_RUN_STORE` chosen; `s3://` if the machine is ephemeral
 - [ ] `CHIDORI_DURABILITY=strict`
 - [ ] `.chidori/` backed up, or a hydration drill done against the mirror

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -61,7 +61,10 @@ settle, a server-side delivery) fold the blobs into the table file and delete
 them; readers union both, per-op blobs winning by id. The per-op blob is what
 keeps the crash-between-resolve-and-record dedup guarantee: a resolved effect
 whose journal record never landed is still recognized on resume and not
-re-executed. The manifest's embedded copy of the table has the same freshness
+re-executed. Recognition requires the recorded arguments to match the
+re-executed call's (ignoring the derived `request_digest`); a mismatch is a
+hard replay-divergence error rather than a silent live re-execution
+(`CHIDORI_REPLAY_LAX=1` restores the old tolerate-and-re-execute behavior). The manifest's embedded copy of the table has the same freshness
 contract as `checkpoint.json` (compaction-time snapshot; runtime resume never
 reads it).
 

--- a/docs/os-isolation-plan.md
+++ b/docs/os-isolation-plan.md
@@ -284,7 +284,9 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
 - **Off by default**; in-process stays the default for trusted local dev.
 - New worker subcommand `chidori __run-worker` (hidden), added to the clap
   `Commands` enum (`main.rs:44`); the parent `exec`s its own binary in this mode.
-- Opt-in: `--isolate` flag on `run`/`serve` and `CHIDORI_ISOLATE=process` (env).
+- Default-on for the CLI on Unix; `--no-isolate` / `CHIDORI_ISOLATE=off` opts
+  out, `--isolate` / `CHIDORI_ISOLATE=process` overrides an ambient `off`.
+  Embedders keep opt-in semantics (unset means off).
   Naturally pairs with `--untrusted` — consider having the `untrusted` /
   `supervised` policy profiles *imply* isolation when the platform supports it.
 - The server already runs each request under `tokio::task::spawn_blocking`
@@ -382,7 +384,7 @@ error frame the child writes from its `catch_unwind` boundary before exiting:
 
 | Env var | Default | Effect |
 |---|---|---|
-| `CHIDORI_ISOLATE` | unset (off) | `process` runs each agent in a confined child worker. Set by `--isolate`. |
+| `CHIDORI_ISOLATE` | unset (on for the CLI on Unix; off for embedders) | `process` runs each agent in a confined child worker. Set by `--isolate`. |
 | `CHIDORI_ISOLATE_REQUIRE_SANDBOX` | off | Fail the run closed if the platform's core confinement (seccomp/Seatbelt) can't be applied. |
 | `CHIDORI_ISOLATE_DEADLINE_MS` | off | Parent-side wall-clock `SIGKILL` of a wedged worker. |
 | `CHIDORI_ISOLATE_CPU_SECS` | off | Hard `RLIMIT_CPU` ceiling on worker compute. |

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -13,6 +13,22 @@ outputs.
 2. **Checkpoint:** The call log is a JSON array — save it to disk, send it over the wire, commit it to git.
 3. **Replay:** Re-run the agent with the call log pre-loaded. Each host function call checks the log for its seq number — hit returns the cached result instantly, miss executes normally.
 
+Replay is guarded, not best-effort:
+
+- **Source verification:** every resume surface (the server's resume/approve
+  routes *and* `chidori resume`) verifies the agent's entry + module source
+  fingerprints against the run's snapshot manifest before replaying, and
+  refuses on mismatch — cached results are never paired with changed code.
+  (Runs persisted before manifests existed skip with a warning.)
+- **Divergence checks compare arguments, not just names:** a replayed call
+  must match the recorded call's function *and* arguments (the derived
+  `request_digest` field is ignored). A completed async host operation whose
+  recorded arguments differ from the re-executed call's is a hard divergence
+  error instead of a silent live re-execution of the side effect.
+- **Escape hatch:** `CHIDORI_REPLAY_LAX=1` downgrades argument-level
+  divergence to a warning (serving the cached result / re-executing live,
+  the historical behavior). Function-name mismatches are always fatal.
+
 This means you can:
 - **Debug without spending money:** save a failing session, replay locally with breakpoints.
 - **Run deterministic tests:** check in a checkpoint, assert the agent's behavior hasn't changed.

--- a/docs/running-modes.md
+++ b/docs/running-modes.md
@@ -41,8 +41,11 @@ chidori serve agents/my_agent.ts --port 8080
 The server is **deny-by-default**: unless you configure a policy
 (`CHIDORI_POLICY*` env vars) or pass `--trusted`, gated effects (network
 requests via `fetch`/`node:http`, workspace mutations) are refused — sessions
-arrive from callers you may not control. Local `chidori run` keeps the
-permissive default. See [`docs/sandbox-model.md`](./sandbox-model.md).
+arrive from callers you may not control. Local `chidori run` is
+**ask-by-default**: with nothing configured, gated effects pause for a y/N
+prompt on your terminal (and fail closed without one); pass `--trusted` for
+the permissive allow-all posture when running agents you wrote yourself. See
+[`docs/sandbox-model.md`](./sandbox-model.md).
 
 Exposes:
 - `GET  /health` — health check

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -150,11 +150,11 @@ Two complementary layers:
 
 1. **Per-op string cap (always on, in-engine).** `op_add` and `ConcatStrings`
    (template join) throw `RangeError` when a single concatenation would exceed
-   `MAX_STRING_LEN` (16M code units, `crates/chidori-js/src/value.rs`). This closes the
-   exponential `s += s` / `` s = `${s}${s}` `` OOM
+   `MAX_STRING_LEN` (2^28 = ~268M code units, `crates/chidori-js/src/value.rs`). This
+   closes the exponential `s += s` / `` s = `${s}${s}` `` OOM
    and matches the caps on `repeat`/`padStart`/`padEnd` and on
-   dense-array allocation (`MAX_DENSE_ARRAY` = 1M). With these caps, no *single*
-   opcode can allocate without bound.
+   dense-array allocation (`MAX_DENSE_ARRAY` = 2^25 = ~33.5M elements). With these
+   caps, no *single* opcode can allocate without bound.
 
 2. **Per-run live-heap ceiling (watchdog).** A `CountingAllocator`
    (`src/mem_guard.rs`) is installed as the binary's `#[global_allocator]`. Each
@@ -204,7 +204,7 @@ The same watchdog can enforce a wall-clock deadline, also via `vm.interrupt`.
 | Memory ceiling (MB, per-run meter) | `CHIDORI_JS_MEM_CAP_MB` | `4096` | `0` |
 | Memory watchdog poll interval (ms) | `CHIDORI_JS_MEM_POLL_MS` | `10` | — |
 | Wall-clock deadline (ms) | `CHIDORI_JS_DEADLINE_MS` | off | — |
-| String length | (compile constant) | 16M code units | — |
+| String length | (compile constant) | 2^28 (~268M) code units | — |
 | Dense array length | (compile constant) | 1,000,000 | — |
 | Call depth | (compile constant) | 2,000 | — |
 | Regex steps | (compile constant) | 100,000 | — |
@@ -356,16 +356,21 @@ a structured error frame from its `catch_unwind` boundary before exiting):
 
 ### Enabling it
 
-`--isolate` is accepted on both `chidori run` and `chidori serve` (equivalently
-`CHIDORI_ISOLATE=process`); the worker child always has the env var stripped so
-it never recursively re-isolates. The startup banner prints an `Isolation:` line
-describing the active posture. Isolation (process sandbox) and `--untrusted`
-(policy) are **orthogonal but composable** — running untrusted *without*
-isolation prints a nudge rather than silently changing behavior.
+Isolation is **on by default** for the CLI on Unix (Linux and macOS get an OS
+sandbox layer; other Unixes get process separation + rlimits): when
+`CHIDORI_ISOLATE` is unset, `chidori run`/`chidori serve` isolate each run.
+Opt out with `--no-isolate` or `CHIDORI_ISOLATE=off`; `--isolate` remains as an
+explicit override of an ambient `off`. Embedders of the library keep the
+historical opt-in behavior (unset means off) — only the `chidori` binary flips
+the default. The worker child always has the env var explicitly set to `off`
+so it never recursively re-isolates. The startup banner prints an `Isolation:`
+line describing the active posture. Isolation (process sandbox) and
+`--untrusted` (policy) are **orthogonal but composable** — running untrusted
+*without* isolation prints a nudge rather than silently changing behavior.
 
 | Env var | Default | Effect |
 |---|---|---|
-| `CHIDORI_ISOLATE` | unset (off) | `process` runs each agent in a confined child worker. Set by `--isolate`. |
+| `CHIDORI_ISOLATE` | unset (on for the CLI on Unix; off for embedders) | `process` runs each agent in a confined child worker; `off` disables. Set by `--isolate` / `--no-isolate`. |
 | `CHIDORI_ISOLATE_REQUIRE_SANDBOX` | off | Fail the run closed if the platform's core confinement (seccomp/Seatbelt) can't be applied. |
 | `CHIDORI_ISOLATE_DEADLINE_MS` | off | Parent-side wall-clock `SIGKILL` of a wedged worker. |
 | `CHIDORI_ISOLATE_CPU_SECS` | off | Hard `RLIMIT_CPU` ceiling on worker compute. |
@@ -434,7 +439,7 @@ resource-precision gaps.
      macOS CI host yet); it degrades to a logged skip on failure.
 
 5. **Container element counts beyond arrays are uncapped.** Arrays are bounded by
-   `MAX_DENSE_ARRAY` (1M), but `Map`/`Set`/object property counts are not
+   `MAX_DENSE_ARRAY` (2^25, ~33.5M), but `Map`/`Set`/object property counts are not
    individually capped. The memory ceiling (gap 2) is the backstop for the bytes
    they consume; there is no separate per-container element limit.
 

--- a/llm.txt
+++ b/llm.txt
@@ -634,8 +634,9 @@ Session endpoints:
 - `POST /sessions/{id}/replay`: replay from a call-log checkpoint.
 - `POST /sessions/stream`: run with SSE events.
 
-Use `CHIDORI_DB_PATH=/path/to/chidori.sqlite` to persist sessions across server
-restarts.
+Sessions persist across server restarts by default (SQLite at
+`.chidori/sessions.sqlite3` next to the agent). `CHIDORI_DB_PATH` overrides
+the path; `CHIDORI_DB_PATH=:memory:` opts out of durable sessions.
 
 ## TypeScript SDK
 


### PR DESCRIPTION
Defaults (previously trust-everything unless configured):

- chidori run is now ask-by-default: with no CHIDORI_POLICY* configured,
  gated effects (http, workspace mutations, tools) pause for a y/N prompt
  on the controlling terminal (/dev/tty, so --stream and piped stdin still
  prompt) and fail closed with an actionable reason when there is no
  terminal. Approvals are cached per (target, args) for the run. The old
  allow-all posture is an explicit opt-in: `run --trusted` / `chat
  --trusted` (the demo, which runs the repo's own examples, stays trusted).
- OS isolation is default-on for the CLI on Unix: CHIDORI_ISOLATE unset now
  means `process` for `chidori` commands, with --no-isolate /
  CHIDORI_ISOLATE=off as the opt-outs. Embedders keep the historical
  opt-in semantics; the worker child gets an explicit `off` (not unset) so
  a default-on parent can never recursively re-isolate it.
- The session store is durable by default: SQLite at
  .chidori/sessions.sqlite3 next to the agent when CHIDORI_DB_PATH is
  unset, CHIDORI_DB_PATH=:memory: as the explicit opt-out, and a store
  that fails to open is a hard startup error instead of a silent fallback
  to the in-memory store.

Replay correctness (previously positional and best-effort):

- `chidori resume` now verifies the run's snapshot-manifest source
  fingerprints (entry + module graph) before replaying, sharing the
  validator with the server resume routes; a missing manifest (pre-manifest
  runs) warns instead of silently skipping.
- Sync divergence checks compare arguments as well as function names
  (request_digest stripped, matching the async path); an arg mismatch is a
  hard error naming CHIDORI_REPLAY_LAX=1 as the escape hatch.
- A completed async host operation whose recorded args differ from the
  re-executed call's is now a divergence error instead of a silent live
  re-execution of the side effect.
- Engine B (chidori-js ReplayRuntime): restore() actually compares the
  journal's bundle_hash (exposed as bundle_changed()), and journal entries
  record call args so a pre-frontier edit that keeps effect order but
  changes an already-executed call's arguments diverges loudly.

Engine hardening:

- The cycle collector gains a pre-sweep verification pass: every sweep
  candidate's strong count must be exactly explained by edges from other
  candidates plus weak entries of surviving collections; any mismatch (the
  double-subtract failure mode of shared interior Rcs) rescues the object
  instead of sweeping it, turning a use-after-free-equivalent sweep into a
  bounded leak, with a debug-build assertion so regressions surface in
  tests.
- The MAX_DENSE_ARRAY / MAX_STRING_LEN caps (raised to 2^25 / 2^28 in
  #113) get boundary tests pinning the catchable RangeError behavior, and
  the stale 1M / 16M numbers in docs/sandbox-model.md are corrected.

Docs updated: deployment, sandbox-model, os-isolation-plan, running-modes,
replay, durable-storage, llm.txt.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012PzkQzzDkJfxTHqsEwqds5