### PR TITLE
examples/record-replay: fix commands broken by the safe-defaults sweep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ members = [
     "crates/chidori-js",
     "crates/test262-runner",
 ]
+# Bare `cargo run` / `cargo build` at the workspace root mean the CLI — the
+# form every README and doc uses (`cargo run -- run agents/my_agent.ts`).
+# Without this, the test262-runner binary makes `cargo run` ambiguous and it
+# refuses to run anything. CI's workspace-wide jobs pass `--workspace`
+# explicitly, so they are unaffected.
+default-members = ["crates/chidori"]
 resolver = "2"
 
 # Workspace-wide lint levels, inherited by every crate via `[lints]

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -1253,10 +1253,14 @@ fn cmd_run_stream(
             Ok(())
         }
         Err(e) => {
+            // Frames arrive in transpiled coordinates; the stream consumer
+            // sees the same original-TypeScript positions the CLI reporter
+            // shows. The returned error stays raw — report_cli_error remaps
+            // it once at its own display boundary.
             let line = serde_json::json!({
                 "type": "done",
                 "status": "failed",
-                "error": format!("{e:#}"),
+                "error": crate::runtime::rust_engine::remap_stack_frames(&format!("{e:#}")),
             });
             println!("{line}");
             Err(e)

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -214,9 +214,21 @@ pub(crate) fn set_display_project_root(root: PathBuf) {
 pub(crate) fn read_project_source(file: &str) -> Option<String> {
     let root = DISPLAY_PROJECT_ROOT
         .with(|r| r.borrow().clone())
-        .or_else(|| std::env::current_dir().ok())?
-        .canonicalize()
-        .ok()?;
+        .or_else(|| std::env::current_dir().ok())?;
+    read_project_source_within(&root, file)
+}
+
+/// As [`read_project_source`], but confined to an explicit `root` instead of
+/// the thread-local display root — for surfaces whose display boundary is not
+/// the CLI process's JS thread (the HTTP server's session errors). An empty
+/// root (the parent of a bare `agent.ts`) means the current directory.
+pub(crate) fn read_project_source_within(root: &Path, file: &str) -> Option<String> {
+    let root = if root.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        root
+    };
+    let root = root.canonicalize().ok()?;
     let full = Path::new(file).canonicalize().ok()?;
     full.starts_with(&root)
         .then(|| std::fs::read_to_string(&full).ok())
@@ -283,6 +295,19 @@ pub(crate) fn parse_stack_frame(line: &str) -> Option<StackFrame<'_>> {
 /// uniform transpiled coordinates); error path only, so each distinct file
 /// re-runs the transpile pipeline once with map generation on.
 pub(crate) fn remap_stack_frames(err: &str) -> String {
+    remap_stack_frames_via(err, read_project_source)
+}
+
+/// As [`remap_stack_frames`], but confining frame source reads to an explicit
+/// project root — the server's variant, applied where a run error becomes a
+/// session's stored/returned `error` (the CLI resolves its root from the
+/// thread-local set at command startup; the server handlers run on tokio
+/// threads that never set it, so the agent's workspace root is passed in).
+pub(crate) fn remap_stack_frames_within(root: &Path, err: &str) -> String {
+    remap_stack_frames_via(err, |file| read_project_source_within(root, file))
+}
+
+fn remap_stack_frames_via(err: &str, read: impl Fn(&str) -> Option<String>) -> String {
     use std::collections::HashMap;
     let mut sources: HashMap<&str, Option<String>> = HashMap::new();
     let mut out = String::with_capacity(err.len());
@@ -294,7 +319,7 @@ pub(crate) fn remap_stack_frames(err: &str) -> String {
             let file = frame.file?;
             let source = sources
                 .entry(file)
-                .or_insert_with(|| read_project_source(file))
+                .or_insert_with(|| read(file))
                 .as_deref()?;
             let pos = crate::runtime::typescript::transpile::remap_to_original(
                 Path::new(file),

--- a/crates/chidori/src/server.rs
+++ b/crates/chidori/src/server.rs
@@ -676,7 +676,8 @@ pub async fn serve(
     let acp_state = AcpState {
         store: state.session_store.clone(),
         run_prompt: Arc::new(move |inputs: Value| -> Result<Value, String> {
-            run_agent_sync(&acp_runner_state, inputs).map_err(|e| e.to_string())
+            run_agent_sync(&acp_runner_state, inputs)
+                .map_err(|e| agent_error_string(&acp_runner_state.agent_path, &e))
         }),
     };
 
@@ -1350,7 +1351,7 @@ async fn create_session(
     };
     match result {
         Ok(run_result) => apply_run_outcome(&mut session, run_result),
-        Err(e) => session.error = Some(e.to_string()),
+        Err(e) => session.error = Some(agent_error_string(&state.agent_path, &e)),
     }
 
     if let Some(err) = store_or_500(&state, &session) {
@@ -1911,7 +1912,8 @@ async fn stream_session(
                         Err(e) => {
                             session.status = SessionStatus::Failed;
                             session.output = None;
-                            session.error = Some(e.to_string());
+                            session.error =
+                                Some(agent_error_string(&state_for_stream.agent_path, &e));
                         }
                     }
                     if was_cancelled {
@@ -2105,6 +2107,18 @@ async fn cancel_session(
         "reason": reason,
     }))
     .into_response()
+}
+
+/// Render an agent-run error for a session's stored/returned `error` field.
+/// Uncaught-exception stack frames arrive from the engine in transpiled
+/// coordinates; remap them to positions in the original TypeScript against
+/// the served agent's workspace root — the same display-boundary remap the
+/// CLI applies in `main::report_cli_error` (which resolves its root from a
+/// thread-local these tokio handlers never set). Frames that can't be read
+/// or remapped pass through unchanged, as does any error without frames.
+fn agent_error_string(agent_path: &FsPath, e: &anyhow::Error) -> String {
+    let root = crate::runtime::typescript::transpile::find_workspace_root(agent_path);
+    crate::runtime::rust_engine::remap_stack_frames_within(&root, &e.to_string())
 }
 
 /// Map a finished engine run onto a stored session: status, output, call log,
@@ -2363,13 +2377,14 @@ async fn complete_pending_and_resume(
             (StatusCode::OK, Json(session_view(&session))).into_response()
         }
         Err(e) => {
+            let error = agent_error_string(&state.agent_path, &e);
             session.status = SessionStatus::Failed;
-            session.error = Some(e.to_string());
+            session.error = Some(error.clone());
             let _ = state.session_store.put(&session);
             state.warm_runs.lock().unwrap().remove(&session.id);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": e.to_string()})),
+                Json(json!({"error": error})),
             )
                 .into_response()
         }
@@ -2447,7 +2462,7 @@ async fn resume_session(
                     Some(Ok(run_result)) => apply_run_outcome(&mut session, run_result),
                     Some(Err(e)) => {
                         session.status = SessionStatus::Failed;
-                        session.error = Some(e.to_string());
+                        session.error = Some(agent_error_string(&state.agent_path, &e));
                     }
                     None => {
                         session.status = SessionStatus::Failed;
@@ -2927,12 +2942,13 @@ async fn approve_session(
             (StatusCode::OK, Json(session_view(&session))).into_response()
         }
         Err(e) => {
+            let error = agent_error_string(&state.agent_path, &e);
             session.status = SessionStatus::Failed;
-            session.error = Some(e.to_string());
+            session.error = Some(error.clone());
             let _ = state.session_store.put(&session);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": e.to_string()})),
+                Json(json!({"error": error})),
             )
                 .into_response()
         }
@@ -3012,7 +3028,7 @@ async fn handle_event(
         }
         Err(e) => {
             eprintln!("Agent error: {e:#}");
-            let error = json!({"error": e.to_string()});
+            let error = json!({"error": agent_error_string(&state.agent_path, &e)});
             (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
         }
     }
@@ -3025,6 +3041,73 @@ mod tests {
         RuntimePolicy, SnapshotAbi, SourceFingerprint, HOST_PROMISE_TABLE_FILE,
     };
     use axum::body;
+
+    /// A failed session's `error` must carry stack frames in ORIGINAL
+    /// TypeScript coordinates for every frame, not just the throwing one —
+    /// the engine hands the server transpiled-bundle positions, and the
+    /// server (whose tokio handlers never set the CLI's thread-local display
+    /// root) remaps them against the agent's workspace root.
+    #[test]
+    fn agent_error_string_remaps_every_frame_to_original_source() {
+        let dir = std::env::temp_dir().join(format!("chidori-srv-frames-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let agent_path = dir.join("agent.ts");
+        // The interface block exists only in the original TypeScript, so every
+        // transpiled line number below it disagrees with the original.
+        let src = "interface Row {\n\
+                   \x20 id: string;\n\
+                   }\n\
+                   function inner(row: Row): never {\n\
+                   \x20 throw new Error(\"bad \" + row.id);\n\
+                   }\n\
+                   function outer(): never {\n\
+                   \x20 return inner({ id: \"x\" });\n\
+                   }\n\
+                   export async function agent() { return outer(); }\n";
+        std::fs::write(&agent_path, src).unwrap();
+
+        // Derive the frames' transpiled coordinates the same way the engine
+        // stamps them: the emitted definition line of each function.
+        let (js, _map) =
+            crate::runtime::typescript::transpile::transpile_source_with_map(&agent_path, src)
+                .unwrap();
+        let emitted_line = |name: &str| {
+            js.lines()
+                .position(|l| l.contains(&format!("function {name}")))
+                .map(|i| i as u32 + 1)
+                .unwrap()
+        };
+        let (inner_line, outer_line) = (emitted_line("inner"), emitted_line("outer"));
+        // The interface strip is what makes this test meaningful: emitted
+        // positions must disagree with the original definition lines (4, 7).
+        assert_ne!(
+            inner_line, 4,
+            "transpile no longer shifts lines; rewrite this test"
+        );
+
+        let path_str = agent_path.to_string_lossy();
+        let err = anyhow::anyhow!(
+            "JavaScript exception: Error: bad x\n    at inner ({path_str}:{inner_line}:10)\n    at outer ({path_str}:{outer_line}:10)"
+        );
+        let remapped = agent_error_string(&agent_path, &err);
+        assert!(
+            remapped.contains(&format!("at inner ({path_str}:4:")),
+            "throwing frame lands on the original definition line: {remapped}"
+        );
+        assert!(
+            remapped.contains(&format!("at outer ({path_str}:7:")),
+            "the frame ABOVE the throwing one lands on its original line too: {remapped}"
+        );
+
+        // Errors without frames pass through byte-identical.
+        let plain = anyhow::anyhow!("policy: `tool:x` denied");
+        assert_eq!(
+            agent_error_string(&agent_path, &plain),
+            "policy: `tool:x` denied"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 
     #[test]
     fn bearer_token_matches_single_key() {

--- a/examples/interactive-pipeline/README.md
+++ b/examples/interactive-pipeline/README.md
@@ -35,12 +35,17 @@ examples/interactive-pipeline/run.sh
 
 # …or directly
 chidori run examples/interactive-pipeline/interactive_pipeline.ts \
-  -i '{"pipeline":"triage","stages":5,"itemsPerStage":4}'
+  -i '{"pipeline":"triage","stages":5,"itemsPerStage":4}' --trusted
 
 # …or from source
 cargo run -- run examples/interactive-pipeline/interactive_pipeline.ts \
-  -i '{"pipeline":"triage","stages":5,"itemsPerStage":4}'
+  -i '{"pipeline":"triage","stages":5,"itemsPerStage":4}' --trusted
 ```
+
+(`--trusted`: the per-stage `review_batch` tool call is a gated effect, and
+`chidori run` is ask-by-default — without the flag each stage stops for an
+extra y/N approval before its checkpoint. This is in-repo code you're running
+on yourself; see [`docs/running-modes.md`](../../docs/running-modes.md).)
 
 At each checkpoint the agent prints a prompt to your terminal and **blocks on
 stdin** (`chidori.input`). Type one of:
@@ -62,7 +67,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
 export OTEL_SERVICE_NAME=interactive-pipeline        # optional (defaults to "chidori")
 
 chidori run examples/interactive-pipeline/interactive_pipeline.ts \
-  -i '{"pipeline":"triage","stages":5,"itemsPerStage":4}'
+  -i '{"pipeline":"triage","stages":5,"itemsPerStage":4}' --trusted
 ```
 
 `run.sh` does this for you, but only when tael is actually listening on `:4317`.

--- a/examples/interactive-pipeline/run.sh
+++ b/examples/interactive-pipeline/run.sh
@@ -29,5 +29,8 @@ else
   echo "  (start tael, then re-run; or set OTEL_EXPORTER_OTLP_ENDPOINT yourself)" >&2
 fi
 
+# --trusted: the per-stage review_batch tool call is a gated effect, and
+# `chidori run` asks before gated effects by default — the flag keeps the
+# session's only prompts the agent's own checkpoints.
 exec cargo run --quiet --manifest-path "$REPO/Cargo.toml" \
-  -- run "$AGENT" -i "$INPUT"
+  -- run "$AGENT" -i "$INPUT" --trusted

--- a/examples/record-replay/README.md
+++ b/examples/record-replay/README.md
@@ -38,6 +38,21 @@ All commands are run **from the repository root**.
   cargo build --release          # produces ./target/release/chidori
   ```
 
+- Build the TypeScript SDK once (needed only for the SDK driver in step 3 —
+  `driver.mjs` imports the built `sdk/typescript/dist/`):
+
+  ```bash
+  npm --prefix sdk/typescript install
+  npm --prefix sdk/typescript run build
+  ```
+
+> **Why `--trusted` below:** tool calls are gated effects. `chidori run` is
+> **ask-by-default** (each tool call pauses for a y/N prompt on your terminal,
+> and fails closed without one) and `chidori serve` is **deny-by-default**.
+> These agents are in-repo code you're running on yourself, so the commands
+> pass `--trusted` for the permissive posture; drop it to see the prompts.
+> See [`docs/running-modes.md`](../../docs/running-modes.md).
+
 ### 1. Layer 1 — run the Rust engine examples (no server, fastest)
 
 Run one:
@@ -65,8 +80,8 @@ to copy it by hand:
 ```bash
 BIN=./target/release/chidori
 
-# record
-$BIN run examples/record-replay/exactly_once.ts -i name=Ada
+# record (--trusted: the agent's tool calls run without per-call prompts)
+$BIN run examples/record-replay/exactly_once.ts -i name=Ada --trusted
 
 # grab the id of the run just created
 RUN_ID=$(ls -t examples/record-replay/.chidori/runs | head -1)
@@ -87,8 +102,8 @@ Swap `exactly_once.ts` for any agent in this directory
 Two terminals: one serves a single agent, the other records + replays it.
 
 ```bash
-# terminal 1 — serve one agent
-cargo run -- serve examples/record-replay/exactly_once.ts --port 8080
+# terminal 1 — serve one agent (--trusted: allow its tool calls)
+cargo run -- serve examples/record-replay/exactly_once.ts --port 8080 --trusted
 
 # terminal 2 — run, checkpoint, replay; assert the output is byte-identical
 node examples/record-replay/driver.mjs --scenario exactly_once
@@ -162,23 +177,30 @@ it: tool calls return their recorded results instead of executing.
 
 ```bash
 # record
-cargo run -- run examples/record-replay/exactly_once.ts -i name=Ada
+cargo run -- run examples/record-replay/exactly_once.ts -i name=Ada --trusted
 # inspect the recorded call log
 cargo run -- trace <run-id> -d examples/record-replay
 # replay — open_ticket / send_email are NOT re-invoked
 cargo run -- resume examples/record-replay/exactly_once.ts <run-id> -d examples/record-replay
 ```
 
+(`resume` needs no `--trusted`: the recorded tool calls are served from the
+call log, so no gated effect ever re-executes.)
+
 **See exactly-once for yourself:** record a run, then break a tool body so it
 throws, and resume. The replay still succeeds with the original result — proof
 the tool body was never re-run:
 
 ```bash
-cargo run -- run examples/record-replay/exactly_once.ts -i name=Ada
+cargo run -- run examples/record-replay/exactly_once.ts -i name=Ada --trusted
 # edit tools/send_email.ts to `throw new Error("boom")`, then:
 cargo run -- resume examples/record-replay/exactly_once.ts <run-id> -d examples/record-replay
 # -> still returns the recorded { delivered: true, ... }
 ```
+
+(Tool files live outside the agent's import graph, so editing one doesn't
+trip the resume source-fingerprint check — the *agent* file is what must
+stay unchanged, unless you opt in with `--allow-source-change`, below.)
 
 ### Option B — the SDK (`AgentClient`, over HTTP)
 
@@ -187,8 +209,8 @@ This mirrors how you'd use the published `@1kbirds/chidori` npm package
 the matching driver scenario:
 
 ```bash
-# terminal 1 — serve one agent
-cargo run -- serve examples/record-replay/exactly_once.ts --port 8080
+# terminal 1 — serve one agent (--trusted: allow its tool calls)
+cargo run -- serve examples/record-replay/exactly_once.ts --port 8080 --trusted
 
 # terminal 2 — record, checkpoint, replay; assert the output is identical
 node examples/record-replay/driver.mjs --scenario exactly_once
@@ -197,7 +219,7 @@ node examples/record-replay/driver.mjs --scenario exactly_once
 For the human-in-the-loop agent, the driver demonstrates **pause → resume**:
 
 ```bash
-cargo run -- serve examples/record-replay/human_approval.ts --port 8080
+cargo run -- serve examples/record-replay/human_approval.ts --port 8080 --trusted
 node examples/record-replay/driver.mjs --scenario human_approval
 #   run -> status "paused"
 #   client.resume(id, "approve") -> status "completed", refund issued
@@ -211,9 +233,18 @@ Scenarios: `exactly_once`, `deterministic_identity`, `retry_flaky_tool`,
 
 Record any run, edit the agent's logic *after* the point it paused/finished
 reading effects (e.g. change how `tool_pipeline` formats its briefing), and
-`resume`: the recorded tool calls are reused and only the new tail runs. Editing
-an *already-executed* step instead is rejected with a clear divergence error
-(the `edit_and_resume.rs` example shows both halves).
+resume with `--allow-source-change`: the recorded tool calls are reused and
+only the new tail runs. The flag is required because resume verifies the
+agent source against the run's snapshot manifest and refuses on mismatch —
+cached results are never silently paired with changed code:
+
+```bash
+cargo run -- resume examples/record-replay/tool_pipeline.ts <run-id> \
+  -d examples/record-replay --allow-source-change
+```
+
+Editing an *already-executed* step instead is rejected with a clear divergence
+error (the `edit_and_resume.rs` example shows both halves).
 
 ---
 

--- a/examples/record-replay/driver.mjs
+++ b/examples/record-replay/driver.mjs
@@ -7,8 +7,10 @@
 // pause -> resume.
 //
 // Usage:
-//   1. Start a server for ONE scenario (each binds a single agent file):
-//        cargo run -- serve examples/record-replay/exactly_once.ts --port 8080
+//   1. Start a server for ONE scenario (each binds a single agent file;
+//      --trusted allows the example's tool calls, which the server's
+//      deny-by-default posture would otherwise refuse):
+//        cargo run -- serve examples/record-replay/exactly_once.ts --port 8080 --trusted
 //   2. Run the matching driver scenario:
 //        node examples/record-replay/driver.mjs --scenario exactly_once
 //
@@ -98,6 +100,6 @@ try {
   }
 } catch (err) {
   console.error(`\nFAILED: ${err.message}`);
-  console.error(`(is a server running? try: cargo run -- serve examples/record-replay/${scenario}.ts --port 8080)`);
+  console.error(`(is a server running? try: cargo run -- serve examples/record-replay/${scenario}.ts --port 8080 --trusted)`);
   process.exitCode = 1;
 }

--- a/examples/record-replay/exactly_once.ts
+++ b/examples/record-replay/exactly_once.ts
@@ -9,7 +9,7 @@ import { chidori, run } from "chidori:agent";
  * are served from the log instead of re-executing — so the ticket isn't filed
  * twice and the email isn't sent twice, no matter how many times you replay.
  *
- *   chidori run examples/record-replay/exactly_once.ts -i name=Ada
+ *   chidori run examples/record-replay/exactly_once.ts -i name=Ada --trusted
  *   chidori trace <run-id>            # see the recorded tool calls
  *   chidori resume examples/record-replay/exactly_once.ts <run-id>   # no re-send
  */


### PR DESCRIPTION
The ask-by-default CLI / deny-by-default server posture (#130) gates
tool calls, so every `run`/`serve` command in this README failed as
written (non-interactive `run` fails closed; the served agents' tool
calls were refused). Pass `--trusted` — these are in-repo,
developer-authored agents — and explain the posture once up top.

Also catch the README up with two more changes it predates:

* resume now verifies the agent source against the run's snapshot
  manifest (#130), so the modify-and-resume walkthrough needs
  `--allow-source-change`; the break-a-tool exactly-once proof still
  works flag-free because tool files sit outside the import graph.
* driver.mjs imports sdk/typescript/dist/, which a fresh checkout
  doesn't have — add the SDK build to the prerequisites.

Every command block was re-run end-to-end: record → trace → resume,
the broken-tool resume proof, the edit-and-resume refusal + opt-in,
both serve+driver scenarios, the Rust engine examples, and the
tsc typecheck.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLNwvZmeoxFsATq78m6TQa