### PR TITLE
Rebuild /playground as a chat agent with tools and generative UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ node_modules/
 /website/next-env.d.ts
 # Playground runtime assets, mirrored from the wasm build by scripts/build-wasm.sh
 /website/public/chidori-wasm/
+# Docs index for the /playground chat agent (regenerate with
+# website/scripts/build-playground-context.mjs; runs as part of npm run build)
+/website/public/playground-docs.json
 
 # Secrets / local env
 .env

--- a/website/app/(home)/playground/agent-source.ts
+++ b/website/app/(home)/playground/agent-source.ts
@@ -1,0 +1,72 @@
+/**
+ * The chidori agent that drives the playground chat. This exact source is
+ * transpiled and executed by the wasm engine; it is also displayed on the
+ * page ("under the hood"), so it is written to read well.
+ *
+ * The loop is a plain ReAct agent: block on `chidori.input()` for the next
+ * user message, then alternate `chidori.prompt()` (decide) and
+ * `chidori.tool()` (act) until the model replies. Every effect is journaled,
+ * so the whole conversation suspends, resumes, and replays offline.
+ *
+ * Each feed event is one JSON line on the console — the page renders the
+ * chat (bubbles, tool cards) purely from the journaled console output.
+ */
+export const AGENT_SOURCE = `type Decision = { tool?: string; args?: unknown; reply?: string };
+type Message = { role: string; content: string };
+
+const transcript: Message[] = [];
+
+function emit(event: unknown): void {
+  console.log(JSON.stringify(event));
+}
+
+async function turn(userText: string): Promise<void> {
+  transcript.push({ role: 'user', content: userText });
+  emit({ kind: 'user', text: userText });
+
+  for (let hop = 0; hop < 6; hop++) {
+    // The host answers with one JSON decision: {tool, args} or {reply}.
+    const raw = await chidori.prompt(JSON.stringify(transcript), {
+      protocol: 'chat-v1',
+    });
+    let decision: Decision;
+    try {
+      decision = JSON.parse(String(raw)) as Decision;
+    } catch (err) {
+      decision = { reply: String(raw) };
+    }
+
+    if (decision.tool) {
+      let result: unknown;
+      try {
+        result = await chidori.tool(decision.tool, decision.args);
+      } catch (err) {
+        result = { error: String(err) };
+      }
+      emit({ kind: 'tool', name: decision.tool, args: decision.args, result });
+      transcript.push({
+        role: 'tool',
+        content: JSON.stringify({ name: decision.tool, result }),
+      });
+      continue;
+    }
+
+    const reply = decision.reply ? String(decision.reply) : '\\u2026';
+    emit({ kind: 'assistant', text: reply });
+    transcript.push({ role: 'assistant', content: reply });
+    return;
+  }
+
+  const bail = 'I hit the tool-call limit for this turn \\u2014 ask me to continue.';
+  emit({ kind: 'assistant', text: bail });
+  transcript.push({ role: 'assistant', content: bail });
+}
+
+async function main(): Promise<void> {
+  for (;;) {
+    const text = await chidori.input('message');
+    await turn(String(text));
+  }
+}
+main();
+`;

--- a/website/app/(home)/playground/brain.ts
+++ b/website/app/(home)/playground/brain.ts
@@ -1,0 +1,423 @@
+/**
+ * The "decide" half of the playground agent: given the agent's transcript,
+ * produce one JSON decision — {tool, args} or {reply}.
+ *
+ * Two interchangeable brains serve `chidori.prompt()`:
+ *  - a real model via OpenRouter (grounded in the docs index), or
+ *  - a deterministic offline router, so the playground works with no key
+ *    and replays byte-identically.
+ */
+
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'tool';
+  content: string;
+}
+
+export interface Decision {
+  tool?: string;
+  args?: Json;
+  reply?: string;
+}
+
+export type FeedEvent =
+  | { kind: 'user'; text: string }
+  | { kind: 'assistant'; text: string }
+  | { kind: 'tool'; name: string; args?: Json; result?: Json }
+  | { kind: 'note'; text: string };
+
+/** Console lines (one JSON event per line) → renderable feed. */
+export function parseFeed(lines: string[]): FeedEvent[] {
+  return lines.map((line): FeedEvent => {
+    try {
+      const ev = JSON.parse(line);
+      if (ev && (ev.kind === 'user' || ev.kind === 'assistant') && typeof ev.text === 'string') return ev;
+      if (ev && ev.kind === 'tool' && typeof ev.name === 'string') return ev;
+    } catch {
+      /* not an event line */
+    }
+    return { kind: 'note', text: line };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Docs index: built by scripts/build-playground-context.mjs into
+// public/playground-docs.json; grounds the system prompt and serves the
+// agent's `search_docs` tool.
+
+export interface DocSection {
+  heading: string;
+  text: string;
+  /** Lowercased copies, cached once at load time for scoring. */
+  lc?: string;
+  hlc?: string;
+}
+
+export interface DocPage {
+  slug: string;
+  route: string;
+  title: string;
+  tlc?: string;
+  sections: DocSection[];
+}
+
+export interface DocsIndex {
+  pages: DocPage[];
+}
+
+export interface DocHit {
+  title: string;
+  heading: string;
+  route: string;
+  excerpt: string;
+}
+
+export function prepareDocsIndex(raw: DocsIndex): DocsIndex {
+  for (const page of raw.pages) {
+    page.tlc = page.title.toLowerCase();
+    for (const s of page.sections) {
+      s.lc = s.text.toLowerCase();
+      s.hlc = s.heading.toLowerCase();
+    }
+  }
+  return raw;
+}
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'that', 'this', 'what', 'how', 'does', 'can',
+  'you', 'are', 'was', 'not', 'has', 'have', 'its', 'about', 'from', 'into',
+  'when', 'why', 'where', 'which', 'chidori',
+]);
+
+function terms(query: string): string[] {
+  return (query.toLowerCase().match(/[a-z0-9]{3,}/g) ?? []).filter((t) => !STOPWORDS.has(t));
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  let n = 0;
+  for (let i = haystack.indexOf(needle); i !== -1 && n < 5; i = haystack.indexOf(needle, i + needle.length)) n++;
+  return n;
+}
+
+export function searchDocs(index: DocsIndex | null, query: string, k = 4): DocHit[] {
+  if (!index) return [];
+  const ts = terms(query);
+  if (!ts.length) return [];
+  const scored: { score: number; hit: DocHit }[] = [];
+  for (const page of index.pages) {
+    for (const s of page.sections) {
+      let score = 0;
+      for (const t of ts) {
+        score += countOccurrences(s.lc ?? '', t);
+        if ((page.tlc ?? '').includes(t)) score += 4;
+        if ((s.hlc ?? '').includes(t)) score += 2;
+      }
+      if (score > 0) {
+        scored.push({
+          score,
+          hit: {
+            title: page.title,
+            heading: s.heading,
+            route: page.route,
+            excerpt: s.text.slice(0, 300),
+          },
+        });
+      }
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+  // At most two sections per page, so one page can't fill every slot.
+  const hits: DocHit[] = [];
+  const perPage = new Map<string, number>();
+  for (const { hit } of scored) {
+    const seen = perPage.get(hit.route) ?? 0;
+    if (seen >= 2) continue;
+    perPage.set(hit.route, seen + 1);
+    hits.push(hit);
+    if (hits.length >= k) break;
+  }
+  return hits;
+}
+
+// ---------------------------------------------------------------------------
+// Shared prompt material
+
+export const OVERVIEW =
+  'Chidori is an agent framework where every run is durable, replayable, and ' +
+  'resumable by default. Agents are plain async TypeScript (real if/for/try, ' +
+  'no graph DSL) executed by a pure-Rust runtime — its own JS engine, GC, and ' +
+  'a journaled host-effect boundary. Because every side effect (LLM calls, ' +
+  'tools, HTTP, input, timers, randomness) is journaled, a run can suspend at ' +
+  'chidori.input(), be saved as one blob, resume later, and replay offline ' +
+  'with byte-identical output. The engine also compiles to WebAssembly — ' +
+  'this very chat is a chidori agent running in your browser tab.';
+
+const TOOL_SPEC = `Tools you can call (one per decision):
+- search_docs {query: string} — full-text search over the chidori documentation; returns titles, links, and excerpts. Call this before answering any question about chidori.
+- weather {city: string} — live current conditions + 5-day forecast (Open-Meteo, no key).
+- calculate {expression: string} — arithmetic with + - * / % ^ ( ), functions sqrt sin cos tan abs ln log exp round floor ceil, constants pi and e.
+- chart {title?: string, kind?: "bar" | "line", series: [{label: string, value: number}, ...]} — renders a chart card in the chat. Provide the data yourself.
+- color_palette {mood: string, colors: [{hex: string, name: string} x5]} — renders five swatches. Pick the hex values yourself.
+- roll_dice {count?: number, sides?: number} — fair dice, rolled by the host.`;
+
+export function buildSystemPrompt(index: DocsIndex | null, latestUser: string): string {
+  const hits = searchDocs(index, latestUser, 4);
+  const context = hits.length
+    ? hits
+        .map((h) => `[${h.title}${h.heading ? ` — ${h.heading}` : ''}] (${h.route})\n${h.excerpt}`)
+        .join('\n\n')
+    : '(no matching docs sections for this message)';
+  return `You are the Chidori Playground agent — a chidori agent running client-side on the wasm build of the chidori runtime, inside the visitor's browser on the chidori docs site.
+
+About chidori: ${OVERVIEW}
+
+${TOOL_SPEC}
+
+Protocol — respond with EXACTLY one JSON object and nothing else:
+  {"tool": "<name>", "args": {...}}   to call a tool, or
+  {"reply": "<text>"}                 to answer the user.
+Messages whose content starts with TOOL RESULT are journaled tool outputs from your own earlier calls this turn.
+
+Guidance: ground chidori answers in search_docs results and name the doc pages you drew from; prefer showing over telling (chart, color_palette); keep replies under ~120 words; plain text only.
+
+Docs context retrieved for the current message:
+${context}`;
+}
+
+// ---------------------------------------------------------------------------
+// Real brain: OpenRouter chat completions (CORS-enabled for browser use).
+
+export async function openRouterDecide(cfg: {
+  apiKey: string;
+  model: string;
+  transcript: ChatMessage[];
+  index: DocsIndex | null;
+}): Promise<Decision> {
+  const { apiKey, model, transcript, index } = cfg;
+  const latestUser = [...transcript].reverse().find((m) => m.role === 'user')?.content ?? '';
+  const messages = [
+    { role: 'system', content: buildSystemPrompt(index, latestUser) },
+    ...transcript.slice(-30).map((m) => ({
+      role: m.role === 'tool' ? 'user' : m.role,
+      content: (m.role === 'tool' ? `TOOL RESULT ${m.content}` : m.content).slice(0, 4000),
+    })),
+  ];
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+      'HTTP-Referer': typeof location !== 'undefined' ? location.origin : 'https://thousandbirdsinc.github.io',
+      'X-Title': 'Chidori Playground',
+    },
+    body: JSON.stringify({ model, messages }),
+  });
+  if (!res.ok) throw new Error(`openrouter: ${res.status} ${await res.text()}`);
+  const body = await res.json();
+  return extractDecision(String(body.choices?.[0]?.message?.content ?? ''));
+}
+
+/** Normalize whatever the model emitted into a protocol decision. */
+export function extractDecision(raw: string): Decision {
+  let text = raw.trim();
+  const fence = /^```[a-z]*\s*([\s\S]*?)\s*```$/.exec(text);
+  if (fence) text = fence[1].trim();
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    try {
+      const obj = JSON.parse(text.slice(start, end + 1));
+      if (obj && typeof obj === 'object' && (typeof obj.tool === 'string' || typeof obj.reply === 'string')) {
+        return obj as Decision;
+      }
+    } catch {
+      /* fall through to plain reply */
+    }
+  }
+  return { reply: raw };
+}
+
+// ---------------------------------------------------------------------------
+// Offline brain: a deterministic router, so the playground demos every tool
+// (and docs Q&A) with no key, and replays are byte-identical.
+
+export function mockDecide(transcript: ChatMessage[], index: DocsIndex | null): Decision {
+  let userIdx = -1;
+  for (let i = transcript.length - 1; i >= 0; i--) {
+    if (transcript[i].role === 'user') {
+      userIdx = i;
+      break;
+    }
+  }
+  const text = userIdx >= 0 ? transcript[userIdx].content : '';
+  const toolMsgs = transcript.slice(userIdx + 1).filter((m) => m.role === 'tool');
+  if (toolMsgs.length) {
+    try {
+      return composeReply(JSON.parse(toolMsgs[toolMsgs.length - 1].content));
+    } catch {
+      return { reply: 'That tool result confused me — try rephrasing?' };
+    }
+  }
+  return route(text, index);
+}
+
+function route(text: string, index: DocsIndex | null): Decision {
+  const t = text.toLowerCase();
+
+  const dice = /(\d+)\s*d\s*(\d+)/.exec(t);
+  if (dice || /\b(roll|dice)\b/.test(t)) {
+    return {
+      tool: 'roll_dice',
+      args: { count: dice ? Number(dice[1]) : 2, sides: dice ? Number(dice[2]) : 6 },
+    };
+  }
+
+  if (/\b(weather|forecast|temperature|raining|sunny|snowing)\b/.test(t)) {
+    const m = /\b(?:in|for|at)\s+([a-zA-Z][a-zA-Z\s'.-]*)/.exec(text);
+    let city = m ? m[1] : text.replace(/[^a-zA-Z\s'.-]/g, ' ');
+    city = city
+      .replace(/\b(the|weather|forecast|temperature|right|now|today|tomorrow|please|what|whats|is|like)\b/gi, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return { tool: 'weather', args: { city: city || 'Tokyo' } };
+  }
+
+  if (/\b(chart|plot|graph)\b/.test(t)) {
+    const kind = /\b(line|trend|over time)\b/.test(t) ? 'line' : 'bar';
+    let values: number[];
+    let title: string;
+    if (/fibonacci|fib\b/.test(t)) {
+      const n = Math.min(Number((/\b(\d+)\b/.exec(t) ?? [])[1] ?? 10), 16);
+      values = [1, 1];
+      while (values.length < n) values.push(values[values.length - 1] + values[values.length - 2]);
+      values = values.slice(0, n);
+      title = `First ${values.length} Fibonacci numbers`;
+    } else if (/\bsquares?\b/.test(t)) {
+      const n = Math.min(Number((/\b(\d+)\b/.exec(t) ?? [])[1] ?? 8), 16);
+      values = Array.from({ length: n }, (_, i) => (i + 1) * (i + 1));
+      title = `Squares 1–${n}`;
+    } else {
+      values = (text.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number).slice(0, 24);
+      title = 'Your numbers';
+    }
+    if (!values.length) {
+      return { reply: 'Give me numbers to chart — e.g. "chart 3 1 4 1 5 9" or "chart the first 10 fibonacci numbers".' };
+    }
+    return {
+      tool: 'chart',
+      args: { title, kind, series: values.map((v, i) => ({ label: String(i + 1), value: v })) },
+    };
+  }
+
+  if (/\b(palette|colou?rs?|swatch)\b/.test(t)) {
+    const mood =
+      text
+        .replace(/\b(a|an|the|for|of|make|give|me|generate|show|color|colour|colors|colours|palette|swatches?|please)\b/gi, ' ')
+        .replace(/[^\w\s-]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim() || 'chidori';
+    return { tool: 'color_palette', args: { mood, colors: paletteFor(mood) } };
+  }
+
+  const calcM = /(?:what\s+is|calc(?:ulate)?|compute|evaluate)\s+(.+)|^([\d\s+\-*/^%().]+)[?]?$/i.exec(text.trim());
+  if (calcM) {
+    const expr = (calcM[1] ?? calcM[2] ?? '').replace(/[?.]+$/, '').trim();
+    if (/\d/.test(expr) && /^[\d\s+\-*/^%().,a-z]+$/i.test(expr) && /[\d)]\s*[+\-*/^%]|\b(sqrt|sin|cos|tan|log|ln|abs|exp|pi)\b/i.test(expr)) {
+      return { tool: 'calculate', args: { expression: expr } };
+    }
+  }
+
+  if (index && (/\?\s*$/.test(text) || /\b(chidori|agent|replay|durable|journal|resume|suspend|wasm|runtime|effect|host|deploy|cli|actor|sdk|typescript|prompt|memory|browser)\b/.test(t))) {
+    return { tool: 'search_docs', args: { query: text } };
+  }
+
+  return {
+    reply:
+      'Offline brain here (connect OpenRouter above for a real model). I can still do a lot deterministically — try:\n' +
+      '• "How does offline replay work?" (searches these docs)\n' +
+      '• "Weather in Tokyo"\n' +
+      '• "Chart the first 10 fibonacci numbers"\n' +
+      '• "What is 2^16 / 3?"  • "Roll 3d6"  • "A palette for a storm at dusk"',
+  };
+}
+
+function composeReply(toolMsg: { name?: string; result?: Json }): Decision {
+  const name = toolMsg.name ?? '';
+  const r = (toolMsg.result ?? {}) as Record<string, Json>;
+  if (r && typeof r === 'object' && 'error' in r) {
+    return { reply: `That ${name} call failed: ${String(r.error)}` };
+  }
+  switch (name) {
+    case 'weather': {
+      const cond = r.condition as { label?: string } | undefined;
+      return {
+        reply:
+          `${String(r.city)}: ${String(r.tempC)}°C and ${String(cond?.label ?? 'unknown').toLowerCase()}, ` +
+          `wind ${String(r.windKph)} km/h, humidity ${String(r.humidity)}%.` +
+          (r.simulated ? ' (Network was unavailable, so this one is simulated.)' : ''),
+      };
+    }
+    case 'search_docs': {
+      const hits = (r.hits ?? []) as unknown as DocHit[];
+      if (!hits.length) return { reply: 'Nothing in the docs matched — try different words.' };
+      const top = hits[0];
+      return {
+        reply:
+          `From “${top.title}”${top.heading ? ` (§ ${top.heading})` : ''}:\n${top.excerpt}\n\n` +
+          'The cards above link to the full pages.',
+      };
+    }
+    case 'calculate':
+      return { reply: `${String(r.expression)} = ${String(r.value)}` };
+    case 'chart':
+      return { reply: `Charted ${String(r.points)} points — rendered above.` };
+    case 'roll_dice': {
+      const rolls = (r.rolls ?? []) as number[];
+      return { reply: `🎲 ${rolls.join(' + ')} = ${String(r.total)}` };
+    }
+    case 'color_palette':
+      return { reply: `Five swatches for “${String(r.mood)}” — rendered above.` };
+    default:
+      return { reply: `Done: ${JSON.stringify(r).slice(0, 200)}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small deterministic helpers
+
+export function hashString(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export function hslToHex(h: number, s: number, l: number): string {
+  const ln = l / 100;
+  const a = (s * Math.min(ln, 1 - ln)) / 100;
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const c = ln - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * c)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+const SWATCH_NAMES = ['base', 'shade', 'accent', 'glow', 'contrast'];
+
+/** Five deterministic swatches derived from the mood string. */
+export function paletteFor(mood: string): { hex: string; name: string }[] {
+  const seed = hashString(mood.toLowerCase());
+  const baseHue = seed % 360;
+  return SWATCH_NAMES.map((name, i) => {
+    const hue = (baseHue + i * 137.5) % 360;
+    const sat = 35 + ((seed >>> (i * 3)) % 45);
+    const light = 30 + ((seed >>> (i * 5)) % 45);
+    return { hex: hslToHex(hue, sat, light), name };
+  });
+}

--- a/website/app/(home)/playground/cards.tsx
+++ b/website/app/(home)/playground/cards.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+/**
+ * Generative UI for the chat feed: each tool event renders as a purpose-built
+ * card driven by the (journaled) tool args + result, so replays repaint the
+ * exact same UI with zero live calls.
+ */
+import type { DocHit, Json } from './brain';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+const card =
+  'w-full max-w-md rounded-xl border border-fd-border bg-fd-card p-4 shadow-sm';
+
+const asObj = (v: Json | undefined): Record<string, Json> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, Json>) : {};
+
+export function ToolCard({ name, args, result }: { name: string; args?: Json; result?: Json }) {
+  const r = asObj(result);
+  if ('error' in r) {
+    return (
+      <div className={card}>
+        <CardTitle name={name} />
+        <p className="mt-1 text-sm text-fd-muted-foreground">{String(r.error)}</p>
+      </div>
+    );
+  }
+  switch (name) {
+    case 'weather':
+      return <WeatherCard r={r} />;
+    case 'search_docs':
+      return <DocsCard r={r} />;
+    case 'chart':
+      return <ChartCard args={asObj(args)} />;
+    case 'calculate':
+      return <CalcCard r={r} />;
+    case 'roll_dice':
+      return <DiceCard r={r} />;
+    case 'color_palette':
+      return <PaletteCard r={r} />;
+    default:
+      return (
+        <div className={card}>
+          <CardTitle name={name} />
+          <pre className="mt-2 overflow-x-auto text-xs text-fd-muted-foreground">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        </div>
+      );
+  }
+}
+
+function CardTitle({ name, extra }: { name: string; extra?: string }) {
+  return (
+    <p className="text-[11px] font-medium uppercase tracking-wider text-fd-muted-foreground">
+      ⚙ {name}
+      {extra ? <span className="normal-case tracking-normal"> · {extra}</span> : null}
+    </p>
+  );
+}
+
+function WeatherCard({ r }: { r: Record<string, Json> }) {
+  const cond = asObj(r.condition);
+  const daily = Array.isArray(r.daily) ? (r.daily as Json[]).map(asObj) : [];
+  return (
+    <div className={card}>
+      <CardTitle name="weather" extra={r.simulated ? 'simulated (offline)' : 'open-meteo'} />
+      <div className="mt-2 flex items-center gap-3">
+        <span className="text-4xl leading-none">{String(cond.emoji ?? '🌡')}</span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-semibold">
+            {String(r.city)}
+            {r.country ? <span className="font-normal text-fd-muted-foreground"> · {String(r.country)}</span> : null}
+          </p>
+          <p className="text-sm text-fd-muted-foreground">
+            {String(cond.label ?? '')} · wind {String(r.windKph)} km/h · {String(r.humidity)}%
+          </p>
+        </div>
+        <span className="text-3xl font-semibold tabular-nums">{String(r.tempC)}°</span>
+      </div>
+      {daily.length > 0 && (
+        <div className="mt-3 grid grid-cols-5 gap-1 border-t border-fd-border pt-3 text-center">
+          {daily.slice(0, 5).map((d, i) => (
+            <div key={i} className="text-xs">
+              <p className="text-fd-muted-foreground">{String(d.day)}</p>
+              <p className="text-base">{String(d.emoji)}</p>
+              <p className="tabular-nums">
+                {String(d.max)}°<span className="text-fd-muted-foreground">/{String(d.min)}°</span>
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DocsCard({ r }: { r: Record<string, Json> }) {
+  const hits = Array.isArray(r.hits) ? (r.hits as unknown as DocHit[]) : [];
+  return (
+    <div className={card}>
+      <CardTitle name="search_docs" extra={`“${String(r.query ?? '')}”`} />
+      {hits.length === 0 ? (
+        <p className="mt-2 text-sm text-fd-muted-foreground">No matching docs sections.</p>
+      ) : (
+        <ul className="mt-2 space-y-2.5">
+          {hits.map((h, i) => (
+            <li key={i}>
+              <a href={`${BASE}${h.route}`} className="text-sm font-medium text-fd-primary hover:underline">
+                {h.title}
+                {h.heading ? <span className="text-fd-muted-foreground"> § {h.heading}</span> : null}
+              </a>
+              <p className="mt-0.5 line-clamp-2 text-xs text-fd-muted-foreground">{h.excerpt}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ChartCard({ args }: { args: Record<string, Json> }) {
+  const series = (Array.isArray(args.series) ? (args.series as Json[]).map(asObj) : []).map((p) => ({
+    label: String(p.label ?? ''),
+    value: Number(p.value ?? 0),
+  }));
+  if (!series.length) return null;
+  const W = 320;
+  const H = 120;
+  const max = Math.max(...series.map((p) => p.value), 0);
+  const min = Math.min(...series.map((p) => p.value), 0);
+  const span = max - min || 1;
+  const y = (v: number) => H - ((v - min) / span) * H;
+  const line = args.kind === 'line';
+  const step = W / series.length;
+  return (
+    <div className={card}>
+      <CardTitle name="chart" extra={args.title ? String(args.title) : undefined} />
+      <svg viewBox={`0 0 ${W} ${H + 16}`} className="mt-2 w-full text-fd-primary" role="img" aria-label={String(args.title ?? 'chart')}>
+        {min < 0 && <line x1={0} x2={W} y1={y(0)} y2={y(0)} stroke="currentColor" strokeOpacity={0.25} />}
+        {line ? (
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinejoin="round"
+            points={series.map((p, i) => `${i * step + step / 2},${y(p.value)}`).join(' ')}
+          />
+        ) : (
+          series.map((p, i) => (
+            <rect
+              key={i}
+              x={i * step + step * 0.15}
+              width={step * 0.7}
+              y={Math.min(y(p.value), y(0))}
+              height={Math.max(2, Math.abs(y(p.value) - y(0)))}
+              rx={2}
+              fill="currentColor"
+              fillOpacity={0.75}
+            >
+              <title>{`${p.label}: ${p.value}`}</title>
+            </rect>
+          ))
+        )}
+        {series.length <= 16 &&
+          series.map((p, i) => (
+            <text
+              key={i}
+              x={i * step + step / 2}
+              y={H + 12}
+              textAnchor="middle"
+              className="fill-fd-muted-foreground"
+              fontSize={9}
+            >
+              {p.label.slice(0, 6)}
+            </text>
+          ))}
+      </svg>
+    </div>
+  );
+}
+
+function CalcCard({ r }: { r: Record<string, Json> }) {
+  return (
+    <div className={card}>
+      <CardTitle name="calculate" />
+      <p className="mt-1 font-mono text-sm">
+        {String(r.expression)} = <span className="text-base font-semibold text-fd-primary">{String(r.value)}</span>
+      </p>
+    </div>
+  );
+}
+
+const D6 = ['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'];
+
+function DiceCard({ r }: { r: Record<string, Json> }) {
+  const rolls = Array.isArray(r.rolls) ? (r.rolls as number[]) : [];
+  const d6 = Number(r.sides) === 6;
+  return (
+    <div className={card}>
+      <CardTitle name="roll_dice" extra={`${String(r.count)}d${String(r.sides)}`} />
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        {rolls.map((v, i) =>
+          d6 ? (
+            <span key={i} className="text-4xl leading-none" title={String(v)}>
+              {D6[v - 1]}
+            </span>
+          ) : (
+            <span key={i} className="rounded-lg border border-fd-border px-2.5 py-1 font-mono text-sm tabular-nums">
+              {v}
+            </span>
+          ),
+        )}
+        <span className="ml-1 text-sm text-fd-muted-foreground">= {String(r.total)}</span>
+      </div>
+    </div>
+  );
+}
+
+function PaletteCard({ r }: { r: Record<string, Json> }) {
+  const colors = (Array.isArray(r.colors) ? (r.colors as Json[]).map(asObj) : []).map((c) => ({
+    hex: String(c.hex ?? '#888888'),
+    name: String(c.name ?? ''),
+  }));
+  return (
+    <div className={card}>
+      <CardTitle name="color_palette" extra={`“${String(r.mood ?? '')}”`} />
+      <div className="mt-2 flex gap-1.5">
+        {colors.map((c, i) => (
+          <div key={i} className="min-w-0 flex-1">
+            <div className="h-14 rounded-lg border border-fd-border" style={{ backgroundColor: c.hex }} title={c.name} />
+            <p className="mt-1 truncate text-center font-mono text-[10px] text-fd-muted-foreground">{c.hex}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/website/app/(home)/playground/page.tsx
+++ b/website/app/(home)/playground/page.tsx
@@ -4,25 +4,19 @@ import { PlaygroundClient } from './playground-client';
 export const metadata: Metadata = {
   title: 'Playground — Chidori',
   description:
-    'Run a durable chidori agent entirely in your browser: the pure-Rust engine compiled to WebAssembly, with suspend, resume, and offline replay.',
+    'Chat with a chidori agent running entirely in your browser: the pure-Rust engine compiled to WebAssembly, with tools, generative UI, and docs-grounded answers.',
 };
 
 export default function PlaygroundPage() {
   return (
-    <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
+    <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-12">
       <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
         Playground
       </h1>
-      <p className="mt-4 max-w-3xl text-fd-muted-foreground">
-        A <b>client-side-only</b> chidori agent — the pure-Rust engine and its
-        durable replay runtime compiled to WebAssembly, running in this tab.
-        The agent below suspends at <code>chidori.input()</code>: the run is
-        saved to <code>localStorage</code>, survives a page reload, resumes
-        exactly where it stopped, and replays offline with zero live host
-        calls. No server involved. <code>chidori.prompt()</code> runs against a
-        deterministic mock by default — or connect OpenRouter (one click, PKCE
-        login, no key pasting) to use real models; either way, replay never
-        calls the LLM again.
+      <p className="mt-3 text-fd-muted-foreground">
+        A chidori agent running entirely in this tab — ask it about chidori, or
+        hand it a tool. Reload mid-conversation and it resumes; every effect is
+        journaled.
       </p>
       <PlaygroundClient />
     </main>

--- a/website/app/(home)/playground/playground-client.tsx
+++ b/website/app/(home)/playground/playground-client.tsx
@@ -1,55 +1,66 @@
 'use client';
 
 /**
- * The interactive part of /playground: loads the wasm engine and the browser
- * SDK at runtime from /public (they are build artifacts produced by
- * scripts/build-wasm.sh, deliberately outside the Next bundle — hence the
- * webpackIgnore'd dynamic imports), then drives a durable agent through
- * record → suspend → resume → offline replay.
+ * The /playground chat: a chidori agent (agent-source.ts) running on the wasm
+ * engine in this tab, talking through a ReAct loop. This component is the
+ * *host*: it serves `chidori.prompt()` from a brain (offline router or
+ * OpenRouter), `chidori.tool()` from tools.ts, and `chidori.input()` from the
+ * chat box. The feed renders purely from the journaled console, so restored
+ * and replayed runs repaint identically — cards included.
+ *
+ * The wasm engine + browser SDK load at runtime from /public (build artifacts
+ * of scripts/build-wasm.sh, hence the webpackIgnore'd imports); the docs
+ * index loads from /playground-docs.json (scripts/build-playground-context.mjs).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AGENT_SOURCE } from './agent-source';
+import {
+  type ChatMessage,
+  type DocsIndex,
+  type FeedEvent,
+  type Json,
+  mockDecide,
+  openRouterDecide,
+  parseFeed,
+  prepareDocsIndex,
+} from './brain';
+import { makeTools } from './tools';
+import { ToolCard } from './cards';
 
-// Inlined at build time from DOCS_BASE_PATH (see next.config.mjs) so asset
-// URLs work both locally ('') and on GitHub Pages ('/chidori').
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const ASSETS = `${BASE}/chidori-wasm`;
-const SAVE_KEY = 'chidori-playground-run';
+const SAVE_KEY = 'chidori-playground-chat-v1';
 // The exchanged OpenRouter key lives in sessionStorage: it survives the PKCE
 // redirect back to this page, and is gone when the tab closes.
 const OR_KEY = 'chidori-playground-openrouter-key';
 
-const SAMPLE_AGENT = `interface Weather { tempC: number; sky: string }
-
-async function main(): Promise<void> {
-  await chidori.log('starting research');
-  const city = await chidori.input('Which city should I research?');
-  const weather = await chidori.tool('weather', { city }) as Weather;
-  const fact = await chidori.fetch('${ASSETS}/fact.json');
-  const stamp = await chidori.now();
-  const summary = await chidori.prompt(
-    \`One line on \${city}: \${weather.tempC}C, \${weather.sky}\`);
-  console.log(\`city: \${city}\`);
-  console.log(\`weather: \${weather.tempC}C, \${weather.sky}\`);
-  console.log(\`fact: \${fact.json.text}\`);
-  console.log(\`summary: \${summary}\`);
-  console.log(\`researched at \${stamp}\`);
-}
-main();
-`;
+const SUGGESTIONS = [
+  'What is chidori, in one paragraph?',
+  'How does offline replay work?',
+  'Weather in Tokyo',
+  'Chart the first 10 fibonacci numbers',
+  'What is 2^16 / 3?',
+  'Roll 3d6',
+  'A color palette for a storm at dusk',
+];
 
 interface RunView {
   status: string;
   console: string[];
   liveCalls: number;
-  pendingInput?: { prompt: string };
+}
+
+interface AgentHandle {
+  run(): Promise<RunView>;
+  console(): string[];
+  blob(): Uint8Array;
 }
 
 declare global {
   interface Window {
-    /** Set once the wasm assets are loaded; the e2e tests key off these. */
+    /** Set once the wasm assets are loaded; smoke checks key off this. */
     __chidoriReady?: boolean;
-    __lastRun?: RunView;
   }
 }
 
@@ -73,28 +84,164 @@ async function loadAssets(): Promise<Loaded> {
 }
 
 export function PlaygroundClient() {
-  const [source, setSource] = useState(SAMPLE_AGENT);
+  const [ready, setReady] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [feed, setFeed] = useState<FeedEvent[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
   const [statusLine, setStatusLine] = useState('');
-  const [consoleLines, setConsoleLines] = useState<string[]>([]);
-  const [hostLines, setHostLines] = useState<string[]>([]);
-  const [question, setQuestion] = useState<string | null>(null);
-  const [answer, setAnswer] = useState('');
   const [hasSaved, setHasSaved] = useState(false);
+  const [draft, setDraft] = useState('');
   const [provider, setProvider] = useState<'mock' | 'openrouter'>('mock');
   const [orKey, setOrKey] = useState<string | null>(null);
   const [model, setModel] = useState('openrouter/auto');
+
   const loadedRef = useRef<Loaded | null>(null);
-  const agentRef = useRef<{ run(): Promise<RunView>; blob(): Uint8Array } | null>(null);
-  const askResolveRef = useRef<((answer: string) => void) | null>(null);
+  const loadedPromiseRef = useRef<Promise<Loaded | null> | null>(null);
+  const agentRef = useRef<AgentHandle | null>(null);
+  // The host closures live as long as the agent; anything they must see live
+  // goes through a ref. `token` invalidates a whole agent on Reset.
+  const tokenRef = useRef(0);
+  const resolveRef = useRef<((answer: string) => void) | null>(null);
+  const queueRef = useRef<string[]>([]);
+  const providerRef = useRef(provider);
+  const orKeyRef = useRef(orKey);
+  const modelRef = useRef(model);
+  const docsIndexRef = useRef<DocsIndex | null>(null);
+  const feedBoxRef = useRef<HTMLDivElement | null>(null);
+
+  const refreshFeed = useCallback(() => {
+    const agent = agentRef.current;
+    if (agent) setFeed(parseFeed(agent.console()));
+  }, []);
+
+  const persist = useCallback(() => {
+    const agent = agentRef.current;
+    if (!agent || agent.console().length === 0) return;
+    try {
+      localStorage.setItem(SAVE_KEY, new TextDecoder().decode(agent.blob()));
+      setHasSaved(true);
+    } catch {
+      /* storage full/blocked — chat still works, just not durable */
+    }
+  }, []);
+
+  /** Host implementations for one agent generation. */
+  const buildHost = useCallback(
+    (token: number) => {
+      const stale = () => token !== tokenRef.current;
+      const hang = () => new Promise<never>(() => {});
+      const baseTools = makeTools(() => docsIndexRef.current);
+      const tools: Record<string, (kwargs: Json) => Promise<Json>> = {};
+      for (const [name, impl] of Object.entries(baseTools)) {
+        tools[name] = async (kwargs) => {
+          if (stale()) return hang();
+          setBusy(`running ${name}…`);
+          refreshFeed();
+          return impl(kwargs);
+        };
+      }
+      return {
+        llm: async ({ text }: { text: string }) => {
+          if (stale()) return hang();
+          setBusy('thinking…');
+          refreshFeed();
+          let transcript: ChatMessage[] = [];
+          try {
+            transcript = JSON.parse(text);
+          } catch {
+            /* not a transcript — leave empty */
+          }
+          try {
+            const decision =
+              providerRef.current === 'openrouter' && orKeyRef.current
+                ? await openRouterDecide({
+                    apiKey: orKeyRef.current,
+                    model: modelRef.current,
+                    transcript,
+                    index: docsIndexRef.current,
+                  })
+                : mockDecide(transcript, docsIndexRef.current);
+            return JSON.stringify(decision);
+          } catch (err) {
+            // Keep the loop alive: surface the failure as the reply.
+            return JSON.stringify({ reply: `LLM call failed: ${String(err)}` });
+          }
+        },
+        tools,
+        onInput: () => {
+          if (stale()) return hang();
+          setBusy(null);
+          refreshFeed();
+          persist();
+          const queued = queueRef.current.shift();
+          if (queued !== undefined) return queued;
+          return new Promise<string>((resolve) => {
+            resolveRef.current = resolve;
+          });
+        },
+      };
+    },
+    [refreshFeed, persist],
+  );
+
+  const drive = useCallback(
+    (agent: AgentHandle, token: number) => {
+      agent
+        .run()
+        .then(() => {
+          if (token !== tokenRef.current) return;
+          setBusy(null);
+          refreshFeed();
+        })
+        .catch((err) => {
+          if (token !== tokenRef.current) return;
+          setBusy(null);
+          setStatusLine(`Agent error: ${String(err)}`);
+        });
+    },
+    [refreshFeed],
+  );
+
+  /** Restore a saved conversation: replays the journal, waits at input. */
+  const restoreSaved = useCallback(
+    (loaded: Loaded): boolean => {
+      const saved = localStorage.getItem(SAVE_KEY);
+      if (saved === null) return false;
+      try {
+        const token = tokenRef.current;
+        const agent = loaded.sdk.BrowserAgent.restore(
+          loaded.wasm,
+          new TextEncoder().encode(saved),
+          buildHost(token),
+        ) as AgentHandle;
+        agentRef.current = agent;
+        setHasSaved(true);
+        setStatusLine('Restored from localStorage — earlier turns replayed offline.');
+        drive(agent, token);
+        return true;
+      } catch {
+        localStorage.removeItem(SAVE_KEY);
+        return false;
+      }
+    },
+    [buildHost, drive],
+  );
 
   useEffect(() => {
-    setHasSaved(localStorage.getItem(SAVE_KEY) !== null);
-    // Preload so the first click is instant; surface a friendly error if the
-    // assets have not been built into public/chidori-wasm.
-    loadAssets()
+    let cancelled = false;
+    const loading = loadAssets();
+    loadedPromiseRef.current = loading.catch(() => null);
+    fetch(`${BASE}/playground-docs.json`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (json && !cancelled) docsIndexRef.current = prepareDocsIndex(json);
+      })
+      .catch(() => {
+        /* docs search degrades gracefully */
+      });
+    loading
       .then(async (loaded) => {
+        if (cancelled) return;
         loadedRef.current = loaded;
         // Finish the OpenRouter PKCE login if this page load is the redirect
         // back from openrouter.ai (no-op otherwise).
@@ -106,136 +253,71 @@ export function PlaygroundClient() {
         }
         const key = sessionStorage.getItem(OR_KEY);
         if (key) {
+          orKeyRef.current = key;
           setOrKey(key);
+          providerRef.current = 'openrouter';
           setProvider('openrouter');
         }
+        setReady(true);
         window.__chidoriReady = true;
+        restoreSaved(loaded);
       })
-      .catch(() =>
-        setLoadError(
-          'The wasm assets are missing. Build them with scripts/build-wasm.sh, then reload.',
-        ),
-      );
-  }, []);
-
-  const host = useCallback(
-    (interactive: boolean) => ({
-      llm:
-        provider === 'openrouter' && orKey && loadedRef.current
-          ? loadedRef.current.sdk.openRouterLlm({
-              apiKey: orKey,
-              model,
-              appName: 'Chidori Playground',
-              appUrl: typeof location !== 'undefined' ? location.origin : undefined,
-            })
-          : async ({ text }: { text: string }) =>
-              text.startsWith('One line on')
-                ? 'crisp skies, bring a light jacket'
-                : `[mock] ${text}`,
-      tools: {
-        weather: (kwargs: unknown) => {
-          const { city } = kwargs as { city: string };
-          return { tempC: 11 + city.length, sky: 'clear' };
-        },
-      },
-      onLog: ({ message }: { message: string }) =>
-        setHostLines((l) => [...l, `log: ${message}`]),
-      onInput: ({ prompt }: { prompt: string }) => {
-        if (!interactive) return undefined; // suspend: savable frontier
-        setQuestion(prompt);
-        return new Promise<string>((resolve) => {
-          askResolveRef.current = resolve;
-        });
-      },
-    }),
-    [provider, orKey, model],
-  );
-
-  const connectOpenRouter = useCallback(() => {
-    // Redirects to openrouter.ai's consent page; the redirect back lands on
-    // this page with ?code=, which the mount effect exchanges for a key.
-    loadedRef.current?.sdk.startOpenRouterLogin();
-  }, []);
-
-  const disconnectOpenRouter = useCallback(() => {
-    sessionStorage.removeItem(OR_KEY);
-    setOrKey(null);
-    setProvider('mock');
-  }, []);
-
-  const finish = useCallback((result: RunView, mode: string) => {
-    setConsoleLines(result.console);
-    if (agentRef.current) {
-      localStorage.setItem(
-        SAVE_KEY,
-        new TextDecoder().decode(agentRef.current.blob()),
-      );
-    }
-    setHasSaved(true);
-    if (result.status === 'suspended') {
-      setStatusLine(
-        `⏸ Suspended at input("${result.pendingInput?.prompt}") — saved to localStorage. Reload this page, then hit Resume.`,
-      );
-    } else {
-      setStatusLine(`✅ Completed — ${mode}: ${result.liveCalls} live host call(s).`);
-      setHostLines((l) => [...l, `— ${mode}: ${result.liveCalls} live host call(s) —`]);
-    }
-    window.__lastRun = result;
-  }, []);
-
-  const begin = useCallback(() => {
-    setBusy(true);
-    setStatusLine('');
-    setConsoleLines([]);
-    setHostLines([]);
-    setQuestion(null);
-  }, []);
-
-  const run = useCallback(async () => {
-    const loaded = loadedRef.current;
-    if (!loaded) return;
-    begin();
-    try {
-      const agent = loaded.sdk.BrowserAgent.start(loaded.wasm, {
-        source,
-        ...host(false),
+      .catch(() => {
+        if (!cancelled) {
+          setLoadError(
+            'The wasm assets are missing. Build them with scripts/build-wasm.sh, then reload.',
+          );
+        }
       });
-      agentRef.current = agent;
-      finish((await agent.run()) as RunView, 'record');
-    } catch (err) {
-      setStatusLine(`Error: ${String(err)}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [source, host, begin, finish]);
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const resume = useCallback(async () => {
-    const loaded = loadedRef.current;
-    const saved = localStorage.getItem(SAVE_KEY);
-    if (!loaded || saved === null) return;
-    begin();
-    try {
-      const agent = loaded.sdk.BrowserAgent.restore(
-        loaded.wasm,
-        new TextEncoder().encode(saved),
-        host(true),
-      );
-      agentRef.current = agent;
-      finish((await agent.run()) as RunView, 'resume');
-    } catch (err) {
-      setStatusLine(`Error: ${String(err)}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [host, begin, finish]);
+  useEffect(() => {
+    const box = feedBoxRef.current;
+    if (box) box.scrollTop = box.scrollHeight;
+  }, [feed, busy]);
+
+  const ensureAgent = useCallback(async () => {
+    if (agentRef.current) return;
+    const loaded = loadedRef.current ?? (await loadedPromiseRef.current);
+    if (!loaded || agentRef.current) return;
+    const token = tokenRef.current;
+    const agent = loaded.sdk.BrowserAgent.start(loaded.wasm, {
+      source: AGENT_SOURCE,
+      ...buildHost(token),
+    }) as AgentHandle;
+    agentRef.current = agent;
+    drive(agent, token);
+  }, [buildHost, drive]);
+
+  const send = useCallback(
+    (text: string) => {
+      const message = text.trim();
+      if (!message || !ready) return;
+      setDraft('');
+      setStatusLine('');
+      const resolve = resolveRef.current;
+      if (resolve) {
+        resolveRef.current = null;
+        resolve(message);
+      } else {
+        queueRef.current.push(message);
+        void ensureAgent();
+      }
+    },
+    [ready, ensureAgent],
+  );
 
   const replay = useCallback(async () => {
     const loaded = loadedRef.current;
     const saved = localStorage.getItem(SAVE_KEY);
     if (!loaded || saved === null) return;
-    begin();
     try {
-      // No host at all: every effect must come from the journal.
+      // No brain, no tools, no network: every effect must come from the
+      // journal. The whole chat — cards included — repaints from it.
       const agent = loaded.sdk.BrowserAgent.restore(
         loaded.wasm,
         new TextEncoder().encode(saved),
@@ -243,30 +325,50 @@ export function PlaygroundClient() {
           llm: () => {
             throw new Error('replay must not call the LLM');
           },
-          fetchImpl: () => {
+          fetchImpl: (() => {
             throw new Error('replay must not touch the network');
-          },
+          }) as unknown as typeof fetch,
         },
+      ) as AgentHandle;
+      const result = await agent.run();
+      setFeed(parseFeed(result.console));
+      setStatusLine(
+        `⚡ Replayed offline: ${result.console.length} journaled events re-rendered with ${result.liveCalls} live host calls.`,
       );
-      agentRef.current = agent;
-      finish((await agent.run()) as RunView, 'replay');
     } catch (err) {
-      setStatusLine(`Error: ${String(err)}`);
-    } finally {
-      setBusy(false);
+      setStatusLine(`Replay error: ${String(err)}`);
     }
-  }, [begin, finish]);
+  }, []);
 
-  const sendAnswer = useCallback(() => {
-    setQuestion(null);
-    askResolveRef.current?.(answer);
-    askResolveRef.current = null;
-  }, [answer]);
-
-  const discard = useCallback(() => {
+  const reset = useCallback(() => {
+    tokenRef.current += 1; // orphan the running agent; its host calls hang
+    agentRef.current = null;
+    resolveRef.current = null;
+    queueRef.current = [];
     localStorage.removeItem(SAVE_KEY);
+    setFeed([]);
+    setBusy(null);
+    setStatusLine('');
     setHasSaved(false);
-    setStatusLine('Saved run discarded.');
+  }, []);
+
+  const connectOpenRouter = useCallback(() => {
+    // Redirects to openrouter.ai's consent page; the redirect back lands on
+    // this page with ?code=, which the mount effect exchanges for a key.
+    void loadedRef.current?.sdk.startOpenRouterLogin();
+  }, []);
+
+  const disconnectOpenRouter = useCallback(() => {
+    sessionStorage.removeItem(OR_KEY);
+    orKeyRef.current = null;
+    setOrKey(null);
+    providerRef.current = 'mock';
+    setProvider('mock');
+  }, []);
+
+  const pickProvider = useCallback((p: 'mock' | 'openrouter') => {
+    providerRef.current = p;
+    setProvider(p);
   }, []);
 
   if (loadError) {
@@ -278,39 +380,27 @@ export function PlaygroundClient() {
   }
 
   const button =
-    'rounded-lg border border-fd-border px-4 py-2 text-sm font-medium transition-colors hover:bg-fd-accent disabled:pointer-events-none disabled:opacity-40';
+    'rounded-lg border border-fd-border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-fd-accent disabled:pointer-events-none disabled:opacity-40';
+  const segment = (active: boolean) =>
+    `rounded-md px-2.5 py-1 text-sm font-medium transition-colors ${
+      active ? 'bg-fd-background shadow-sm' : 'text-fd-muted-foreground hover:text-fd-foreground'
+    }`;
 
   return (
-    <div className="mt-8">
-      <textarea
-        value={source}
-        onChange={(e) => setSource(e.target.value)}
-        spellCheck={false}
-        aria-label="Agent source (TypeScript)"
-        className="min-h-[22rem] w-full rounded-lg border border-fd-border bg-fd-card p-4 font-mono text-sm"
-      />
-      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
-        <span className="font-medium">LLM for chidori.prompt():</span>
-        <label className="flex items-center gap-1.5">
-          <input
-            type="radio"
-            name="provider"
-            id="provider-mock"
-            checked={provider === 'mock'}
-            onChange={() => setProvider('mock')}
-          />
-          Deterministic mock (offline, free)
-        </label>
-        <label className="flex items-center gap-1.5">
-          <input
-            type="radio"
-            name="provider"
+    <div className="mt-6">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+        <div className="flex items-center gap-1 rounded-lg bg-fd-accent/60 p-1" role="group" aria-label="Brain">
+          <button id="provider-mock" className={segment(provider === 'mock')} onClick={() => pickProvider('mock')}>
+            Offline brain
+          </button>
+          <button
             id="provider-openrouter"
-            checked={provider === 'openrouter'}
-            onChange={() => setProvider('openrouter')}
-          />
-          OpenRouter (real models)
-        </label>
+            className={segment(provider === 'openrouter')}
+            onClick={() => pickProvider('openrouter')}
+          >
+            OpenRouter
+          </button>
+        </div>
         {provider === 'openrouter' &&
           (orKey ? (
             <span className="flex items-center gap-2">
@@ -321,81 +411,149 @@ export function PlaygroundClient() {
                 id="or-model"
                 type="text"
                 value={model}
-                onChange={(e) => setModel(e.target.value)}
+                onChange={(e) => {
+                  modelRef.current = e.target.value;
+                  setModel(e.target.value);
+                }}
                 aria-label="OpenRouter model"
-                className="w-56 rounded-lg border border-fd-border bg-fd-background px-2 py-1"
+                className="w-52 rounded-lg border border-fd-border bg-fd-background px-2 py-1"
               />
               <button id="or-disconnect" className={button} onClick={disconnectOpenRouter}>
                 Disconnect
               </button>
             </span>
           ) : (
-            <button id="or-connect" className={button} onClick={connectOpenRouter}>
+            <button id="or-connect" className={button} onClick={connectOpenRouter} disabled={!ready}>
               Connect OpenRouter
             </button>
           ))}
+        <span className="ml-auto flex gap-2">
+          <button id="replay" className={button} disabled={!ready || !hasSaved} onClick={replay} title="Re-render this chat from its journal — zero live calls">
+            ↺ Replay offline
+          </button>
+          <button id="clear" className={button} disabled={!hasSaved && feed.length === 0} onClick={reset}>
+            ✕ Reset
+          </button>
+        </span>
       </div>
-      <div className="mt-4 flex flex-wrap gap-3">
-        <button id="run" className={button} disabled={busy || (provider === 'openrouter' && !orKey)} onClick={run}>
-          ▶ Run agent
-        </button>
-        <button id="resume" className={button} disabled={busy || !hasSaved} onClick={resume}>
-          ⏯ Resume saved run
-        </button>
-        <button id="replay" className={button} disabled={busy || !hasSaved} onClick={replay}>
-          ↺ Replay offline
-        </button>
-        <button id="clear" className={button} disabled={busy || !hasSaved} onClick={discard}>
-          ✕ Discard saved run
-        </button>
-      </div>
-
-      {question !== null && (
-        <div
-          id="ask"
-          className="mt-4 rounded-lg border border-fd-border bg-fd-accent/50 p-4"
-        >
-          <label htmlFor="answer" className="block text-sm font-medium">
-            {question}
-          </label>
-          <div className="mt-2 flex gap-2">
-            <input
-              id="answer"
-              type="text"
-              value={answer}
-              onChange={(e) => setAnswer(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && sendAnswer()}
-              className="w-64 rounded-lg border border-fd-border bg-fd-background px-3 py-1.5 text-sm"
-            />
-            <button id="send" className={button} onClick={sendAnswer}>
-              Answer
-            </button>
-          </div>
-        </div>
+      {provider === 'openrouter' && !orKey && (
+        <p className="mt-2 text-xs text-fd-muted-foreground">
+          Not connected yet — messages fall back to the offline brain until you connect.
+        </p>
       )}
 
-      {statusLine && <p id="status" className="mt-4 font-medium">{statusLine}</p>}
-
-      <div className="mt-6 grid gap-4 md:grid-cols-2">
-        <section>
-          <h2 className="text-sm font-semibold">Agent console</h2>
-          <pre
-            id="console"
-            className="mt-2 min-h-[8rem] rounded-lg border border-fd-border bg-fd-card p-4 text-xs whitespace-pre-wrap"
-          >
-            {consoleLines.join('\n')}
-          </pre>
-        </section>
-        <section>
-          <h2 className="text-sm font-semibold">Host log</h2>
-          <pre
-            id="hostlog"
-            className="mt-2 min-h-[8rem] rounded-lg border border-fd-border bg-fd-card p-4 text-xs whitespace-pre-wrap"
-          >
-            {hostLines.join('\n')}
-          </pre>
-        </section>
+      <div className="mt-3 overflow-hidden rounded-xl border border-fd-border bg-fd-card/50">
+        <div ref={feedBoxRef} className="h-[28rem] overflow-y-auto p-4">
+          {feed.length === 0 && !busy ? (
+            <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+              <p className="text-sm text-fd-muted-foreground">
+                {ready ? 'Ask about chidori, or put the tools to work:' : 'Loading the wasm engine…'}
+              </p>
+              <div className="flex max-w-lg flex-wrap justify-center gap-2">
+                {SUGGESTIONS.map((s) => (
+                  <button
+                    key={s}
+                    className="rounded-full border border-fd-border px-3 py-1.5 text-xs transition-colors hover:bg-fd-accent disabled:opacity-40"
+                    disabled={!ready}
+                    onClick={() => send(s)}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {feed.map((event, i) => {
+                if (event.kind === 'user') {
+                  return (
+                    <div key={i} className="flex justify-end">
+                      <p className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-fd-primary px-3.5 py-2 text-sm text-fd-primary-foreground">
+                        {event.text}
+                      </p>
+                    </div>
+                  );
+                }
+                if (event.kind === 'assistant') {
+                  return (
+                    <div key={i} className="flex">
+                      <p className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-bl-md border border-fd-border bg-fd-background px-3.5 py-2 text-sm">
+                        {event.text}
+                      </p>
+                    </div>
+                  );
+                }
+                if (event.kind === 'tool') {
+                  return (
+                    <div key={i} className="flex">
+                      <ToolCard name={event.name} args={event.args} result={event.result} />
+                    </div>
+                  );
+                }
+                return (
+                  <p key={i} className="text-center text-xs text-fd-muted-foreground">
+                    {event.text}
+                  </p>
+                );
+              })}
+              {busy && (
+                <p className="animate-pulse text-xs text-fd-muted-foreground" id="busy">
+                  {busy}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+        <form
+          className="flex gap-2 border-t border-fd-border p-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            send(draft);
+          }}
+        >
+          <input
+            id="chat-input"
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={ready ? 'Message the agent…' : 'Loading…'}
+            disabled={!ready}
+            autoComplete="off"
+            className="min-w-0 flex-1 rounded-lg border border-fd-border bg-fd-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-fd-primary/40"
+          />
+          <button id="send" type="submit" className={button} disabled={!ready || !draft.trim()}>
+            Send
+          </button>
+        </form>
       </div>
+
+      {statusLine && (
+        <p id="status" className="mt-2 text-sm text-fd-muted-foreground">
+          {statusLine}
+        </p>
+      )}
+
+      <details className="mt-8 rounded-lg border border-fd-border p-4">
+        <summary className="cursor-pointer text-sm font-medium">Under the hood</summary>
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-fd-muted-foreground">
+          <li>
+            This chat is a chidori agent — the source below — executed by the pure-Rust engine
+            compiled to WebAssembly, entirely in this tab.
+          </li>
+          <li>
+            Every <code>chidori.prompt / tool / input</code> effect is journaled: the conversation
+            auto-saves each turn, survives a reload, and <em>Replay offline</em> repaints it — cards
+            and all — with zero live calls.
+          </li>
+          <li>
+            Docs answers are grounded: these docs are indexed at build time, retrieved into the
+            model&apos;s context, and exposed as the <code>search_docs</code> tool.
+          </li>
+        </ul>
+        <pre className="mt-3 overflow-x-auto rounded-lg border border-fd-border bg-fd-card p-4 text-xs">
+          {AGENT_SOURCE}
+        </pre>
+      </details>
     </div>
   );
 }

--- a/website/app/(home)/playground/tools.ts
+++ b/website/app/(home)/playground/tools.ts
@@ -1,0 +1,232 @@
+/**
+ * Host-side implementations for the agent's `chidori.tool()` calls. Results
+ * are journaled by the runtime, so the network-backed ones (weather) run
+ * live exactly once and replay offline forever after.
+ */
+import { type DocsIndex, type Json, hashString, paletteFor, searchDocs } from './brain';
+
+// WMO weather interpretation codes → something a card can render.
+const WMO: [number, string, string][] = [
+  [0, 'Clear', '☀️'],
+  [1, 'Mostly clear', '🌤️'],
+  [2, 'Partly cloudy', '⛅'],
+  [3, 'Overcast', '☁️'],
+  [45, 'Fog', '🌫️'],
+  [51, 'Drizzle', '🌦️'],
+  [61, 'Rain', '🌧️'],
+  [71, 'Snow', '🌨️'],
+  [80, 'Showers', '🌧️'],
+  [95, 'Thunderstorm', '⛈️'],
+];
+
+function condition(code: number): { label: string; emoji: string } {
+  let best = WMO[0];
+  for (const row of WMO) if (code >= row[0]) best = row;
+  return { label: best[1], emoji: best[2] };
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+async function liveWeather(city: string): Promise<Json> {
+  const geoRes = await fetch(
+    `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1`,
+  );
+  if (!geoRes.ok) throw new Error(`geocoding failed: ${geoRes.status}`);
+  const geo = (await geoRes.json()).results?.[0];
+  if (!geo) throw new Error(`no such place: ${city}`);
+  const fcRes = await fetch(
+    `https://api.open-meteo.com/v1/forecast?latitude=${geo.latitude}&longitude=${geo.longitude}` +
+      '&current=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m' +
+      '&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=auto&forecast_days=5',
+  );
+  if (!fcRes.ok) throw new Error(`forecast failed: ${fcRes.status}`);
+  const fc = await fcRes.json();
+  return {
+    city: geo.name,
+    country: geo.country ?? '',
+    tempC: Math.round(fc.current.temperature_2m),
+    condition: condition(fc.current.weather_code),
+    windKph: Math.round(fc.current.wind_speed_10m),
+    humidity: Math.round(fc.current.relative_humidity_2m),
+    daily: (fc.daily.time as string[]).map((date, i) => ({
+      day: WEEKDAYS[new Date(`${date}T12:00:00Z`).getUTCDay()],
+      min: Math.round(fc.daily.temperature_2m_min[i]),
+      max: Math.round(fc.daily.temperature_2m_max[i]),
+      emoji: condition(fc.daily.weather_code[i]).emoji,
+    })),
+  };
+}
+
+/** Offline stand-in so the tool still demos without network access. */
+function simulatedWeather(city: string): Json {
+  const seed = hashString(city.toLowerCase());
+  const temp = 4 + (seed % 24);
+  const conds = [condition(0), condition(2), condition(3), condition(61)];
+  return {
+    city,
+    country: '',
+    tempC: temp,
+    condition: conds[seed % conds.length],
+    windKph: 4 + ((seed >>> 4) % 28),
+    humidity: 35 + ((seed >>> 8) % 55),
+    daily: WEEKDAYS.slice(0, 5).map((day, i) => ({
+      day,
+      min: temp - 4 + ((seed >>> i) % 4),
+      max: temp + 1 + ((seed >>> (i + 2)) % 5),
+      emoji: conds[(seed >>> i) % conds.length].emoji,
+    })),
+    simulated: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// calculate: a tiny recursive-descent evaluator — no eval(), no Function().
+
+const CALC_FNS: Record<string, (x: number) => number> = {
+  sqrt: Math.sqrt,
+  sin: Math.sin,
+  cos: Math.cos,
+  tan: Math.tan,
+  abs: Math.abs,
+  ln: Math.log,
+  log: Math.log10,
+  exp: Math.exp,
+  round: Math.round,
+  floor: Math.floor,
+  ceil: Math.ceil,
+};
+const CALC_CONSTS: Record<string, number> = { pi: Math.PI, e: Math.E };
+
+export function evaluateExpression(input: string): number {
+  const s = input.replace(/\s+/g, '').replace(/×/g, '*').replace(/÷/g, '/').toLowerCase();
+  let i = 0;
+  const fail = (msg: string): never => {
+    throw new Error(`${msg} at position ${i} in "${s}"`);
+  };
+  const expr = (): number => {
+    let v = term();
+    while (s[i] === '+' || s[i] === '-') v = s[i++] === '+' ? v + term() : v - term();
+    return v;
+  };
+  const term = (): number => {
+    let v = unary();
+    for (;;) {
+      if (s[i] === '*') { i++; v *= unary(); }
+      else if (s[i] === '/') { i++; v /= unary(); }
+      else if (s[i] === '%') { i++; v %= unary(); }
+      else return v;
+    }
+  };
+  // Unary minus binds looser than ^ (so -3^2 = -9), while exponents may be
+  // signed (2^-3 works): the exponent recurses through unary, not factor.
+  const unary = (): number => {
+    if (s[i] === '-') { i++; return -unary(); }
+    if (s[i] === '+') { i++; return unary(); }
+    return factor();
+  };
+  const factor = (): number => {
+    const base = atom();
+    if (s[i] === '^') { i++; return Math.pow(base, unary()); }
+    return base;
+  };
+  const atom = (): number => {
+    if (s[i] === '(') {
+      i++;
+      const v = expr();
+      if (s[i] !== ')') fail('expected )');
+      i++;
+      return v;
+    }
+    const word = /^[a-z]+/.exec(s.slice(i));
+    if (word) {
+      const name = word[0];
+      i += name.length;
+      if (name in CALC_CONSTS) return CALC_CONSTS[name];
+      const fn = CALC_FNS[name];
+      if (!fn) fail(`unknown name "${name}"`);
+      if (s[i] !== '(') fail(`expected ( after ${name}`);
+      i++;
+      const v = expr();
+      if (s[i] !== ')') fail('expected )');
+      i++;
+      return fn(v);
+    }
+    const num = /^\d*\.?\d+(?:e[+-]?\d+)?/.exec(s.slice(i));
+    if (!num) fail('expected a number');
+    i += num![0].length;
+    return Number(num![0]);
+  };
+  const value = expr();
+  if (i !== s.length) fail('unexpected input');
+  if (!Number.isFinite(value)) throw new Error('result is not a finite number');
+  // Trim float noise (0.30000000000000004 → 0.3) without losing precision.
+  return Number(value.toPrecision(12));
+}
+
+// ---------------------------------------------------------------------------
+
+const asObj = (kwargs: Json): Record<string, Json> =>
+  kwargs && typeof kwargs === 'object' && !Array.isArray(kwargs) ? kwargs : {};
+
+/**
+ * Build the tool table for a BrowserAgent host. `getIndex` is read at call
+ * time so tools see the docs index even if it loads after the agent starts.
+ */
+export function makeTools(getIndex: () => DocsIndex | null): Record<string, (kwargs: Json) => Json | Promise<Json>> {
+  return {
+    search_docs: (kwargs) => {
+      const query = String(asObj(kwargs).query ?? '');
+      const index = getIndex();
+      return {
+        query,
+        hits: searchDocs(index, query, 4) as unknown as Json,
+        ...(index ? {} : { note: 'docs index not loaded' }),
+      };
+    },
+
+    weather: async (kwargs) => {
+      const city = String(asObj(kwargs).city ?? 'Tokyo').trim() || 'Tokyo';
+      try {
+        return await liveWeather(city);
+      } catch {
+        return simulatedWeather(city);
+      }
+    },
+
+    calculate: (kwargs) => {
+      const expression = String(asObj(kwargs).expression ?? '');
+      return { expression, value: evaluateExpression(expression) };
+    },
+
+    chart: (kwargs) => {
+      const { series } = asObj(kwargs);
+      if (!Array.isArray(series) || !series.length) throw new Error('chart needs a non-empty series array');
+      const bad = series.find(
+        (p) => !p || typeof p !== 'object' || Array.isArray(p) || typeof (p as { value?: Json }).value !== 'number',
+      );
+      if (bad !== undefined) throw new Error('every series point needs a numeric value');
+      return { ok: true, points: series.length };
+    },
+
+    color_palette: (kwargs) => {
+      const o = asObj(kwargs);
+      const mood = String(o.mood ?? 'chidori');
+      let colors = Array.isArray(o.colors)
+        ? o.colors.filter(
+            (c) => c && typeof c === 'object' && /^#[0-9a-f]{6}$/i.test(String((c as { hex?: Json }).hex ?? '')),
+          )
+        : [];
+      // A model may send only a mood; derive swatches deterministically.
+      if (!colors.length) colors = paletteFor(mood) as unknown as Json[];
+      return { mood, colors: colors.slice(0, 6) };
+    },
+
+    roll_dice: (kwargs) => {
+      const o = asObj(kwargs);
+      const count = Math.max(1, Math.min(12, Math.round(Number(o.count ?? 2)) || 2));
+      const sides = Math.max(2, Math.min(1000, Math.round(Number(o.sides ?? 6)) || 6));
+      const rolls = Array.from({ length: count }, () => 1 + Math.floor(Math.random() * sides));
+      return { count, sides, rolls, total: rolls.reduce((a, b) => a + b, 0) };
+    },
+  };
+}

--- a/website/package.json
+++ b/website/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "node scripts/build-playground-context.mjs && next dev",
+    "build": "node scripts/build-playground-context.mjs && next build",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/website/scripts/build-playground-context.mjs
+++ b/website/scripts/build-playground-context.mjs
@@ -1,0 +1,96 @@
+// Builds public/playground-docs.json — a plain-text index of docs/ that the
+// /playground chat agent loads at runtime: it grounds the LLM's system prompt
+// and serves the agent's `search_docs` tool. Runs before `next dev`/`next
+// build` (see package.json); the output is gitignored like the wasm assets.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const docsDir = path.resolve(here, '../../docs');
+const outFile = path.resolve(here, '../public/playground-docs.json');
+
+// Mirror the site's content rules (source.config.ts): every docs/*.md except
+// the GitHub-facing README and the posts thread, which are not site pages.
+const EXCLUDE = new Set(['README.md', 'posts/harness-engineering-thread.md']);
+// Internal review/meta artifacts stay on the site but out of the agent's
+// context — their headings ("Blocker 3: ...") drown out the real docs when
+// retrieving grounding for a question.
+const EXCLUDE_PATTERNS = [/^consumer-usability-review/, /^ai-sdk-gap-analysis/];
+const MAX_SECTION_CHARS = 1600;
+const MIN_SECTION_CHARS = 40;
+
+function* mdFiles(dir, rel = '') {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'media') continue;
+      yield* mdFiles(path.join(dir, entry.name), relPath);
+    } else if (
+      entry.name.endsWith('.md') &&
+      !EXCLUDE.has(relPath) &&
+      !EXCLUDE_PATTERNS.some((p) => p.test(relPath))
+    ) {
+      yield relPath;
+    }
+  }
+}
+
+/** Markdown → searchable plain text (code block contents are kept: agent
+ *  API questions often match on identifiers). */
+function toText(md) {
+  return md
+    .replace(/```[^\n]*\n([\s\S]*?)```/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^[ \t]*[|>#*-]+[ \t]*/gm, '')
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{2,}/g, '\n')
+    .trim();
+}
+
+const pages = [];
+for (const rel of [...mdFiles(docsDir)].sort()) {
+  let raw = fs.readFileSync(path.join(docsDir, rel), 'utf8');
+
+  let title = '';
+  const fm = /^---\n([\s\S]*?)\n---\n/.exec(raw);
+  if (fm) {
+    const m = /^title:\s*["']?(.+?)["']?\s*$/m.exec(fm[1]);
+    if (m) title = m[1];
+    raw = raw.slice(fm[0].length);
+  }
+  const h1 = /^#\s+(.+)$/m.exec(raw);
+  if (!title) title = h1 ? h1[1].trim() : rel.replace(/\.md$/, '');
+
+  const slug = rel.replace(/\.md$/, '');
+  const route = slug === 'index' ? '/docs' : `/docs/${slug}`;
+
+  // One section per `##` heading, plus the pre-heading intro.
+  const sections = [];
+  let heading = '';
+  let buf = [];
+  const flush = () => {
+    const text = toText(buf.join('\n')).slice(0, MAX_SECTION_CHARS);
+    if (text.length >= MIN_SECTION_CHARS) sections.push({ heading, text });
+    buf = [];
+  };
+  for (const line of raw.split('\n')) {
+    const h = /^##\s+(.+)$/.exec(line);
+    if (h) {
+      flush();
+      heading = h[1].trim();
+    } else {
+      buf.push(line);
+    }
+  }
+  flush();
+  if (sections.length) pages.push({ slug, route, title, sections });
+}
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(outFile, JSON.stringify({ pages }));
+const kb = Math.round(fs.statSync(outFile).size / 1024);
+console.log(`playground docs context: ${pages.length} pages → ${path.relative(process.cwd(), outFile)} (${kb} KB)`);


### PR DESCRIPTION
The playground is now a full chat experience instead of a code-editing
demo, with much less explanatory text:

- The chat is driven by a chidori agent (a ReAct loop shown under
  "Under the hood") executing on the wasm engine in the visitor's tab.
  Feed events are JSON console lines, so the whole conversation —
  including tool cards — renders purely from the journaled console:
  it auto-saves each turn, survives reloads, and replays offline.
- Tools with purpose-built generative UI cards: search_docs (grounded
  docs Q&A with links), weather (live Open-Meteo with an offline
  fallback), chart (SVG bar/line), calculate (no-eval expression
  parser), color_palette, and roll_dice.
- The docs become part of the agent's context: a new build step
  (website/scripts/build-playground-context.mjs) indexes docs/ into
  public/playground-docs.json; retrieval grounds the system prompt and
  serves the search_docs tool, so you can chat about chidori itself.
- Brains are swappable: a deterministic offline router by default (no
  key needed, replay-stable), or real models via the existing
  OpenRouter PKCE login.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGnArYPPQQJePBcWTwiQry