### PR TITLE
Pin policy-denial error frames to the gated call, not the run( line

### DIFF
--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -1418,6 +1418,74 @@ mod tests {
     }
 
     #[test]
+    fn policy_denied_effect_frame_anchors_at_the_gated_call_not_run() {
+        // Critique E3 regression (experiments/critique/RESULTS.md): the
+        // policy-denial error used to anchor at `run(` — the handler's
+        // definition line — instead of the gated call. Unlike a plain JS
+        // throw, the denial is raised by the HOST binding (an `Err(String)`
+        // crossing back into the VM mid-await), so this pins the one path
+        // where the frame position must come from the per-op position table
+        // at the awaiting call site rather than the proto's definition site.
+        let dir = std::env::temp_dir().join(format!("chidori-policy-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        // `run(` sits on line 3; the gated `fetch(...)` call (which routes
+        // through the policy-checked `__chidori_http` host op) on line 4.
+        let src = "import { chidori, run } from \"chidori:agent\";\n\n\
+                   run(async () => {\n\
+                   \x20 const res = await fetch(\"https://denied.test/\");\n\
+                   \x20 return res.status;\n\
+                   });\n";
+        std::fs::write(&path, src).unwrap();
+
+        let policy = PolicyConfig {
+            rules: vec![crate::policy::PolicyRule {
+                target: "http".to_string(),
+                decision: crate::policy::Decision::NeverAllow,
+                match_args: None,
+                reason: Some("network disabled in this test".to_string()),
+            }],
+            ..PolicyConfig::default()
+        };
+        let backend = HostBindingBackend::for_runtime(
+            RuntimeContext::new(),
+            Arc::new(ProviderRegistry::new()),
+            Arc::new(TemplateEngine::new(".")),
+            Arc::new(tokio::runtime::Runtime::new().unwrap()),
+            Arc::new(policy),
+            Arc::new(StdMutex::new(PolicyCache::default())),
+            RuntimePolicy::durable_default("rust-engine-test"),
+            Arc::new(ToolRegistry::new()),
+            Arc::new(McpManager::new()),
+        );
+
+        let err = run_agent(&path, src, &serde_json::json!({}), &backend)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("policy: `http` denied"),
+            "the denial names the gated target: {err}"
+        );
+
+        // Frames arrive in transpiled coordinates; remap at the display
+        // boundary exactly as the CLI does, then the handler frame must land
+        // on the gated call (line 4), not the `run(` line (line 3).
+        super::set_display_project_root(dir.clone());
+        let remapped = remap_stack_frames(&err);
+        let path_str = path.to_string_lossy();
+        assert!(
+            remapped.contains(&format!("at <anonymous> ({path_str}:4:")),
+            "handler frame anchors at the gated fetch call: {remapped}"
+        );
+        assert!(
+            !remapped.contains(&format!("({path_str}:3:")),
+            "no frame anchors at the run( line: {remapped}"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn run_agent_executes_ts_through_rust_engine_and_records_host_calls() {
         // A single-file TS agent that does JS work (a nested function call) and a
         // chidori.log host effect, then returns a value derived from its input.

--- a/docs/consumer-usability-review.md
+++ b/docs/consumer-usability-review.md
@@ -175,8 +175,9 @@ with five prompts and two tools, "your agent failed at `run(`" is no
 information at all; in a 1,000-line agent it would be actively painful. The
 divergence errors prove the runtime knows the failing seq and call; the
 frames just don't use the real call site. (This clearly improved recently —
-#132 added stack traces — but the top frame shown to the user is still the
-registration site.)
+#132 added stack traces — but at review time the top frame shown to the
+user was still the registration site. Since fixed by the per-op position
+table; see the note in the fixes section below.)
 
 ## Friction 6: CLI/server asymmetries a consumer trips on, in order
 
@@ -300,14 +301,23 @@ workspace root as run/serve/resume; `llm.txt` warns about the
 and regression tests pin the new behaviors (target-wide approval cache,
 tolerant-but-loud journal argument comparison, priced-vs-unknown cost).
 
-**Not fixed: error frames anchored at `run(`.** Investigated: the engine's
-stack frames carry each function's *definition site*
-(`FuncProto.source_line`), and the bytecode has no per-instruction line
-table, so pointing a frame at the failing `await` requires adding a pc→span
-table to compiled functions and teaching the unwinder to read the current pc
-— a real engine project rather than a polish fix. Runtime error *messages*
-carry the failing seq and call details, which mitigates but does not replace
-call-site frames.
+**Fixed since this review: error frames anchored at `run(`.** At the time
+of the investigation the engine's stack frames carried each function's
+*definition site* (`FuncProto.source_line`) and the bytecode had no
+per-instruction line table — pointing a frame at the failing `await` meant
+adding a pc→span table to compiled functions and teaching the unwinder to
+read the current pc. That engine work has since landed (#135): a per-op
+position table (`FuncProto::pos`, index-parallel to the code and remapped by
+every code-shortening pass) is threaded through both interpreter tiers, and
+the unwinder records each frame at the position the throw crossed it — the
+throwing statement for the innermost frame, the awaiting call for outer
+frames. Host-raised failures (policy denials, provider errors, workspace
+errors, unknown tools) now anchor at the gated call rather than the `run(`
+registration line, with the definition site remaining only as the fallback
+for synthetic protos. Regression tests pin the behavior in
+`crates/chidori-js/tests/errors.rs` and
+`crates/chidori/src/runtime/rust_engine.rs`
+(`policy_denied_effect_frame_anchors_at_the_gated_call_not_run`).
 
 ## Closing
 


### PR DESCRIPTION
The critique's E3/E7 findings (error frames anchored at run( / at
function declaration lines) were fixed by the per-op position table
(FuncProto::pos) threaded through both interpreter tiers in #135, but
the host-raised-denial path — a policy Err(String) crossing back into
the VM at the awaiting call — had no regression test. Add one: a
NeverAllow http policy under a run(handler) agent must produce a frame
at the gated fetch(...) line after display-time remap, and no frame on
the run( line.

Verified the surrounding behavior end-to-end against fresh repros
(throws in helpers/getters/callbacks/try-finally, awaited rejections,
policy and unknown-tool denials, nested tool files, register tier and
budget-off runs, --stream events): all frames anchor at throw/call
sites on current main.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K3Wtbc7BQg2DwJwYZJ5Lgq