### PR TITLE
Debuggability: stack traces on runtime errors, line/column on parse errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,14 +22,17 @@
 .claude/shell-snapshots/
 .claude/statsig/
 
-# Run artifacts and runtime state produced by `chidori run`
-# (kept out of source control)
+# Run artifacts and runtime state produced by `chidori run` / `chidori serve`
+# (kept out of source control; sessions.sqlite3* also matches SQLite -wal/-shm
+# sidecar files)
 .chidori/runs/
 .chidori/wasm-cache/
 .chidori/memory/
+.chidori/sessions.sqlite3*
 **/.chidori/runs/
 **/.chidori/wasm-cache/
 **/.chidori/memory/
+**/.chidori/sessions.sqlite3*
 
 # Python build/dist
 __pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "oxc",
+ "oxc_sourcemap",
  "rand 0.8.6",
  "reqwest",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "icu_locale_core",
  "icu_plurals",
  "indexmap 2.14.0",
+ "miette",
  "mimalloc",
  "num-bigint 0.5.1",
  "num-integer",

--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ chidori run summarizer.ts \
   --input document="Rust is a systems programming language..."
 ```
 
+`chidori run` **asks before powerful effects by default**: tool calls, network
+access (`chidori.fetch`), and workspace writes pause for a one-keypress
+approval at the terminal (LLM prompts and pure compute never ask). That's the
+safe default for running code you didn't write; for your own agents, in
+scripts, or in CI — where there is no terminal to ask at, so gated effects
+fail closed — pass `--trusted`:
+
+```bash
+chidori run my_agent.ts --trusted --tools tools
+```
+
 Re-run the same agent with `chidori resume summarizer.ts <run_id>` to replay it
 byte-for-byte with zero model calls (the run id is printed under
 `.chidori/runs/`).
@@ -246,6 +257,10 @@ chidori run examples/agents/hello.ts --input name=Colton  # no LLM calls
 chidori run examples/agents/tool_use.ts \
   --input query=chidori --tools examples/tools            # local TS tool, no LLM
 ```
+
+(The tool call in the second example is a gated effect: approve it at the
+prompt, or add `--trusted` to skip the ask — see
+[Running modes](./docs/running-modes.md).)
 
 For a guided walkthrough — inspecting a run, the demo picker, and the
 human-in-the-loop pause/resume loop — see

--- a/crates/chidori-js/Cargo.toml
+++ b/crates/chidori-js/Cargo.toml
@@ -36,6 +36,11 @@ mimalloc = ["dep:mimalloc"]
 [dependencies]
 # Front end only: we consume the oxc AST and write no lexer/parser of our own.
 oxc = { version = "0.133", features = ["semantic", "transformer", "codegen"] }
+# Span→line/column resolution for parse-error rendering (oxc diagnostics carry
+# miette labeled spans; `SourceCode::read_span` turns a byte offset into a
+# position). Core only — no report-rendering features. Already in the tree
+# transitively, so this adds no new crates.
+miette = { version = "7", default-features = false }
 # Deterministic, insertion-ordered property maps. Object/Map/Set iteration order
 # must be address-independent for replay to be correct (see determinism contract).
 indexmap = "2"

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -135,6 +135,11 @@ pub struct FuncProto {
     pub kind: FuncKind,
     /// Source span for stack traces (start byte offset).
     pub source_start: u32,
+    /// 1-based line/column of the function's definition site in its source,
+    /// rendered in error stack traces (`at name (line:col)`). `0` = unknown
+    /// (synthetic protos, sources compiled without position tracking).
+    pub source_line: u32,
+    pub source_col: u32,
     /// Whether this function references `arguments`.
     pub uses_arguments: bool,
     /// Names of the positional params, for `arguments`/debug.
@@ -262,6 +267,8 @@ impl FuncProto {
             upvalues: Vec::new(),
             kind,
             source_start: 0,
+            source_line: 0,
+            source_col: 0,
             uses_arguments: false,
             param_names: Vec::new(),
             mapped_param_cells: Vec::new(),

--- a/crates/chidori-js/src/bytecode.rs
+++ b/crates/chidori-js/src/bytecode.rs
@@ -140,6 +140,11 @@ pub struct FuncProto {
     /// (synthetic protos, sources compiled without position tracking).
     pub source_line: u32,
     pub source_col: u32,
+    /// Which source this function came from — the module key/path supplied to
+    /// [`crate::compiler::compile_module_labeled`] — rendered in stack frames
+    /// as `at name (label:line:col)` so an embedder can resolve the frame back
+    /// to a file. `None` for unlabeled compilations (plain scripts, eval).
+    pub source_label: Option<Rc<str>>,
     /// Whether this function references `arguments`.
     pub uses_arguments: bool,
     /// Names of the positional params, for `arguments`/debug.
@@ -269,6 +274,7 @@ impl FuncProto {
             source_start: 0,
             source_line: 0,
             source_col: 0,
+            source_label: None,
             uses_arguments: false,
             param_names: Vec::new(),
             mapped_param_cells: Vec::new(),

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -1648,6 +1648,10 @@ impl Compiler {
         fc.strict = true;
         fc.script_global = false;
         fc.is_toplevel = true;
+        // Anchor the module body at its first byte so a throw during module
+        // evaluation renders `at <module> (its/path.ts:1:1)` — naming WHICH
+        // module failed to import — instead of a bare `at <module>`.
+        fc.source_start = Some(0);
         fc.contains_eval = self.source.contains("eval");
         let module_has_eval = fc.contains_eval;
         self.fns.push(fc);

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -52,6 +52,74 @@ fn decode_lone_surrogates(value: &str) -> JsString {
     JsString::from_code_units(&units)
 }
 
+/// Byte offset of each line start in `src` (`[0]` is always 0). Backs
+/// [`Compiler::line_col_of`], the per-compiled-function position lookup: that
+/// path runs once per function of every compiled source (a vendored bundle
+/// has thousands), so it needs an indexed table rather than miette's
+/// scan-from-the-start `read_span` (which is linear per lookup and fine for
+/// the parse-error path below, where at most a few diagnostics render).
+fn line_starts(src: &str) -> Vec<u32> {
+    let mut starts = vec![0u32];
+    for (i, b) in src.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push(i as u32 + 1);
+        }
+    }
+    starts
+}
+
+/// 1-based (line, column) of byte `offset` in `src`, given its line-start
+/// table. Columns count characters, not bytes.
+fn line_col_at(src: &str, starts: &[u32], offset: u32) -> (u32, u32) {
+    let offset = offset.min(src.len() as u32);
+    let line = starts.partition_point(|&s| s <= offset).max(1);
+    let start = starts[line - 1] as usize;
+    let col = src
+        .get(start..offset as usize)
+        .map(|s| s.chars().count())
+        .unwrap_or(0) as u32
+        + 1;
+    (line as u32, col)
+}
+
+/// Render one oxc diagnostic with the 1-based line/column of its primary
+/// label — `Unexpected token (line 3, column 7)` — so a parse error points at
+/// its source position instead of leaving the user to hunt for it. The span
+/// is resolved by miette (the diagnostic toolkit oxc's errors are built on).
+/// `line_offset` shifts reported lines up by that many wrapper lines (direct
+/// eval compiles inside a synthetic wrapper), clamped at line 1.
+fn render_diagnostic(src: &str, e: &oxc::diagnostics::OxcDiagnostic, line_offset: u32) -> String {
+    use miette::SourceCode as _;
+    let msg = e.to_string();
+    let Some(offset) = e
+        .labels
+        .as_ref()
+        .and_then(|l| l.first())
+        .map(|l| l.offset())
+    else {
+        return msg;
+    };
+    let Ok(span) = src.read_span(&miette::SourceSpan::new(offset.into(), 0), 0, 0) else {
+        return msg;
+    };
+    let line = (span.line() as u32 + 1).saturating_sub(line_offset).max(1);
+    let col = span.column() as u32 + 1;
+    format!("{msg} (line {line}, column {col})")
+}
+
+/// Render a diagnostic list (each with its position) joined with `"; "`.
+fn render_diagnostics(
+    src: &str,
+    errors: &[oxc::diagnostics::OxcDiagnostic],
+    line_offset: u32,
+) -> String {
+    errors
+        .iter()
+        .map(|e| render_diagnostic(src, e, line_offset))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 pub fn compile_script(src: &str) -> Result<FuncProto, String> {
     compile_script_impl(src, false, true, true)
 }
@@ -118,13 +186,10 @@ pub fn compile_script_kernels(src: &str, kernels: bool) -> Result<FuncProto, Str
     let source_type = SourceType::script();
     let ret = Parser::new(&allocator, src, source_type).parse();
     if !ret.errors.is_empty() {
-        let msg = ret
-            .errors
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(format!("SyntaxError: {msg}"));
+        return Err(format!(
+            "SyntaxError: {}",
+            render_diagnostics(src, &ret.errors, 0)
+        ));
     }
     let program = ret.program;
     let sem = oxc::semantic::SemanticBuilder::new()
@@ -133,11 +198,7 @@ pub fn compile_script_kernels(src: &str, kernels: bool) -> Result<FuncProto, Str
     if !sem.errors.is_empty() {
         return Err(format!(
             "SyntaxError: {}",
-            sem.errors
-                .iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join("; ")
+            render_diagnostics(src, &sem.errors, 0)
         ));
     }
     let mut c = Compiler::new();
@@ -161,13 +222,10 @@ pub fn compile_script_regs(src: &str, regs: bool) -> Result<FuncProto, String> {
     let source_type = SourceType::script();
     let ret = Parser::new(&allocator, src, source_type).parse();
     if !ret.errors.is_empty() {
-        let msg = ret
-            .errors
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(format!("SyntaxError: {msg}"));
+        return Err(format!(
+            "SyntaxError: {}",
+            render_diagnostics(src, &ret.errors, 0)
+        ));
     }
     let program = ret.program;
     let sem = oxc::semantic::SemanticBuilder::new()
@@ -176,11 +234,7 @@ pub fn compile_script_regs(src: &str, regs: bool) -> Result<FuncProto, String> {
     if !sem.errors.is_empty() {
         return Err(format!(
             "SyntaxError: {}",
-            sem.errors
-                .iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join("; ")
+            render_diagnostics(src, &sem.errors, 0)
         ));
     }
     let mut c = Compiler::new();
@@ -218,13 +272,10 @@ fn compile_script_impl(
     let source_type = SourceType::script();
     let ret = Parser::new(&allocator, src, source_type).parse();
     if !ret.errors.is_empty() {
-        let msg = ret
-            .errors
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(format!("SyntaxError: {msg}"));
+        return Err(format!(
+            "SyntaxError: {}",
+            render_diagnostics(src, &ret.errors, 0)
+        ));
     }
     let program = ret.program;
     // Semantic early-errors (duplicate lexical declarations, illegal `await`,
@@ -236,11 +287,7 @@ fn compile_script_impl(
     if !sem.errors.is_empty() {
         return Err(format!(
             "SyntaxError: {}",
-            sem.errors
-                .iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join("; ")
+            render_diagnostics(src, &sem.errors, 0)
         ));
     }
     let mut c = Compiler::new();
@@ -312,15 +359,18 @@ pub fn compile_direct_eval(src: &str, desc: &EvalScopeDesc) -> Result<CompiledEv
         Wrap::Method => format!("({{ m(){{\n{strict_prefix}{src}\n}} }})"),
     };
     let source_type = SourceType::script();
+    // Positions are computed against the wrapped text, then shifted back by
+    // the wrapper's leading lines so they land on the user's eval source.
+    let wrapper_lines = match wrap {
+        Wrap::None => 0,
+        Wrap::Function | Wrap::Method => 1,
+    } + u32::from(desc.strict);
     let ret = Parser::new(&allocator, &wrapped, source_type).parse();
     if !ret.errors.is_empty() {
-        let msg = ret
-            .errors
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(format!("SyntaxError: {msg}"));
+        return Err(format!(
+            "SyntaxError: {}",
+            render_diagnostics(&wrapped, &ret.errors, wrapper_lines)
+        ));
     }
     let program = ret.program;
     let sem = oxc::semantic::SemanticBuilder::new()
@@ -338,17 +388,18 @@ pub fn compile_direct_eval(src: &str, desc: &EvalScopeDesc) -> Result<CompiledEv
     let sem_errors: Vec<String> = sem
         .errors
         .iter()
-        .map(|e| e.to_string())
-        .filter(|msg| {
+        .filter(|e| {
+            let msg = e.to_string();
             let name = msg
                 .strip_prefix("Private identifier '#")
                 .or_else(|| msg.strip_prefix("Private field '#"))
-                .and_then(|r| r.split('\'').next());
+                .and_then(|r| r.split('\'').next().map(str::to_string));
             match name {
-                Some(n) => !seeded.contains(n),
+                Some(n) => !seeded.contains(n.as_str()),
                 None => true,
             }
         })
+        .map(|e| render_diagnostic(&wrapped, e, wrapper_lines))
         .collect();
     if !sem_errors.is_empty() {
         return Err(format!("SyntaxError: {}", sem_errors.join("; ")));
@@ -532,13 +583,10 @@ pub fn compile_module(src: &str) -> Result<crate::module::CompiledModule, String
     let source_type = SourceType::default().with_module(true);
     let ret = Parser::new(&allocator, src, source_type).parse();
     if !ret.errors.is_empty() {
-        let msg = ret
-            .errors
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(format!("SyntaxError: {msg}"));
+        return Err(format!(
+            "SyntaxError: {}",
+            render_diagnostics(src, &ret.errors, 0)
+        ));
     }
     let program = ret.program;
     let sem = oxc::semantic::SemanticBuilder::new()
@@ -547,11 +595,7 @@ pub fn compile_module(src: &str) -> Result<crate::module::CompiledModule, String
     if !sem.errors.is_empty() {
         return Err(format!(
             "SyntaxError: {}",
-            sem.errors
-                .iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join("; ")
+            render_diagnostics(src, &sem.errors, 0)
         ));
     }
     let mut c = Compiler::new();
@@ -710,6 +754,11 @@ struct FnCtx {
     templates: Vec<TemplateParts>,
     /// Object-literal templates (see [`crate::bytecode::ObjTemplate`]).
     obj_tpls: Vec<std::rc::Rc<crate::bytecode::ObjTemplate>>,
+    /// Byte offset of the function's definition site in `Compiler::source`
+    /// (the parameter list's span start). `None` for synthetic contexts
+    /// (toplevel scripts/modules, eval bodies, `%fieldinit`, …), which then
+    /// render in stack traces without a position.
+    source_start: Option<u32>,
 }
 
 impl FnCtx {
@@ -751,6 +800,7 @@ impl FnCtx {
             obj_tpls: Vec::new(),
             home_super: false,
             eval_scopes: Vec::new(),
+            source_start: None,
         }
     }
     fn alloc_cell(&mut self) -> u32 {
@@ -820,6 +870,10 @@ struct Compiler {
     /// for the word `arguments` — when absent, the per-call `arguments` object is
     /// not materialized (a hot-path win for the common case).
     source: String,
+    /// Byte offset of each line start in `source` (`[0]` is always 0). Built
+    /// lazily on the first function-position lookup (`line_col_of`), so
+    /// compilations that finish without one pay nothing.
+    line_starts: std::cell::OnceCell<Vec<u32>>,
     /// Escaping `var`/function names collected while compiling a SLOPPY
     /// direct-eval body (see `FnCtx::eval_sloppy`).
     eval_var_names: Vec<String>,
@@ -870,6 +924,7 @@ impl Compiler {
             module_requested: Vec::new(),
             is_module: false,
             source: String::new(),
+            line_starts: std::cell::OnceCell::new(),
             eval_var_names: Vec::new(),
             pending_method: false,
             in_class_body: false,
@@ -879,6 +934,13 @@ impl Compiler {
             kernelize: !cfg!(feature = "op-histogram"),
             regify: !cfg!(feature = "op-histogram"),
         }
+    }
+
+    /// 1-based (line, column) of byte `offset` in `self.source`, via the
+    /// lazily built line-start table. Columns count characters, not bytes.
+    fn line_col_of(&self, offset: u32) -> (u32, u32) {
+        let starts = self.line_starts.get_or_init(|| line_starts(&self.source));
+        line_col_at(&self.source, starts, offset)
     }
 
     /// Whether the source region `[start, end)` mentions `arguments` (the word).
@@ -1904,6 +1966,12 @@ impl Compiler {
         } else {
             None
         };
+        // Definition-site position for stack traces (0 = unknown: synthetic
+        // contexts, or a Compiler driven without its source text).
+        let (source_line, source_col) = match fc.source_start {
+            Some(off) if !self.source.is_empty() => self.line_col_of(off),
+            _ => (0, 0),
+        };
         FuncProto {
             eval_scopes: fc.eval_scopes.clone(),
             name: fc.name,
@@ -1928,7 +1996,9 @@ impl Compiler {
             has_rest: fc.has_rest,
             upvalues: fc.upvalues,
             kind: fc.kind,
-            source_start: 0,
+            source_start: fc.source_start.unwrap_or(0),
+            source_line,
+            source_col,
             uses_arguments: fc.uses_arguments,
             param_names: fc.param_names,
             mapped_param_cells: fc.mapped_param_cells,
@@ -5807,6 +5877,9 @@ impl Compiler {
         ctor_fields: Option<&[&PropertyDefinition]>,
     ) -> R {
         let mut fc = FnCtx::new(name.unwrap_or(""), kind);
+        // The parameter list's span start is the function's definition site —
+        // resolved to line/column in `finish` for error stack traces.
+        fc.source_start = Some(params.span.start);
         // A function defined inside a `with` block (directly or transitively)
         // resolves free identifiers against the captured with-scope chain.
         fc.enclosed_in_with = self

--- a/crates/chidori-js/src/compiler.rs
+++ b/crates/chidori-js/src/compiler.rs
@@ -578,6 +578,17 @@ pub fn compile_direct_eval(src: &str, desc: &EvalScopeDesc) -> Result<CompiledEv
 /// top-level `this` is `undefined`, and top-level declarations are lexical cells
 /// (NOT global-object properties).
 pub fn compile_module(src: &str) -> Result<crate::module::CompiledModule, String> {
+    compile_module_labeled(src, None)
+}
+
+/// As [`compile_module`], with a source label — the module's registry key or
+/// file path — stamped on every compiled function so stack frames render as
+/// `at name (label:line:col)` and an embedder can resolve a frame back to a
+/// file.
+pub fn compile_module_labeled(
+    src: &str,
+    label: Option<&str>,
+) -> Result<crate::module::CompiledModule, String> {
     use crate::module::*;
     let allocator = Allocator::default();
     let source_type = SourceType::default().with_module(true);
@@ -601,6 +612,7 @@ pub fn compile_module(src: &str) -> Result<crate::module::CompiledModule, String
     let mut c = Compiler::new();
     c.source = src.to_string();
     c.is_module = true;
+    c.source_label = label.map(Rc::from);
     let (proto, cell_of_name) = c.compile_module_toplevel(&program).map_err(|e| {
         if e.starts_with("SyntaxError") {
             e
@@ -874,6 +886,10 @@ struct Compiler {
     /// lazily on the first function-position lookup (`line_col_of`), so
     /// compilations that finish without one pay nothing.
     line_starts: std::cell::OnceCell<Vec<u32>>,
+    /// Module key/path this compilation came from (see
+    /// [`compile_module_labeled`]) — stamped on every finished `FuncProto` so
+    /// stack frames can name their source.
+    source_label: Option<Rc<str>>,
     /// Escaping `var`/function names collected while compiling a SLOPPY
     /// direct-eval body (see `FnCtx::eval_sloppy`).
     eval_var_names: Vec<String>,
@@ -925,6 +941,7 @@ impl Compiler {
             is_module: false,
             source: String::new(),
             line_starts: std::cell::OnceCell::new(),
+            source_label: None,
             eval_var_names: Vec::new(),
             pending_method: false,
             in_class_body: false,
@@ -1999,6 +2016,7 @@ impl Compiler {
             source_start: fc.source_start.unwrap_or(0),
             source_line,
             source_col,
+            source_label: self.source_label.clone(),
             uses_arguments: fc.uses_arguments,
             param_names: fc.param_names,
             mapped_param_cells: fc.mapped_param_cells,

--- a/crates/chidori-js/src/convert.rs
+++ b/crates/chidori-js/src/convert.rs
@@ -31,6 +31,34 @@ impl Vm {
         self.to_string_lossy(err)
     }
 
+    /// As [`Vm::error_to_string`], but when the thrown value carries frames
+    /// recorded during unwinding (see `Vm::record_unwind_frame`), append them —
+    /// multi-line `Name: message\n    at f (line:col)\n    at g (...)` output
+    /// for surfaces that show an uncaught error to a human. Values without
+    /// recorded frames render exactly as [`Vm::error_to_string`].
+    pub fn error_to_string_with_stack(&mut self, err: &Value) -> String {
+        let head = self.error_to_string(err);
+        if let Value::Object(o) = err {
+            let b = o.borrow();
+            if matches!(b.internal, Internal::Error) {
+                if let Some(prop) = b.own_get(&StrKeyRef("stack")) {
+                    if let PropertyKind::Data {
+                        value: Value::String(s),
+                        ..
+                    } = &prop.kind
+                    {
+                        if let Some(i) = s.as_str().find("\n    at ") {
+                            let mut out = head;
+                            out.push_str(&s.as_str()[i..]);
+                            return out;
+                        }
+                    }
+                }
+            }
+        }
+        head
+    }
+
     /// Engine value → JSON (host boundary). Mirrors `JSON.stringify` semantics
     /// for plain data; functions/symbols/undefined become `null`.
     pub fn value_to_json(&mut self, v: &Value) -> Json {

--- a/crates/chidori-js/src/exec.rs
+++ b/crates/chidori-js/src/exec.rs
@@ -3275,7 +3275,8 @@ impl Vm {
     /// stack path by construction: their protos contain suspension ops, which
     /// decline register translation.
     pub fn run_frame(&mut self, frame: Box<Frame>) -> Flow {
-        if let Some(reg) = &frame.func.proto.reg {
+        let proto = frame.func.proto.clone();
+        let flow = if let Some(reg) = &proto.reg {
             // Budgeted runs (the production op budget, the conformance
             // runner, untrusted eval) stay on the register tier too:
             // `RegProto::costs` charges each register op its EXACT
@@ -3288,9 +3289,17 @@ impl Vm {
                 frame.ip == 0 && frame.pending_throw.is_none() && frame.pending_return.is_none()
             );
             let reg = reg.clone();
-            return self.run_reg_frame(frame, &reg);
+            self.run_reg_frame(frame, &reg)
+        } else {
+            self.run_stack_frame(frame)
+        };
+        // A throw unwinding out of this activation records it on the error's
+        // `.stack`, so an uncaught error carries a real stack trace. Success
+        // pays only the `proto` Rc clone above.
+        if let Flow::Throw(e) = &flow {
+            self.record_unwind_frame(e, &proto);
         }
-        self.run_stack_frame(frame)
+        flow
     }
 
     fn run_stack_frame(&mut self, mut frame: Box<Frame>) -> Flow {

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -930,7 +930,7 @@ impl Engine {
         registry.modules.insert(entry.to_string(), rec.clone());
         self.vm
             .run_module_graph(&registry, entry)
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
         // Entrypoint: whatever `run(...)` captured, else the named export.
         let handler = slot.borrow().clone().or_else(|| {
             cell_of_name
@@ -945,11 +945,11 @@ impl Engine {
         let ret = self
             .vm
             .call(handler, Value::Undefined, &[arg, chidori])
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
         let settled = self
             .vm
             .settle(ret)
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
         Ok(self.vm.value_to_json(&settled))
     }
 
@@ -1000,7 +1000,7 @@ impl Engine {
 
         self.vm
             .run_module_graph(&registry, entry_key)
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
 
         let entry_rec = entry_rec.ok_or_else(|| "entry module was not loaded".to_string())?;
         let cell_of_name =
@@ -1019,11 +1019,11 @@ impl Engine {
         let ret = self
             .vm
             .call(handler, Value::Undefined, &[arg, chidori])
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
         let settled = self
             .vm
             .settle(ret)
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
         Ok(self.vm.value_to_json(&settled))
     }
 
@@ -1068,7 +1068,7 @@ impl Engine {
 
         self.vm
             .run_module_graph(&registry, entry_key)
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
 
         let entry_rec = entry_rec.ok_or_else(|| "entry module was not loaded".to_string())?;
         let cell_of_name =
@@ -1080,7 +1080,7 @@ impl Engine {
         let settled = self
             .vm
             .settle(val)
-            .map_err(|e| self.vm.error_to_string(&e))?;
+            .map_err(|e| self.vm.error_to_string_with_stack(&e))?;
         Ok(self.vm.value_to_json(&settled))
     }
 }

--- a/crates/chidori-js/src/lib.rs
+++ b/crates/chidori-js/src/lib.rs
@@ -978,7 +978,7 @@ impl Engine {
             if registry.modules.contains_key(&key) {
                 continue;
             }
-            let compiled = compiler::compile_module(&src)
+            let compiled = compiler::compile_module_labeled(&src, Some(&key))
                 .map_err(|e| format!("compiling module '{key}': {e}"))?;
             let cell_of_name = compiled.cell_of_name.clone();
             let requested = compiled.requested.clone();
@@ -1046,7 +1046,7 @@ impl Engine {
             if registry.modules.contains_key(&key) {
                 continue;
             }
-            let compiled = compiler::compile_module(&src)
+            let compiled = compiler::compile_module_labeled(&src, Some(&key))
                 .map_err(|e| format!("compiling module '{key}': {e}"))?;
             let cell_of_name = compiled.cell_of_name.clone();
             let requested = compiled.requested.clone();

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -777,7 +777,14 @@ impl Vm {
         out.push_str(name);
         if proto.source_line > 0 {
             use std::fmt::Write;
-            let _ = write!(out, " ({}:{})", proto.source_line, proto.source_col);
+            match &proto.source_label {
+                Some(label) => {
+                    let _ = write!(out, " ({label}:{}:{})", proto.source_line, proto.source_col);
+                }
+                None => {
+                    let _ = write!(out, " ({}:{})", proto.source_line, proto.source_col);
+                }
+            }
         }
         *value = Value::str(out);
     }

--- a/crates/chidori-js/src/vm.rs
+++ b/crates/chidori-js/src/vm.rs
@@ -739,6 +739,49 @@ impl Vm {
         Value::Object(obj)
     }
 
+    /// Append `proto`'s activation to the `.stack` of a propagating exception.
+    /// Called by `run_frame` as a throw unwinds out of a frame, so an uncaught
+    /// error accumulates one `    at name (line:col)` line per JS frame it
+    /// crossed, innermost first — a stack trace built entirely on the unwind
+    /// path (the happy path pays nothing). The position is the function's
+    /// *definition* site (the engine keeps no per-op line table). Only `Error`
+    /// objects whose `stack` is still a plain string are annotated, and frames
+    /// stop accumulating once the trace is `MAX_UNWIND_FRAMES` deep (a rethrow
+    /// loop must not grow the string unboundedly).
+    pub(crate) fn record_unwind_frame(&self, err: &Value, proto: &crate::bytecode::FuncProto) {
+        const MAX_UNWIND_FRAMES: usize = 32;
+        let Value::Object(o) = err else { return };
+        let mut b = o.borrow_mut();
+        if !matches!(b.internal, Internal::Error) {
+            return;
+        }
+        let Some(prop) = b.own_get_mut(&crate::value::StrKeyRef("stack")) else {
+            return;
+        };
+        let PropertyKind::Data { value, .. } = &mut prop.kind else {
+            return;
+        };
+        let Value::String(s) = &*value else { return };
+        let cur = s.as_str();
+        if cur.matches("\n    at ").count() >= MAX_UNWIND_FRAMES {
+            return;
+        }
+        let name: &str = if proto.name.is_empty() {
+            "<anonymous>"
+        } else {
+            &proto.name
+        };
+        let mut out = String::with_capacity(cur.len() + name.len() + 24);
+        out.push_str(cur);
+        out.push_str("\n    at ");
+        out.push_str(name);
+        if proto.source_line > 0 {
+            use std::fmt::Write;
+            let _ = write!(out, " ({}:{})", proto.source_line, proto.source_col);
+        }
+        *value = Value::str(out);
+    }
+
     pub fn throw_type(&self, msg: &str) -> Value {
         self.make_error(ErrorKind::Type, msg)
     }

--- a/crates/chidori-js/tests/errors.rs
+++ b/crates/chidori-js/tests/errors.rs
@@ -1,0 +1,100 @@
+//! Error-reporting DX: line/column on parse errors, and stack traces on
+//! runtime errors (recorded on `.stack` as the exception unwinds — see
+//! `Vm::record_unwind_frame`). Positions on stack frames are the function's
+//! *definition* site (the engine keeps no per-op line table).
+
+use chidori_js::Engine;
+
+fn run(src: &str) -> String {
+    let mut e = Engine::new();
+    match e.eval(src) {
+        Ok(v) => e.vm.to_string_lossy(&v),
+        Err(err) => format!("ERR: {err}"),
+    }
+}
+
+#[test]
+fn parse_error_reports_line_and_column() {
+    let err = run("let x = 1;\nlet y = ;\n");
+    assert!(err.starts_with("ERR: SyntaxError:"), "got: {err}");
+    assert!(err.contains("(line 2, column 9)"), "got: {err}");
+}
+
+#[test]
+fn semantic_early_error_reports_line_and_column() {
+    // Duplicate lexical declaration is a semantic-pass early error.
+    let err = run("let a = 1;\nlet a = 2;");
+    assert!(err.starts_with("ERR: SyntaxError:"), "got: {err}");
+    assert!(
+        err.contains("line 2") || err.contains("line 1"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn parse_error_without_position_still_reports() {
+    // Whatever the diagnostic, the SyntaxError prefix survives.
+    let err = run("for (;;");
+    assert!(err.starts_with("ERR: SyntaxError:"), "got: {err}");
+}
+
+#[test]
+fn caught_error_stack_lists_frames_innermost_first() {
+    let stack = run("function inner() { throw new TypeError('boom'); }\n\
+         function outer() { inner(); }\n\
+         var s; try { outer(); } catch (e) { s = e.stack; } s");
+    let inner_at = stack.find("at inner (1:").expect(&stack);
+    let outer_at = stack.find("at outer (2:").expect(&stack);
+    assert!(stack.starts_with("TypeError: boom\n"), "got: {stack}");
+    assert!(inner_at < outer_at, "innermost first: {stack}");
+}
+
+#[test]
+fn uncaught_error_message_format_is_unchanged() {
+    // `Engine::eval` renders thrown values with `error_to_string` — the
+    // single-line `Name: message` shape is a compatibility contract for
+    // embedders; the frames live on `.stack` (and on the module entrypoint
+    // paths, which render with `error_to_string_with_stack`).
+    let err = run("function f(){ throw new TypeError('x'); } f();");
+    assert_eq!(err, "ERR: TypeError: x");
+}
+
+#[test]
+fn async_rejection_carries_frames() {
+    // The completion value is computed before microtasks drain, so observe
+    // the rejection through the console (captured after the drain).
+    let mut e = Engine::new();
+    e.eval(
+        "async function fails() { throw new Error('nope'); }\n\
+         fails().catch((e) => { console.log(e.stack); });",
+    )
+    .expect("eval ok");
+    let out = e.console().join("\n");
+    assert!(out.contains("at fails (1:"), "got: {out}");
+}
+
+#[test]
+fn thrown_non_error_values_are_untouched() {
+    assert_eq!(
+        run("function f(){ throw 'plain string'; } try { f(); } catch (e) { e }"),
+        "plain string"
+    );
+}
+
+#[test]
+fn rethrow_loop_stops_accumulating_frames_at_the_cap() {
+    let stack = run("var e = new RangeError('deep');\n\
+         function hop() { throw e; }\n\
+         for (let i = 0; i < 100; i++) { try { hop(); } catch (_) {} }\n\
+         e.stack");
+    let frames = stack.matches("\n    at ").count();
+    assert!(frames <= 32, "cap held: {frames} frames");
+    assert!(frames >= 30, "frames recorded up to the cap: {frames}");
+}
+
+#[test]
+fn anonymous_functions_render_as_anonymous() {
+    let stack = run("var s; try { (function () { throw new Error('x'); })(); } \
+         catch (e) { s = e.stack; } s");
+    assert!(stack.contains("at <anonymous> (1:"), "got: {stack}");
+}

--- a/crates/chidori/Cargo.toml
+++ b/crates/chidori/Cargo.toml
@@ -97,6 +97,10 @@ opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
 # `satisfies` in odd positions, and overload signatures. oxc parses to a real
 # AST and emits JS via codegen, so unsupported sugar can't slip through.
 oxc = { version = "0.133", features = ["transformer", "codegen", "semantic"] }
+# Generated→original position lookup for the codegen source maps that back
+# error-frame remapping (`CodegenReturn::map` is this crate's `SourceMap`;
+# the oxc facade does not re-export it).
+oxc_sourcemap = "6"
 nodejs-semver = "5.0.0"
 tar = "0.4.46"
 flate2 = "1.1.9"

--- a/crates/chidori/src/init.rs
+++ b/crates/chidori/src/init.rs
@@ -69,6 +69,10 @@ until it finishes. Tools live in `tools/`; a sample `reverse` tool is included.
       --input task="Reverse the word 'chidori' and tell me the result." \
       --tools tools
 
+Each tool call asks for a y/N approval at the terminal (the ask-by-default
+policy for running unfamiliar code). Add `--trusted` to skip the prompts —
+required when running non-interactively, where gated effects fail closed.
+
 Add your own tools under `tools/` and list their names in the agent's
 `.tools([...])` call. Set a provider key first (e.g. `ANTHROPIC_API_KEY` or
 `OPENAI_API_KEY`) — or just run `chidori model-login` to sign in with OpenRouter and
@@ -273,9 +277,11 @@ you want available in the agent's `.tools([...])` call, then invoke one with
 
 ## Running agents (CLI)
 
-- `chidori run <file.ts> [--input key=value] [--tools <dir>] [--trace] [--stream]`
+- `chidori run <file.ts> [--input key=value] [--tools <dir>] [--trusted] [--trace] [--stream]`
   — execute an agent. `--input` accepts `key=value` pairs or a JSON object;
-  `@file` loads a value from a file.
+  `@file` loads a value from a file. Powerful effects (tool calls, network,
+  workspace writes) ask for approval at the terminal by default; `--trusted`
+  skips the ask (required non-interactively, where gated effects fail closed).
 - `chidori chat [agent.ts]` — interactive REPL. With no file it chats with the
   model directly; with a file it drives the agent's `messages` input per turn.
 - `chidori demo` — interactive menu of example agents (several need no API key).
@@ -320,9 +326,13 @@ need no key at all.
 
 Agents run in a pure-Rust JavaScript sandbox — there is no raw shell or
 unfettered filesystem access. Effects that touch the outside world go through a
-policy layer. By default `chidori run` is permissive; `--untrusted` switches to
-deny-by-default (workspace reads allowed, writes and network denied unless
-approved). The workspace is always scoped to the project directory.
+policy layer. By default `chidori run` asks before powerful effects (tool
+calls, network, workspace writes) with a y/N prompt at the terminal; LLM
+prompts and pure compute never ask. Pass `--trusted` for the permissive
+allow-all behavior (needed for non-interactive runs, where gated effects fail
+closed), or `--untrusted` for deny-by-default (workspace reads allowed, writes
+and network denied outright). The workspace is always scoped to the project
+directory.
 "#;
 
 /// One file a template writes, relative to the target directory.

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -380,7 +380,7 @@ fn main() {
     // The isolate worker speaks a binary frame protocol over stdout, so it must
     // short-circuit before any of the normal startup path can write there.
     if let Commands::RunWorker = cli.command {
-        std::process::exit(match crate::runtime::isolate::worker::run() {
+        std::process::exit(match on_js_stack(crate::runtime::isolate::worker::run) {
             Ok(()) => 0,
             Err(e) => {
                 eprintln!("isolate worker error: {e}");
@@ -397,7 +397,60 @@ fn main() {
 
     // Commands that only do parsing/validation return exit code 2 on failure;
     // everything else returns 1. Success is 0.
-    let (result, parse_only) = match cli.command {
+    let (result, parse_only) = on_js_stack(move || dispatch_command(cli.command));
+
+    // Flush any buffered OTLP spans before the process exits. No-op when
+    // OTEL_EXPORTER_OTLP_ENDPOINT wasn't set.
+    crate::runtime::otel::shutdown_on_exit();
+
+    match result {
+        Ok(()) => std::process::exit(0),
+        Err(e) => {
+            report_cli_error(&e);
+            std::process::exit(if parse_only { 2 } else { 1 });
+        }
+    }
+}
+
+/// Run `f` on a thread with [`scheduler::JS_THREAD_STACK_BYTES`] of stack.
+/// The interpreter recurses on the native stack (its depth guard allows 2000
+/// JS frames), and the default main-thread stack aborts the whole process on
+/// deep-but-legal recursion instead of letting the guard throw its catchable
+/// RangeError — so every command body (and the isolate worker, whose agent
+/// also runs on its process main thread) executes on one big-stack thread.
+/// One thread per process: the thread-local compile/transpile caches stay
+/// warm for the command's whole lifetime.
+fn on_js_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .name("chidori-cmd".to_string())
+        .stack_size(scheduler::JS_THREAD_STACK_BYTES)
+        .spawn(f)
+        .expect("spawning the command thread")
+        .join()
+        .expect("command thread panicked")
+}
+
+/// Dispatch one parsed CLI command to its handler, returning its result and
+/// whether it is a parse/validation-only command (exit code 2 on failure).
+fn dispatch_command(command: Commands) -> (Result<()>, bool) {
+    // Confine error-report source snippets to the entry agent's workspace root
+    // (see `rust_engine::read_project_source`): a run/check names a `.ts` file,
+    // whose workspace root is where its modules live.
+    let entry_file = match &command {
+        Commands::Run { file, .. }
+        | Commands::Check { file }
+        | Commands::Resume { file, .. }
+        | Commands::Serve { file, .. } => Some(file.clone()),
+        Commands::Chat { agent, .. } => agent.clone(),
+        _ => None,
+    };
+    if let Some(file) = entry_file {
+        crate::runtime::rust_engine::set_display_project_root(
+            crate::runtime::typescript::transpile::find_workspace_root(&file),
+        );
+    }
+
+    match command {
         Commands::Run {
             file,
             input,
@@ -514,18 +567,6 @@ fn main() {
                 false,
             )
         }
-    };
-
-    // Flush any buffered OTLP spans before the process exits. No-op when
-    // OTEL_EXPORTER_OTLP_ENDPOINT wasn't set.
-    crate::runtime::otel::shutdown_on_exit();
-
-    match result {
-        Ok(()) => std::process::exit(0),
-        Err(e) => {
-            report_cli_error(&e);
-            std::process::exit(if parse_only { 2 } else { 1 });
-        }
     }
 }
 
@@ -552,8 +593,13 @@ fn report_cli_error(e: &anyhow::Error) {
     };
     // `{:#}` prints outer contexts first, so everything before the marker is
     // context ("resume refused: …") and everything after it is the thrown
-    // error's `Name: message` line plus the recorded `    at …` frames.
-    let body = &text[idx + "JavaScript exception: ".len()..];
+    // error's `Name: message` line plus the recorded `    at …` frames. The
+    // frames arrive in transpiled-bundle coordinates; remap them to the
+    // original TypeScript here, at the single display boundary.
+    let body = crate::runtime::rust_engine::remap_stack_frames(
+        &text[idx + "JavaScript exception: ".len()..],
+    );
+    let body = body.as_str();
     let context = text[..idx].trim_end().trim_end_matches(':');
 
     // Snippet: the innermost frame with a readable file anchors it, and every
@@ -563,7 +609,13 @@ fn report_cli_error(e: &anyhow::Error) {
     let frames: Vec<_> = body.lines().skip(1).filter_map(parse_stack_frame).collect();
     let snippet_source = frames.iter().find_map(|f| {
         let file = f.file?;
-        Some((file, std::fs::read_to_string(file).ok()?))
+        // Confined to the project root — see `read_project_source`. A frame's
+        // file is agent-controlled (via `.stack`); never render a snippet of
+        // something outside the project the operator is running.
+        Some((
+            file,
+            crate::runtime::rust_engine::read_project_source(file)?,
+        ))
     });
     let mut diagnostic = OxcDiagnostic::error(body.to_string());
     if let Some((file, source)) = &snippet_source {

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -531,14 +531,19 @@ fn main() {
 
 /// Print a failed command's error to stderr. An uncaught JavaScript exception
 /// (the `JavaScript exception:` framing from `runtime::rust_engine`, carrying
-/// the stack frames recorded on the thrown error's `.stack`) renders through
-/// miette's graphical report handler — the same presentation TypeScript parse
-/// errors already get — so runtime and compile-time failures read alike at
-/// the CLI. Every other error keeps the plain anyhow context chain. This is
-/// presentation only: the compact `JavaScript exception: …` string is what
-/// the durable records, `--stream` events, and server responses carry.
+/// the stack frames recorded on the thrown error's `.stack`, already remapped
+/// to original-source coordinates) renders through miette's graphical report
+/// handler — the same presentation TypeScript parse errors already get. The
+/// innermost frames that live in a readable source file additionally render
+/// as a labeled snippet of that file, one caret per frame, the way rustc
+/// points at code. Every other error keeps the plain anyhow context chain.
+/// This is presentation only: the compact `JavaScript exception: …` string is
+/// what the durable records, `--stream` events, and server responses carry.
 fn report_cli_error(e: &anyhow::Error) {
-    use oxc::diagnostics::{GraphicalReportHandler, GraphicalTheme, OxcDiagnostic};
+    use crate::runtime::rust_engine::parse_stack_frame;
+    use oxc::diagnostics::{
+        GraphicalReportHandler, GraphicalTheme, LabeledSpan, NamedSource, OxcDiagnostic,
+    };
 
     let text = format!("{e:#}");
     let Some(idx) = text.find("JavaScript exception: ") else {
@@ -550,12 +555,51 @@ fn report_cli_error(e: &anyhow::Error) {
     // error's `Name: message` line plus the recorded `    at …` frames.
     let body = &text[idx + "JavaScript exception: ".len()..];
     let context = text[..idx].trim_end().trim_end_matches(':');
-    let mut rendered = String::new();
+
+    // Snippet: the innermost frame with a readable file anchors it, and every
+    // frame in that same file becomes a labeled caret (capped so a deep
+    // same-file recursion stays readable).
+    const MAX_SNIPPET_LABELS: usize = 6;
+    let frames: Vec<_> = body.lines().skip(1).filter_map(parse_stack_frame).collect();
+    let snippet_source = frames.iter().find_map(|f| {
+        let file = f.file?;
+        Some((file, std::fs::read_to_string(file).ok()?))
+    });
+    let mut diagnostic = OxcDiagnostic::error(body.to_string());
+    if let Some((file, source)) = &snippet_source {
+        let mut seen = std::collections::HashSet::new();
+        let labels: Vec<LabeledSpan> = frames
+            .iter()
+            .filter(|f| f.file == Some(file))
+            .filter_map(|f| {
+                let offset = byte_offset_of(source, f.line, f.col)?;
+                seen.insert(offset).then(|| {
+                    LabeledSpan::new(
+                        Some(format!("at {}", f.name)),
+                        offset,
+                        identifier_len_at(source, offset).max(1),
+                    )
+                })
+            })
+            .take(MAX_SNIPPET_LABELS)
+            .collect();
+        if !labels.is_empty() {
+            diagnostic = diagnostic.with_labels(labels);
+        }
+    }
+
     let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-    if handler
-        .render_report(&mut rendered, &OxcDiagnostic::error(body.to_string()))
-        .is_err()
-    {
+    let mut rendered = String::new();
+    let ok = match snippet_source {
+        Some((file, source)) if diagnostic.labels.is_some() => {
+            let report = diagnostic.with_source_code(NamedSource::new(file, source));
+            handler
+                .render_report(&mut rendered, report.as_ref())
+                .is_ok()
+        }
+        _ => handler.render_report(&mut rendered, &diagnostic).is_ok(),
+    };
+    if !ok {
         eprintln!("Error: {text}");
         return;
     }
@@ -564,6 +608,36 @@ fn report_cli_error(e: &anyhow::Error) {
     } else {
         eprintln!("Error: {context}: uncaught JavaScript exception{rendered}");
     }
+}
+
+/// Byte offset of a 1-based (line, character-column) position in `src`.
+fn byte_offset_of(src: &str, line: u32, col: u32) -> Option<usize> {
+    let mut offset = 0usize;
+    for (i, l) in src.split_inclusive('\n').enumerate() {
+        if i + 1 == line as usize {
+            let mut bytes = 0usize;
+            for (n, c) in l.chars().enumerate() {
+                if n + 1 >= col as usize {
+                    break;
+                }
+                bytes += c.len_utf8();
+            }
+            return Some(offset + bytes);
+        }
+        offset += l.len();
+    }
+    None
+}
+
+/// Length in bytes of the identifier starting at `offset` (0 when the byte
+/// there doesn't start one) — so a frame label underlines the function name
+/// it points at rather than a single character.
+fn identifier_len_at(src: &str, offset: usize) -> usize {
+    src[offset..]
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '$')
+        .map(char::len_utf8)
+        .sum()
 }
 
 struct DemoExample {

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -523,9 +523,46 @@ fn main() {
     match result {
         Ok(()) => std::process::exit(0),
         Err(e) => {
-            eprintln!("Error: {e:#}");
+            report_cli_error(&e);
             std::process::exit(if parse_only { 2 } else { 1 });
         }
+    }
+}
+
+/// Print a failed command's error to stderr. An uncaught JavaScript exception
+/// (the `JavaScript exception:` framing from `runtime::rust_engine`, carrying
+/// the stack frames recorded on the thrown error's `.stack`) renders through
+/// miette's graphical report handler — the same presentation TypeScript parse
+/// errors already get — so runtime and compile-time failures read alike at
+/// the CLI. Every other error keeps the plain anyhow context chain. This is
+/// presentation only: the compact `JavaScript exception: …` string is what
+/// the durable records, `--stream` events, and server responses carry.
+fn report_cli_error(e: &anyhow::Error) {
+    use oxc::diagnostics::{GraphicalReportHandler, GraphicalTheme, OxcDiagnostic};
+
+    let text = format!("{e:#}");
+    let Some(idx) = text.find("JavaScript exception: ") else {
+        eprintln!("Error: {text}");
+        return;
+    };
+    // `{:#}` prints outer contexts first, so everything before the marker is
+    // context ("resume refused: …") and everything after it is the thrown
+    // error's `Name: message` line plus the recorded `    at …` frames.
+    let body = &text[idx + "JavaScript exception: ".len()..];
+    let context = text[..idx].trim_end().trim_end_matches(':');
+    let mut rendered = String::new();
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+    if handler
+        .render_report(&mut rendered, &OxcDiagnostic::error(body.to_string()))
+        .is_err()
+    {
+        eprintln!("Error: {text}");
+        return;
+    }
+    if context.is_empty() {
+        eprintln!("Error: uncaught JavaScript exception{rendered}");
+    } else {
+        eprintln!("Error: {context}: uncaught JavaScript exception{rendered}");
     }
 }
 

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -235,6 +235,14 @@ enum Commands {
         /// earlier point in its history (`docs/durable-storage.md`).
         #[arg(long)]
         until_seq: Option<u64>,
+
+        /// Edit-and-resume: proceed even though the agent source changed
+        /// since this run was recorded. Recorded calls replay positionally
+        /// against the edited code; an edit that touches already-replayed
+        /// calls fails loudly as a divergence, an edit past the pause point
+        /// resumes cleanly.
+        #[arg(long)]
+        allow_source_change: bool,
     },
 
     /// List a run's persisted `chidori.branch` sub-runs and their states.
@@ -458,7 +466,17 @@ fn main() {
             run_id,
             dir,
             until_seq,
-        } => (cmd_resume(&file, &run_id, dir.as_deref(), until_seq), false),
+            allow_source_change,
+        } => (
+            cmd_resume(
+                &file,
+                &run_id,
+                dir.as_deref(),
+                until_seq,
+                allow_source_change,
+            ),
+            false,
+        ),
         Commands::Branches { run_id, dir } => (cmd_branches(&run_id, dir.as_deref()), false),
         Commands::BranchResume {
             run_id,
@@ -1304,6 +1322,7 @@ fn cmd_resume(
     run_id: &str,
     dir: Option<&std::path::Path>,
     until_seq: Option<u64>,
+    allow_source_change: bool,
 ) -> Result<()> {
     let base_dir = dir
         .map(|d| d.to_path_buf())
@@ -1348,9 +1367,14 @@ fn cmd_resume(
     // source fingerprints recorded in the run's snapshot manifest, exactly as
     // the server resume routes do, so cached results are never paired with
     // changed code. (Runs persisted before manifests existed skip with a
-    // warning.)
-    crate::runtime::snapshot::validate_manifest_for_resume(&run_base, Some(run_id), file)
-        .context("resume refused: the agent source no longer matches this run's checkpoint")?;
+    // warning; `--allow-source-change` is the edit-and-resume opt-in.)
+    crate::runtime::snapshot::validate_manifest_for_resume(
+        &run_base,
+        Some(run_id),
+        file,
+        allow_source_change,
+    )
+    .context("resume refused: the agent source no longer matches this run's checkpoint")?;
 
     let providers = Arc::new(ProviderRegistry::from_env());
     let template_engine = Arc::new(TemplateEngine::new(&base_dir));
@@ -1369,7 +1393,7 @@ fn cmd_resume(
     eprintln!(
         "\nResumed from {} ({} calls replayed)",
         run_id,
-        result.call_log.total_duration_ms()
+        result.call_log.records().len()
     );
     Ok(())
 }

--- a/crates/chidori/src/runtime/call_log.rs
+++ b/crates/chidori/src/runtime/call_log.rs
@@ -84,7 +84,6 @@ impl CallLog {
         self.records.push(record);
     }
 
-    #[allow(dead_code)]
     pub fn records(&self) -> &[CallRecord] {
         &self.records
     }

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -9,7 +9,7 @@
 //! round-trip a self-describing blob of `{bundle, effects, journal}` rather than
 //! threading the bundle through the trait signature.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -117,6 +117,17 @@ pub(crate) fn run_agent(
     )
 }
 
+const ERROR_NAMES: &[&str] = &[
+    "Error",
+    "TypeError",
+    "RangeError",
+    "ReferenceError",
+    "SyntaxError",
+    "EvalError",
+    "URIError",
+    "AggregateError",
+];
+
 /// Reframe a chidori-js entrypoint error so an uncaught JS exception surfaces
 /// as `JavaScript exception: <message>` — the shape the durable format, the
 /// host-call span tree, and the SDKs expect. chidori-js stringifies a thrown
@@ -125,34 +136,96 @@ pub(crate) fn run_agent(
 /// apply the host framing. An error carrying stack frames (recorded on
 /// `.stack` during unwinding) keeps its class name: the multi-line shape is
 /// new, nothing parses its head line as a bare message, and `TypeError` vs
-/// `RangeError` is diagnostic signal the CLI report should show. Pause
-/// sentinels pass through untouched — they are control flow, not exceptions,
-/// and `engine.rs` / `host_core` detect them by substring.
+/// `RangeError` is diagnostic signal the CLI report should show.
+///
+/// Frames stay in their raw (transpiled-bundle) coordinates here; remapping to
+/// original TypeScript is a display concern applied ONCE at the human-facing
+/// boundary (`main::report_cli_error`, via [`remap_stack_frames`]). Doing it
+/// here instead would remap twice for nested execution — a tool/sub-agent
+/// error is framed by its own engine and then re-framed by the agent that
+/// awaited it — corrupting the already-remapped positions.
+///
+/// Idempotent: a nested error re-enters the awaiting engine as
+/// `Error: JavaScript exception: <inner>`, so an input already carrying this
+/// framing is collapsed rather than double-prefixed. Pause sentinels pass
+/// through untouched — control flow, not exceptions, detected by substring in
+/// `engine.rs` / `host_core`.
 fn js_exception_message(err: &str) -> String {
     if err.contains(crate::runtime::context::PAUSE_MARKER) {
         return err.to_string();
     }
-    if err.contains("\n    at ") {
-        return format!("JavaScript exception: {}", remap_stack_frames(err));
+    let (head, rest) = err.split_once('\n').unwrap_or((err, ""));
+    let bare = ERROR_NAMES
+        .iter()
+        .find_map(|n| head.strip_prefix(&format!("{n}: ")))
+        .unwrap_or(head);
+    // Already framed by a nested tool/sub-agent engine: collapse the layers so
+    // exactly one `JavaScript exception:` prefix survives, frames intact.
+    if let Some(inner) = bare.strip_prefix("JavaScript exception: ") {
+        return join_message(&format!("JavaScript exception: {inner}"), rest);
     }
-    const ERROR_NAMES: &[&str] = &[
-        "Error",
-        "TypeError",
-        "RangeError",
-        "ReferenceError",
-        "SyntaxError",
-        "EvalError",
-        "URIError",
-        "AggregateError",
-    ];
-    for name in ERROR_NAMES {
-        if let Some(rest) = err.strip_prefix(&format!("{name}: ")) {
-            return format!("JavaScript exception: {rest}");
-        }
+    if rest.is_empty() {
+        // Single line: strip the error class for the classic bare-message shape.
+        return format!("JavaScript exception: {bare}");
     }
+    // Frame-carrying: keep the class name (diagnostic signal for the report).
     format!("JavaScript exception: {err}")
 }
 
+/// Reattach a frame block (`rest`, everything after the first newline) to a
+/// rebuilt head line.
+fn join_message(head: &str, rest: &str) -> String {
+    if rest.is_empty() {
+        head.to_string()
+    } else {
+        format!("{head}\n{rest}")
+    }
+}
+
+thread_local! {
+    /// The directory tree stack-frame source reads are confined to (see
+    /// [`read_project_source`]). Set to the entry agent's workspace root at the
+    /// start of each JS-running CLI command; unset (falls back to the current
+    /// directory) in the library and tests that don't establish one.
+    static DISPLAY_PROJECT_ROOT: std::cell::RefCell<Option<PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Confine stack-frame source reads to `root` (the entry agent's workspace
+/// root). Called once as a JS-running command starts, so error rendering can
+/// read the agent's own files — wherever on disk they live — while still
+/// refusing paths outside the project. See [`read_project_source`].
+#[allow(dead_code)] // Called from the `chidori` binary; dead in the lib-only build.
+pub(crate) fn set_display_project_root(root: PathBuf) {
+    DISPLAY_PROJECT_ROOT.with(|r| *r.borrow_mut() = Some(root));
+}
+
+/// Read a stack-frame's source file, but ONLY when it resolves inside the
+/// project (the entry agent's workspace root, or the current directory when no
+/// root was set). A frame's file comes from the thrown error's `.stack`, which
+/// agent code can overwrite with any string — an unconfined read would let a
+/// hostile agent dump an arbitrary file (`/etc/passwd`, an env-file) into the
+/// operator's terminal as a bogus "source snippet". Genuine engine frames name
+/// modules the run loaded, all under the workspace root, so they still
+/// resolve; `node:` shims and spoofed paths that escape the root do not.
+/// Returns `None` when the path is unreadable, escapes the root, or the root
+/// can't be determined.
+#[allow(dead_code)] // Used by the binary (main::report_cli_error) and tests.
+pub(crate) fn read_project_source(file: &str) -> Option<String> {
+    let root = DISPLAY_PROJECT_ROOT
+        .with(|r| r.borrow().clone())
+        .or_else(|| std::env::current_dir().ok())?
+        .canonicalize()
+        .ok()?;
+    let full = Path::new(file).canonicalize().ok()?;
+    full.starts_with(&root)
+        .then(|| std::fs::read_to_string(&full).ok())
+        .flatten()
+}
+
+// Used by the `chidori` binary (main::report_cli_error) and tests; the lib
+// target compiles the module tree without main.rs, so it sees these as dead.
+#[allow(dead_code)]
 /// One parsed `    at name (file:line:col)` stack-frame line. `file` is the
 /// engine's module key — the real path for agent files, `node:x` for builtin
 /// shims — and is `None` for unlabeled frames (`at f (3:1)` / bare `at f`).
@@ -163,6 +236,9 @@ pub(crate) struct StackFrame<'a> {
     pub(crate) col: u32,
 }
 
+// Used by the `chidori` binary (main::report_cli_error) and tests; the lib
+// target compiles the module tree without main.rs, so it sees these as dead.
+#[allow(dead_code)]
 /// Parse one frame line as rendered by `chidori_js`'s unwind recorder.
 pub(crate) fn parse_stack_frame(line: &str) -> Option<StackFrame<'_>> {
     let rest = line.strip_prefix("    at ")?;
@@ -194,14 +270,19 @@ pub(crate) fn parse_stack_frame(line: &str) -> Option<StackFrame<'_>> {
     }
 }
 
+// Used by the `chidori` binary (main::report_cli_error) and tests; the lib
+// target compiles the module tree without main.rs, so it sees these as dead.
+#[allow(dead_code)]
 /// Rewrite the `    at name (file:line:col)` frames of an uncaught-exception
 /// message from transpiled coordinates into positions in the original
 /// TypeScript, via each module's codegen source map (see
-/// `transpile::remap_to_original`). Frames whose file can't be read or
-/// remapped — `node:` shims, vendored modules, synthetic sources — pass
-/// through unchanged. Error path only: each distinct file re-runs the
-/// transpile pipeline once with map generation on.
-fn remap_stack_frames(err: &str) -> String {
+/// `transpile::remap_to_original`). Frames whose file can't be read (confined
+/// to the project root — see [`read_project_source`]) or remapped — `node:`
+/// shims, vendored modules, synthetic or agent-spoofed sources — pass through
+/// unchanged. Applied ONCE at the display boundary (the frames arrive here in
+/// uniform transpiled coordinates); error path only, so each distinct file
+/// re-runs the transpile pipeline once with map generation on.
+pub(crate) fn remap_stack_frames(err: &str) -> String {
     use std::collections::HashMap;
     let mut sources: HashMap<&str, Option<String>> = HashMap::new();
     let mut out = String::with_capacity(err.len());
@@ -213,7 +294,7 @@ fn remap_stack_frames(err: &str) -> String {
             let file = frame.file?;
             let source = sources
                 .entry(file)
-                .or_insert_with(|| std::fs::read_to_string(file).ok())
+                .or_insert_with(|| read_project_source(file))
                 .as_deref()?;
             let pos = crate::runtime::typescript::transpile::remap_to_original(
                 Path::new(file),
@@ -1014,6 +1095,99 @@ impl SnapshotCapableJsEngine for RustReplayEngine {
 }
 
 #[cfg(test)]
+mod frame_tests {
+    use super::{js_exception_message, parse_stack_frame, read_project_source};
+
+    #[test]
+    fn parses_labeled_and_bare_and_node_frames() {
+        let f = parse_stack_frame("    at validate (agent.ts:6:10)").unwrap();
+        assert_eq!(
+            (f.name, f.file, f.line, f.col),
+            ("validate", Some("agent.ts"), 6, 10)
+        );
+        // A `node:` key contains its own colon — the file must survive intact.
+        let n = parse_stack_frame("    at read (node:fs:3:5)").unwrap();
+        assert_eq!(
+            (n.name, n.file, n.line, n.col),
+            ("read", Some("node:fs"), 3, 5)
+        );
+        // Unlabeled position (plain script / eval): file is None.
+        let b = parse_stack_frame("    at f (3:1)").unwrap();
+        assert_eq!((b.name, b.file, b.line, b.col), ("f", None, 3, 1));
+        // A method-name with spaces (`get x`) keeps the whole name.
+        let g = parse_stack_frame("    at get missing (c.ts:2:7)").unwrap();
+        assert_eq!(g.name, "get missing");
+        // Non-frame lines are rejected.
+        assert!(parse_stack_frame("TypeError: boom").is_none());
+        assert!(parse_stack_frame("    at nope").is_none());
+    }
+
+    #[test]
+    fn single_line_error_strips_class_to_bare_message() {
+        assert_eq!(
+            js_exception_message("TypeError: x is not a function"),
+            "JavaScript exception: x is not a function"
+        );
+        // A thrown non-Error string has no class prefix; it is framed verbatim.
+        assert_eq!(
+            js_exception_message("plain string"),
+            "JavaScript exception: plain string"
+        );
+    }
+
+    #[test]
+    fn frame_carrying_error_keeps_class_name() {
+        let framed = js_exception_message("TypeError: boom\n    at f (a.ts:1:1)");
+        assert_eq!(
+            framed,
+            "JavaScript exception: TypeError: boom\n    at f (a.ts:1:1)"
+        );
+    }
+
+    #[test]
+    fn nested_framing_is_idempotent_not_double_prefixed() {
+        // A tool/sub-agent error re-enters the awaiting engine wrapped as
+        // `Error: JavaScript exception: <inner>` — collapse to one prefix,
+        // frames preserved in their raw coordinates (remap is display-time).
+        let nested = "Error: JavaScript exception: RangeError: division by zero\n\
+                      \x20   at run (tools/divide.ts:7:23)\n\
+                      \x20   at <anonymous> (agent.ts:2:5)";
+        let out = js_exception_message(nested);
+        assert_eq!(
+            out,
+            "JavaScript exception: RangeError: division by zero\n\
+             \x20   at run (tools/divide.ts:7:23)\n\
+             \x20   at <anonymous> (agent.ts:2:5)"
+        );
+        // Feeding the result back in is a fixed point.
+        assert_eq!(js_exception_message(&out), out);
+    }
+
+    #[test]
+    fn project_source_read_is_confined_to_the_project_root() {
+        use super::set_display_project_root;
+        // Establish an explicit root (thread-local; not cwd-dependent, so it
+        // survives test-thread reuse) with one file inside it.
+        let root = std::env::temp_dir().join(format!("chidori-confine-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let inside = root.join("agent.ts");
+        std::fs::write(&inside, "// hi\n").unwrap();
+        set_display_project_root(root.canonicalize().unwrap());
+
+        // A file inside the root resolves…
+        assert_eq!(
+            read_project_source(inside.to_str().unwrap()).as_deref(),
+            Some("// hi\n")
+        );
+        // …but an absolute path escaping the root (an agent-spoofed frame) is
+        // refused even though it exists and is readable.
+        assert!(read_project_source("/etc/hostname").is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Arc;
@@ -1167,19 +1341,38 @@ mod tests {
         let err = run_agent(&path, src, &serde_json::json!({}), &backend)
             .unwrap_err()
             .to_string();
+        // Confine snippet reads to this run's temp dir, as the CLI confines to
+        // the agent's workspace root.
+        super::set_display_project_root(dir.clone());
 
         assert!(
             err.starts_with("JavaScript exception: TypeError: bad row: x"),
             "frame-carrying errors keep the class name: {err}"
         );
         let path_str = path.to_string_lossy();
+        // The engine boundary carries raw (transpiled-bundle) frames with
+        // real file labels; remapping to original TypeScript is applied once
+        // at display. Both frames name the agent file with SOME position.
         assert!(
-            err.contains(&format!("at validate ({path_str}:6:")),
-            "innermost frame remaps to the original definition line: {err}"
+            err.contains(&format!("at validate ({path_str}:")),
+            "innermost frame is labeled with its module: {err}"
         );
         assert!(
-            err.contains(&format!("at lookup ({path_str}:10:")),
-            "caller frame remaps too: {err}"
+            err.contains(&format!("at lookup ({path_str}:")),
+            "caller frame is labeled too: {err}"
+        );
+
+        // Display-time remap lands both frames on their original definition
+        // lines (validate on 6, lookup on 10), past the interface block that
+        // only exists in the original TypeScript.
+        let remapped = remap_stack_frames(&err);
+        assert!(
+            remapped.contains(&format!("at validate ({path_str}:6:")),
+            "innermost frame remaps to the original definition line: {remapped}"
+        );
+        assert!(
+            remapped.contains(&format!("at lookup ({path_str}:10:")),
+            "caller frame remaps too: {remapped}"
         );
 
         let _ = std::fs::remove_dir_all(dir);

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -120,12 +120,20 @@ pub(crate) fn run_agent(
 /// Reframe a chidori-js entrypoint error so an uncaught JS exception surfaces
 /// as `JavaScript exception: <message>` — the shape the durable format, the
 /// host-call span tree, and the SDKs expect. chidori-js stringifies a thrown
-/// `Error` as `"<Name>: <message>"`; we strip the standard error-class prefix
-/// to recover the bare message and apply the host framing. Pause sentinels pass through untouched — they are control
-/// flow, not exceptions, and `engine.rs` / `host_core` detect them by substring.
+/// `Error` as `"<Name>: <message>"`; for the classic single-line shape we
+/// strip the standard error-class prefix to recover the bare message and
+/// apply the host framing. An error carrying stack frames (recorded on
+/// `.stack` during unwinding) keeps its class name: the multi-line shape is
+/// new, nothing parses its head line as a bare message, and `TypeError` vs
+/// `RangeError` is diagnostic signal the CLI report should show. Pause
+/// sentinels pass through untouched — they are control flow, not exceptions,
+/// and `engine.rs` / `host_core` detect them by substring.
 fn js_exception_message(err: &str) -> String {
     if err.contains(crate::runtime::context::PAUSE_MARKER) {
         return err.to_string();
+    }
+    if err.contains("\n    at ") {
+        return format!("JavaScript exception: {err}");
     }
     const ERROR_NAMES: &[&str] = &[
         "Error",

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -133,7 +133,7 @@ fn js_exception_message(err: &str) -> String {
         return err.to_string();
     }
     if err.contains("\n    at ") {
-        return format!("JavaScript exception: {err}");
+        return format!("JavaScript exception: {}", remap_stack_frames(err));
     }
     const ERROR_NAMES: &[&str] = &[
         "Error",
@@ -151,6 +151,87 @@ fn js_exception_message(err: &str) -> String {
         }
     }
     format!("JavaScript exception: {err}")
+}
+
+/// One parsed `    at name (file:line:col)` stack-frame line. `file` is the
+/// engine's module key — the real path for agent files, `node:x` for builtin
+/// shims — and is `None` for unlabeled frames (`at f (3:1)` / bare `at f`).
+pub(crate) struct StackFrame<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) file: Option<&'a str>,
+    pub(crate) line: u32,
+    pub(crate) col: u32,
+}
+
+/// Parse one frame line as rendered by `chidori_js`'s unwind recorder.
+pub(crate) fn parse_stack_frame(line: &str) -> Option<StackFrame<'_>> {
+    let rest = line.strip_prefix("    at ")?;
+    let open = rest.rfind(" (")?;
+    let name = &rest[..open];
+    let pos = rest[open + 2..].strip_suffix(')')?;
+    // Split from the right: `col`, `line`, then everything left (which may
+    // itself contain `:`, e.g. `node:fs` or a Windows drive) is the file.
+    let (rest_pos, col) = pos.rsplit_once(':')?;
+    let col: u32 = col.parse().ok()?;
+    match rest_pos.rsplit_once(':') {
+        Some((file, line)) => match line.parse::<u32>() {
+            Ok(line) => Some(StackFrame {
+                name,
+                file: Some(file),
+                line,
+                col,
+            }),
+            // `node:fs:3` style keys parse above; a non-numeric middle means
+            // the whole `rest_pos` was a lineless label — not a frame we know.
+            Err(_) => None,
+        },
+        None => rest_pos.parse::<u32>().ok().map(|line| StackFrame {
+            name,
+            file: None,
+            line,
+            col,
+        }),
+    }
+}
+
+/// Rewrite the `    at name (file:line:col)` frames of an uncaught-exception
+/// message from transpiled coordinates into positions in the original
+/// TypeScript, via each module's codegen source map (see
+/// `transpile::remap_to_original`). Frames whose file can't be read or
+/// remapped — `node:` shims, vendored modules, synthetic sources — pass
+/// through unchanged. Error path only: each distinct file re-runs the
+/// transpile pipeline once with map generation on.
+fn remap_stack_frames(err: &str) -> String {
+    use std::collections::HashMap;
+    let mut sources: HashMap<&str, Option<String>> = HashMap::new();
+    let mut out = String::with_capacity(err.len());
+    for (i, line) in err.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let remapped = parse_stack_frame(line).and_then(|frame| {
+            let file = frame.file?;
+            let source = sources
+                .entry(file)
+                .or_insert_with(|| std::fs::read_to_string(file).ok())
+                .as_deref()?;
+            let pos = crate::runtime::typescript::transpile::remap_to_original(
+                Path::new(file),
+                source,
+                frame.line,
+                frame.col,
+            )?;
+            Some(format!(
+                "    at {} ({file}:{}:{})",
+                frame.name, pos.line, pos.column
+            ))
+        });
+        match remapped {
+            Some(frame) => out.push_str(&frame),
+            None => out.push_str(line),
+        }
+    }
+    out
 }
 
 /// Run a nested TypeScript **tool** file natively on the rust engine (G4).
@@ -1056,6 +1137,50 @@ mod tests {
             .get("hash")
             .and_then(|v| v.as_str())
             .is_some_and(|h| h.len() == 64));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn uncaught_exception_frames_carry_original_source_positions() {
+        let dir = std::env::temp_dir().join(format!("chidori-frames-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        // The interface block only exists in the original TypeScript — the
+        // frames must still point at the original lines (validate on 6,
+        // lookup on 10), proving the source-map remap ran.
+        let src = "import { chidori, run } from \"chidori:agent\";\n\
+                   interface Row {\n\
+                   \x20 id: string;\n\
+                   }\n\n\
+                   function validate(row: Row): Row {\n\
+                   \x20 throw new TypeError(\"bad row: \" + row.id);\n\
+                   }\n\n\
+                   function lookup(row: Row): Row {\n\
+                   \x20 return validate(row);\n\
+                   }\n\n\
+                   run(async () => lookup({ id: \"x\" }));\n";
+        std::fs::write(&path, src).unwrap();
+
+        let ctx = RuntimeContext::new();
+        let backend = test_backend(ctx, Arc::new(ToolRegistry::new()));
+        let err = run_agent(&path, src, &serde_json::json!({}), &backend)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.starts_with("JavaScript exception: TypeError: bad row: x"),
+            "frame-carrying errors keep the class name: {err}"
+        );
+        let path_str = path.to_string_lossy();
+        assert!(
+            err.contains(&format!("at validate ({path_str}:6:")),
+            "innermost frame remaps to the original definition line: {err}"
+        );
+        assert!(
+            err.contains(&format!("at lookup ({path_str}:10:")),
+            "caller frame remaps too: {err}"
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/crates/chidori/src/runtime/snapshot.rs
+++ b/crates/chidori/src/runtime/snapshot.rs
@@ -966,10 +966,20 @@ impl SnapshotManifest {
 /// `chidori resume` CLI) must call this first. Runs persisted before manifests
 /// existed (no readable manifest) are tolerated with a warning; every other
 /// mismatch is an error the caller should surface.
+///
+/// `allow_source_change` is the edit-and-resume opt-in (`--allow-source-change`
+/// on the CLI, `"allow_source_change": true` on the server routes): source and
+/// module fingerprint mismatches downgrade to a warning and the resume
+/// proceeds, relying on the replay engine's own edit-conflict policy — an edit
+/// that touches already-journaled calls is a fail-loud divergence error, while
+/// an edit past the replay frontier resumes cleanly (see
+/// `chidori_js::replay`). ABI and policy mismatches stay fatal either way:
+/// those are environment drift, not a deliberate edit.
 pub fn validate_manifest_for_resume(
     run_base: &Path,
     run_id: Option<&str>,
     agent_path: &Path,
+    allow_source_change: bool,
 ) -> Result<()> {
     let Some(run_id) = run_id else {
         return Ok(());
@@ -1016,13 +1026,28 @@ pub fn validate_manifest_for_resume(
             &expected_policy,
         )?
     };
-    manifest.ensure_resume_compatible(
-        &expected_abi,
-        &expected_policy,
-        &current_entry,
-        &current_modules,
-        &current_module_graph,
-    )
+    manifest.abi.ensure_compatible(&expected_abi)?;
+    manifest.policy.ensure_compatible(&expected_policy)?;
+    let sources = manifest
+        .ensure_sources_match(&current_entry)
+        .and_then(|()| manifest.ensure_modules_match(&current_modules))
+        .and_then(|()| manifest.ensure_module_graph_matches(&current_module_graph));
+    match sources {
+        Ok(()) => Ok(()),
+        Err(err) if allow_source_change => {
+            tracing::warn!(
+                "resume: agent source changed since run {run_id} was recorded; proceeding \
+                 because the caller opted in (allow_source_change) — replay will fail loudly \
+                 if the edit diverges from already-journaled calls: {err}"
+            );
+            Ok(())
+        }
+        Err(err) => Err(err.context(
+            "the agent source changed since this run was recorded; edit-and-resume is \
+             opt-in — pass --allow-source-change (CLI) or \"allow_source_change\": true \
+             (server) to replay the recorded calls against the edited code",
+        )),
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/chidori/src/runtime/typescript/transpile.rs
+++ b/crates/chidori/src/runtime/typescript/transpile.rs
@@ -96,8 +96,8 @@ pub fn transpile_module(path: &Path, source: &str, options: &TranspileOptions) -
     // between calls with identical source and must never be cached.
     validate_imports(path, source, options.import_policy)?;
 
-    // The oxc pipeline below (parse → semantic → transform → codegen → strip →
-    // collapse) is a pure function of `(path, source)` — the transform options
+    // The oxc pipeline below (parse → semantic → transform → codegen → strip)
+    // is a pure function of `(path, source)` — the transform options
     // are compile-time constants and nothing reads the environment — so its
     // output is memoized process-wide. This is the dominant fixed cost paid on
     // EVERY agent execution: initial runs, every pause→resume re-execution,
@@ -174,6 +174,26 @@ fn render_diagnostics(
 
 /// The pure transpile pipeline (no import validation, no filesystem access).
 fn transpile_source(path: &Path, source: &str) -> Result<String> {
+    Ok(transpile_source_impl(path, source, false)?.0)
+}
+
+/// As [`transpile_source`], additionally returning the codegen source map
+/// (original TypeScript → emitted JavaScript). Used by [`remap_to_original`]
+/// on the error path; the hot execution path skips map generation.
+pub fn transpile_source_with_map(
+    path: &Path,
+    source: &str,
+) -> Result<(String, oxc_sourcemap::SourceMap)> {
+    let (js, map) = transpile_source_impl(path, source, true)?;
+    map.map(|m| (js, m))
+        .ok_or_else(|| anyhow::anyhow!("codegen produced no source map"))
+}
+
+fn transpile_source_impl(
+    path: &Path,
+    source: &str,
+    with_map: bool,
+) -> Result<(String, Option<oxc_sourcemap::SourceMap>)> {
     // Treat input as TypeScript regardless of extension — agents may live in
     // `agent.ts` / `tools/*.ts` and the snapshot pipeline only calls us with TS.
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts());
@@ -223,14 +243,14 @@ fn transpile_source(path: &Path, source: &str) -> Result<String> {
         );
     }
 
-    // Emit no comments. The bundler collapses each top-level statement onto a
-    // single line (see `collapse_top_level_statements`); a surviving `//` line
-    // comment would then swallow the rest of that line — including closing
-    // braces — corrupting the bundle. Comments serve no runtime purpose, so we
-    // drop them at codegen rather than trying to rewrite them during collapse.
+    // Emit no comments — they serve no runtime purpose and keeping codegen
+    // output minimal keeps the transpile cache and error positions stable.
+    // When `with_map` is set, codegen also records the source map that error
+    // frames are remapped through (original .ts → emitted JS).
     let codegen_ret = Codegen::new()
         .with_options(CodegenOptions {
             comments: CommentOptions::disabled(),
+            source_map_path: with_map.then(|| path.to_path_buf()),
             ..CodegenOptions::default()
         })
         .build(&program);
@@ -239,128 +259,90 @@ fn transpile_source(path: &Path, source: &str) -> Result<String> {
     // ToolDefinition, etc.) — there's no real module at module-resolution time,
     // so any surviving `import ... from "chidori:agent"` would crash the loader.
     // oxc's TS pass elides import-of-type-only specifiers but keeps value
-    // imports, so we filter the remaining `from "chidori:agent"` lines out of
-    // the emitted code.
+    // imports, so we BLANK the remaining `from "chidori:agent"` lines in the
+    // emitted code — blanked rather than removed so every other line keeps its
+    // line number and the source map (hence error-frame remapping) stays valid.
+    //
+    // Note the emitted code is NOT collapsed onto one line per top-level
+    // statement anymore: nothing line-walks the transpiled output today, and
+    // preserving codegen's line structure is what lets runtime stack frames
+    // map back to real positions in the original TypeScript.
     let js = strip_chidori_sdk_imports(&codegen_ret.code);
-    // The snapshot bundler line-walks the output to rewrite `import` / `export`
-    // statements. oxc splits object literals and function bodies across many
-    // lines, so we join everything inside nested braces/parens/brackets onto
-    // the same line. That keeps each top-level statement on a single line
-    // while leaving string and template-literal contents untouched.
-    Ok(collapse_top_level_statements(&js))
+    Ok((js, codegen_ret.map))
 }
 
+/// Blank (not remove) each `chidori:agent` import line, preserving all other
+/// lines' positions.
 fn strip_chidori_sdk_imports(js: &str) -> String {
     let mut out = String::with_capacity(js.len());
     for line in js.lines() {
-        if is_chidori_sdk_import(line.trim_start()) {
-            continue;
+        if !is_chidori_sdk_import(line.trim_start()) {
+            out.push_str(line);
         }
-        out.push_str(line);
         out.push('\n');
     }
     out
 }
 
-/// Walk `js` and replace newlines that sit inside `{...}`, `(...)`, `[...]`,
-/// or template-literal interpolations with spaces, so each top-level
-/// statement ends up on a single line. Quoted strings and template-literal
-/// text are passed through untouched.
-fn collapse_top_level_statements(js: &str) -> String {
-    enum Mode {
-        Code,
-        DoubleQuote,
-        SingleQuote,
-        TemplateText,
-    }
-    let mut out = String::with_capacity(js.len());
-    let mut mode = Mode::Code;
-    let mut depth: i32 = 0;
-    // Stack of template literals we're currently inside, so we know when a `}`
-    // closes a `${...}` interpolation vs. an object/block.
-    let mut template_interp_starts: Vec<i32> = Vec::new();
-    let mut chars = js.chars().peekable();
-    while let Some(ch) = chars.next() {
-        match mode {
-            Mode::Code => match ch {
-                '"' => {
-                    mode = Mode::DoubleQuote;
-                    out.push(ch);
-                }
-                '\'' => {
-                    mode = Mode::SingleQuote;
-                    out.push(ch);
-                }
-                '`' => {
-                    mode = Mode::TemplateText;
-                    out.push(ch);
-                }
-                '{' | '(' | '[' => {
-                    depth += 1;
-                    out.push(ch);
-                }
-                '}' => {
-                    // If this `}` closes a `${...}` interpolation, drop back into the
-                    // surrounding template literal. The matching `${` already
-                    // incremented depth, so we always decrement here.
-                    depth -= 1;
-                    out.push(ch);
-                    if template_interp_starts
-                        .last()
-                        .is_some_and(|&start| start == depth + 1)
-                    {
-                        template_interp_starts.pop();
-                        mode = Mode::TemplateText;
-                    }
-                }
-                ')' | ']' => {
-                    depth -= 1;
-                    out.push(ch);
-                }
-                '\n' if depth > 0 => {
-                    out.push(' ');
-                }
-                _ => out.push(ch),
-            },
-            Mode::DoubleQuote => {
-                out.push(ch);
-                if ch == '\\' {
-                    if let Some(next) = chars.next() {
-                        out.push(next);
-                    }
-                } else if ch == '"' {
-                    mode = Mode::Code;
-                }
-            }
-            Mode::SingleQuote => {
-                out.push(ch);
-                if ch == '\\' {
-                    if let Some(next) = chars.next() {
-                        out.push(next);
-                    }
-                } else if ch == '\'' {
-                    mode = Mode::Code;
-                }
-            }
-            Mode::TemplateText => {
-                out.push(ch);
-                if ch == '\\' {
-                    if let Some(next) = chars.next() {
-                        out.push(next);
-                    }
-                } else if ch == '`' {
-                    mode = Mode::Code;
-                } else if ch == '$' && chars.peek() == Some(&'{') {
-                    let brace = chars.next().unwrap();
-                    out.push(brace);
-                    depth += 1;
-                    template_interp_starts.push(depth);
-                    mode = Mode::Code;
-                }
-            }
+/// A stack-frame position translated back into the original TypeScript file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OriginalPosition {
+    /// 1-based line in the original source.
+    pub line: u32,
+    /// 1-based character column in the original source.
+    pub column: u32,
+    /// Byte offset into the original source (for miette span labels).
+    pub offset: usize,
+}
+
+/// Translate a 1-based `(line, character-column)` position in the transpiled
+/// output of `source` back to the original TypeScript, via the codegen source
+/// map. This re-runs the transpile pipeline with map generation on — it is an
+/// error-path helper (a run renders at most a handful of frames), not
+/// something to call per executed function.
+pub fn remap_to_original(
+    path: &Path,
+    source: &str,
+    line: u32,
+    column: u32,
+) -> Option<OriginalPosition> {
+    let (js, map) = transpile_source_with_map(path, source).ok()?;
+    // The engine counts columns in characters; source-map columns are UTF-16
+    // code units. Convert against the transpiled line's text.
+    let gen_line0 = line.checked_sub(1)?;
+    let gen_text = js.lines().nth(gen_line0 as usize)?;
+    let gen_col16: u32 = gen_text
+        .chars()
+        .take(column.saturating_sub(1) as usize)
+        .map(|c| c.len_utf16() as u32)
+        .sum();
+    let table = map.generate_lookup_table();
+    let token = map.lookup_token(&table, gen_line0, gen_col16)?;
+    let src_line0 = token.get_src_line();
+    let src_col16 = token.get_src_col();
+    // UTF-16 column → byte offset + 1-based character column in the original.
+    let line_start: usize = source
+        .split_inclusive('\n')
+        .take(src_line0 as usize)
+        .map(str::len)
+        .sum();
+    let line_text = source[line_start..].split('\n').next().unwrap_or_default();
+    let mut units: u32 = 0;
+    let mut chars: u32 = 0;
+    let mut bytes: usize = 0;
+    for c in line_text.chars() {
+        if units >= src_col16 {
+            break;
         }
+        units += c.len_utf16() as u32;
+        chars += 1;
+        bytes += c.len_utf8();
     }
-    out
+    Some(OriginalPosition {
+        line: src_line0 + 1,
+        column: chars + 1,
+        offset: line_start + bytes,
+    })
 }
 
 pub fn validate_imports(
@@ -1162,6 +1144,60 @@ mod tests {
     /// Timing probe (not a CI assertion — run with `--ignored --nocapture`):
     /// prints the cold vs warm cost of `transpile_module` on a synthetic
     /// agent-sized source, i.e. the per-execution cost the cache removes.
+    #[test]
+    fn remap_recovers_original_positions_across_type_stripping() {
+        // The interface block and the type-only import vanish in the
+        // transpiled output, so `priced` sits on a different line there; the
+        // codegen source map takes its position back to the original line 6.
+        let source = "import type { ToolDefinition } from \"chidori:agent\";\n\
+                      interface Order {\n\
+                      \x20 total: number;\n\
+                      }\n\n\
+                      export function priced(o: Order): number {\n\
+                      \x20 return o.total;\n\
+                      }\n";
+        let path = Path::new("remap-test.ts");
+        let (js, _) = transpile_source_with_map(path, source).unwrap();
+        let (line0, text) = js
+            .lines()
+            .enumerate()
+            .find(|(_, l)| l.contains("function priced"))
+            .expect("transpiled output keeps the function");
+        assert_ne!(line0 + 1, 6, "the stripped types must shift the line");
+        let col0 = text.find("priced").unwrap();
+        let pos = remap_to_original(path, source, line0 as u32 + 1, col0 as u32 + 1)
+            .expect("position remaps");
+        assert_eq!(pos.line, 6, "definition maps back to the original line");
+        assert!(
+            source[pos.offset..].starts_with("priced")
+                || source[pos.offset..].starts_with("function priced")
+                || source[pos.offset..].starts_with("export function priced"),
+            "offset lands on the definition: {:?}",
+            &source[pos.offset..pos.offset + 20]
+        );
+    }
+
+    #[test]
+    fn stripped_sdk_import_lines_are_blanked_not_removed() {
+        // Blanking keeps every other line's number stable, which is what
+        // keeps the source map (and error-frame remapping) valid. The import
+        // must actually be used — oxc elides unused imports before the strip
+        // ever sees them.
+        let source = "import { chidori, run } from \"chidori:agent\";\n\
+                      export function f(): number {\n\
+                      \x20 return 1;\n\
+                      }\n\
+                      run(async () => f());\n";
+        let js = transpile_source(Path::new("blank-test.ts"), source).unwrap();
+        assert!(!js.contains("chidori:agent"), "sdk import stripped: {js}");
+        assert!(js.contains("run("), "the agent body survives: {js}");
+        assert_eq!(
+            js.lines().next(),
+            Some(""),
+            "the import line is blanked in place, not removed: {js}"
+        );
+    }
+
     #[test]
     #[ignore]
     fn transpile_cache_timing_probe() {

--- a/crates/chidori/src/runtime/typescript/transpile.rs
+++ b/crates/chidori/src/runtime/typescript/transpile.rs
@@ -146,6 +146,32 @@ fn transpile_cache() -> &'static std::sync::Mutex<TranspileCache> {
     CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
+/// Render oxc diagnostics through miette's graphical report handler (the
+/// diagnostic toolkit oxc's errors are built on): each error shows its
+/// `file:line:column`, the offending source line, and a caret under the exact
+/// span — instead of a bare message that leaves the user hunting for the
+/// position. Unicode box-drawing, no ANSI color (output lands in error chains
+/// and logs, not always a terminal).
+fn render_diagnostics(
+    path: &Path,
+    source: &str,
+    errors: &[oxc::diagnostics::OxcDiagnostic],
+) -> String {
+    use oxc::diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+    let mut out = String::new();
+    for err in errors {
+        let report = err
+            .clone()
+            .with_source_code(NamedSource::new(path.to_string_lossy(), source.to_string()));
+        if handler.render_report(&mut out, report.as_ref()).is_err() {
+            // Rendering is best-effort presentation; never mask the error itself.
+            out.push_str(&format!("\n{err}"));
+        }
+    }
+    out
+}
+
 /// The pure transpile pipeline (no import validation, no filesystem access).
 fn transpile_source(path: &Path, source: &str) -> Result<String> {
     // Treat input as TypeScript regardless of extension — agents may live in
@@ -155,15 +181,10 @@ fn transpile_source(path: &Path, source: &str) -> Result<String> {
 
     let parser_ret = Parser::new(&allocator, source, source_type).parse();
     if !parser_ret.errors.is_empty() {
-        let messages: Vec<String> = parser_ret
-            .errors
-            .iter()
-            .map(|err| err.to_string())
-            .collect();
         anyhow::bail!(
-            "{}: TypeScript parse error: {}",
+            "{}: TypeScript parse error:{}",
             path.display(),
-            messages.join("; ")
+            render_diagnostics(path, source, &parser_ret.errors)
         );
     }
     let mut program = parser_ret.program;
@@ -173,15 +194,10 @@ fn transpile_source(path: &Path, source: &str) -> Result<String> {
         .with_excess_capacity(2.0)
         .build(&program);
     if !semantic_ret.errors.is_empty() {
-        let messages: Vec<String> = semantic_ret
-            .errors
-            .iter()
-            .map(|err| err.to_string())
-            .collect();
         anyhow::bail!(
-            "{}: TypeScript semantic error: {}",
+            "{}: TypeScript semantic error:{}",
             path.display(),
-            messages.join("; ")
+            render_diagnostics(path, source, &semantic_ret.errors)
         );
     }
     let scoping = semantic_ret.semantic.into_scoping();
@@ -200,15 +216,10 @@ fn transpile_source(path: &Path, source: &str) -> Result<String> {
     let transformer_ret = Transformer::new(&allocator, path, &transform_options)
         .build_with_scoping(scoping, &mut program);
     if !transformer_ret.errors.is_empty() {
-        let messages: Vec<String> = transformer_ret
-            .errors
-            .iter()
-            .map(|err| err.to_string())
-            .collect();
         anyhow::bail!(
-            "{}: TypeScript transform error: {}",
+            "{}: TypeScript transform error:{}",
             path.display(),
-            messages.join("; ")
+            render_diagnostics(path, source, &transformer_ret.errors)
         );
     }
 

--- a/crates/chidori/src/scheduler.rs
+++ b/crates/chidori/src/scheduler.rs
@@ -29,8 +29,11 @@ use crate::tools::ToolRegistry;
 /// branch worker threads. The interpreter recurses natively with the agent's
 /// JS call depth (`max_call_depth` = 2000 frames), which needs more headroom
 /// than tokio's 2 MiB default; on 64-bit the extra virtual space is only
-/// committed if actually touched.
-pub const JS_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+/// committed if actually touched. Sized by measurement: a debug build needs
+/// more than 32 MiB for the depth guard to fire its catchable RangeError
+/// before the native stack runs out (release frames are far smaller, but the
+/// reservation is virtual either way, so one generous constant serves both).
+pub const JS_THREAD_STACK_BYTES: usize = 64 * 1024 * 1024;
 
 /// Build the process's tokio runtime. Exactly `tokio::runtime::Runtime::new()`
 /// plus [`JS_THREAD_STACK_BYTES`]-sized threads: agent JS executes on this
@@ -183,4 +186,36 @@ pub async fn run_once(recipe: &Recipe, deps: &SchedulerDeps) -> Result<String> {
 
     deps.session_store.put(&session)?;
     Ok(id)
+}
+
+#[cfg(test)]
+mod stack_tests {
+    use super::JS_THREAD_STACK_BYTES;
+
+    /// A JS thread sized to [`JS_THREAD_STACK_BYTES`] must let the engine's
+    /// default call-depth guard fire its catchable `RangeError` on deep
+    /// recursion, rather than the native stack overflowing and aborting the
+    /// process (which is what a too-small stack did — see the constant's
+    /// rationale). Regression for `chidori run <deeply-recursive-agent>`.
+    #[test]
+    fn default_depth_recursion_throws_not_aborts() {
+        let outcome = std::thread::Builder::new()
+            .stack_size(JS_THREAD_STACK_BYTES)
+            .spawn(|| {
+                let mut engine = chidori_js::Engine::new();
+                // Default max_call_depth (2000); unbounded recursion must hit
+                // the guard, not the stack.
+                engine
+                    .eval("function f(n){ return f(n + 1); } f(0)")
+                    .err()
+                    .unwrap_or_default()
+            })
+            .expect("spawn JS thread")
+            .join()
+            .expect("thread must return an error, not abort");
+        assert!(
+            outcome.contains("Maximum call stack size exceeded"),
+            "expected a catchable RangeError, got: {outcome}"
+        );
+    }
 }

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -304,8 +304,14 @@ fn validate_snapshot_manifest_for_resume(
     run_base: &FsPath,
     run_id: Option<&str>,
     agent_path: &FsPath,
+    allow_source_change: bool,
 ) -> anyhow::Result<()> {
-    crate::runtime::snapshot::validate_manifest_for_resume(run_base, run_id, agent_path)
+    crate::runtime::snapshot::validate_manifest_for_resume(
+        run_base,
+        run_id,
+        agent_path,
+        allow_source_change,
+    )
 }
 
 enum HostPromiseCompletion {
@@ -2371,10 +2377,15 @@ async fn complete_pending_and_resume(
 }
 
 /// POST /sessions/:id/resume — supply a response to the agent's pending
-/// `input()` call and continue the run. Body: `{"response": "<string>"}`.
+/// `input()` call and continue the run. Body: `{"response": "<string>"}`,
+/// plus optional `"allow_source_change": true` — the edit-and-resume opt-in
+/// that lets the resume proceed when the agent source changed since the run
+/// was recorded (replay's divergence checks still guard the journaled calls).
 #[derive(Deserialize)]
 struct ResumeRequest {
     response: String,
+    #[serde(default)]
+    allow_source_change: bool,
 }
 
 async fn resume_session(
@@ -2462,6 +2473,7 @@ async fn resume_session(
         &state.run_base,
         original.run_id.as_deref(),
         &state.agent_path,
+        body.allow_source_change,
     ) {
         return (
             StatusCode::CONFLICT,
@@ -2524,6 +2536,10 @@ struct SignalRequest {
     payload: Value,
     #[serde(default)]
     from: Value,
+    /// Edit-and-resume opt-in: allow the signal-triggered resume even though
+    /// the agent source changed since the run was recorded.
+    #[serde(default)]
+    allow_source_change: bool,
 }
 
 async fn signal_session(
@@ -2629,6 +2645,7 @@ async fn signal_session(
             &state.run_base,
             original.run_id.as_deref(),
             &state.agent_path,
+            body.allow_source_change,
         ) {
             return (
                 StatusCode::CONFLICT,
@@ -2731,6 +2748,10 @@ struct ApproveRequest {
     /// "allow" or "deny". Defaults to "allow" for convenience.
     #[serde(default = "default_decision")]
     decision: String,
+    /// Edit-and-resume opt-in: allow the post-approval resume even though the
+    /// agent source changed since the run was recorded.
+    #[serde(default)]
+    allow_source_change: bool,
 }
 
 fn default_decision() -> String {
@@ -2779,6 +2800,7 @@ async fn approve_session(
         &state.run_base,
         original.run_id.as_deref(),
         &state.agent_path,
+        body.allow_source_change,
     ) {
         return (
             StatusCode::CONFLICT,
@@ -3569,6 +3591,7 @@ mod tests {
                 Path("session-1".to_string()),
                 Json(ResumeRequest {
                     response: "yes".to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -3670,6 +3693,7 @@ mod tests {
                 Path("session-1".to_string()),
                 Json(ResumeRequest {
                     response: "yes".to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -3776,6 +3800,7 @@ mod tests {
                 Path("session-1".to_string()),
                 Json(ResumeRequest {
                     response: "yes".to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -3820,9 +3845,14 @@ mod tests {
         store.save(&manifest, b"snapshot-bytes", &[]).unwrap();
         std::fs::write(&agent_path, "export async function agent() { return 2; }").unwrap();
 
-        let err = validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path)
-            .unwrap_err();
-        assert!(err.to_string().contains("runtime snapshot source mismatch"));
+        let err =
+            validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path, false)
+                .unwrap_err();
+        assert!(format!("{err:#}").contains("runtime snapshot source mismatch"));
+        // The refusal advertises the edit-and-resume opt-in…
+        assert!(format!("{err:#}").contains("allow-source-change"));
+        // …and opting in lets the same resume proceed.
+        validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path, true).unwrap();
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
@@ -3873,11 +3903,10 @@ mod tests {
         ]);
         store.save(&manifest, b"snapshot-bytes", &[]).unwrap();
 
-        let err = validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path)
-            .unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("runtime snapshot module graph mismatch"));
+        let err =
+            validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path, false)
+                .unwrap_err();
+        assert!(format!("{err:#}").contains("runtime snapshot module graph mismatch"));
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
@@ -3907,7 +3936,13 @@ mod tests {
         );
         store.save(&manifest, b"snapshot-bytes", &[]).unwrap();
 
-        let err = validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path)
+        let err =
+            validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path, false)
+                .unwrap_err();
+        assert!(err.to_string().contains("runtime snapshot ABI mismatch"));
+        // ABI drift is environment skew, not an edit: the edit-and-resume
+        // opt-in must NOT bypass it.
+        let err = validate_snapshot_manifest_for_resume(&run_base, Some(run_id), &agent_path, true)
             .unwrap_err();
         assert!(err.to_string().contains("runtime snapshot ABI mismatch"));
 
@@ -4242,6 +4277,7 @@ mod tests {
                 Path(id.to_string()),
                 Json(ResumeRequest {
                     response: response.to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4540,6 +4576,7 @@ mod tests {
                 Path(id),
                 Json(ApproveRequest {
                     decision: "deny".to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4625,6 +4662,7 @@ mod tests {
                 State(state.clone()),
                 Path("s-signal-1".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "approve" }),
                     from: json!({ "kind": "human", "id": "mara" }),
@@ -4679,6 +4717,7 @@ mod tests {
                 State(state.clone()),
                 Path("s-signal-2".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "changes" }),
                     from: json!({ "id": "bot" }),
@@ -4705,6 +4744,7 @@ mod tests {
                 Path("s-signal-2".to_string()),
                 Json(ResumeRequest {
                     response: "ada".to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4752,6 +4792,7 @@ mod tests {
                     name: "review".to_string(),
                     payload: Value::Null,
                     from: Value::Null,
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4801,6 +4842,7 @@ mod tests {
                     name: "review".to_string(),
                     payload: payload.clone(),
                     from: from.clone(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4834,6 +4876,7 @@ mod tests {
                     name: "review".to_string(),
                     payload: payload.clone(),
                     from: from.clone(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4847,6 +4890,7 @@ mod tests {
                 Path("b".to_string()),
                 Json(ResumeRequest {
                     response: "go".to_string(),
+                    allow_source_change: false,
                 }),
             )
             .await,
@@ -4917,6 +4961,7 @@ mod tests {
                 State(state.clone()),
                 Path("tie".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "tag": "new-delivered" }),
                     from: json!({ "id": "live-sender" }),
@@ -4964,6 +5009,7 @@ mod tests {
                 State(state.clone()),
                 Path("two".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "round": 1 }),
                     from: json!({ "id": "r1" }),
@@ -4982,6 +5028,7 @@ mod tests {
                 State(state.clone()),
                 Path("two".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "round": 2 }),
                     from: json!({ "id": "r2" }),
@@ -5036,6 +5083,7 @@ mod tests {
                 State(state.clone()),
                 Path("replay-src".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "approve" }),
                     from: json!({ "id": "x" }),
@@ -5122,6 +5170,7 @@ mod tests {
                 State(state.clone()),
                 Path("any-1".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "steer".to_string(),
                     payload: json!({ "dir": "left" }),
                     from: json!({ "kind": "human", "id": "sam" }),
@@ -5230,6 +5279,7 @@ mod tests {
                 State(state.clone()),
                 Path("race-1".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "approve" }),
                     from: json!({ "id": "mara" }),
@@ -5339,6 +5389,7 @@ mod tests {
                 State(state.clone()),
                 Path("live-1".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "approve" }),
                     from: json!({ "kind": "human", "id": "mara" }),
@@ -5379,6 +5430,7 @@ mod tests {
                 State(state_b.clone()),
                 Path("durable-1".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "approve" }),
                     from: json!({ "kind": "human", "id": "mara" }),
@@ -5438,6 +5490,7 @@ mod tests {
                 State(state.clone()),
                 Path("live-2".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "steer".to_string(),
                     payload: json!({ "dir": "left" }),
                     from: json!({ "id": "sam" }),
@@ -5456,6 +5509,7 @@ mod tests {
                 State(state.clone()),
                 Path("live-2".to_string()),
                 Json(SignalRequest {
+                    allow_source_change: false,
                     name: "review".to_string(),
                     payload: json!({ "decision": "approve" }),
                     from: json!({ "id": "mara" }),

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,13 @@ Expected output:
 }
 ```
 
+> **Approval prompts:** `chidori run` asks before *powerful* effects by
+> default — tool calls, network access, workspace writes — with a y/N prompt
+> at the terminal. (LLM prompts and pure compute, like this example, never
+> ask.) Running non-interactively — scripts, CI — there is no terminal to ask
+> at and gated effects fail closed: pass `--trusted` there, or configure a
+> policy. See [Running modes](./running-modes.md).
+
 What this demonstrates:
 
 - `examples/agents/hello.ts` imports `{ chidori, run }` from `chidori:agent`

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -18,8 +18,15 @@ Replay is guarded, not best-effort:
 - **Source verification:** every resume surface (the server's resume/approve
   routes *and* `chidori resume`) verifies the agent's entry + module source
   fingerprints against the run's snapshot manifest before replaying, and
-  refuses on mismatch — cached results are never paired with changed code.
-  (Runs persisted before manifests existed skip with a warning.)
+  refuses on mismatch — cached results are never paired with changed code
+  *silently*. (Runs persisted before manifests existed skip with a warning.)
+- **Edit-and-resume is an explicit opt-in:** pass `--allow-source-change` to
+  `chidori resume` (or `"allow_source_change": true` on the server's
+  resume/signal/approve routes) to replay a recorded run against edited code.
+  The divergence checks below still guard the journaled prefix — an edit that
+  changes an already-recorded call fails loudly, an edit past the pause point
+  resumes cleanly. ABI/policy mismatches are environment drift, not edits,
+  and always refuse.
 - **Divergence checks compare arguments, not just names:** a replayed call
   must match the recorded call's function *and* arguments (the derived
   `request_digest` field is ignored). A completed async host operation whose

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -1,9 +1,10 @@
 # Sandbox model of the chidori-js runtime
 
-> Two layers ship: the default **in-process** capability-confinement
-> sandbox, and an **opt-in OS-level isolation** mode (`--isolate`) that runs each
-> agent in a confined child process — see
-> [OS-level isolation](#os-level-isolation-opt-in---isolate). Known limitations
+> Two layers ship: the **in-process** capability-confinement sandbox, and an
+> **OS-level isolation** mode that runs each agent in a confined child
+> process — on by default for the `chidori` CLI on Unix, opt-in elsewhere
+> (`--isolate`) — see
+> [OS-level isolation](#os-level-isolation---isolate). Known limitations
 > are documented in [Current gaps](#current-gaps).
 > **Engine:** the pure-Rust `chidori-js` engine — the only JS engine in
 > the tree.
@@ -35,15 +36,16 @@ the host *does* inject (`http`, `workspace.*`). Those are real capabilities;
 whether granting them is "safe" depends entirely on whether the agent code is
 trusted.
 
-For that case there is an **opt-in OS-level isolation mode**
-(`--isolate` / `CHIDORI_ISOLATE=process`): each run executes in a disposable
+For that case there is an **OS-level isolation mode** — on by default for the
+CLI on Unix, opt-in for embedders and elsewhere (`--isolate` /
+`CHIDORI_ISOLATE=process`): each run executes in a disposable
 child process that holds *only* the JS engine and brokers every effect back to
 the trusted parent over a pipe. The child runs under a per-OS sandbox (Linux:
 empty network namespace + Landlock read-only filesystem + seccomp syscall
 denylist; macOS: a Seatbelt deny profile) plus a `setrlimit` floor and a
 parent-side deadline-kill — so even a total compromise of the interpreter has no
 ambient network, filesystem, or sibling-run to reach. See
-[OS-level isolation](#os-level-isolation-opt-in---isolate).
+[OS-level isolation](#os-level-isolation---isolate).
 
 ## Threat model
 
@@ -69,7 +71,7 @@ remaining distance.
 | Crash the host with a panic | ✅ Yes — `catch_unwind` boundary |
 | Abuse an injected powerful effect (`http`, `workspace`) | ✅ On the server (deny-by-default unless the operator opts out); ⚠️ on the bare CLI only if the operator gates it — see [gaps](#current-gaps) |
 | Starve co-tenant agents / exceed a per-agent memory quota | ✅ Per-run meter (thread-attributed; small cross-thread drift) — see [gaps](#current-gaps) |
-| Break out of the process / OS | ⚠️ Default: none (in-process). ✅ With `--isolate`: confined child process — seccomp/Seatbelt + netns/Landlock + rlimits — see [OS-level isolation](#os-level-isolation-opt-in---isolate) |
+| Break out of the process / OS | ✅ CLI on Unix (isolation on by default): confined child process — seccomp/Seatbelt + netns/Landlock + rlimits — see [OS-level isolation](#os-level-isolation---isolate). ⚠️ Embedders / `--no-isolate` / non-Unix: none (in-process) |
 
 ## Architecture: capability injection, not ambient authority
 
@@ -209,14 +211,15 @@ The same watchdog can enforce a wall-clock deadline, also via `vm.interrupt`.
 | Call depth | (compile constant) | 2,000 | — |
 | Regex steps | (compile constant) | 100,000 | — |
 
-## OS-level isolation (opt-in: `--isolate`)
+## OS-level isolation (`--isolate`)
 
-Everything above confines the *language* and bounds resources, but by default the
-VM runs **in-process** with the host: there is no OS boundary, so a hypothetical
-interpreter RCE would land in the host process. The `--isolate` mode adds that
-boundary. It is **off by default** (in-process stays the default for trusted
-local dev) and **additive** — agent code, the SDKs, the durable call log, and
-replay semantics are byte-for-byte unchanged (asserted by
+Everything above confines the *language* and bounds resources, but in-process
+the VM shares its address space with the host: there is no OS boundary, so a
+hypothetical interpreter RCE would land in the host process. Isolation adds
+that boundary. It is **on by default for the `chidori` CLI on Unix** (see
+[Enabling it](#enabling-it) — embedders and non-Unix platforms keep the
+historical opt-in) and **additive** — agent code, the SDKs, the durable call
+log, and replay semantics are byte-for-byte unchanged (asserted by
 `rust_engine::tests::isolated_run_matches_in_process_byte_for_byte`). The full
 design lives in [`docs/os-isolation-plan.md`](./os-isolation-plan.md); this
 is the operator-facing summary. Code: `crates/chidori/src/runtime/isolate/`.
@@ -408,7 +411,7 @@ resource-precision gaps.
    charged (the meter clamps at zero in the other direction). For a
    single-threaded VM run this drift is small; only true ownership accounting
    (charge at string/object allocation, credit on `Drop` inside the engine)
-   would eliminate it. **Under [`--isolate`](#os-level-isolation-opt-in---isolate) this
+   would eliminate it. **Under [`--isolate`](#os-level-isolation---isolate) this
    drift disappears**: each run is its own process, so the meter is a clean
    per-process measure with no cross-tenant attribution.
 
@@ -418,15 +421,17 @@ resource-precision gaps.
    unwinding. Bounded in practice because the per-op size caps mean no single
    opcode allocates more than ~16 MB, but it is not a hard instantaneous ceiling.
    A *hard*, kernel-enforced ceiling (cgroup v2 `memory.max`) under
-   [`--isolate`](#os-level-isolation-opt-in---isolate) is not yet wired — see
+   [`--isolate`](#os-level-isolation---isolate) is not yet wired — see
    gap #4.
 
-4. **OS-level isolation is opt-in, not the default.** By default the engine runs
-   in-process with the host — no seccomp, namespace, or separate-process boundary
-   — so the default posture is purely capability-confinement plus Rust memory
-   safety. The [`--isolate` mode](#os-level-isolation-opt-in---isolate)
-   *provides* that boundary, but the operator must enable it; in-process is
-   the default for trusted local dev. Sub-gaps within the isolated path:
+4. **OS-level isolation is default-on only for the CLI on Unix.** Embedders of
+   the library, `--no-isolate` runs, and non-Unix platforms run the engine
+   in-process with the host — no seccomp, namespace, or separate-process
+   boundary — so that posture is purely capability-confinement plus Rust
+   memory safety. The [`--isolate` mode](#os-level-isolation---isolate)
+   *provides* the boundary (and the `chidori` binary enables it by default on
+   Unix); everywhere else the operator must enable it. Sub-gaps within the
+   isolated path:
    - **No hard memory ceiling.** cgroup v2 `memory.max` needs delegation and
      is not yet wired; `RLIMIT_AS` is too blunt for a multi-threaded VM. The polled
      heap watchdog (cleaner per-process under isolation) is the stand-in.
@@ -452,7 +457,7 @@ resource-precision gaps.
    `crates/chidori-js/src/gc.rs`) but is not wired into the run loop, so
    within a run cycles accumulate until teardown. The per-run memory cap is
    the backstop for the bytes involved. **The
-   [`--isolate`](#os-level-isolation-opt-in---isolate) path sidesteps this
+   [`--isolate`](#os-level-isolation---isolate) path sidesteps this
    entirely**: the child process exits after one run (spawn-per-run, no warm
    pool), so no state — leaked or otherwise — survives across runs.
 
@@ -579,7 +584,7 @@ If you intend to run code you do not trust on this engine today:
    ambient process to land in. Layers are best-effort — set
    `CHIDORI_ISOLATE_REQUIRE_SANDBOX=1` to fail closed if the platform's core
    confinement can't be applied. See
-   [OS-level isolation](#os-level-isolation-opt-in---isolate) for the full
+   [OS-level isolation](#os-level-isolation---isolate) for the full
    posture. (Running each agent in its own container is still complementary.)
 4. Keep `node:fs` on `FsPolicy::Captured` (the VFS) and avoid `workspace.*`.
 

--- a/llm.txt
+++ b/llm.txt
@@ -52,6 +52,7 @@ chidori chat --system "You are a concise assistant." --model claude-sonnet
 chidori chat agents/chat.ts                 # chat through a conversational agent file
 chidori serve agents/webhook.ts --port 8080 --trusted
 chidori resume agents/my_agent.ts <run_id>  # replay a recorded run byte-for-byte with zero model calls (durable resume)
+chidori resume agents/my_agent.ts <run_id> --allow-source-change  # edit-and-resume: replay against edited code (divergence-checked)
 chidori trace <run_id>
 chidori snapshot <run_id>
 ```
@@ -611,10 +612,13 @@ chidori serve examples/agents/webhook.ts --port 8080 --trusted
 
 `chidori serve` is deny-by-default: without `--trusted` or explicit
 `CHIDORI_POLICY*` configuration, gated effects (network requests via
-`fetch`/`node:http`, workspace mutations) are refused under the built-in
-`untrusted` profile (read-only
-workspace introspection stays allowed). `--untrusted` forces that profile over
-any env configuration; `chidori run` keeps the permissive default.
+`fetch`/`node:http`, tool calls, workspace mutations) are refused under the
+built-in `untrusted` profile (read-only workspace introspection stays
+allowed). `--untrusted` forces that profile over any env configuration.
+`chidori run` is ask-by-default: gated effects prompt for a y/N approval at
+the terminal, and fail closed when no terminal is available (scripts, CI) —
+pass `--trusted` there for the permissive allow-all behavior. LLM prompts and
+pure compute are never gated.
 
 Session endpoints:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,11 +1,19 @@
 [toolchain]
-# Build on stable. The previous nightly pin existed only because
-# oxc_transformer 0.133 used `if let` match-arm guards, an unstable feature
-# (rust-lang/rust#51114) stabilized in Rust 1.95. With a stable toolchain >=
-# 1.95 the whole workspace compiles on stable, so the pin is now just a floor.
-# rustup auto-fetches the channel on first build, including inside the
-# rust:1-bookworm grpc image.
-channel = "stable"
+# Build on stable, pinned to the workspace floor. The previous nightly pin
+# existed only because oxc_transformer 0.133 used `if let` match-arm guards,
+# an unstable feature (rust-lang/rust#51114) stabilized in Rust 1.95.
+#
+# Pinned to a concrete release rather than "stable" so a first build cannot
+# fail late: bare "stable" resolves to whatever stable is already installed,
+# and on a machine with a pre-1.95 stable the build spends minutes
+# downloading (or, on older cargos, compiling) the whole dependency graph
+# before the `rust-version = "1.95"` check in the crate manifests finally
+# rejects the toolchain. With a concrete channel rustup auto-fetches a
+# compatible compiler up front instead, including inside the rust:1-bookworm
+# grpc image — and CI's clippy/rustfmt run against a known version instead of
+# drifting with the latest stable. Keep this >= the `rust-version` floor in
+# crates/*/Cargo.toml when bumping either.
+channel = "1.97"
 # Ensure `cargo fmt`/`cargo clippy` ship with the pinned channel: the
 # auto-fetched toolchain otherwise omits these components, which breaks the
 # CI "Check formatting" step (it runs against this pinned toolchain).

--- a/sdk/python/chidori/client.py
+++ b/sdk/python/chidori/client.py
@@ -449,6 +449,10 @@ class AgentClient:
             after every host function call (prompt, tool, http, ...)
           * `{"type": "prompt_start" | "prompt_delta" | "prompt_end", ...}`
             — emitted for labelled prompt progress streams
+          * `{"type": "paused", "id": ..., "status": "paused",
+            "pending_seq": ..., ...}` — emitted when the run parks at a
+            `chidori.signal(...)` listen point; deliver the signal (e.g.
+            `client.signal(...)`) and the stream continues
           * `{"type": "done", "id": ..., "status": ..., "output": ...}`
             — emitted once when the run finishes
 
@@ -516,6 +520,7 @@ class AgentClient:
                                 "prompt_start",
                                 "prompt_delta",
                                 "prompt_end",
+                                "paused",
                             }:
                                 decoded["type"] = event_name
                                 yield decoded

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -27,3 +27,8 @@ Repository = "https://github.com/ThousandBirdsInc/chidori"
 
 [tool.setuptools.packages.find]
 include = ["chidori*"]
+
+# PEP 561: ship the `py.typed` marker so type checkers (mypy, pyright) consume
+# the package's inline annotations instead of treating it as untyped.
+[tool.setuptools.package-data]
+chidori = ["py.typed"]

--- a/sdk/python/tests/test_client_http.py
+++ b/sdk/python/tests/test_client_http.py
@@ -142,5 +142,54 @@ class HttpLayerTests(unittest.TestCase):
             silent.server_close()
 
 
+class _SseHandler(http.server.BaseHTTPRequestHandler):
+    """Emits a fixed SSE stream for `POST /sessions/stream`: one of every
+    event kind the server produces, so the parser's pass-through is pinned."""
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib naming
+        frames = [
+            ("call", {"seq": 1, "function": "prompt"}),
+            ("prompt_delta", {"label": "draft", "delta": "hi"}),
+            ("paused", {"id": "s-1", "status": "paused", "pending_seq": 2}),
+            ("done", {"id": "s-1", "status": "completed", "output": {"ok": True}}),
+        ]
+        body = "".join(
+            f"event: {name}\ndata: {json.dumps(payload)}\n\n" for name, payload in frames
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: object) -> None:
+        pass
+
+
+class StreamParserTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = socketserver.TCPServer(("127.0.0.1", 0), _SseHandler)
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+        port = cls.server.server_address[1]
+        cls.client = AgentClient(f"http://127.0.0.1:{port}", retries=0, timeout_seconds=5)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def test_stream_yields_every_event_kind_including_paused(self) -> None:
+        events = list(self.client.stream({"q": 1}))
+        self.assertEqual(
+            [e["type"] for e in events],
+            ["call", "prompt_delta", "paused", "done"],
+        )
+        paused = events[2]
+        self.assertEqual(paused["status"], "paused")
+        self.assertEqual(paused["pending_seq"], 2)
+        self.assertEqual(events[3]["status"], "completed")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Runtime errors now carry a stack trace. `Vm::run_frame` — the single funnel
every activation exits through — appends `    at name (line:col)` to a
propagating exception's `.stack` as it unwinds, so an uncaught error lists
the JS frames it crossed, innermost first. The trace is built entirely on
the unwind path (success pays one Rc clone per activation), positions are
the function's definition site (`FuncProto` now records line/column,
resolved at compile time from the parameter-list span), non-Error thrown
values are untouched, and a rethrow loop stops accumulating at 32 frames.
The module entrypoint paths render errors with the new
`error_to_string_with_stack`, so `chidori run` surfaces the frames;
`Engine::eval`'s single-line `Name: message` shape is unchanged for
embedders.

Parse errors now carry positions. Engine-side, oxc diagnostics render with
the 1-based line/column of their primary span (resolved via miette, the
diagnostic toolkit oxc's errors are built on): `SyntaxError: Unexpected
token (line 2, column 9)`. Direct-eval sources shift positions back past
the synthetic wrapper. Host-side, TypeScript parse/semantic/transform
errors render through miette's graphical report handler — file:line:column,
the offending source line, and a caret under the span.

Covered by the new tests/errors.rs suite.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W47D4NiMSGCcTc1Mdt9Q5U