### PR TITLE
Close out the open consumer-usability-review findings (rounds 1–6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,11 @@ human-in-the-loop pause/resume loop — see
 - **Cost-efficient prompting** — structural [prompt
   caching](./docs/context-management.md) re-bills stable prefixes at the cached
   rate, and replay pays zero tokens.
+- **Agents that learn across sessions** — persist distilled lessons and
+  preferences in [`chidori.memory`](./docs/memory.md), a namespaced key-value
+  store anchored to the agent's directory, and render reusable prompt
+  [templates](./docs/template.md) (Jinja with strict undefined-variable
+  checking) instead of concatenating strings.
 - **npm packages without Node** — `chidori add zod` installs straight from the
   npm registry into a content-addressed cache (SHA-512 verified, hardlinked
   `node_modules`, merge-friendly JSONL lockfile, no install scripts ever), and
@@ -386,6 +391,8 @@ deterministic, replayable, and testable for free.
 | [JavaScript conformance (Test262)](./docs/conformance.md) | Running the pure-Rust JS engine against the TC39 suite |
 | [Sandbox & security model](./docs/sandbox-model.md) | Deny-by-default policy, capability injection, resource limits |
 | [Context management & caching](./docs/context-management.md) | Immutable contexts, compaction, cost accounting |
+| [Prompt templates](./docs/template.md) | `chidori.template`: Jinja rendering, inline vs. file templates, path resolution, strict undefined variables |
+| [Agent memory](./docs/memory.md) | `chidori.memory`: persistent cross-run key-value store — namespacing, on-disk anchoring, replay semantics |
 | [Signals & multiplayer](./docs/signals.md) | Named listen points, mailboxes, fan-in |
 | [Actors & supervision](./docs/actors.md) | Spawned agent processes, message passing, supervision trees, restart strategies |
 | [Detached agents](./docs/detached-agents.md) | Durable, addressable, hibernating agent processes; `chidori.alarm`; the `/agents/detached` HTTP surface |

--- a/crates/chidori/src/export.rs
+++ b/crates/chidori/src/export.rs
@@ -1,0 +1,193 @@
+//! `chidori export` — carve a minimal, committable verification fixture out
+//! of a full run directory.
+//!
+//! A run directory carries everything `chidori resume` might need — the
+//! multi-megabyte runtime snapshot blob (`runtime.snapshot`), the host promise
+//! table, pending-operation state, leases — which makes "commit a run and
+//! `chidori verify` it in CI" impractical at tens of MB per checkpoint.
+//! `chidori verify` itself reads only four artifacts:
+//!
+//! - `records.jsonl` / `checkpoint.json` — the call journal (the two are the
+//!   same log twice; the export writes one compacted `records.jsonl` from
+//!   their union),
+//! - `runtime.snapshot.json` — the snapshot *manifest* (source fingerprints,
+//!   policy/ABI, recorded default model) that gates source drift,
+//! - `output.json` — the recorded output the replay must reproduce,
+//! - `input.json` — the run's input.
+//!
+//! `cmd_export` copies exactly that set into `<dest>/<run_id>/`, refusing runs
+//! whose journal is not yet a complete, verifiable record (live lease, pending
+//! host operation, no recorded output). The fixture is consumed with
+//! `chidori verify <agent.ts> <run_id> --runs-dir <dest>`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::runtime::snapshot::{
+    SnapshotManifest, PENDING_HOST_OPERATION_FILE, SNAPSHOT_MANIFEST_FILE,
+};
+use crate::runtime::store::{FsRunStore, RunLease, RunStore as _, LEASE_FILE, RECORDS_FILE};
+
+/// The recorded-output artifact `chidori verify` compares the replay against.
+const OUTPUT_FILE: &str = "output.json";
+/// The run-input artifact `chidori verify` replays with.
+const INPUT_FILE: &str = "input.json";
+
+pub fn cmd_export(run_id: &str, fixture_dest: &Path, dir: Option<&Path>) -> Result<()> {
+    let base_dir = dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let run_dir = base_dir.join(".chidori").join("runs").join(run_id);
+    if !run_dir.is_dir() {
+        anyhow::bail!("No persisted run at {}", run_dir.display());
+    }
+    let store = FsRunStore::new(run_dir.clone());
+
+    // --- Refuse runs whose journal is not a complete, verifiable record. ---
+
+    // A live (unexpired) lease means some process still owns and is writing
+    // this run: its journal is mid-flight, not a fixture.
+    if let Some(bytes) = store.get_blob(LEASE_FILE)? {
+        if let Ok(lease) = serde_json::from_slice::<RunLease>(&bytes) {
+            if lease.expires_at > chrono::Utc::now() {
+                anyhow::bail!(
+                    "refusing to export run {run_id}: it is still leased by `{}` (until {}) — \
+                     a running run's journal is incomplete. Wait for the run to finish (or the \
+                     lease to expire) and re-export.",
+                    lease.owner,
+                    lease.expires_at
+                );
+            }
+        }
+    }
+
+    // The snapshot manifest is what lets `verify` refuse source drift and
+    // recover the recorded model; a fixture without one would verify against
+    // whatever code happens to be on disk.
+    let manifest_bytes = store.get_blob(SNAPSHOT_MANIFEST_FILE)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "refusing to export run {run_id}: no {SNAPSHOT_MANIFEST_FILE} under {} — without \
+             the snapshot manifest, `chidori verify` cannot check the agent source against \
+             the recorded fingerprints",
+            run_dir.display()
+        )
+    })?;
+    let manifest: SnapshotManifest = serde_json::from_slice(&manifest_bytes)
+        .with_context(|| format!("parsing {}", run_dir.join(SNAPSHOT_MANIFEST_FILE).display()))?;
+
+    // A pending host operation (or its durable artifact) marks a paused run;
+    // `verify` only accepts runs that replay to completion.
+    if manifest.pending.is_some() || store.get_blob(PENDING_HOST_OPERATION_FILE)?.is_some() {
+        anyhow::bail!(
+            "refusing to export run {run_id}: it is paused at a pending host operation — \
+             only completed runs can be verified. Resume it to completion first."
+        );
+    }
+
+    // `output.json` is written when a run settles; without it there is no
+    // recorded output for `verify` to hold the replay to.
+    let output_bytes = store.get_blob(OUTPUT_FILE)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "refusing to export run {run_id}: no recorded {OUTPUT_FILE} — the run never \
+             completed (it is still running, paused, or failed), so its journal is not a \
+             verifiable record. Only completed runs can be exported as fixtures."
+        )
+    })?;
+
+    let records = store.load_call_log()?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "refusing to export run {run_id}: no call journal (records.jsonl / \
+             checkpoint.json) under {}",
+            run_dir.display()
+        )
+    })?;
+
+    // --- Write the fixture: `<dest>/<run_id>/` with exactly what verify reads. ---
+
+    let fixture_dir = fixture_dest.join(run_id);
+    std::fs::create_dir_all(&fixture_dir)
+        .with_context(|| format!("creating {}", fixture_dir.display()))?;
+
+    // One compacted journal from the checkpoint ∪ appended-tail union, so the
+    // fixture needs no `checkpoint.json` duplicate of the same log.
+    let mut journal = Vec::new();
+    for record in &records {
+        journal.extend(serde_json::to_vec(record)?);
+        journal.push(b'\n');
+    }
+    let mut written: Vec<(String, u64)> = Vec::new();
+    let mut write_artifact = |name: &str, bytes: &[u8]| -> Result<()> {
+        let path = fixture_dir.join(name);
+        std::fs::write(&path, bytes).with_context(|| format!("writing {}", path.display()))?;
+        written.push((name.to_string(), bytes.len() as u64));
+        Ok(())
+    };
+    write_artifact(RECORDS_FILE, &journal)?;
+    write_artifact(SNAPSHOT_MANIFEST_FILE, &manifest_bytes)?;
+    write_artifact(OUTPUT_FILE, &output_bytes)?;
+    if let Some(input_bytes) = store.get_blob(INPUT_FILE)? {
+        write_artifact(INPUT_FILE, &input_bytes)?;
+    }
+
+    // --- Report: what was copied, what it saved, how to consume it. ---
+
+    let run_dir_size = dir_size(&run_dir);
+    let fixture_size: u64 = written.iter().map(|(_, size)| size).sum();
+    let name_width = written
+        .iter()
+        .map(|(name, _)| name.len())
+        .max()
+        .unwrap_or(0);
+    println!("exported fixture: {}", fixture_dir.display());
+    for (name, size) in &written {
+        println!("  {name:<name_width$}  {:>10}", human_size(*size));
+    }
+    println!(
+        "exported fixture: {} (run dir was {})",
+        human_size(fixture_size),
+        human_size(run_dir_size)
+    );
+    println!(
+        "verify with: chidori verify {} {run_id} --runs-dir {}",
+        manifest.entry.path.display(),
+        fixture_dest.display()
+    );
+    Ok(())
+}
+
+/// Total size in bytes of every regular file under `path`, recursively.
+/// Unreadable entries count as zero — the number feeds a summary line, not a
+/// correctness decision.
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.is_dir() {
+                stack.push(entry_path);
+            } else if let Ok(meta) = entry.metadata() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+/// `312 B` / `4.2 KB` / `24.1 MB` — coarse, human-first sizes for the summary.
+fn human_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    let bytes_f = bytes as f64;
+    if bytes_f >= MB {
+        format!("{:.1} MB", bytes_f / MB)
+    } else if bytes_f >= KB {
+        format!("{:.1} KB", bytes_f / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -1,4 +1,5 @@
 mod acp;
+mod export;
 mod init;
 mod mcp;
 mod mem_guard;
@@ -289,6 +290,33 @@ enum Commands {
         run_id: String,
 
         /// Project dir containing `.chidori/runs/` (defaults to agent file's parent)
+        #[arg(short, long)]
+        dir: Option<PathBuf>,
+
+        /// Read the run from `<runs-dir>/<run_id>` instead of
+        /// `<dir>/.chidori/runs/<run_id>` — the consumption side of
+        /// `chidori export --fixture`: point this at the committed fixture
+        /// directory.
+        #[arg(long)]
+        runs_dir: Option<PathBuf>,
+    },
+
+    /// Export a completed run as a minimal, committable verification fixture:
+    /// copies just the artifacts `chidori verify` reads (records.jsonl,
+    /// runtime.snapshot.json, output.json, input.json) into `<dest>/<run_id>/`,
+    /// leaving the multi-megabyte runtime snapshot blob and resume-only state
+    /// behind. Commit the fixture and run
+    /// `chidori verify <agent.ts> <run_id> --runs-dir <dest>` in CI.
+    Export {
+        /// Run id (subdirectory name under `.chidori/runs/`)
+        run_id: String,
+
+        /// Destination directory for the fixture; the run's artifacts land in
+        /// `<dest>/<run_id>/`.
+        #[arg(long)]
+        fixture: PathBuf,
+
+        /// Project dir containing `.chidori/runs/` (defaults to current dir)
         #[arg(short, long)]
         dir: Option<PathBuf>,
     },
@@ -653,9 +681,23 @@ fn dispatch_command(command: Commands) -> (Result<()>, bool) {
             },
             false,
         ),
-        Commands::Verify { file, run_id, dir } => {
-            (cmd_verify(&file, &run_id, dir.as_deref()), false)
-        }
+        Commands::Verify {
+            file,
+            run_id,
+            dir,
+            runs_dir,
+        } => (
+            cmd_verify(&file, &run_id, dir.as_deref(), runs_dir.as_deref()),
+            false,
+        ),
+        Commands::Export {
+            run_id,
+            fixture,
+            dir,
+        } => (
+            crate::export::cmd_export(&run_id, &fixture, dir.as_deref()),
+            false,
+        ),
         Commands::Branches { run_id, dir } => (cmd_branches(&run_id, dir.as_deref()), false),
         Commands::BranchResume {
             run_id,
@@ -2231,12 +2273,22 @@ fn cmd_resume(
 /// changed source refuses via the manifest check, a diverging recorded call
 /// errors positionally, a run that reaches for anything live has no provider
 /// (and no allowed gated effects) to reach.
-fn cmd_verify(file: &Path, run_id: &str, dir: Option<&std::path::Path>) -> Result<()> {
+fn cmd_verify(
+    file: &Path,
+    run_id: &str,
+    dir: Option<&std::path::Path>,
+    runs_dir: Option<&std::path::Path>,
+) -> Result<()> {
     let base_dir = dir
         .map(|d| d.to_path_buf())
         .or_else(|| file.parent().map(|p| p.to_path_buf()))
         .unwrap_or_else(|| PathBuf::from("."));
-    let run_base = base_dir.join(".chidori").join("runs");
+    // `--runs-dir` points straight at a runs base (e.g. a committed
+    // `chidori export --fixture` directory); otherwise the run lives under
+    // the project's `.chidori/runs/` as usual.
+    let run_base = runs_dir
+        .map(|d| d.to_path_buf())
+        .unwrap_or_else(|| base_dir.join(".chidori").join("runs"));
     let run_dir = run_base.join(run_id);
 
     use crate::runtime::store::RunStore as _;

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -2017,7 +2017,7 @@ fn cmd_resume(
     // diverge against — it is ordinary live execution, so a different
     // args/result on the retry needs no opt-in.
     if retry_failed {
-        if records.last().map_or(true, |r| r.error.is_none()) {
+        if records.last().is_none_or(|r| r.error.is_none()) {
             let store = factory.store_for(run_id);
             let state = if store.get_blob("output.json").ok().flatten().is_some() {
                 "completed — it already has a recorded output, so there is nothing to \

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -1190,6 +1190,72 @@ fn abs_dir(dir: &std::path::Path) -> PathBuf {
     })
 }
 
+/// Spawn a stderr progress listener for plain (non `--stream`) runs: one line
+/// per live prompt call, so a long model call shows a sign of life instead of
+/// dead air until the run ends. Reuses the runtime's existing event channel —
+/// the returned sender is handed to the engine's `*_streaming` entry point and
+/// the drain thread prints only `PromptStart`/`PromptEnd` (per-record `Call`
+/// and per-token `PromptDelta` events flow on the same channel and are
+/// ignored). Replayed and locally-cached prompt calls short-circuit in
+/// `host_core` before the provider-request path that emits `PromptStart`, so
+/// a resume never prints phantom "started" lines for calls it served from the
+/// journal. Stdout is untouched: it stays reserved for the agent's output.
+///
+/// Returns `None` when `CHIDORI_QUIET` is set (to anything but `0`/empty),
+/// the opt-out for scripts that want the old fully-silent stderr; the caller
+/// then runs without an event sender attached, exactly as before.
+fn spawn_prompt_progress_listener() -> Option<(
+    tokio::sync::mpsc::UnboundedSender<crate::runtime::context::RuntimeEvent>,
+    std::thread::JoinHandle<()>,
+)> {
+    if std::env::var_os("CHIDORI_QUIET").is_some_and(|v| !v.is_empty() && v != "0") {
+        return None;
+    }
+    let (event_tx, event_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::runtime::context::RuntimeEvent>();
+    let drain = std::thread::spawn(move || {
+        use crate::runtime::context::RuntimeEvent;
+        use std::collections::HashMap;
+        use std::time::Instant;
+
+        let mut rx = event_rx;
+        let mut started: HashMap<String, Instant> = HashMap::new();
+        while let Some(event) = rx.blocking_recv() {
+            match event {
+                RuntimeEvent::PromptStart {
+                    stream_id,
+                    seq,
+                    model,
+                    ..
+                } => {
+                    started.insert(stream_id, Instant::now());
+                    eprintln!("seq {seq}: prompt started ({model})");
+                }
+                RuntimeEvent::PromptEnd {
+                    stream_id,
+                    seq,
+                    error,
+                    ..
+                } => {
+                    // A failed prompt surfaces through the run's own error
+                    // path; the progress line only marks successful finishes.
+                    let elapsed = started.remove(&stream_id);
+                    if error.is_none() {
+                        if let Some(t0) = elapsed {
+                            eprintln!(
+                                "seq {seq}: prompt finished ({:.1}s)",
+                                t0.elapsed().as_secs_f64()
+                            );
+                        }
+                    }
+                }
+                RuntimeEvent::Call(_) | RuntimeEvent::PromptDelta { .. } => {}
+            }
+        }
+    });
+    Some((event_tx, drain))
+}
+
 fn cmd_run(
     file: &Path,
     inputs: &[String],
@@ -1251,7 +1317,19 @@ fn cmd_run(
     // Run the agent.
     // Announce the run id up front (stderr): after a crash — where buffered
     // stdout is lost — the id `chidori resume` needs is already on record.
-    let result = engine.run_announced(file, &input_value)?;
+    // With the progress listener attached (the default), each live prompt
+    // call also gets a one-line stderr note — long model calls are otherwise
+    // total silence on the plain path. CHIDORI_QUIET=1 restores that silence.
+    let result = match spawn_prompt_progress_listener() {
+        Some((event_tx, drain)) => {
+            let result = engine.run_streaming_announced(file, &input_value, event_tx);
+            // The sender moved into the engine and drops when the run
+            // returns; join so the last progress lines land before output.
+            drain.join().ok();
+            result?
+        }
+        None => engine.run_announced(file, &input_value)?,
+    };
 
     // A `chidori.signal(name)` listen point with an empty mailbox pauses the run
     // (there is no stdin fallback for signals, unlike `input()`). The engine has
@@ -2011,7 +2089,18 @@ fn cmd_resume(
         .iter()
         .filter(|r| r.function == "workspace" && r.parent_seq.is_none())
         .count() as u64;
-    let result = engine.resume_run(file, &input_value, records, run_id);
+    // Same one-line-per-prompt stderr progress as plain `run`, and only for
+    // calls executed live past the replay frontier: replayed records
+    // short-circuit before the provider path that emits PromptStart, so the
+    // replayed prefix stays silent. CHIDORI_QUIET=1 opts out.
+    let result = match spawn_prompt_progress_listener() {
+        Some((event_tx, drain)) => {
+            let result = engine.resume_run_streaming(file, &input_value, records, run_id, event_tx);
+            drain.join().ok();
+            result
+        }
+        None => engine.resume_run(file, &input_value, records, run_id),
+    };
     let _ =
         crate::runtime::store::release_lease(factory.store_for(run_id).as_ref(), &cli_lease_owner);
     let result = result?;

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -233,6 +233,15 @@ enum Commands {
         #[arg(long)]
         until_seq: Option<u64>,
 
+        /// Repair a failed run: strip the trailing failed record(s) — and any
+        /// nested effects the failed call consumed — from the journal, replay
+        /// everything before the failure from cache, then re-execute the
+        /// failed call live. Errors if the run's journal has no trailing
+        /// failure (a completed run needs nothing; a paused run wants plain
+        /// `resume`). Mutually exclusive with `--until-seq`.
+        #[arg(long, conflicts_with = "until_seq")]
+        retry_failed: bool,
+
         /// Edit-and-resume: proceed even though the agent source changed
         /// since this run was recorded. Recorded calls replay positionally
         /// against the edited code; an edit that touches already-replayed
@@ -620,6 +629,7 @@ fn dispatch_command(command: Commands) -> (Result<()>, bool) {
             run_id,
             dir,
             until_seq,
+            retry_failed,
             allow_source_change,
             model,
             untrusted,
@@ -634,6 +644,7 @@ fn dispatch_command(command: Commands) -> (Result<()>, bool) {
                     &run_id,
                     dir.as_deref(),
                     until_seq,
+                    retry_failed,
                     allow_source_change,
                     model,
                     untrusted,
@@ -1969,6 +1980,7 @@ fn cmd_resume(
     run_id: &str,
     dir: Option<&std::path::Path>,
     until_seq: Option<u64>,
+    retry_failed: bool,
     allow_source_change: bool,
     model: Option<String>,
     untrusted: bool,
@@ -1992,6 +2004,63 @@ fn cmd_resume(
         .store_for(run_id)
         .load_call_log()?
         .ok_or_else(|| anyhow::anyhow!("No checkpoint found under {}", run_dir.display()))?;
+
+    // `--retry-failed`: first-class repair for a failed run. The trailing
+    // failed record(s) — the crash frontier — are stripped with the exact
+    // fixpoint the actor `restart: "resume"` path and the detached-agent
+    // supervisor use (`strip_crash_frontier`): pop trailing failed records,
+    // then sweep out every record whose parent is stripped, so a failed
+    // call's nested effects re-execute live too. Divergence scoping falls out
+    // of the strip: the surviving prefix still replays under the normal
+    // strict rules (nothing here loosens them, and `--allow-source-change`
+    // keeps its usual meaning), while the retried tail has no records left to
+    // diverge against — it is ordinary live execution, so a different
+    // args/result on the retry needs no opt-in.
+    if retry_failed {
+        if records.last().map_or(true, |r| r.error.is_none()) {
+            let store = factory.store_for(run_id);
+            let state = if store.get_blob("output.json").ok().flatten().is_some() {
+                "completed — it already has a recorded output, so there is nothing to \
+                 retry (use `chidori verify` to re-check it, or `--until-seq` to \
+                 time-travel into its history)"
+                    .to_string()
+            } else if store
+                .get_blob(crate::runtime::snapshot::PENDING_HOST_OPERATION_FILE)
+                .ok()
+                .flatten()
+                .is_some()
+            {
+                "paused on a pending operation, not failed — continue it with a plain \
+                 `chidori resume` (or deliver its input/signal through `chidori serve`)"
+                    .to_string()
+            } else {
+                format!(
+                    "not in a failed state: its journal's last record ({}) completed, so \
+                     there is no failure frontier to retry",
+                    records
+                        .last()
+                        .map(|r| format!("seq {} `{}`", r.seq, r.function))
+                        .unwrap_or_else(|| "empty journal".to_string())
+                )
+            };
+            anyhow::bail!("--retry-failed: run {run_id} is {state}.");
+        }
+        let before_seqs: Vec<u64> = records.iter().map(|r| r.seq).collect();
+        records = crate::runtime::host_actor::strip_crash_frontier(records);
+        let kept: std::collections::HashSet<u64> = records.iter().map(|r| r.seq).collect();
+        let removed: Vec<u64> = before_seqs
+            .into_iter()
+            .filter(|seq| !kept.contains(seq))
+            .collect();
+        let low = removed.iter().min().copied().unwrap_or_default();
+        let high = removed.iter().max().copied().unwrap_or_default();
+        eprintln!(
+            "retry-failed: stripped {} failed record(s) (seqs {low}..{high}), \
+             replaying {} records then executing live",
+            removed.len(),
+            records.len()
+        );
+    }
 
     // Time travel: truncate the journal at the requested frontier; replay
     // serves everything up to it from cache and the run continues live there.
@@ -2077,7 +2146,13 @@ fn cmd_resume(
         .with_policy(cli_policy(untrusted, trusted))
         .with_persist_base(run_base.clone())
         .with_default_model(default_model)
-        .with_history_rewrite_allowed(until_seq.is_some())
+        // Both `--until-seq` and `--retry-failed` intentionally hand the
+        // engine a journal SHORTER than the durable one; without the opt-in
+        // the shorter-log floor would refuse to compact the repaired history
+        // (e.g. a retry that settles in fewer records than the failed attempt
+        // journaled), leaving stale failed records behind for `verify` to
+        // trip over.
+        .with_history_rewrite_allowed(until_seq.is_some() || retry_failed)
         .with_workspace_root(abs_dir(&base_dir));
 
     // Journaled top-level workspace records re-execute on every replay by

--- a/crates/chidori/src/main.rs
+++ b/crates/chidori/src/main.rs
@@ -1600,7 +1600,7 @@ fn cmd_chat(
     let engine = Engine::new(providers, template_engine, tokio_rt)
         .with_tools(tools)
         .with_policy(cli_policy(untrusted, trusted))
-        .with_persist_base(run_base)
+        .with_persist_base(run_base.clone())
         .with_workspace_root(abs_dir(&base_dir));
 
     eprintln!("chidori chat — type a message and press enter. Type 'exit' or Ctrl-D to quit.");
@@ -1665,7 +1665,7 @@ fn cmd_chat(
                         let text = turn.get("text").and_then(Value::as_str).unwrap_or("");
                         match turn.get("role").and_then(Value::as_str) {
                             Some("user") => println!("\nyou> {text}"),
-                            _ => println!("{text}"),
+                            _ => println!("assistant> {text}"),
                         }
                     }
                 }
@@ -1711,6 +1711,11 @@ fn cmd_chat(
             let mut streamed = false;
             while let Some(evt) = rx.blocking_recv() {
                 if let RuntimeEvent::PromptDelta { delta, .. } = evt {
+                    // Mark where the reply starts (mirrors the `you> ` prompt)
+                    // so scrollback distinguishes the two speakers.
+                    if !streamed {
+                        print!("assistant> ");
+                    }
                     print!("{delta}");
                     out.flush().ok();
                     streamed = true;
@@ -1748,7 +1753,7 @@ fn cmd_chat(
                         })
                         .and_then(|turn| turn.get("text").and_then(Value::as_str))
                         .unwrap_or("");
-                    print!("{reply}");
+                    print!("assistant> {reply}");
                 }
                 println!();
                 call_log = result.call_log.into_records();
@@ -1772,6 +1777,7 @@ fn cmd_chat(
         );
     }
     if !call_log.is_empty() {
+        print_chat_session_summary(&run_base, &session_id, messages.len());
         let agent_arg = agent
             .map(|p| format!("{} ", p.display()))
             .unwrap_or_default();
@@ -1785,6 +1791,86 @@ fn cmd_chat(
         let _ = std::fs::remove_dir_all(&temp_dir);
     }
     Ok(())
+}
+
+/// One-line usage/cost summary printed when a chat session ends. Reads the
+/// session's journaled records from its run dir and prices them exactly like
+/// `chidori stats` (same record parsing, same journaled-pricing fallback, and
+/// the same "unknown, not $0" treatment for unpriced models).
+fn print_chat_session_summary(run_base: &Path, session_id: &str, turns: usize) {
+    use crate::runtime::cost::{estimate_cost_usd_with_cache, is_priced_model};
+    use crate::runtime::store::RunStore as _;
+
+    let run_dir = run_base.join(session_id);
+    let Ok(Some(records)) = crate::runtime::store::FsRunStore::new(&run_dir).load_call_log() else {
+        return;
+    };
+    // Price under the pricing table recorded in the session's manifest, same
+    // as `stats` (a live CHIDORI_PRICING still wins inside the cost module).
+    if let Ok(manifest) = crate::runtime::snapshot::SnapshotStore::new(&run_dir).load_manifest() {
+        if let Some(ref pricing) = manifest.pricing {
+            crate::runtime::cost::install_journaled_pricing(pricing);
+        }
+    }
+
+    let mut prompt_calls: u64 = 0;
+    let mut input_tokens: u64 = 0;
+    let mut output_tokens: u64 = 0;
+    let mut cache_read: u64 = 0;
+    let mut cost: f64 = 0.0;
+    let mut any_unpriced = false;
+    for r in &records {
+        if r.function != "prompt" {
+            continue;
+        }
+        prompt_calls += 1;
+        let model = r
+            .args
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        if !is_priced_model(model) {
+            any_unpriced = true;
+        }
+        if let Some(ref usage) = r.token_usage {
+            input_tokens += usage.input_tokens;
+            output_tokens += usage.output_tokens;
+            let read = usage.cache_read_tokens.unwrap_or(0);
+            let write = usage.cache_creation_tokens.unwrap_or(0);
+            cache_read += read;
+            cost += estimate_cost_usd_with_cache(
+                model,
+                usage.input_tokens,
+                usage.output_tokens,
+                write,
+                read,
+            );
+        }
+    }
+    if prompt_calls == 0 {
+        return;
+    }
+
+    let cache_note = if cache_read > 0 {
+        format!(", {cache_read} cache reads")
+    } else {
+        String::new()
+    };
+    // Same distinction as `stats`: an unpriced model's cost is unknown, not $0.
+    let cost_note = if !any_unpriced {
+        format!("est. cost: ${cost:.6}")
+    } else if cost > 0.0 {
+        format!(
+            "est. cost: ${cost:.6} + unknown (unpriced model; supply rates via CHIDORI_PRICING)"
+        )
+    } else {
+        "est. cost: unknown (unpriced model; supply rates via CHIDORI_PRICING)".to_string()
+    };
+    eprintln!(
+        "session usage: {turns} turn(s), {prompt_calls} prompt call(s), {} tokens \
+         ({input_tokens} in / {output_tokens} out{cache_note}), {cost_note}",
+        input_tokens + output_tokens
+    );
 }
 
 fn cmd_check(file: &Path) -> Result<()> {

--- a/crates/chidori/src/pkg/manifest.rs
+++ b/crates/chidori/src/pkg/manifest.rs
@@ -89,8 +89,11 @@ impl Manifest {
             .entry(key.to_string())
             .or_insert_with(|| Value::Object(Map::new()));
         if let Some(map) = section.as_object_mut() {
+            // This build's serde_json (no `preserve_order`) backs objects
+            // with a BTreeMap, so dependency sections stay alphabetized
+            // automatically, matching npm. Top-level key order is imposed
+            // separately in `save`.
             map.insert(name.to_string(), Value::String(range.to_string()));
-            sort_map_in_place(map);
         }
     }
 
@@ -106,18 +109,78 @@ impl Manifest {
     }
 
     pub fn save(&self) -> Result<()> {
-        let mut out = serde_json::to_string_pretty(&self.value).expect("manifest serializes");
+        let obj = self.value.as_object().expect("validated as object");
+        let mut out = serde_json::to_string_pretty(&ConventionallyOrdered(obj))
+            .expect("manifest serializes");
         out.push('\n');
         std::fs::write(&self.path, out).with_context(|| format!("writing {}", self.path.display()))
     }
 }
 
-/// serde_json preserves insertion order by default; rewrite the map sorted so
-/// dependency sections stay alphabetized like npm keeps them.
-fn sort_map_in_place(map: &mut Map<String, Value>) {
-    let mut entries: Vec<(String, Value)> = std::mem::take(map).into_iter().collect();
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-    map.extend(entries);
+/// Top-level `package.json` keys in npm's conventional order. `save` emits
+/// these first, in this order, then any remaining keys alphabetically.
+///
+/// This build's serde_json does *not* enable the `preserve_order` feature
+/// (objects are BTreeMaps, keys always sorted), so a plain
+/// `to_string_pretty` would sink `name` below `dependencies`. Enabling
+/// `preserve_order` globally would change JSON map ordering across the whole
+/// binary — journal/checkpoint serialization included — so instead we impose
+/// a stable conventional order at write time.
+const TOP_LEVEL_KEY_ORDER: &[&str] = &[
+    "name",
+    "version",
+    "private",
+    "description",
+    "keywords",
+    "homepage",
+    "bugs",
+    "repository",
+    "funding",
+    "license",
+    "author",
+    "contributors",
+    "type",
+    "main",
+    "module",
+    "types",
+    "exports",
+    "imports",
+    "bin",
+    "files",
+    "engines",
+    "os",
+    "cpu",
+    "scripts",
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "peerDependenciesMeta",
+    "optionalDependencies",
+    "bundledDependencies",
+    "overrides",
+];
+
+/// Serializes the manifest object with [`TOP_LEVEL_KEY_ORDER`] applied to the
+/// top level only; nested objects (dependency sections included) keep their
+/// natural sorted order, which matches how npm alphabetizes them.
+struct ConventionallyOrdered<'a>(&'a Map<String, Value>);
+
+impl serde::Serialize for ConventionallyOrdered<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap as _;
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for key in TOP_LEVEL_KEY_ORDER {
+            if let Some(value) = self.0.get(*key) {
+                map.serialize_entry(key, value)?;
+            }
+        }
+        for (key, value) in self.0 {
+            if !TOP_LEVEL_KEY_ORDER.contains(&key.as_str()) {
+                map.serialize_entry(key, value)?;
+            }
+        }
+        map.end()
+    }
 }
 
 #[cfg(test)]
@@ -141,6 +204,36 @@ mod tests {
         assert_eq!(v["customField"]["keep"], Value::Bool(true));
         let deps: Vec<&String> = v["dependencies"].as_object().unwrap().keys().collect();
         assert_eq!(deps, ["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn save_keeps_name_first_in_conventional_key_order() {
+        let dir = tempfile::tempdir().unwrap();
+        // Keys deliberately chosen so a plain alphabetical dump would put
+        // `dependencies` before `name` and `version`.
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"zebraCustom":1,"version":"0.1.0","name":"demo","scripts":{"start":"x"}}"#,
+        )
+        .unwrap();
+        let mut m = Manifest::load_or_default(dir.path()).unwrap();
+        m.set_dependency("alpha", "^2.0.0", false);
+        m.save().unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        let pos = |key: &str| {
+            raw.find(&format!("\"{key}\""))
+                .unwrap_or_else(|| panic!("missing key {key}:\n{raw}"))
+        };
+        assert!(pos("name") < pos("version"), "{raw}");
+        assert!(pos("version") < pos("scripts"), "{raw}");
+        assert!(pos("scripts") < pos("dependencies"), "{raw}");
+        // Unknown keys trail the conventional ones.
+        assert!(pos("dependencies") < pos("zebraCustom"), "{raw}");
+        // The reordering is purely cosmetic: same JSON value.
+        let v: Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["dependencies"]["alpha"], "^2.0.0");
+        assert_eq!(v["zebraCustom"], 1);
     }
 
     #[test]

--- a/crates/chidori/src/pkg/manifest.rs
+++ b/crates/chidori/src/pkg/manifest.rs
@@ -110,8 +110,8 @@ impl Manifest {
 
     pub fn save(&self) -> Result<()> {
         let obj = self.value.as_object().expect("validated as object");
-        let mut out = serde_json::to_string_pretty(&ConventionallyOrdered(obj))
-            .expect("manifest serializes");
+        let mut out =
+            serde_json::to_string_pretty(&ConventionallyOrdered(obj)).expect("manifest serializes");
         out.push('\n');
         std::fs::write(&self.path, out).with_context(|| format!("writing {}", self.path.display()))
     }

--- a/crates/chidori/src/pkg/registry.rs
+++ b/crates/chidori/src/pkg/registry.rs
@@ -39,9 +39,19 @@ pub struct PackageVersion {
     pub optional_dependencies: BTreeMap<String, String>,
     #[serde(default, rename = "peerDependencies")]
     pub peer_dependencies: BTreeMap<String, String>,
+    #[serde(default, rename = "peerDependenciesMeta")]
+    pub peer_dependencies_meta: BTreeMap<String, PeerDependencyMeta>,
     pub dist: Dist,
     #[serde(default)]
     pub deprecated: Option<String>,
+}
+
+/// Per-peer metadata (`peerDependenciesMeta.<name>`): today just the
+/// `optional` flag, which marks a peer as fine to leave uninstalled.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PeerDependencyMeta {
+    #[serde(default)]
+    pub optional: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/chidori/src/pkg/resolve.rs
+++ b/crates/chidori/src/pkg/resolve.rs
@@ -268,6 +268,22 @@ pub async fn resolve(
         // Peer dependency check: warn when nothing in the resolved set
         // satisfies a peer range. We don't auto-install peers (v1).
         for (peer, peer_range) in &meta.peer_dependencies {
+            // Peers marked optional in `peerDependenciesMeta` are explicitly
+            // fine to leave uninstalled — never warn about them.
+            if meta
+                .peer_dependencies_meta
+                .get(peer)
+                .is_some_and(|m| m.optional)
+            {
+                continue;
+            }
+            // The chidori runtime transpiles and executes TypeScript itself,
+            // so a `typescript` peer (declared by e.g. valibot) is always
+            // effectively satisfied; warning about it would be noise on
+            // every install.
+            if peer == "typescript" {
+                continue;
+            }
             let satisfied = resolution
                 .packages
                 .keys()

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -2443,6 +2443,74 @@ mod tests {
     }
 
     #[test]
+    fn prompt_non_empty_option_rejects_blank_reply_and_defaults_stay_lenient() {
+        // Round-4 usability finding: a response truncated to emptiness flows
+        // on as "" and the run "succeeds" with an empty product. The opt-in
+        // `nonEmpty: true` prompt option must turn that into a catchable
+        // error; WITHOUT the option the empty string still resolves (default
+        // behavior unchanged). Whitespace-only output counts as empty.
+        let _env = PROMPT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let ctx = RuntimeContext::new();
+        let dir = std::env::temp_dir().join(format!(
+            "chidori-rust-nonempty-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("agent.ts");
+        let src = r#"
+            export async function agent(input: {}) {
+                let guarded: string | null = null;
+                let error = "";
+                try {
+                    guarded = await chidori.prompt("guarded-empty-question?", {
+                        model: "test-model",
+                        nonEmpty: true,
+                    });
+                } catch (e: any) {
+                    error = String(e && e.message ? e.message : e);
+                }
+                const unguarded = await chidori.prompt("unguarded-empty-question?", {
+                    model: "test-model",
+                });
+                return { guarded, error, unguarded };
+            }
+        "#;
+        std::fs::write(&path, src).unwrap();
+
+        let requests = Arc::new(StdMutex::new(Vec::new()));
+        let mut providers = crate::providers::ProviderRegistry::new();
+        providers.register(Box::new(SequenceProvider {
+            // Whitespace-only for the guarded call (trims to empty), truly
+            // empty for the unguarded one.
+            responses: vec!["   \n".to_string(), String::new()],
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            requests: Arc::clone(&requests),
+        }));
+        let backend = context_test_backend(ctx.clone(), providers);
+        let output = run_agent(&path, src, &serde_json::json!({}), &backend).unwrap();
+
+        // The guarded prompt rejected: the assignment never happened and the
+        // error names the failure, the likely truncation cause, and the knobs.
+        assert_eq!(output["guarded"], serde_json::Value::Null);
+        let error = output["error"].as_str().unwrap();
+        assert!(
+            error.contains("no visible output"),
+            "error must name the failure, got: {error}"
+        );
+        assert!(
+            error.contains("truncated") && error.contains("maxTokens"),
+            "error must point at the likely cause and remedy, got: {error}"
+        );
+        // The unguarded prompt kept the default lenient behavior: "".
+        assert_eq!(output["unguarded"], serde_json::json!(""));
+        // Both calls actually reached the provider (the guard runs on the
+        // reply, it does not short-circuit the request).
+        assert_eq!(requests.lock().unwrap().len(), 2);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn run_agent_resolves_relative_module_imports() {
         // A multi-file agent: the entry imports a helper from a sibling `.ts`
         // module. The rust engine resolves + transpiles + links the graph.

--- a/crates/chidori/src/runtime/rust_engine.rs
+++ b/crates/chidori/src/runtime/rust_engine.rs
@@ -2451,10 +2451,8 @@ mod tests {
         // behavior unchanged). Whitespace-only output counts as empty.
         let _env = PROMPT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let ctx = RuntimeContext::new();
-        let dir = std::env::temp_dir().join(format!(
-            "chidori-rust-nonempty-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("chidori-rust-nonempty-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("agent.ts");
         let src = r#"

--- a/crates/chidori/src/runtime/template.rs
+++ b/crates/chidori/src/runtime/template.rs
@@ -1,7 +1,8 @@
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use minijinja::{Environment, UndefinedBehavior};
+use minijinja::{Environment, ErrorKind, UndefinedBehavior};
 use serde_json::Value;
 
 /// Template engine backed by minijinja.
@@ -30,10 +31,10 @@ impl TemplateEngine {
     pub fn render_string(&self, template: &str, vars: &Value) -> Result<String> {
         let mut env = self.create_env();
         env.add_template("__inline__", template)
-            .context("Failed to parse inline template")?;
+            .map_err(|err| describe_template_error("parse", "inline template", &err))?;
         let tmpl = env.get_template("__inline__").unwrap();
         tmpl.render(vars)
-            .context("Failed to render inline template")
+            .map_err(|err| describe_template_error("render", "inline template", &err))
     }
 
     /// Render a template from a .jinja file with the given variables.
@@ -55,10 +56,10 @@ impl TemplateEngine {
         });
 
         env.add_template("__file__", &source)
-            .with_context(|| format!("Failed to parse template: {path}"))?;
+            .map_err(|err| describe_template_error("parse", &format!("template {path}"), &err))?;
         let tmpl = env.get_template("__file__").unwrap();
         tmpl.render(vars)
-            .with_context(|| format!("Failed to render template: {path}"))
+            .map_err(|err| describe_template_error("render", &format!("template {path}"), &err))
     }
 
     /// Determine if a template arg is a file path or an inline string, and render it.
@@ -76,8 +77,63 @@ impl TemplateEngine {
         env.set_undefined_behavior(UndefinedBehavior::SemiStrict);
         env.set_trim_blocks(true);
         env.set_lstrip_blocks(true);
+        // Embed the template source in errors so failure messages can point at
+        // the offending expression and its line/column (on by default only in
+        // debug builds; force it on so release builds report the same detail).
+        env.set_debug(true);
         env
     }
+}
+
+/// Turn a minijinja error into a single self-contained anyhow error whose
+/// primary message carries the located detail — error kind, offending
+/// expression (e.g. the undefined variable's name), and line/column. Without
+/// this the detail lives only in the anyhow source chain, which the runtime
+/// drops when it stringifies errors for the user-facing frame.
+fn describe_template_error(action: &str, what: &str, err: &minijinja::Error) -> anyhow::Error {
+    let mut msg = format!("Failed to {action} {what}: {}", err.kind());
+    if let Some(detail) = err.detail() {
+        let _ = write!(msg, ": {detail}");
+    }
+    // The error's span points at the failing expression in the template
+    // source; for an undefined-variable error that is the variable itself.
+    let located = err
+        .template_source()
+        .zip(err.range())
+        .and_then(|(source, range)| Some((source, source.get(range.clone())?, range.start)));
+    if let Some((_, snippet, _)) = located {
+        let snippet = snippet.trim();
+        if !snippet.is_empty() && !snippet.contains('\n') && snippet.len() <= 80 {
+            if err.kind() == ErrorKind::UndefinedError {
+                let _ = write!(msg, " (variable `{snippet}`)");
+            } else {
+                let _ = write!(msg, " (in `{snippet}`)");
+            }
+        }
+    }
+    if let Some(line) = err.line() {
+        let _ = write!(msg, " at line {line}");
+        if let Some(col) = located.and_then(|(source, _, start)| column_at(source, start)) {
+            let _ = write!(msg, ", column {col}");
+        }
+    }
+    // Chained errors (e.g. a failing include wraps the real cause) would
+    // otherwise stay hidden as sources — fold them into the message.
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        let _ = write!(msg, ": {cause}");
+        source = cause.source();
+    }
+    anyhow::anyhow!(msg)
+}
+
+/// 1-based column of `offset` within its line of `source`.
+fn column_at(source: &str, offset: usize) -> Option<usize> {
+    if offset > source.len() || !source.is_char_boundary(offset) {
+        return None;
+    }
+    let line_start = source[..offset].rfind('\n').map_or(0, |pos| pos + 1);
+    Some(source[line_start..offset].chars().count() + 1)
 }
 
 #[cfg(test)]
@@ -123,6 +179,63 @@ mod tests {
         let engine = TemplateEngine::new(".");
         let result = engine.render_string("Hello {{ name }}!", &json!({}));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_render_inline_undefined_variable_error_names_variable_and_location() {
+        let engine = TemplateEngine::new(".");
+        let err = engine
+            .render_string("line one\nHello {{ usernme }}!", &json!({"username": "x"}))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("inline template"), "missing template name: {msg}");
+        assert!(msg.contains("undefined value"), "missing error kind: {msg}");
+        assert!(msg.contains("`usernme`"), "missing variable name: {msg}");
+        assert!(msg.contains("line 2"), "missing line number: {msg}");
+        assert!(msg.contains("column 10"), "missing column: {msg}");
+    }
+
+    #[test]
+    fn test_render_inline_unknown_filter_error_names_filter_and_line() {
+        let engine = TemplateEngine::new(".");
+        let err = engine
+            .render_string("{{ name | shuot }}", &json!({"name": "x"}))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("inline template"), "missing template name: {msg}");
+        assert!(msg.contains("unknown filter"), "missing error kind: {msg}");
+        assert!(msg.contains("shuot"), "missing filter name: {msg}");
+        assert!(msg.contains("line 1"), "missing line number: {msg}");
+    }
+
+    #[test]
+    fn test_render_file_error_names_path_variable_and_line() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("summary.md.j2"),
+            "# Report\n\nAuthor: {{ author }}\nUser: {{ usernme }}\n",
+        )
+        .unwrap();
+        let engine = TemplateEngine::new(dir.path());
+        let err = engine
+            .render_file("summary.md.j2", &json!({"author": "a", "username": "x"}))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("summary.md.j2"), "missing template path: {msg}");
+        assert!(msg.contains("undefined value"), "missing error kind: {msg}");
+        assert!(msg.contains("`usernme`"), "missing variable name: {msg}");
+        assert!(msg.contains("line 4"), "missing line number: {msg}");
+    }
+
+    #[test]
+    fn test_parse_error_names_line() {
+        let engine = TemplateEngine::new(".");
+        let err = engine
+            .render_string("ok\n{% if x %}\nnever closed", &json!({}))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to parse"), "missing action: {msg}");
+        assert!(msg.contains("syntax error"), "missing error kind: {msg}");
     }
 
     #[test]

--- a/crates/chidori/src/runtime/template.rs
+++ b/crates/chidori/src/runtime/template.rs
@@ -188,7 +188,10 @@ mod tests {
             .render_string("line one\nHello {{ usernme }}!", &json!({"username": "x"}))
             .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("inline template"), "missing template name: {msg}");
+        assert!(
+            msg.contains("inline template"),
+            "missing template name: {msg}"
+        );
         assert!(msg.contains("undefined value"), "missing error kind: {msg}");
         assert!(msg.contains("`usernme`"), "missing variable name: {msg}");
         assert!(msg.contains("line 2"), "missing line number: {msg}");
@@ -202,7 +205,10 @@ mod tests {
             .render_string("{{ name | shuot }}", &json!({"name": "x"}))
             .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("inline template"), "missing template name: {msg}");
+        assert!(
+            msg.contains("inline template"),
+            "missing template name: {msg}"
+        );
         assert!(msg.contains("unknown filter"), "missing error kind: {msg}");
         assert!(msg.contains("shuot"), "missing filter name: {msg}");
         assert!(msg.contains("line 1"), "missing line number: {msg}");
@@ -221,7 +227,10 @@ mod tests {
             .render_file("summary.md.j2", &json!({"author": "a", "username": "x"}))
             .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("summary.md.j2"), "missing template path: {msg}");
+        assert!(
+            msg.contains("summary.md.j2"),
+            "missing template path: {msg}"
+        );
         assert!(msg.contains("undefined value"), "missing error kind: {msg}");
         assert!(msg.contains("`usernme`"), "missing variable name: {msg}");
         assert!(msg.contains("line 4"), "missing line number: {msg}");

--- a/crates/chidori/src/runtime/typescript/helpers.rs
+++ b/crates/chidori/src/runtime/typescript/helpers.rs
@@ -535,6 +535,7 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
                         const respondOptions = turnOptions(perTurn);
                         delete respondOptions.format;
                         delete respondOptions.strict;
+                        delete respondOptions.nonEmpty;
                         const loop = await globalThis.chidori.__fnToolLoop(
                             ctx,
                             respondOptions,
@@ -708,6 +709,24 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
             }
         }
 
+        // Opt-in guard against silent degradation on PLAIN-TEXT prompts: a
+        // response truncated to nothing (stop reason aside) otherwise flows on
+        // as "" and the run "succeeds" with an empty product. `format:"json"`
+        // needs no such guard — strict-by-default parsing (above) already
+        // throws on an empty/unparseable reply — so nonEmpty only applies to
+        // the plain-string result.
+        function assertNonEmptyReply(text) {
+            const reply = String(text == null ? "" : text);
+            if (reply.trim() !== "") return reply;
+            throw new Error(
+                "nonEmpty: prompt() returned no visible output (empty after trimming " +
+                    "whitespace) - was the response truncated? reasoning models spend the " +
+                    "maxTokens budget on hidden reasoning before any visible text. Raise " +
+                    "`maxTokens` in the prompt options, or drop `nonEmpty: true` to get " +
+                    "the empty string back.",
+            );
+        }
+
         function stringifyResult(value) {
             return typeof value === "string" ? value : JSON.stringify(value);
         }
@@ -769,7 +788,14 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
             const opts = options || {};
             const list = Array.isArray(opts.tools) ? opts.tools : [];
             if (!list.some(isHandle)) {
-                return nativePrompt.call(globalThis.chidori, text, options);
+                const out = nativePrompt.call(globalThis.chidori, text, options);
+                // nonEmpty is a JS-layer contract (the host ignores the key):
+                // check the resolved reply here. JSON mode is exempt — the
+                // host's strict format:"json" parsing already throws on empty.
+                if (opts.nonEmpty === true && opts.format !== "json") {
+                    return Promise.resolve(out).then(assertNonEmptyReply);
+                }
+                return out;
             }
             return (async () => {
                 const maxTurns = Number.isFinite(Number(opts.maxTurns))
@@ -783,6 +809,7 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
                 delete respondOptions.system;
                 delete respondOptions.format;
                 delete respondOptions.strict;
+                delete respondOptions.nonEmpty;
                 delete respondOptions.maxTurns;
                 const { handles } = splitTools(list);
                 const { text: reply } = await runToolLoop(
@@ -793,6 +820,9 @@ pub(crate) const CHIDORI_JS_HELPERS_SCRIPT: &str = r#"
                 );
                 if (opts.format === "json") {
                     return parseJsonReply(reply, opts.strict);
+                }
+                if (opts.nonEmpty === true) {
+                    return assertNonEmptyReply(reply);
                 }
                 return reply;
             })();

--- a/crates/chidori/src/server/events.rs
+++ b/crates/chidori/src/server/events.rs
@@ -30,6 +30,38 @@ use super::{session_view, store_or_500, AppState};
 // Event-driven handler (fallback for non-session routes)
 // ---------------------------------------------------------------------------
 
+/// Paths that are overwhelmingly automatic browser/scanner noise, not
+/// deliberate events: browsers request these on their own (favicon, touch
+/// icons), and crawlers/probes sweep them constantly. Kept deliberately
+/// conservative — only paths a browser or well-behaved bot fetches without
+/// the user asking — because a matching request is answered 404 without
+/// running the agent (each event run executes the full agent and burns
+/// tokens). `CHIDORI_SERVE_ALL_PATHS=1` disables the short-circuit for
+/// agents that genuinely serve these paths.
+pub(super) fn is_probe_noise_path(path: &str) -> bool {
+    path == "/favicon.ico"
+        || path == "/robots.txt"
+        || path.starts_with("/apple-touch-icon")
+        || path.starts_with("/.well-known/")
+}
+
+/// Escape hatch for the noise short-circuit: `CHIDORI_SERVE_ALL_PATHS=1`
+/// (or `true`/`on`) routes every path to the agent, including the ones
+/// [`is_probe_noise_path`] would answer 404.
+fn serve_all_paths_from_env() -> bool {
+    matches!(
+        std::env::var("CHIDORI_SERVE_ALL_PATHS").as_deref(),
+        Ok("1") | Ok("true") | Ok("on")
+    )
+}
+
+/// Whether a request path should be answered 404 without invoking the agent.
+/// Split from the env read so both branches are unit-testable without
+/// mutating process-global environment state.
+pub(super) fn noise_short_circuit(path: &str, serve_all_paths: bool) -> bool {
+    !serve_all_paths && is_probe_noise_path(path)
+}
+
 pub(super) async fn handle_event(
     State(state): State<AppState>,
     method: Method,
@@ -38,6 +70,15 @@ pub(super) async fn handle_event(
     query: Query<HashMap<String, String>>,
     body: Bytes,
 ) -> Response {
+    // Short-circuit obvious browser/scanner noise (favicon, robots.txt,
+    // touch icons, /.well-known/*) with an empty 404 before the agent runs:
+    // every event run executes the whole agent end-to-end, so stray probes
+    // would otherwise burn tokens. See docs/running-modes.md §3;
+    // CHIDORI_SERVE_ALL_PATHS=1 restores agent(event) for these paths.
+    if noise_short_circuit(uri.path(), serve_all_paths_from_env()) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
     let mut header_map = serde_json::Map::new();
     for (key, value) in headers.iter() {
         if let Ok(v) = value.to_str() {

--- a/crates/chidori/src/server/mod.rs
+++ b/crates/chidori/src/server/mod.rs
@@ -830,7 +830,9 @@ pub async fn serve(
     eprintln!("              POST /sessions/{{id}}/signal     → deliver a signal to a run");
     eprintln!("              POST /sessions/{{id}}/cancel     → cancel running session");
     eprintln!("              POST /sessions/stream            → run with SSE events");
-    eprintln!("              GET  /sessions/{{id}}/stream     → re-attach: replay + follow SSE events");
+    eprintln!(
+        "              GET  /sessions/{{id}}/stream     → re-attach: replay + follow SSE events"
+    );
     eprintln!("  Health:     GET  /health");
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/crates/chidori/src/server/mod.rs
+++ b/crates/chidori/src/server/mod.rs
@@ -36,6 +36,7 @@ mod detached;
 mod engine;
 mod events;
 mod hardening;
+mod preflight;
 mod recipes;
 mod sessions;
 #[cfg(test)]
@@ -51,7 +52,7 @@ use hardening::{
 };
 use recipes::{list_recipes, run_recipe};
 use sessions::resume::{approve_session, resume_session, signal_session};
-use sessions::stream::stream_session;
+use sessions::stream::{attach_session_stream, stream_session, SessionEventLog};
 use sessions::{
     agent_error_string, arm_signal_timeout, cancel_session, create_session, get_checkpoint,
     get_session, get_snapshot_manifest, list_agents, list_sessions, replay_session, session_policy,
@@ -59,6 +60,8 @@ use sessions::{
 
 // Test-only re-imports: they keep the flat namespace the test module's
 // `use super::*` saw when this module was a single file.
+#[cfg(test)]
+use events::{is_probe_noise_path, noise_short_circuit};
 #[cfg(test)]
 use hardening::bearer_token_matches;
 #[cfg(test)]
@@ -263,6 +266,11 @@ struct ActiveSession {
     /// enqueues straight into the live run's mailbox and wakes the worker,
     /// skipping the HTTP pause→deliver→resume round-trip.
     signals: Option<LiveSignalSession>,
+    /// The SSE event journal + broadcast of a live streaming session, so a
+    /// client whose stream dropped can re-attach via
+    /// `GET /sessions/{id}/stream`, replay what it missed, and follow live.
+    /// `None` for non-streaming runs (nothing is emitted to re-attach to).
+    event_log: Option<Arc<SessionEventLog>>,
 }
 
 /// The live-delivery handle a streaming worker registers in `active_sessions`.
@@ -740,6 +748,11 @@ pub async fn serve(
         .route("/sessions/{id}/approve", post(approve_session))
         .route("/sessions/{id}/cancel", post(cancel_session))
         .route("/sessions/stream", post(stream_session))
+        // SSE re-attach: catch up on a live streaming session's already-
+        // emitted events and follow it to settlement, or replay a settled
+        // session's journal. Same bearer auth as the other session routes
+        // (the auth middleware wraps the whole router).
+        .route("/sessions/{id}/stream", get(attach_session_stream))
         // Example agent discovery — peer directory of the server's
         // configured agent. Lets clients like util-trace-webgl pick an
         // example to run without restarting the server.
@@ -787,6 +800,14 @@ pub async fn serve(
         }
     );
     eprintln!("  Policy:      {}", policy_posture);
+    // Effect preflight (warning only, see server/preflight.rs): agents don't
+    // statically declare their effects, so scan the served agent's source for
+    // references to policy-gated effect surfaces and warn about any target
+    // the active policy unconditionally denies — otherwise nothing surfaces
+    // the mismatch until a run fails mid-flight.
+    if has_default_agent {
+        preflight::warn_denied_static_effects(&state.agent_path, &state.policy, &policy_posture);
+    }
     eprintln!(
         "  CORS:        {}",
         match std::env::var("CHIDORI_CORS_ORIGINS").ok() {
@@ -809,6 +830,7 @@ pub async fn serve(
     eprintln!("              POST /sessions/{{id}}/signal     → deliver a signal to a run");
     eprintln!("              POST /sessions/{{id}}/cancel     → cancel running session");
     eprintln!("              POST /sessions/stream            → run with SSE events");
+    eprintln!("              GET  /sessions/{{id}}/stream     → re-attach: replay + follow SSE events");
     eprintln!("  Health:     GET  /health");
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/crates/chidori/src/server/preflight.rs
+++ b/crates/chidori/src/server/preflight.rs
@@ -1,0 +1,165 @@
+//! Startup / session-creation preflight for policy-vs-agent mismatches.
+//!
+//! Chidori agents do NOT statically declare their effects anywhere — there is
+//! no manifest field like `effects: ["workspace:write"]`; effects are whatever
+//! host calls the agent's code makes at runtime (`fetch(...)`,
+//! `chidori.workspace.write(...)`, ...). The closest honest preflight is
+//! therefore a *static source scan*: grep the agent's TypeScript source for
+//! the well-known spellings of the policy-gated effect surfaces and check each
+//! referenced target against the active policy. When a referenced target is
+//! *unconditionally* denied — no argument shape could ever get it past the
+//! policy — the server prints a startup warning instead of letting the first
+//! real run fail mid-flight.
+//!
+//! This is deliberately a warning, never a refusal: the scan is a heuristic
+//! (an agent may mention `fetch` in dead code, or reach an effect through a
+//! spelling the scan does not know), so the server always starts. False
+//! negatives are fine (the run fails later with the same policy error the
+//! warning would have quoted); false positives are kept rare by only warning
+//! when the policy denies the target for EVERY possible argument.
+
+use std::path::Path;
+
+use serde_json::json;
+
+use crate::policy::{Decision, PolicyConfig};
+
+/// One statically-scanned reference to a policy-gated effect surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct StaticEffectRef {
+    /// The policy target the reference resolves to (e.g. `workspace:write`).
+    pub(super) target: &'static str,
+    /// The source spelling that evidenced it (e.g. `chidori.workspace.write`).
+    pub(super) evidence: &'static str,
+}
+
+/// The gated effect surfaces the scanner knows, as (needle, target, evidence).
+/// `needle` is matched as a substring of the agent source with a cheap
+/// identifier-boundary check on the preceding character, so `myFetch(` does
+/// not count as `fetch(`. Only the *powerful* (policy-gated) surfaces are
+/// listed — pure effects (`log`, `prompt`, ...) never reach the policy gate.
+const EFFECT_MARKERS: &[(&str, &str, &str)] = &[
+    ("fetch(", "http", "fetch(...)"),
+    ("node:http", "http", "node:http import"),
+    ("node:https", "http", "node:https import"),
+    ("workspace.write(", "workspace:write", "chidori.workspace.write"),
+    ("workspace.delete(", "workspace:delete", "chidori.workspace.delete"),
+    ("workspace.remove(", "workspace:delete", "chidori.workspace.remove"),
+    ("workspace.read(", "workspace:read", "chidori.workspace.read"),
+    ("workspace.list(", "workspace:list", "chidori.workspace.list"),
+    (
+        "workspace.manifest(",
+        "workspace:manifest",
+        "chidori.workspace.manifest",
+    ),
+];
+
+/// True when `source` contains `needle` at an identifier boundary: the
+/// character before the match must not be part of an identifier, so
+/// `prefetch(` / `myFetch(` do not evidence the `http` effect while
+/// `fetch(`, `globalThis.fetch(`, `await fetch(` all do.
+fn contains_at_identifier_boundary(source: &str, needle: &str) -> bool {
+    let mut from = 0;
+    while let Some(pos) = source[from..].find(needle) {
+        let abs = from + pos;
+        let boundary = abs == 0
+            || !source[..abs]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$');
+        if boundary {
+            return true;
+        }
+        from = abs + needle.len();
+    }
+    false
+}
+
+/// Scan agent source for references to policy-gated effect surfaces.
+/// Best-effort and entry-file-only: imports are not followed and commented-out
+/// code counts — acceptable for a warning-only preflight.
+pub(super) fn static_effect_refs(source: &str) -> Vec<StaticEffectRef> {
+    let mut refs: Vec<StaticEffectRef> = Vec::new();
+    for (needle, target, evidence) in EFFECT_MARKERS {
+        if contains_at_identifier_boundary(source, needle)
+            && !refs.iter().any(|r| r.target == *target)
+        {
+            refs.push(StaticEffectRef { target, evidence });
+        }
+    }
+    refs
+}
+
+/// True when SOME argument shape could get a call to `target` past this
+/// config layer (i.e. resolve to a decision other than `NeverAllow`).
+/// Rules are first-match-wins: a rule with `match_args` only covers the args
+/// it matches, so scanning continues past it; a rule without `match_args`
+/// covers every remaining argument shape and ends the scan.
+fn local_may_allow(cfg: &PolicyConfig, target: &str) -> bool {
+    for rule in &cfg.rules {
+        if rule.target != target && rule.target != "*" {
+            continue;
+        }
+        if rule.match_args.is_some() {
+            if rule.decision != Decision::NeverAllow {
+                return true;
+            }
+        } else {
+            return rule.decision != Decision::NeverAllow;
+        }
+    }
+    cfg.default != Decision::NeverAllow
+}
+
+/// True when some argument shape could get `target` past the FULL layered
+/// policy (base plus overlays; overlays only tighten, so every layer must
+/// leave a path open). Approximate in exactly one direction: it may report
+/// `true` when the layers' allowed argument sets do not actually intersect,
+/// which suppresses a warning — never fabricates one.
+fn may_allow(cfg: &PolicyConfig, target: &str) -> bool {
+    local_may_allow(cfg, target)
+        && cfg
+            .overlay
+            .as_ref()
+            .is_none_or(|overlay| may_allow(overlay, target))
+}
+
+/// The effect targets referenced by `source` that the active policy denies
+/// for every possible argument, each with the denial reason the run would
+/// have surfaced. Empty when nothing is unconditionally denied.
+pub(super) fn denied_static_effects(
+    source: &str,
+    policy: &PolicyConfig,
+) -> Vec<(StaticEffectRef, Option<String>)> {
+    static_effect_refs(source)
+        .into_iter()
+        .filter(|r| !may_allow(policy, r.target))
+        .map(|r| {
+            let (_, reason) = policy.decide(r.target, &json!({}));
+            (r, reason)
+        })
+        .collect()
+}
+
+/// Print a stderr warning for every effect surface the agent's source
+/// statically references that `policy` unconditionally denies. `posture` is
+/// the human-readable name of the active policy (the startup banner's policy
+/// posture, or a session's profile name). Warning only — never refuses.
+/// Unreadable agent files are silently skipped (the run itself will surface
+/// the real error).
+pub(super) fn warn_denied_static_effects(agent_path: &Path, policy: &PolicyConfig, posture: &str) {
+    let Ok(source) = std::fs::read_to_string(agent_path) else {
+        return;
+    };
+    for (r, reason) in denied_static_effects(&source, policy) {
+        eprintln!(
+            "WARNING: the agent references {} but the active policy ({posture}) \
+             unconditionally denies `{}`; runs that attempt it will fail{}",
+            r.evidence,
+            r.target,
+            reason
+                .map(|reason| format!(" — {reason}"))
+                .unwrap_or_default(),
+        );
+    }
+}

--- a/crates/chidori/src/server/preflight.rs
+++ b/crates/chidori/src/server/preflight.rs
@@ -42,11 +42,31 @@ const EFFECT_MARKERS: &[(&str, &str, &str)] = &[
     ("fetch(", "http", "fetch(...)"),
     ("node:http", "http", "node:http import"),
     ("node:https", "http", "node:https import"),
-    ("workspace.write(", "workspace:write", "chidori.workspace.write"),
-    ("workspace.delete(", "workspace:delete", "chidori.workspace.delete"),
-    ("workspace.remove(", "workspace:delete", "chidori.workspace.remove"),
-    ("workspace.read(", "workspace:read", "chidori.workspace.read"),
-    ("workspace.list(", "workspace:list", "chidori.workspace.list"),
+    (
+        "workspace.write(",
+        "workspace:write",
+        "chidori.workspace.write",
+    ),
+    (
+        "workspace.delete(",
+        "workspace:delete",
+        "chidori.workspace.delete",
+    ),
+    (
+        "workspace.remove(",
+        "workspace:delete",
+        "chidori.workspace.remove",
+    ),
+    (
+        "workspace.read(",
+        "workspace:read",
+        "chidori.workspace.read",
+    ),
+    (
+        "workspace.list(",
+        "workspace:list",
+        "chidori.workspace.list",
+    ),
     (
         "workspace.manifest(",
         "workspace:manifest",

--- a/crates/chidori/src/server/sessions.rs
+++ b/crates/chidori/src/server/sessions.rs
@@ -226,6 +226,17 @@ pub(super) async fn create_session(
         }
         None => state.agent_path.clone(),
     };
+    // A per-session profile can tighten the server policy past what the
+    // startup preflight checked against — re-run the (warning-only) static
+    // effect scan under the session's effective policy so the mismatch shows
+    // up in the server log at creation, not only as a mid-run failure.
+    if let Some(profile) = body.policy_profile.as_deref() {
+        super::preflight::warn_denied_static_effects(
+            &effective_agent_path,
+            &session_policy(&state, Some(profile)),
+            &format!("session policy profile '{profile}'"),
+        );
+    }
     let app_state = state.clone();
 
     let result = if warm_resume_enabled() {

--- a/crates/chidori/src/server/sessions/stream.rs
+++ b/crates/chidori/src/server/sessions/stream.rs
@@ -37,8 +37,14 @@ pub(in crate::server) fn stamp_attempt(mut value: Value, attempt_number: Option<
     value
 }
 
-fn runtime_event_to_sse_event(evt: RuntimeEvent, attempt_number: Option<u64>) -> Event {
-    let (name, data) = match evt {
+/// Serialize a runtime event into its SSE (event name, data) pair — the
+/// canonical wire shape shared by the live POST stream, the re-attach log,
+/// and the GET replay path.
+fn runtime_event_to_sse_parts(
+    evt: RuntimeEvent,
+    attempt_number: Option<u64>,
+) -> (&'static str, String) {
+    match evt {
         RuntimeEvent::Call(record) => (
             "call",
             serde_json::to_string(&stamp_attempt(json!(record), attempt_number))
@@ -98,8 +104,232 @@ fn runtime_event_to_sse_event(evt: RuntimeEvent, attempt_number: Option<u64>) ->
             ))
             .unwrap_or_else(|_| "{}".into()),
         ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SSE event log: catch-up + live re-attach (GET /sessions/{id}/stream)
+// ---------------------------------------------------------------------------
+
+/// The in-memory SSE journal of one live streaming session: every event the
+/// POST stream emits is appended here and fanned out on a broadcast channel,
+/// so a client whose SSE connection dropped can `GET /sessions/{id}/stream`,
+/// replay everything it missed, and follow live from exactly where the
+/// replay ends. Appends and subscriptions serialize on one lock — an append
+/// broadcasts while holding it and a subscriber snapshots + subscribes while
+/// holding it — so no event can be both absent from a snapshot and sent
+/// before that subscriber's receiver existed.
+pub(in crate::server) struct SessionEventLog {
+    inner: StdMutex<SessionEventLogInner>,
+    broadcast: tokio::sync::broadcast::Sender<(String, String)>,
+}
+
+struct SessionEventLogInner {
+    entries: Vec<(String, String)>,
+    /// Set once a `done` event lands; later appends are dropped so the
+    /// disconnect-cleanup guard can never write past a real terminal event.
+    closed: bool,
+}
+
+impl SessionEventLog {
+    fn new() -> Self {
+        let (broadcast, _) = tokio::sync::broadcast::channel(1024);
+        Self {
+            inner: StdMutex::new(SessionEventLogInner {
+                entries: Vec::new(),
+                closed: false,
+            }),
+            broadcast,
+        }
+    }
+
+    /// Append an event and fan it out to live subscribers. A `done` event
+    /// closes the log; appends after close are dropped.
+    fn append(&self, name: &str, data: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.closed {
+            return;
+        }
+        if name == "done" {
+            inner.closed = true;
+        }
+        inner.entries.push((name.to_string(), data.to_string()));
+        let _ = self.broadcast.send((name.to_string(), data.to_string()));
+    }
+
+    /// Everything logged so far, whether the log is closed, and a receiver
+    /// positioned exactly after the snapshot (atomic with it, see above).
+    fn snapshot_and_subscribe(
+        &self,
+    ) -> (
+        Vec<(String, String)>,
+        bool,
+        tokio::sync::broadcast::Receiver<(String, String)>,
+    ) {
+        let inner = self.inner.lock().unwrap();
+        (
+            inner.entries.clone(),
+            inner.closed,
+            self.broadcast.subscribe(),
+        )
+    }
+}
+
+/// Dropped when the POST stream's supervisor future ends. On the normal
+/// paths a real `done` event has already closed the log and this append is a
+/// no-op; if the originating client disconnected mid-run (the SSE body
+/// future dropped without reaching a terminal event), it closes the log with
+/// a synthetic `done` so re-attached clients don't hang on a feed nobody
+/// supervises anymore.
+struct EventLogCloseGuard {
+    log: Arc<SessionEventLog>,
+    session_id: String,
+}
+
+impl Drop for EventLogCloseGuard {
+    fn drop(&mut self) {
+        let data = json!({
+            "id": self.session_id,
+            "status": "failed",
+            "error": "the originating stream disconnected before the run settled; \
+                      check GET /sessions/{id} for the session's current state",
+        });
+        self.log.append("done", &data.to_string());
+    }
+}
+
+/// The terminal SSE `done` payload for a session's current state — one
+/// mapping shared by the live POST stream's final event and the GET
+/// re-attach replay of a settled session. `Running` only occurs on the GET
+/// path (a session with no live event log to follow, e.g. created via POST
+/// /sessions): the stream reports the status honestly and closes.
+fn final_session_event(session: &StoredSession) -> Value {
+    match session.status {
+        SessionStatus::Completed => json!({
+            "id": session.id,
+            "status": "completed",
+            "output": session.output,
+        }),
+        SessionStatus::Paused if !session.pending_signal_names.is_empty() => json!({
+            "id": session.id,
+            "status": "paused",
+            "pending_seq": session.pending_seq,
+            "pending_signal_name": session.pending_signal_name,
+            "pending_signal_names": session.pending_signal_names,
+            "pending_signal_deadline": session.pending_signal_deadline,
+        }),
+        SessionStatus::Paused => json!({
+            "id": session.id,
+            "status": "paused",
+            "pending_seq": session.pending_seq,
+            "pending_prompt": session.pending_prompt,
+            "pending_details": session.pending_details,
+        }),
+        SessionStatus::AwaitingApproval => json!({
+            "id": session.id,
+            "status": "awaiting_approval",
+            "pending_approval": session.pending_approval,
+        }),
+        SessionStatus::Cancelled => json!({
+            "id": session.id,
+            "status": "cancelled",
+            "error": session.error,
+        }),
+        SessionStatus::Running => json!({
+            "id": session.id,
+            "status": "running",
+        }),
+        SessionStatus::Failed => json!({
+            "id": session.id,
+            "status": "failed",
+            "error": session.error,
+        }),
+    }
+}
+
+/// GET /sessions/{id}/stream — (re-)attach to a session's SSE event stream.
+///
+/// For a session with a live streaming supervisor (started via POST
+/// /sessions/stream and not yet settled), replays every event already logged
+/// — so a client whose connection dropped catches up — then follows the live
+/// broadcast until the run settles (`done`). For any other stored session,
+/// replays the logged call records as `call` events and closes with a `done`
+/// event carrying the session's current state. Same SSE event format as the
+/// POST stream; same bearer auth as every session route (applied by the
+/// router-wide middleware).
+pub(in crate::server) async fn attach_session_stream(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Response {
+    // Live re-attach: snapshot + subscribe atomically, then stream.
+    let live_log = state
+        .active_sessions
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|active| active.event_log.clone());
+    if let Some(log) = live_log {
+        let (snapshot, closed, mut rx) = log.snapshot_and_subscribe();
+        let stream = async_stream::stream! {
+            for (name, data) in snapshot {
+                yield Ok::<_, std::convert::Infallible>(Event::default().event(name).data(data));
+            }
+            if !closed {
+                loop {
+                    match rx.recv().await {
+                        Ok((name, data)) => {
+                            let is_done = name == "done";
+                            yield Ok::<_, std::convert::Infallible>(
+                                Event::default().event(name).data(data),
+                            );
+                            if is_done {
+                                break;
+                            }
+                        }
+                        // Lagged: this attacher fell >capacity events behind;
+                        // skip the overwritten ones and keep following.
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }
+        };
+        return Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response();
+    }
+
+    // No live supervisor: replay the stored session's journal, then close
+    // with its current state.
+    let session = match state.session_store.get(&id) {
+        Ok(Some(session)) => session,
+        Ok(None) => {
+            return (
+                axum::http::StatusCode::NOT_FOUND,
+                Json(json!({"error": "Session not found"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
     };
-    Event::default().event(name).data(data)
+    let stream = async_stream::stream! {
+        for record in &session.call_log {
+            let data = serde_json::to_string(&json!(record)).unwrap_or_else(|_| "{}".into());
+            yield Ok::<_, std::convert::Infallible>(Event::default().event("call").data(data));
+        }
+        let data = serde_json::to_string(&final_session_event(&session))
+            .unwrap_or_else(|_| "{}".into());
+        yield Ok::<_, std::convert::Infallible>(Event::default().event("done").data(data));
+    };
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 /// Spawn one blocking agent run for the streaming supervisor, reporting the
@@ -240,6 +470,15 @@ pub(in crate::server) async fn stream_session(
             .into_response();
     }
     let policy_profile = body.policy_profile.clone();
+    // Warning-only static effect preflight under the session's tightened
+    // policy — mirrors create_session (see server/preflight.rs).
+    if let Some(profile) = policy_profile.as_deref() {
+        super::super::preflight::warn_denied_static_effects(
+            &state.agent_path,
+            &super::session_policy(&state, Some(profile)),
+            &format!("session policy profile '{profile}'"),
+        );
+    }
 
     let session_id = body
         .session_id
@@ -273,6 +512,10 @@ pub(in crate::server) async fn stream_session(
     let run_id = ctx.run_id();
     let ctx_slot = Arc::new(StdMutex::new(ctx.clone()));
 
+    // Journal every SSE event this stream emits so a dropped client can
+    // re-attach via GET /sessions/{id}/stream, catch up, and follow live.
+    let event_log = Arc::new(SessionEventLog::new());
+
     state.active_sessions.lock().unwrap().insert(
         session_id.clone(),
         ActiveSession {
@@ -283,6 +526,7 @@ pub(in crate::server) async fn stream_session(
                 ctx_slot: ctx_slot.clone(),
                 signal_tx,
             }),
+            event_log: Some(event_log.clone()),
         },
     );
     let mut session = StoredSession {
@@ -319,6 +563,12 @@ pub(in crate::server) async fn stream_session(
     let stream = async_stream::stream! {
         // The supervisor's share of the run slot (see acquire above).
         let permit = permit;
+        // Closes the re-attach log with a synthetic `done` if this future is
+        // dropped (client disconnect) before a real terminal event lands.
+        let _close_guard = EventLogCloseGuard {
+            log: event_log.clone(),
+            session_id: session.id.clone(),
+        };
         // The signal pause currently supervised: (pending seq, listen set).
         // While set, the run idles and a matching delivery (or the timeout
         // deadline) resumes it in-process without an HTTP round-trip.
@@ -327,7 +577,9 @@ pub(in crate::server) async fn stream_session(
         loop {
             tokio::select! {
                 Some(evt) = event_rx.recv() => {
-                    yield Ok::<_, std::convert::Infallible>(runtime_event_to_sse_event(evt, attempt_number));
+                    let (name, data) = runtime_event_to_sse_parts(evt, attempt_number);
+                    event_log.append(name, &data);
+                    yield Ok::<_, std::convert::Infallible>(Event::default().event(name).data(data));
                 }
                 Some(reason) = cancel_rx.recv() => {
                     cancelled.store(true, Ordering::SeqCst);
@@ -346,6 +598,7 @@ pub(in crate::server) async fn stream_session(
                         "error": reason,
                     }), attempt_number);
                     let data = serde_json::to_string(&final_event).unwrap_or_else(|_| "{}".into());
+                    event_log.append("done", &data);
                     yield Ok::<_, std::convert::Infallible>(Event::default().event("done").data(data));
                     break;
                 }
@@ -429,6 +682,7 @@ pub(in crate::server) async fn stream_session(
                             "pending_signal_deadline": session.pending_signal_deadline,
                         }), attempt_number);
                         let data = serde_json::to_string(&paused_event).unwrap_or_else(|_| "{}".into());
+                        event_log.append("paused", &data);
                         yield Ok::<_, std::convert::Infallible>(Event::default().event("paused").data(data));
 
                         let queued = ctx_slot.lock().unwrap().take_queued_signal_any(&names);
@@ -462,36 +716,9 @@ pub(in crate::server) async fn stream_session(
                     // close the stream, and input/approval pauses hand off to
                     // the durable HTTP resume/approve endpoints.
                     state_for_stream.active_sessions.lock().unwrap().remove(&session.id);
-                    let final_event = match session.status {
-                        SessionStatus::Completed => json!({
-                            "id": session.id,
-                            "status": "completed",
-                            "output": session.output,
-                        }),
-                        SessionStatus::Paused => json!({
-                            "id": session.id,
-                            "status": "paused",
-                            "pending_seq": session.pending_seq,
-                            "pending_prompt": session.pending_prompt,
-                            "pending_details": session.pending_details,
-                        }),
-                        SessionStatus::AwaitingApproval => json!({
-                            "id": session.id,
-                            "status": "awaiting_approval",
-                            "pending_approval": session.pending_approval,
-                        }),
-                        SessionStatus::Cancelled => json!({
-                            "id": session.id,
-                            "status": "cancelled",
-                            "error": session.error,
-                        }),
-                        _ => json!({
-                            "id": session.id,
-                            "status": "failed",
-                            "error": session.error,
-                        }),
-                    };
+                    let final_event = final_session_event(&session);
                     let data = serde_json::to_string(&stamp_attempt(final_event, attempt_number)).unwrap_or_else(|_| "{}".into());
+                    event_log.append("done", &data);
                     yield Ok::<_, std::convert::Infallible>(Event::default().event("done").data(data));
                     break;
                 }

--- a/crates/chidori/src/server/tests.rs
+++ b/crates/chidori/src/server/tests.rs
@@ -176,6 +176,7 @@ async fn cancel_session_marks_active_session_cancelled() {
             cancel_tx,
             attempt_number: Some(7),
             signals: None,
+            event_log: None,
         },
     );
     state
@@ -2749,10 +2750,13 @@ async fn event_run_that_completes_stays_stateless() {
     );
     let state = signal_test_state(&temp_dir, agent_path);
 
+    // A stray path that is NOT on the noise short-circuit list (favicon &
+    // friends are answered 404 before the agent — covered separately below):
+    // the agent runs and its cheap {status: 400} branch is honored.
     let response = handle_event(
         State(state.clone()),
         axum::http::Method::GET,
-        "/favicon.ico".parse().unwrap(),
+        "/stray/scanner-probe".parse().unwrap(),
         axum::http::HeaderMap::new(),
         axum::extract::Query(HashMap::new()),
         axum::body::Bytes::new(),
@@ -2767,4 +2771,295 @@ async fn event_run_that_completes_stays_stateless() {
     );
 
     let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+// ---------------------------------------------------------------------------
+// Round-6 usability fixes: event noise short-circuit, SSE re-attach, and the
+// static effect preflight.
+// ---------------------------------------------------------------------------
+
+/// The noise predicate stays conservative: only paths browsers and
+/// well-behaved bots fetch on their own, matched at the path root.
+#[test]
+fn noise_path_predicate_matches_only_browser_scanner_noise() {
+    assert!(is_probe_noise_path("/favicon.ico"));
+    assert!(is_probe_noise_path("/robots.txt"));
+    assert!(is_probe_noise_path("/apple-touch-icon.png"));
+    assert!(is_probe_noise_path("/apple-touch-icon-precomposed.png"));
+    assert!(is_probe_noise_path("/.well-known/security.txt"));
+    // Deliberate event paths never match.
+    assert!(!is_probe_noise_path("/"));
+    assert!(!is_probe_noise_path("/alerts/pagerduty"));
+    assert!(!is_probe_noise_path("/webhooks/favicon.ico"));
+    assert!(!is_probe_noise_path("/robots"));
+    assert!(!is_probe_noise_path("/.well-known")); // only paths UNDER it
+}
+
+/// `CHIDORI_SERVE_ALL_PATHS=1` disables the short-circuit (tested through the
+/// split-out pure function so no test mutates process-global env state).
+#[test]
+fn noise_short_circuit_escape_hatch_serves_all_paths() {
+    assert!(noise_short_circuit("/favicon.ico", false));
+    assert!(!noise_short_circuit("/favicon.ico", true));
+    assert!(!noise_short_circuit("/alerts/pagerduty", false));
+}
+
+/// In event mode, browser/scanner noise paths are answered 404 with an empty
+/// body BEFORE the agent runs — this agent answers 200 to anything, so a 404
+/// proves the short-circuit fired — and no session row is stored.
+#[tokio::test]
+async fn event_noise_paths_404_without_running_the_agent() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("chidori-event-noise-{}", uuid::Uuid::new_v4()));
+    let agent_path = write_agent(
+        &temp_dir,
+        r#"
+            export async function agent(input) {
+                return { status: 200, body: { ran: true } };
+            }
+        "#,
+    );
+    let state = signal_test_state(&temp_dir, agent_path);
+
+    for path in ["/favicon.ico", "/robots.txt", "/.well-known/security.txt"] {
+        let response = handle_event(
+            State(state.clone()),
+            axum::http::Method::GET,
+            path.parse().unwrap(),
+            axum::http::HeaderMap::new(),
+            axum::extract::Query(HashMap::new()),
+            axum::body::Bytes::new(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "path: {path}");
+        let bytes = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(bytes.is_empty(), "noise 404 must have an empty body: {path}");
+    }
+    assert!(
+        state.session_store.list().unwrap().is_empty(),
+        "noise short-circuits must not store sessions"
+    );
+
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+// -----------------------------------------------------------------------
+// GET /sessions/{id}/stream — SSE re-attach (catch-up + follow).
+// -----------------------------------------------------------------------
+
+/// Collect a (finite or done-terminated) SSE response body to a string.
+async fn collect_sse(response: Response) -> String {
+    let bytes = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8_lossy(&bytes).to_string()
+}
+
+/// Re-attaching to an unknown session id is a 404, not an empty stream.
+#[tokio::test]
+async fn attach_stream_unknown_session_is_404() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("chidori-attach-404-{}", uuid::Uuid::new_v4()));
+    let agent_path = write_agent(&temp_dir, "export async function agent() { return {}; }");
+    let state = signal_test_state(&temp_dir, agent_path);
+
+    let response = attach_session_stream(State(state), Path("no-such".to_string())).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+/// Re-attaching to a SETTLED session replays its logged call records as
+/// `call` events (same SSE format as the live stream) and closes with a
+/// `done` event carrying the terminal state.
+#[tokio::test]
+async fn attach_stream_replays_settled_session_journal() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("chidori-attach-settled-{}", uuid::Uuid::new_v4()));
+    let agent_path = write_agent(
+        &temp_dir,
+        r#"
+            export async function agent(input, chidori) {
+                const queued = await chidori.pollSignal("steer");
+                return { ok: true, queued: queued !== null };
+            }
+        "#,
+    );
+    let state = signal_test_state(&temp_dir, agent_path);
+
+    let (status, body) = response_json(
+        create_session(State(state.clone()), Json(warm_create_request("settled-1"))).await,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(body["status"], json!("completed"), "body: {body}");
+
+    let response =
+        attach_session_stream(State(state.clone()), Path("settled-1".to_string())).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let sse_text = collect_sse(response).await;
+    assert!(sse_text.contains("event: call"), "sse: {sse_text}");
+    assert!(
+        sse_text.contains("\"function\":\"poll_signal\""),
+        "replayed journal must carry the recorded call: {sse_text}"
+    );
+    assert!(sse_text.contains("event: done"), "sse: {sse_text}");
+    assert!(
+        sse_text.contains("\"status\":\"completed\""),
+        "sse: {sse_text}"
+    );
+    assert!(
+        sse_text.contains("\"ok\":true"),
+        "done event must carry the output: {sse_text}"
+    );
+
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+/// The re-attach flow the endpoint exists for: a streaming session pauses on
+/// a signal, the original client's stream is gone, a second client attaches
+/// via GET — catches up on the already-emitted events (the `paused`
+/// announcement) — and then follows live through the delivered signal to
+/// `done`, in the same SSE format as the POST stream.
+#[tokio::test]
+async fn attach_stream_catches_up_and_follows_live_run() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("chidori-attach-live-{}", uuid::Uuid::new_v4()));
+    let agent_path = write_agent(
+        &temp_dir,
+        r#"
+            export async function agent(input, chidori) {
+                const review = await chidori.signal("review");
+                return { decision: review.payload.decision, by: review.from.id };
+            }
+        "#,
+    );
+    let state = signal_test_state(&temp_dir, agent_path);
+
+    let sse = start_stream(&state, "reattach-1", json!({})).await;
+    wait_for_status(&state, "reattach-1", SessionStatus::Paused).await;
+
+    // Attach while the session is live and paused: the response must be an
+    // SSE stream that first replays what was already emitted.
+    let response =
+        attach_session_stream(State(state.clone()), Path("reattach-1".to_string())).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let attached = tokio::spawn(collect_sse(response));
+
+    // Deliver the signal; the supervisor resumes in-process and completes.
+    let (status, body) = response_json(
+        signal_session(
+            State(state.clone()),
+            Path("reattach-1".to_string()),
+            Json(SignalRequest {
+                allow_source_change: false,
+                name: "review".to_string(),
+                payload: json!({ "decision": "approve" }),
+                from: json!({ "kind": "human", "id": "mara" }),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "body: {body}");
+    wait_for_status(&state, "reattach-1", SessionStatus::Completed).await;
+
+    // The attached stream terminates on `done` — with catch-up (paused) and
+    // the live tail (consumed signal + completion) all present.
+    let attached_text = attached.await.unwrap();
+    assert!(
+        attached_text.contains("event: paused"),
+        "catch-up must replay the pause announcement: {attached_text}"
+    );
+    assert!(
+        attached_text.contains("\"function\":\"signal\"")
+            && attached_text.contains("\"id\":\"mara\""),
+        "live tail must carry the consumed signal record: {attached_text}"
+    );
+    assert!(
+        attached_text.contains("event: done")
+            && attached_text.contains("\"status\":\"completed\""),
+        "attached stream must follow to settlement: {attached_text}"
+    );
+
+    // The original POST stream saw the same terminal event.
+    let sse_text = sse.await.unwrap();
+    assert!(sse_text.contains("\"status\":\"completed\""), "{sse_text}");
+
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+// -----------------------------------------------------------------------
+// Static effect preflight (server/preflight.rs): agents declare no effects,
+// so the scan greps the source for gated-surface spellings and flags only
+// targets the policy denies for EVERY argument shape.
+// -----------------------------------------------------------------------
+
+#[test]
+fn static_effect_scan_finds_gated_references_at_identifier_boundaries() {
+    let refs = preflight::static_effect_refs(
+        r#"
+            const res = await fetch("https://example.com/");
+            await chidori.workspace.write("out.txt", "hi");
+            await chidori.workspace.read("in.txt");
+        "#,
+    );
+    let targets: Vec<&str> = refs.iter().map(|r| r.target).collect();
+    assert!(targets.contains(&"http"), "targets: {targets:?}");
+    assert!(targets.contains(&"workspace:write"), "targets: {targets:?}");
+    assert!(targets.contains(&"workspace:read"), "targets: {targets:?}");
+
+    // Identifier-boundary check: a user-defined `myFetch(...)` is not the
+    // http effect, while `globalThis.fetch(...)` is.
+    assert!(preflight::static_effect_refs("myFetch(1)").is_empty());
+    assert!(!preflight::static_effect_refs("globalThis.fetch(url)").is_empty());
+}
+
+#[test]
+fn preflight_flags_only_unconditionally_denied_targets() {
+    let untrusted = crate::policy::builtin_profile("untrusted").unwrap();
+
+    // http under the untrusted profile: denied for every argument → flagged,
+    // and the denial reason rides along.
+    let denied = preflight::denied_static_effects(HTTP_AGENT, &untrusted);
+    assert_eq!(denied.len(), 1, "denied: {denied:?}");
+    assert_eq!(denied[0].0.target, "http");
+
+    // Read-only workspace introspection is on the untrusted allowlist → not
+    // flagged.
+    let denied = preflight::denied_static_effects(
+        r#"await chidori.workspace.read("a.txt");"#,
+        &untrusted,
+    );
+    assert!(denied.is_empty(), "denied: {denied:?}");
+
+    // A deny-by-default policy with a SCOPED http allow rule can pass some
+    // calls, so the warning must stay quiet (no false positives).
+    let scoped: PolicyConfig = serde_json::from_value(json!({
+        "rules": [{
+            "target": "http",
+            "decision": "always_allow",
+            "match_args": { "url_prefix": "https://api.example.com/" }
+        }],
+        "default": "never_allow"
+    }))
+    .unwrap();
+    assert!(
+        preflight::denied_static_effects(HTTP_AGENT, &scoped).is_empty(),
+        "a scoped allow means http is not unconditionally denied"
+    );
+
+    // Ask-by-default (supervised) pauses rather than denies → not flagged.
+    let supervised = crate::policy::builtin_profile("supervised").unwrap();
+    assert!(preflight::denied_static_effects(HTTP_AGENT, &supervised).is_empty());
+
+    // Layered: a permissive server policy tightened by an untrusted session
+    // profile denies http at the overlay → flagged.
+    let layered =
+        PolicyConfig::default().restricted_by(Arc::new(crate::policy::builtin_profile("untrusted").unwrap()));
+    let denied = preflight::denied_static_effects(HTTP_AGENT, &layered);
+    assert_eq!(denied.len(), 1, "denied: {denied:?}");
+    assert_eq!(denied[0].0.target, "http");
 }

--- a/crates/chidori/src/server/tests.rs
+++ b/crates/chidori/src/server/tests.rs
@@ -2835,7 +2835,10 @@ async fn event_noise_paths_404_without_running_the_agent() {
         let bytes = body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
-        assert!(bytes.is_empty(), "noise 404 must have an empty body: {path}");
+        assert!(
+            bytes.is_empty(),
+            "noise 404 must have an empty body: {path}"
+        );
     }
     assert!(
         state.session_store.list().unwrap().is_empty(),
@@ -2896,8 +2899,7 @@ async fn attach_stream_replays_settled_session_journal() {
     assert_eq!(status, StatusCode::CREATED);
     assert_eq!(body["status"], json!("completed"), "body: {body}");
 
-    let response =
-        attach_session_stream(State(state.clone()), Path("settled-1".to_string())).await;
+    let response = attach_session_stream(State(state.clone()), Path("settled-1".to_string())).await;
     assert_eq!(response.status(), StatusCode::OK);
     let sse_text = collect_sse(response).await;
     assert!(sse_text.contains("event: call"), "sse: {sse_text}");
@@ -2979,8 +2981,7 @@ async fn attach_stream_catches_up_and_follows_live_run() {
         "live tail must carry the consumed signal record: {attached_text}"
     );
     assert!(
-        attached_text.contains("event: done")
-            && attached_text.contains("\"status\":\"completed\""),
+        attached_text.contains("event: done") && attached_text.contains("\"status\":\"completed\""),
         "attached stream must follow to settlement: {attached_text}"
     );
 
@@ -3029,10 +3030,8 @@ fn preflight_flags_only_unconditionally_denied_targets() {
 
     // Read-only workspace introspection is on the untrusted allowlist → not
     // flagged.
-    let denied = preflight::denied_static_effects(
-        r#"await chidori.workspace.read("a.txt");"#,
-        &untrusted,
-    );
+    let denied =
+        preflight::denied_static_effects(r#"await chidori.workspace.read("a.txt");"#, &untrusted);
     assert!(denied.is_empty(), "denied: {denied:?}");
 
     // A deny-by-default policy with a SCOPED http allow rule can pass some
@@ -3057,8 +3056,9 @@ fn preflight_flags_only_unconditionally_denied_targets() {
 
     // Layered: a permissive server policy tightened by an untrusted session
     // profile denies http at the overlay → flagged.
-    let layered =
-        PolicyConfig::default().restricted_by(Arc::new(crate::policy::builtin_profile("untrusted").unwrap()));
+    let layered = PolicyConfig::default().restricted_by(Arc::new(
+        crate::policy::builtin_profile("untrusted").unwrap(),
+    ));
     let denied = preflight::denied_static_effects(HTTP_AGENT, &layered);
     assert_eq!(denied.len(), 1, "denied: {denied:?}");
     assert_eq!(denied[0].0.target, "http");

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -907,6 +907,158 @@ fn cli_plain_run_reports_prompt_progress_on_stderr() {
     fs::remove_dir_all(dir).ok();
 }
 
+/// Run chidori with every LLM provider hook removed (and HOME pointed at the
+/// empty project dir so saved `model-login` credentials can't register a
+/// provider either). Used to force a deterministic provider failure — and to
+/// prove `verify` needs no provider.
+fn run_chidori_without_providers(args: &[&str], cwd: &Path) -> Output {
+    let mut command = Command::new(chidori_bin());
+    command.args(args).current_dir(cwd).env("HOME", cwd);
+    for key in [
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "CHIDORI_OPENAI_COMPAT_URL",
+        "CHIDORI_OPENAI_COMPAT_KEY",
+        "LITELLM_API_URL",
+        "LITELLM_API_KEY",
+        "OPENROUTER_API_KEY",
+        "CHIDORI_TEST_LLM_RESPONSE",
+    ] {
+        command.env_remove(key);
+    }
+    command.output().unwrap()
+}
+
+fn first_run_id(dir: &Path) -> String {
+    fs::read_dir(dir.join(".chidori").join("runs"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .file_name()
+        .into_string()
+        .unwrap()
+}
+
+// `chidori resume --retry-failed` — first-class repair for a failed run:
+// strip the trailing failed record(s) from the journal, replay the intact
+// prefix from cache, re-execute the failure live. The repaired journal must
+// then hold up to `chidori verify` — the whole point over hand-computed
+// `--until-seq` surgery.
+#[test]
+fn cli_resume_retry_failed_repairs_failed_run_and_verify_passes() {
+    let dir = temp_project("retry-failed");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.log("start", {});
+                const text = await chidori.prompt("say hi");
+                return { text };
+            }
+        "#,
+    )
+    .unwrap();
+
+    // Force the failure: no provider configured, so the prompt call fails
+    // and journals as the run's trailing failed record.
+    let output = run_chidori_without_providers(&["run", agent.to_str().unwrap()], &dir);
+    assert_failure(&output);
+    let run_id = first_run_id(&dir);
+
+    // A plain resume would replay the recorded failure. --retry-failed
+    // strips it and re-executes the prompt live against the now-working
+    // provider — no --allow-source-change needed for the retried tail.
+    let output = run_chidori_with_str_env(
+        &["resume", agent.to_str().unwrap(), &run_id, "--retry-failed"],
+        &dir,
+        &[("CHIDORI_TEST_LLM_RESPONSE", "repaired")],
+    );
+    assert_success(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("retry-failed: stripped 1 failed record(s)"),
+        "expected the stripped-count line on stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("replaying 1 records then executing live"),
+        "expected the replay/live split in the stripped line, got:\n{stderr}"
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(stdout["text"], "repaired");
+
+    // The repaired run is a coherent recorded run: verify replays it to the
+    // identical output with NO provider configured.
+    let output =
+        run_chidori_without_providers(&["verify", agent.to_str().unwrap(), &run_id], &dir);
+    assert_success(&output);
+
+    fs::remove_dir_all(dir).ok();
+}
+
+// --retry-failed on a run with nothing to retry must say what state the run
+// is actually in and what to do instead.
+#[test]
+fn cli_resume_retry_failed_on_completed_run_errors_clearly() {
+    let dir = temp_project("retry-failed-completed");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.log("fine", {});
+                return { ok: true };
+            }
+        "#,
+    )
+    .unwrap();
+
+    let output = run_chidori(&["run", agent.to_str().unwrap()], &dir);
+    assert_success(&output);
+    let run_id = first_run_id(&dir);
+
+    let output = run_chidori(
+        &["resume", agent.to_str().unwrap(), &run_id, "--retry-failed"],
+        &dir,
+    );
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("completed") && stderr.contains("nothing to retry"),
+        "expected a clear completed-run refusal naming the state, got:\n{stderr}"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
+// --retry-failed and --until-seq name different frontiers; combining them is
+// ambiguous and must be rejected up front.
+#[test]
+fn cli_resume_retry_failed_rejects_until_seq_combination() {
+    let dir = temp_project("retry-failed-conflict");
+    let output = run_chidori(
+        &[
+            "resume",
+            "agent.ts",
+            "some-run",
+            "--retry-failed",
+            "--until-seq",
+            "3",
+        ],
+        &dir,
+    );
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--retry-failed") && stderr.contains("--until-seq"),
+        "expected a flag-conflict error naming both flags, got:\n{stderr}"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
 // A chat session is a durable run: the session id is announced, every turn
 // journals under `.chidori/runs/<session_id>` with `input.json` holding the
 // dialogue state, and `--resume` replays the transcript and continues the

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -991,8 +991,7 @@ fn cli_resume_retry_failed_repairs_failed_run_and_verify_passes() {
 
     // The repaired run is a coherent recorded run: verify replays it to the
     // identical output with NO provider configured.
-    let output =
-        run_chidori_without_providers(&["verify", agent.to_str().unwrap(), &run_id], &dir);
+    let output = run_chidori_without_providers(&["verify", agent.to_str().unwrap(), &run_id], &dir);
     assert_success(&output);
 
     fs::remove_dir_all(dir).ok();

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -875,6 +875,27 @@ fn cli_chat_session_persists_and_resumes() {
         stderr.contains("session saved"),
         "exit should point at --resume/trace, got:\n{stderr}"
     );
+    // The reply is marked like the `you> ` prompt, so scrollback shows who
+    // said what instead of one undifferentiated text column.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("assistant> "),
+        "reply should carry an assistant> marker, got:\n{stdout}"
+    );
+    // Exit prints a usage/cost summary before the "session saved" line,
+    // computed from the journaled records the same way `chidori stats` is.
+    let summary = stderr
+        .lines()
+        .find(|line| line.starts_with("session usage:"))
+        .expect("exit should print a session usage summary");
+    assert!(
+        summary.contains("1 prompt call(s)") && summary.contains("est. cost:"),
+        "summary should count prompt calls and estimate cost, got:\n{summary}"
+    );
+    assert!(
+        stderr.find("session usage:").unwrap() < stderr.find("session saved").unwrap(),
+        "summary should precede the session-saved line, got:\n{stderr}"
+    );
 
     let run_dir = dir.join(".chidori").join("runs").join(&session_id);
     let input: serde_json::Value =

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -853,6 +853,60 @@ fn cli_stream_matches_plain_run_posture() {
     fs::remove_dir_all(dir).ok();
 }
 
+// Plain `chidori run` prints a one-line sign of life per live prompt call on
+// stderr (`seq N: prompt started (<model>)`, then a matching `prompt
+// finished` line) — long model calls are otherwise total silence until the
+// run ends, with `--stream` as the only progress path. Stdout stays reserved
+// for the agent's output, and CHIDORI_QUIET=1 restores the old silent stderr.
+#[test]
+fn cli_plain_run_reports_prompt_progress_on_stderr() {
+    let dir = temp_project("prompt-progress");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                const text = await chidori.prompt("say hi");
+                return { text };
+            }
+        "#,
+    )
+    .unwrap();
+
+    let envs = [("CHIDORI_TEST_LLM_RESPONSE", "hi back")];
+    let output = run_chidori_with_str_env(&["run", agent.to_str().unwrap()], &dir, &envs);
+    assert_success(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("prompt started ("),
+        "plain run should print a prompt progress line on stderr, got:\n{stderr}"
+    );
+    // Progress must not leak into stdout: the agent's JSON output is still
+    // the only thing there, byte-parseable as before.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("prompt started"),
+        "progress lines must stay on stderr, got stdout:\n{stdout}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(parsed["text"], "hi back");
+
+    // CHIDORI_QUIET=1 suppresses the progress lines entirely.
+    let quiet_envs = [
+        ("CHIDORI_TEST_LLM_RESPONSE", "hi back"),
+        ("CHIDORI_QUIET", "1"),
+    ];
+    let output = run_chidori_with_str_env(&["run", agent.to_str().unwrap()], &dir, &quiet_envs);
+    assert_success(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("prompt started"),
+        "CHIDORI_QUIET=1 should suppress progress lines, got:\n{stderr}"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
 // A chat session is a durable run: the session id is announced, every turn
 // journals under `.chidori/runs/<session_id>` with `input.json` holding the
 // dialogue state, and `--resume` replays the transcript and continues the

--- a/crates/chidori/tests/cli_typescript.rs
+++ b/crates/chidori/tests/cli_typescript.rs
@@ -1133,3 +1133,205 @@ fn cli_chat_session_persists_and_resumes() {
 
     fs::remove_dir_all(dir).ok();
 }
+
+/// Total size in bytes of every regular file under `path`, recursively.
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.is_dir() {
+                stack.push(entry_path);
+            } else if let Ok(meta) = entry.metadata() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+// `chidori export <run_id> --fixture <dest>` — a run directory is tens of MB
+// (snapshot blob, promise table, duplicated journal), too heavy to commit as
+// a CI test. Export carves out just what `chidori verify` reads
+// (records.jsonl, runtime.snapshot.json, output.json, input.json), and
+// `verify --runs-dir <dest>` must pass against the fixture alone.
+#[test]
+fn cli_export_fixture_is_minimal_and_verify_consumes_it() {
+    let dir = temp_project("export-fixture");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.log("start", { who: input.who });
+                const text = await chidori.prompt("say hi to " + input.who);
+                return { text };
+            }
+        "#,
+    )
+    .unwrap();
+
+    let output = run_chidori_with_str_env(
+        &[
+            "run",
+            agent.to_str().unwrap(),
+            "--input",
+            r#"{"who":"fixture"}"#,
+        ],
+        &dir,
+        &[("CHIDORI_TEST_LLM_RESPONSE", "hi fixture")],
+    );
+    assert_success(&output);
+    let run_id = first_run_id(&dir);
+    let run_dir = dir.join(".chidori").join("runs").join(&run_id);
+    // Precondition for the size claim: the full run dir carries the heavy
+    // resume-only artifacts export must leave behind.
+    assert!(run_dir.join("runtime.snapshot").exists());
+    assert!(run_dir.join("checkpoint.json").exists());
+    // A mock run's snapshot blob is tiny; real runs carry multi-MB blobs —
+    // that's the whole reason export exists. Pad the blob to a representative
+    // size: export must not copy it, so the fixture stays small regardless.
+    fs::write(run_dir.join("runtime.snapshot"), vec![0u8; 1 << 20]).unwrap();
+
+    let fixture = dir.join("fixtures");
+    let output = run_chidori(
+        &["export", &run_id, "--fixture", fixture.to_str().unwrap()],
+        &dir,
+    );
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("exported fixture:") && stdout.contains("run dir was"),
+        "export should summarize fixture vs run-dir size, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--runs-dir"),
+        "export should print the verify hint, got:\n{stdout}"
+    );
+
+    // The fixture holds exactly the verify set — no snapshot blob, no
+    // duplicated checkpoint.json, no host-promise/pending/lease state.
+    let fixture_run = fixture.join(&run_id);
+    assert!(fixture_run.join("records.jsonl").exists());
+    assert!(fixture_run.join("runtime.snapshot.json").exists());
+    assert!(fixture_run.join("output.json").exists());
+    assert!(fixture_run.join("input.json").exists());
+    assert!(!fixture_run.join("runtime.snapshot").exists());
+    assert!(!fixture_run.join("checkpoint.json").exists());
+    assert!(!fixture_run.join("host_promises.json").exists());
+    assert!(!fixture_run.join("pending.json").exists());
+    assert!(!fixture_run.join("lease.json").exists());
+
+    // Dramatically smaller: the snapshot blob and duplicated journal dominate
+    // the run dir, so the fixture must come in at a small fraction of it.
+    let run_size = dir_size(&run_dir);
+    let fixture_size = dir_size(&fixture_run);
+    assert!(
+        fixture_size * 10 < run_size,
+        "fixture ({fixture_size} B) should be far smaller than the run dir ({run_size} B)"
+    );
+
+    // The fixture alone must satisfy `chidori verify` — no provider, and the
+    // original run directory is not consulted.
+    fs::remove_dir_all(&run_dir).unwrap();
+    let output = run_chidori_without_providers(
+        &[
+            "verify",
+            agent.to_str().unwrap(),
+            &run_id,
+            "--runs-dir",
+            fixture.to_str().unwrap(),
+        ],
+        &dir,
+    );
+    assert_success(&output);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("verified:"),
+        "verify against the fixture should report success"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
+// Exporting a run that does not exist must error cleanly, naming the path it
+// looked at.
+#[test]
+fn cli_export_nonexistent_run_errors_cleanly() {
+    let dir = temp_project("export-missing");
+    let fixture = dir.join("fixtures");
+    let output = run_chidori(
+        &[
+            "export",
+            "no-such-run",
+            "--fixture",
+            fixture.to_str().unwrap(),
+        ],
+        &dir,
+    );
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No persisted run") && stderr.contains("no-such-run"),
+        "expected a clear missing-run error, got:\n{stderr}"
+    );
+    assert!(
+        !fixture.exists(),
+        "a failed export must not leave a fixture directory behind"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}
+
+// A run that is still owned by a live process (unexpired lease) has a
+// mid-flight journal; export must refuse it rather than freeze an incomplete
+// record as a "passing" fixture.
+#[test]
+fn cli_export_refuses_leased_run() {
+    let dir = temp_project("export-leased");
+    let agent = dir.join("agent.ts");
+    fs::write(
+        &agent,
+        r#"
+            export async function agent(input, chidori) {
+                await chidori.log("ok", {});
+                return { ok: true };
+            }
+        "#,
+    )
+    .unwrap();
+    let output = run_chidori(&["run", agent.to_str().unwrap()], &dir);
+    assert_success(&output);
+    let run_id = first_run_id(&dir);
+
+    // Simulate a live owner: an unexpired lease on the run directory.
+    let lease = serde_json::json!({
+        "owner": "some-other-process",
+        "expires_at": chrono::Utc::now() + chrono::Duration::hours(1),
+    });
+    fs::write(
+        dir.join(".chidori")
+            .join("runs")
+            .join(&run_id)
+            .join("lease.json"),
+        serde_json::to_vec(&lease).unwrap(),
+    )
+    .unwrap();
+
+    let fixture = dir.join("fixtures");
+    let output = run_chidori(
+        &["export", &run_id, "--fixture", fixture.to_str().unwrap()],
+        &dir,
+    );
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("leased") && stderr.contains("some-other-process"),
+        "expected a live-lease refusal naming the owner, got:\n{stderr}"
+    );
+
+    fs::remove_dir_all(dir).ok();
+}

--- a/crates/chidori/tests/pkg_install.rs
+++ b/crates/chidori/tests/pkg_install.rs
@@ -47,6 +47,8 @@ struct MockRegistryData {
 
 struct MockVersion {
     deps: BTreeMap<String, String>,
+    /// peer name -> (range, optional-in-peerDependenciesMeta).
+    peers: BTreeMap<String, (String, bool)>,
     tarball: Vec<u8>,
     /// Serve bytes that don't match the advertised integrity.
     corrupt: bool,
@@ -104,17 +106,34 @@ impl MockRegistry {
     /// Publish `name@version` with the given dependencies and a package.json
     /// + index.js generated to match.
     fn publish(&self, name: &str, version: &str, deps: &[(&str, &str)]) {
-        self.publish_inner(name, version, deps, false);
+        self.publish_inner(name, version, deps, &[], false);
     }
 
     fn publish_corrupt(&self, name: &str, version: &str) {
-        self.publish_inner(name, version, &[], true);
+        self.publish_inner(name, version, &[], &[], true);
     }
 
-    fn publish_inner(&self, name: &str, version: &str, deps: &[(&str, &str)], corrupt: bool) {
+    /// Publish with `peerDependencies`; each peer is (name, range, optional),
+    /// where `optional` marks it optional in `peerDependenciesMeta`.
+    fn publish_with_peers(&self, name: &str, version: &str, peers: &[(&str, &str, bool)]) {
+        self.publish_inner(name, version, &[], peers, false);
+    }
+
+    fn publish_inner(
+        &self,
+        name: &str,
+        version: &str,
+        deps: &[(&str, &str)],
+        peers: &[(&str, &str, bool)],
+        corrupt: bool,
+    ) {
         let deps: BTreeMap<String, String> = deps
             .iter()
             .map(|(n, v)| (n.to_string(), v.to_string()))
+            .collect();
+        let peers: BTreeMap<String, (String, bool)> = peers
+            .iter()
+            .map(|(n, r, opt)| (n.to_string(), (r.to_string(), *opt)))
             .collect();
         let manifest = serde_json::json!({
             "name": name,
@@ -139,6 +158,7 @@ impl MockRegistry {
                 version.to_string(),
                 MockVersion {
                     deps,
+                    peers,
                     tarball,
                     corrupt,
                 },
@@ -177,18 +197,33 @@ fn handle(data: &MockRegistryData, base: &str, path: &str) -> Vec<u8> {
                 base64::engine::general_purpose::STANDARD
                     .encode(sha2::Sha512::digest(&v.tarball))
             );
-            (
-                version.clone(),
-                serde_json::json!({
-                    "name": name,
-                    "version": version,
-                    "dependencies": v.deps,
-                    "dist": {
-                        "tarball": format!("{base}/tarballs/{}__{version}.tgz", name.replace('/', "+")),
-                        "integrity": integrity,
-                    }
-                }),
-            )
+            let mut vjson = serde_json::json!({
+                "name": name,
+                "version": version,
+                "dependencies": v.deps,
+                "dist": {
+                    "tarball": format!("{base}/tarballs/{}__{version}.tgz", name.replace('/', "+")),
+                    "integrity": integrity,
+                }
+            });
+            if !v.peers.is_empty() {
+                let ranges: serde_json::Map<String, serde_json::Value> = v
+                    .peers
+                    .iter()
+                    .map(|(n, (r, _))| (n.clone(), serde_json::Value::String(r.clone())))
+                    .collect();
+                vjson["peerDependencies"] = ranges.into();
+                let meta: serde_json::Map<String, serde_json::Value> = v
+                    .peers
+                    .iter()
+                    .filter(|(_, (_, optional))| *optional)
+                    .map(|(n, _)| (n.clone(), serde_json::json!({ "optional": true })))
+                    .collect();
+                if !meta.is_empty() {
+                    vjson["peerDependenciesMeta"] = meta.into();
+                }
+            }
+            (version.clone(), vjson)
         })
         .collect();
     let packument = serde_json::json!({
@@ -560,6 +595,96 @@ fn unsupported_manifest_deps_are_skipped_per_dependency() {
         .unwrap_err()
         .to_string();
     assert!(err.contains("file dependencies are not supported"), "{err}");
+
+    registry.stop();
+}
+
+#[test]
+fn add_writes_manifest_with_name_before_dependencies() {
+    let registry = MockRegistry::start();
+    registry.publish("apple", "1.0.0", &[]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let _env = setup_env(&registry.base, &tmp.path().join("store"));
+
+    // Start from a manifest whose keys would alphabetize badly ("dependencies"
+    // sorts before "name"); after `add` the file must keep npm's conventional
+    // top-level order with `name` first.
+    std::fs::write(
+        project.join("package.json"),
+        r#"{"name":"demo","version":"0.1.0","private":true}"#,
+    )
+    .unwrap();
+    cmd_add(&project, &["apple".to_string()], false).unwrap();
+
+    let raw = std::fs::read_to_string(project.join("package.json")).unwrap();
+    let pos = |key: &str| {
+        raw.find(&format!("\"{key}\""))
+            .unwrap_or_else(|| panic!("missing key {key}:\n{raw}"))
+    };
+    assert!(
+        pos("name") < pos("dependencies"),
+        "`name` must stay above `dependencies`:\n{raw}"
+    );
+    assert!(pos("version") < pos("dependencies"), "{raw}");
+    assert!(pos("name") < pos("version"), "{raw}");
+
+    registry.stop();
+}
+
+#[test]
+fn peer_warnings_skip_optional_and_typescript_peers() {
+    let registry = MockRegistry::start();
+    // Like valibot: a `typescript` peer, plus one optional and one required
+    // peer. Only the required non-typescript peer should warn.
+    registry.publish_with_peers(
+        "valibot-like",
+        "1.0.0",
+        &[
+            ("typescript", ">=5", false),
+            ("softpeer", "^1.0.0", true),
+            ("hardpeer", "^2.0.0", false),
+        ],
+    );
+
+    let client = chidori::pkg::registry::RegistryClient::new(registry.base.clone()).unwrap();
+    let root_deps: BTreeMap<String, String> =
+        [("valibot-like".to_string(), "^1.0.0".to_string())].into();
+    let resolution = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(chidori::pkg::resolve::resolve(
+            &client,
+            &root_deps,
+            &std::collections::HashMap::new(),
+        ))
+        .unwrap();
+
+    let peer_warnings: Vec<&String> = resolution
+        .warnings
+        .iter()
+        .filter(|w| w.contains("unmet peer dependency"))
+        .collect();
+    assert_eq!(
+        peer_warnings.len(),
+        1,
+        "exactly the required non-typescript peer should warn: {:?}",
+        resolution.warnings
+    );
+    assert!(peer_warnings[0].contains("hardpeer"), "{peer_warnings:?}");
+    assert!(
+        !resolution.warnings.iter().any(|w| w.contains("softpeer")),
+        "optional peer must not warn: {:?}",
+        resolution.warnings
+    );
+    assert!(
+        !resolution.warnings.iter().any(|w| w.contains("typescript")),
+        "typescript peer must not warn: {:?}",
+        resolution.warnings
+    );
 
     registry.stop();
 }

--- a/crates/chidori/tests/pkg_install.rs
+++ b/crates/chidori/tests/pkg_install.rs
@@ -194,8 +194,7 @@ fn handle(data: &MockRegistryData, base: &str, path: &str) -> Vec<u8> {
         .map(|(version, v)| {
             let integrity = format!(
                 "sha512-{}",
-                base64::engine::general_purpose::STANDARD
-                    .encode(sha2::Sha512::digest(&v.tarball))
+                base64::engine::general_purpose::STANDARD.encode(sha2::Sha512::digest(&v.tarball))
             );
             let mut vjson = serde_json::json!({
                 "name": name,

--- a/docs/consumer-usability-review-2.md
+++ b/docs/consumer-usability-review-2.md
@@ -306,8 +306,10 @@ Every finding above was addressed on this branch, in the same series of
 commits as this update, and re-verified against the original scenarios:
 
 - **Finding 1 (crash-resume)** — `chidori resume` accepts
-  `--trusted`/`--untrusted`/`--tools`, journals live continuation into the
+  `--trusted`/`--untrusted`, journals live continuation into the
   same run dir, and takes the run's lease against concurrent drivers.
+  (No `--tools` flag exists anymore on any command: the tool model moved
+  to in-VM `defineTool` handles, so there is nothing for resume to load.)
   Investigating the re-verification exposed the *actual* root cause beneath
   the policy gap: replayed `spawn_actor` records never re-created actors
   unless a live `send`/`join` addressed them — a `receive`-driven fan-in

--- a/docs/consumer-usability-review.md
+++ b/docs/consumer-usability-review.md
@@ -272,8 +272,10 @@ of commits as this document:
   error now points at `POST /sessions/{id}/replay` as the recovery path.
 - **`input()` at EOF** — an empty answer resolves to the declared `default`;
   EOF with no default fails loudly instead of silently returning `""`.
-- **CLI/server asymmetries** — `chidori serve` accepts `--tools` (and the
-  implicit `tools/` convention is documented); the approval prompt gained an
+- **CLI/server asymmetries** — the `run`/`serve` tools asymmetry was resolved
+  by removing the flag and the `tools/`-directory mechanism entirely: tools
+  are now defined in-VM with `defineTool` and passed as handles, so there is
+  nothing to load and no flag to forget; the approval prompt gained an
   `[a]ll further calls to this target` answer; sandbox degradation notes
   (the landlock line) print only under `--verbose` /
   `CHIDORI_ISOLATE_VERBOSE`, with `CHIDORI_ISOLATE_REQUIRE_SANDBOX`
@@ -285,8 +287,11 @@ of commits as this document:
   the argument comparison tolerates keys absent from the recorded side);
   `reasoning_content` from reasoning models is captured on
   `LlmResponse.reasoning`, journaled, and exposed on `respond()`.
-- **Example tool** — `examples/tools/web_search.ts` performs a real
-  (keyless) DuckDuckGo Instant Answer search instead of returning `[]`.
+- **Example tool** — the `examples/tools/web_search.ts` stub went away with
+  the `tools/` mechanism; `llm.txt`'s tool section now shows a real
+  fetch-backed `defineTool` example instead of a stub, and the bundled
+  examples (`examples/release-notes-concierge`, `examples/war-room`) define
+  real HTTP-backed tools inline with `defineTool`.
 - **Types** — the `interface`-vs-`type` input gotcha and the
   SDK-must-match-binary rule are documented in the SDK README. Republishing
   the npm package in lockstep with the binary release remains a

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -15,7 +15,7 @@ directly, so the runtime sees and records everything. See
 | `chidori.prompt(text, { type, ... })` | Send to an LLM, return string or parsed JSON; streamed prompt events carry the optional type |
 | `chidori.context()` | Immutable multi-turn prompt builder with prefix sharing and provider prompt caching |
 | `chidori.conversation(options)` | Stateful chat-assistant wrapper over `context()` — `say(message)` per turn, or `loop()` for an interactive `input()` dialogue |
-| `chidori.template(strOrPath, vars)` | Render a Jinja2 template with minijinja |
+| `chidori.template(strOrPath, vars)` | Render a Jinja2 template (inline string or `.jinja`/`.j2` file) with minijinja — undefined variables fail loudly ([details](./template.md)) |
 | `chidori.tool(name, args)` | Invoke a registered tool |
 | `chidori.callAgent(path, input)` | Call a sub-agent |
 | `chidori.util.parallel(fns)` | Run functions concurrently (in-VM helper — records nothing itself) |
@@ -29,7 +29,7 @@ directly, so the runtime sees and records everything. See
 | `chidori.signal(name, options)` | Multiplayer — pause at a named listen point until an outside party (human or agent) delivers `{ name, payload, from }`; drains a durable mailbox if one is queued; `timeoutMs` resolves to a `{ timedOut: true }` sentinel after the deadline |
 | `chidori.pollSignal(name)` | Non-blocking signal check — consume a queued signal of this name or resolve to `null` |
 | `chidori.signal(names[], options)` | Fan-in — pass an array to pause until ANY of the named signals is delivered; the result's `name` says which fired |
-| `chidori.memory.set/get/delete/list/clear` | Persistent key-value storage, namespaced on disk under the agent's `.chidori/memory/` (anchored to the workspace root, like runs; `CHIDORI_MEMORY_DIR` overrides) |
+| `chidori.memory.set/get/delete/list/clear` | Persistent key-value storage, namespaced on disk under the agent's `.chidori/memory/` (anchored to the workspace root, like runs; `CHIDORI_MEMORY_DIR` overrides) ([details](./memory.md)) |
 | `chidori.workspace.{list,read,write,delete,manifest}` | Shared workspace files under the run's workspace root — policy-gated, recorded like every other effect |
 | `chidori.log(msg, data)` | Structured logging |
 | `chidori.mark(label, data)` | Record a labelled trace marker in the call log (the durable *value* checkpoint is `chidori.step`) |

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -132,6 +132,34 @@ frontier. This is *logic-level* time travel — a stronger operation than
 restoring a database to a past moment, because the run continues executing
 from the restored point.
 
+## Repairing a failed run: `--retry-failed`
+
+A run that failed mid-flight leaves its journal ending in the failed
+record(s), so replaying it replays the failure. Repair used to mean
+hand-computing an `--until-seq` frontier just before the failure —
+error-prone, and easy to get wrong in a way that forfeits `verify`.
+`--retry-failed` does it first-class:
+
+```bash
+chidori resume agent.ts <run_id> --retry-failed
+```
+
+strips the trailing failed record(s) from the journal — cascading to any
+nested effects the failing call consumed, the same crash-frontier rule the
+actor `restart: "resume"` path uses — replays every record before the
+failure from cache, and re-executes the failed call live
+(`retry-failed: stripped N failed record(s) (seqs X..Y), replaying M records
+then executing live` on stderr names the split). On success the run settles
+normally and the repaired journal is coherent: `chidori verify` passes on it.
+
+Tolerance is scoped to the retried call only: the stripped tail re-executes
+live, so a different args/result on the retry needs no opt-in, while the
+surviving prefix still replays under the normal divergence rules
+(`--allow-source-change` keeps its usual meaning). The flag refuses a run
+whose journal has no trailing failure — a completed run needs nothing, a
+paused run wants plain `resume` — and is mutually exclusive with
+`--until-seq`.
+
 ## Leases: single-writer ownership
 
 `lease.json` (via `acquire_lease` / `release_lease` in `store.rs`) records

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,105 @@
+# Memory — persistent key-value storage across runs
+
+> `chidori.memory` is a small, namespaced, JSON key-value store that persists
+> **across runs** — the place for what an agent learns in one session and
+> should remember in the next. **Related:** `docs/core-concepts.md`,
+> `docs/replay.md`, `docs/value-checkpoints.md`. API reference: `llm.txt`.
+> Implementation: `crates/chidori/src/runtime/memory.rs`,
+> `crates/chidori/src/runtime/typescript/bindings.rs` (`memory_base`).
+> Example: `examples/release-notes-concierge/agent.ts` (the house-style
+> pattern).
+
+## 1. What this is
+
+Runs are durable, but a run's journal belongs to *that run*. `chidori.memory`
+is the store that outlives the run: JSON values keyed by string, anchored to
+the agent on disk, readable by every subsequent session of the same agent.
+
+```ts
+await chidori.memory.set("house-style", learned);
+const style = await chidori.memory.get("house-style");   // null when absent
+const items = await chidori.memory.list({ prefix: "user_" });
+await chidori.memory.delete("house-style");              // → true if it existed
+await chidori.memory.clear();                             // empty this namespace
+```
+
+The canonical pattern (from `examples/release-notes-concierge`): at the end of
+a session, distill what the human's feedback taught the agent and `set` it;
+at the start of the next session, `get` it and fold it into the system prompt.
+
+## 2. API
+
+Every method takes a trailing `options` object accepting `namespace`
+(default `"default"`); `list` also accepts `prefix`.
+
+- `set(key, value, options?)` → `null`. `value` is any JSON-compatible value.
+- `get(key, options?)` → the stored value, or `null` when the key is absent.
+- `delete(key, options?)` → `true` if the key existed, else `false`.
+- `list(options?)` → `[{ key, value }, …]`; with `prefix`, only keys starting
+  with that prefix.
+- `clear(options?)` → `null`; empties the namespace (the file remains, as
+  `{}`).
+
+Namespaces isolate stores: `get("k", { namespace: "per-user" })` never sees
+the default namespace's `k`. Namespace names are sanitized for the filesystem
+— any character outside `[A-Za-z0-9_-]` becomes `_`.
+
+## 3. Where it lives on disk
+
+Each namespace is one pretty-printed JSON object at:
+
+```
+<root>/.chidori/memory/<namespace>.json
+```
+
+`<root>` resolves in precedence order:
+
+1. **`CHIDORI_MEMORY_DIR`** — explicit override, wins outright.
+2. **The run's workspace root** — the agent file's directory under
+   `run`/`resume`/`serve` and for detached agents, or
+   `CHIDORI_WORKSPACE_ROOT` when set.
+3. **The process cwd** — last-resort fallback for bare embeddings with no
+   known root. (Unlike `chidori.workspace`, memory never hard-fails on a
+   missing root.)
+
+So memory is **anchored to the agent, like runs and workspace files**:
+running the same agent from a different working directory sees the same
+store, and two different agent directories are two independent stores.
+
+## 4. Record vs. replay
+
+Every memory action is a durable `memory` host call in the run's journal:
+
+- **Live**, the action executes against the JSON file (a whole-file
+  load → mutate → save for writes) and its result is recorded.
+- **On replay** (`chidori resume`, `chidori verify`, server replay), the
+  recorded result is returned and the store is **not touched** — no file is
+  read or written. A replayed `get` returns the value as it was at recording
+  time even if the file has changed since; a replayed `set` does not re-write
+  the file. Only live continuation past the recorded frontier (crash
+  recovery's new work) hits the store again.
+
+Memory is a *pure* effect for policy purposes: it is never policy-gated, so
+it works identically under `--trusted`, ask-mode, and the `untrusted`
+profile.
+
+## 5. Concurrency
+
+Writes are whole-file read-modify-write with **no cross-process locking**.
+Within a single run, host calls execute one at a time, so an agent's own
+actions never interleave. But concurrent writers sharing one store — parallel
+actors, a detached-agent fleet, or two processes anchored at the same root —
+can interleave load/save and lose updates (last write wins at file
+granularity). Keep memory for low-contention state (preferences, distilled
+lessons, per-user notes under distinct keys or namespaces); use
+[signals/mailboxes](./signals.md) or [actor messages](./actors.md) for
+cross-agent coordination.
+
+## 6. Memory vs. its neighbors
+
+| Store | Scope | For |
+|---|---|---|
+| `chidori.memory` | The agent, across all runs | What the agent has learned; small JSON state |
+| `chidori.workspace` | The project directory, across runs | Deliverable files (documents, code) — policy-gated |
+| `chidori.step` | One run's journal | Memoizing expensive pure compute within a run ([value checkpoints](./value-checkpoints.md)) |
+| Run journal | One run | Every recorded effect; replay/resume ([replay](./replay.md)) |

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -64,7 +64,16 @@ This means you can:
   (top-level workspace effects re-materialize their recorded artifacts —
   workspace state is real disk, not journal-served).
   Exit 0 on pass — a full integration test that costs $0 and runs in
-  milliseconds, built for CI.
+  milliseconds, built for CI. A full run directory is heavy (the runtime
+  snapshot blob alone can run to tens of MB), so don't commit it raw:
+  `chidori export <run_id> --fixture tests/fixtures` copies just the four
+  artifacts `verify` reads (`records.jsonl`, `runtime.snapshot.json`,
+  `output.json`, `input.json`) into `tests/fixtures/<run_id>/` — typically
+  a few KB. Commit that, and point verify at it with
+  `chidori verify agent.ts <run_id> --runs-dir tests/fixtures`. Export
+  refuses runs whose journal isn't a complete verifiable record (still
+  leased by a live process, paused at a pending operation, or never
+  completed).
 - **Resume after crashes:** the runtime can persist checkpoints after each call; on restart, replay picks up where it left off.
 - **Pause for human approval:** `input()` suspends execution; when the human responds, the agent replays to that point and continues.
 

--- a/docs/running-modes.md
+++ b/docs/running-modes.md
@@ -73,6 +73,7 @@ Exposes:
 - `POST /sessions/{id}/replay` — replay from a session's checkpoint
 - `POST /sessions/{id}/cancel` — cancel a running or stored session
 - `POST /sessions/stream` — run a session with SSE call and prompt progress events
+- `GET  /sessions/{id}/stream` — re-attach to a session's SSE events: replays everything already emitted (so a dropped client catches up), then follows a still-running streaming session live until it settles; for a settled session, replays the logged call records and closes with a `done` event carrying the final state
 
 ## 3. Event-driven agents
 
@@ -99,7 +100,12 @@ returns as `200` JSON. Two behaviors to design for:
   scanner traffic. Branch on `input.event` early and return a cheap
   `{status: 400, ...}` for non-events before any model call, or the strays
   will cost tokens. (With `CHIDORI_API_KEY` set, unauthenticated requests
-  are rejected before the agent runs.)
+  are rejected before the agent runs.) The server short-circuits the most
+  common automatic noise for you: requests for `/favicon.ico`,
+  `/robots.txt`, `/apple-touch-icon*`, and anything under `/.well-known/`
+  get an immediate empty `404` without invoking the agent. If your agent
+  genuinely serves those paths, set `CHIDORI_SERVE_ALL_PATHS=1` to route
+  every path to `agent(event)` again.
 - **A run that pauses becomes a session.** If the agent reaches a
   `chidori.signal(...)` listen point, an `input()` call, or a policy
   approval gate, the server persists it as a real session and answers

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,98 @@
+# Templates — Jinja prompt rendering
+
+> `chidori.template` renders Jinja2-syntax templates (inline strings or
+> `.jinja`/`.j2` files) with [minijinja], as a recorded durable host call.
+> **Related:** `docs/core-concepts.md`, `docs/replay.md`. API reference:
+> `llm.txt`. Implementation: `crates/chidori/src/runtime/template.rs`.
+
+[minijinja]: https://docs.rs/minijinja/
+
+## 1. What this is
+
+Prompt text wants to be data, not string concatenation. `chidori.template`
+takes a template — inline or from a file — plus a JSON object of variables,
+and returns the rendered string:
+
+```ts
+// Inline template string.
+const greeting = await chidori.template("Hello {{ name }}!", { name: "world" });
+
+// File template, resolved relative to the agent's directory.
+const prompt = await chidori.template("prompts/summary.jinja", {
+  document: input.document,
+});
+
+const summary = await chidori.prompt(prompt, { type: "final" });
+```
+
+Full Jinja2 syntax is supported: `{{ var }}` interpolation, `{% if %}` /
+`{% for %}` blocks, filters, and `{% include %}` / `{% extends %}` composition
+for file templates.
+
+## 2. Inline vs. file templates
+
+The first argument is interpreted by suffix: a string ending in `.jinja` or
+`.j2` is treated as a **file path**; anything else is rendered as an **inline
+template string**. There is no separate option to force one or the other —
+name your template files with one of those two extensions.
+
+## 3. How file paths resolve
+
+File template paths resolve relative to the **project base directory — the
+agent file's directory** (the same root that anchors `chidori.callAgent`
+sub-agent paths). This holds across `run`, `resume`, `serve`, and the branch
+commands, so `prompts/summary.jinja` means the same file no matter which
+directory you launch `chidori` from.
+
+`{% include %}` and `{% extends %}` inside a file template resolve relative to
+**that template file's own directory**, so a template tree can live in its own
+folder (`prompts/base.jinja`, `prompts/partials/header.jinja`) and reference
+its siblings with local names. A referenced template that does not exist fails
+the render with a template-not-found error.
+
+## 4. Undefined variables fail loudly
+
+The engine runs minijinja with `UndefinedBehavior::SemiStrict`. In practice:
+
+- **Printing an undefined variable is an error.** `Hello {{ name }}!` with no
+  `name` in the variables fails the call — a typo cannot silently render as an
+  empty string and flow into a prompt.
+- **Iterating, attribute access, and filter coercion of undefined also fail.**
+  `{% for item in items %}` with a missing (or non-iterable) `items` errors,
+  as does `{{ user.name }}` when `user` is undefined.
+- **Truthiness checks are allowed.** `{% if verbose %}…{% endif %}` treats an
+  undefined `verbose` as false, so *optional* variables are expressed with an
+  `{% if %}` guard rather than by relying on empty-string rendering.
+
+A failed render rejects the `chidori.template` promise with the minijinja
+error (naming the template and the failing operation).
+
+Whitespace control: `trim_blocks` and `lstrip_blocks` are enabled, so block
+tags (`{% … %}`) do not leak their trailing newline or leading indentation
+into the output — templates can be indented for readability without producing
+ragged prompt text.
+
+## 5. Durability and replay
+
+Every `chidori.template` call is a recorded `template` host call in the run's
+journal: the rendered string is journaled live, and **replay returns the
+recorded output without re-reading the template file**. Consequences:
+
+- Replays (`chidori resume`, `chidori verify`, server replay) are stable even
+  if a template file has been edited or deleted since the run was recorded.
+- Conversely, editing a template does not change what an existing checkpoint
+  replays — re-run the agent to render with the new template.
+
+Template rendering is a *pure* effect — it is never policy-gated, so it works
+identically under `--trusted`, ask-mode, and `untrusted` profiles.
+
+## 6. When to reach for it
+
+| Need | Use |
+|---|---|
+| Reusable prompt text with variables, conditionals, loops | `chidori.template` |
+| Multi-turn structure, shared cacheable prefixes | `chidori.context()` ([context management](./context-management.md)) |
+| One-off short prompt | A template literal is fine |
+
+The two compose: render a template into a string, then feed it to
+`chidori.prompt`, a `context()` turn, or a `conversation()` system prompt.

--- a/llm.txt
+++ b/llm.txt
@@ -102,7 +102,6 @@ const text = await chidori.prompt("Write a concise answer", {
   model: "claude-sonnet",
   maxTokens: 500,
   temperature: 0.2,
-  tools: ["web_search"],
 });
 ```
 
@@ -212,7 +211,7 @@ See `examples/agents/context_qa.ts` for a complete corpus-Q&A agent.
 ```ts
 const chat = chidori.conversation({
   system: "You are a concise, friendly assistant.",
-  tools: ["web_search"],          // available on every turn
+  tools: [search],                 // defineTool handles (see the `tools` prompt option), on every turn
   compact: { budgetTokens: 8000 }, // opt-in per-turn window management
 });
 
@@ -318,7 +317,8 @@ agent — MCP-server tools (configured via `CHIDORI_MCP_*`) and Rust-native
 tools registered by an embedding application — dispatched by name:
 
 ```ts
-const result = await chidori.tool("web_search", { query: "snapshot runtime" });
+// e.g. a search tool exposed by a configured MCP server
+const result = await chidori.tool("docs_search", { query: "snapshot runtime" });
 ```
 
 A tool's `fetch` is SSRF-guarded by default: requests to hosts that resolve
@@ -633,18 +633,26 @@ if (!result.ok) {
 `RetryOptions` also accepts `delayMs` and `backoff`, but the helper
 retries immediately — no delay is applied between attempts.
 
-## TypeScript Tool Shape
+## Defining Tools
 
-A TypeScript tool exports JSON-compatible metadata and an async
-`run(args, chidori)` function. Tool discovery evaluates the exported `tool`
-value in a restricted metadata VM context before registration.
+A tool is a plain object made with `defineTool`: JSON-compatible metadata
+(`name`, `description`, JSON-schema `parameters`) wrapped around an async
+`run(args, chidori)` function. Define it inline or import it from any module —
+there is no `tools/` directory and no registration step — and pass the handle
+in the `tools` prompt option. The `run` body executes in the agent's own VM,
+so closures over agent state work, and its side effects (`fetch`, workspace,
+...) are the same captured effects the agent already has: journaled live,
+replayed deterministically. Each invocation is journaled as a
+`mark("tool:<name>")` record for the trace.
 
 ```ts
-import type { Chidori, ToolDefinition } from "chidori:agent";
+import { chidori, run, defineTool } from "chidori:agent";
 
-export const tool: ToolDefinition = {
-  name: "web_search",
-  description: "Search the web for a short query.",
+// A real web lookup: `fetch` inside a tool body is the captured fetch, so
+// every request is policy-gated, journaled, and replays for $0.
+const wikiSearch = defineTool({
+  name: "wiki_search",
+  description: "Search Wikipedia and return the top matching titles and URLs.",
   parameters: {
     type: "object",
     properties: {
@@ -652,16 +660,31 @@ export const tool: ToolDefinition = {
     },
     required: ["query"],
   },
-};
+  run: async (args: { query: string }) => {
+    const url =
+      "https://en.wikipedia.org/w/api.php?action=opensearch&format=json" +
+      "&limit=5&search=" +
+      encodeURIComponent(args.query);
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`wiki_search failed: HTTP ${resp.status}`);
+    const [, titles, , urls] = (await resp.json()) as [string, string[], string[], string[]];
+    return titles.map((title, i) => ({ title, url: urls[i] }));
+  },
+});
 
-export async function run(args: { query: string }, chidori: Chidori) {
-  await chidori.log("Running web_search", { query: args.query });
-  return { query: args.query, results: [] };
-}
+run(async (input: { question: string }) => {
+  const answer = await chidori.prompt(input.question, {
+    tools: [wikiSearch],
+    maxTurns: 4,
+  });
+  return { answer };
+});
 ```
 
-Tool metadata must be JSON-compatible. The `parameters` field is a JSON Schema
-object and is used for provider tool calling.
+The `parameters` field is a JSON Schema object and is what the provider reads
+for tool calling. Tools sourced from OUTSIDE the agent — MCP-server tools and
+Rust-native registrations — are invoked by NAME instead, via the
+`chidori.tool` host effect or a name string in `tools` (see `tool` above).
 
 ## Streaming
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -27,6 +27,7 @@
   "files": ["dist", "src", "README.md"],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "pretest": "tsc",
     "test": "node --test test/*.test.mjs"

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -119,6 +119,15 @@ export interface PromptOptions {
    * returning the raw reply string.
    */
   strict?: boolean;
+  /**
+   * Opt-in guard for plain-text prompts: `true` THROWS a catchable error when
+   * the reply is empty after trimming whitespace — a response truncated to
+   * nothing (e.g. a reasoning model spending the whole `maxTokens` budget on
+   * hidden reasoning) can never flow on as a silently empty result. Has no
+   * effect with `format: "json"`, where strict parsing already throws on an
+   * empty reply. Off by default: an empty reply resolves to `""`.
+   */
+  nonEmpty?: boolean;
   stream?: boolean;
   /**
    * Prompt-cache posture. Defaults to on (`"5m"`): the runtime marks the


### PR DESCRIPTION
Audits every finding across the six consumer-usability-review docs against the code and closes all remaining open items. Each fix below is verified by new or extended tests.

## Doc accuracy (claims that didn't match the code)
- **llm.txt**: removed the phantom `web_search` tool — the `results: []` stub and every `tools:["web_search"]` reference are gone, replaced with a real fetch-backed `defineTool` example matching the actual `prompt({tools})` contract.
- **Review docs (rounds 1–2)**: corrected status notes that claimed a `--tools` flag exists (the mechanism was replaced by in-VM `defineTool`) and that a DuckDuckGo-backed web_search shipped (it never did).
- **pkg/manifest.rs**: removed a false comment claiming serde_json preserves insertion order in this build.

## Round 6
- **Template errors surface the cause**: render/parse failures now name the offending variable or filter, template path, line, and column (e.g. ``undefined value (variable `usernme`) at line 4, column 10``) instead of a generic "Failed to render template" (`runtime/template.rs`).
- **`docs/template.md` and `docs/memory.md`**: new dedicated docs written from verified runtime behavior (path resolution, `SemiStrict` undefined handling, namespacing, record-vs-replay semantics), linked from README and core-concepts.
- **SDK `prepare` script**: `file:../../sdk/typescript` checkouts now build `dist/` automatically on install, fixing the TS2688 first-checkout failure.
- **Chat REPL polish**: replies (streamed, fallback, and resumed transcripts) are prefixed `assistant> `, and exit prints a `session usage:` line with turns, prompt calls, tokens, cache reads, and estimated cost (`unknown` when unpriced, never $0).

## Rounds 3–5 leftovers
- **Declared-effect preflight** (new `server/preflight.rs`): serve startup and session creation warn on stderr when the agent's source statically references a gated surface (http/workspace writes) that the active policy unconditionally denies — warning only, with scoped-allow rules suppressing false positives.
- **SSE re-attach**: new `GET /sessions/{id}/stream` replays the session's journaled events and follows live until settlement; settled sessions replay their call log and close with the standard `done` event.
- **Drive-by request guard**: event-mode serving now 404s browser/scanner noise (`/favicon.ico`, `/robots.txt`, `/apple-touch-icon*`, `/.well-known/*`) before touching the agent or the run-slot semaphore; `CHIDORI_SERVE_ALL_PATHS=1` opts out. Documented in `docs/running-modes.md`.
- **Progress line for plain `chidori run`**: one stderr line per prompt (`seq N: prompt started (<model>)` / `seq N: prompt finished (…s)`) so long model calls show signs of life without `--stream`; replay-safe (no phantom lines for replayed records) and `CHIDORI_QUIET=1` suppresses.
- **Empty-output guard**: opt-in `nonEmpty: true` prompt option throws a catchable error when the model returns no visible text (the truncated-reasoning failure mode), typed in the TS SDK; JSON mode already covered by strict parsing.

## Round 4 (now fully closed)
- **`resume --retry-failed`**: first-class repair for a failed run — reuses the test-pinned `strip_crash_frontier` (trailing failed records plus their nested effects are stripped, the surviving prefix replays under unchanged strict divergence rules, the retried tail executes live without `--allow-source-change`). Mutually exclusive with `--until-seq`; clear errors for completed/paused runs; a repaired run passes `chidori verify`. Documented in `docs/durable-storage.md`.
- **`chidori export --fixture` + `verify --runs-dir`**: verify only reads the journal, snapshot manifest, `output.json`, and `input.json` — export writes exactly those four (journal compacted), turning a ~24 MB run dir into a ~2.5 KB committable fixture consumed via `chidori verify --runs-dir`. Refuses leased/paused/incomplete runs with actionable errors. Documented in `docs/replay.md` with the commit-a-fixture-as-CI-test workflow.
- **Manifest key order**: `chidori add` now writes `package.json` with npm-conventional top-level key order (`name` first) instead of alphabetical BTreeMap order, without enabling `preserve_order` binary-wide.
- **Peer-dependency warnings**: unmet-peer warnings now honor `peerDependenciesMeta.optional` and skip `typescript` peers (the runtime itself transpiles TS), so valibot installs are quiet.

## Out of scope
npm/PyPI republish of SDK 3.6.1 is a maintainer release action; CI drift guards (`check-npm-drift.sh`, `check-sdk-versions.sh`) already enforce it going forward.

## Tests
Server suite 56/56, pkg install 10/10 + lib 26/26, template module 9/9, engine lib 29/29, full CLI suite 26/26 (chat, stream posture, progress line, retry-failed, export fixtures), TS SDK typecheck clean, `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjbosJ1JUA8RCrqYCjuWZR