### PR TITLE
Add rewind & branch controls to the playground chat

### DIFF
--- a/crates/chidori-wasm/src/lib.rs
+++ b/crates/chidori-wasm/src/lib.rs
@@ -336,6 +336,88 @@ mod tests {
         assert_eq!(d2.console_lines(), vec!["sum: 42".to_string()]);
     }
 
+    /// The contract the playground's rewind/branch controls depend on: a blob
+    /// whose journal is truncated just before the Nth `input` entry restores
+    /// to the exact state the run was in before that turn — the surviving
+    /// prefix replays offline, and the run blocks at that `input` frontier.
+    #[test]
+    fn truncating_journal_before_an_input_rewinds_to_that_turn() {
+        const CHAT: &str = r#"
+            async function main() {
+                for (;;) {
+                    const text = await input('message');
+                    if (text === 'quit') return;
+                    const result = await work(text);
+                    console.log(text + ' -> ' + result);
+                }
+            }
+            main();
+        "#;
+        let effects = || vec!["input".to_string(), "work".to_string()];
+
+        // Record two full turns, then quit.
+        let mut d = Driver::record(CHAT, effects());
+        for answer in ["a", "A", "b", "B", "quit"] {
+            let status: serde_json::Value =
+                serde_json::from_str(&d.run_until_blocked().unwrap()).unwrap();
+            assert_eq!(status["status"], json!("blocked"));
+            d.resolve_op(status["opId"].as_f64().unwrap(), &json!(answer).to_string())
+                .unwrap();
+        }
+        let status: serde_json::Value =
+            serde_json::from_str(&d.run_until_blocked().unwrap()).unwrap();
+        assert_eq!(status["status"], json!("completed"));
+        assert_eq!(d.console_lines(), vec!["a -> A", "b -> B"]);
+
+        // Rewind to before turn 2 the way the playground does: parse the
+        // blob, cut the journal's entry list just before the second `input`
+        // entry, and re-encode. No engine involvement — pure data work.
+        let mut blob: serde_json::Value = serde_json::from_slice(&d.to_blob()).unwrap();
+        let journal_bytes: Vec<u8> = blob["journal"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n.as_u64().unwrap() as u8)
+            .collect();
+        let mut journal: serde_json::Value = serde_json::from_slice(&journal_bytes).unwrap();
+        let entries = journal["entries"].as_array().unwrap();
+        let cut = entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e["site"] == json!("input"))
+            .map(|(i, _)| i)
+            .nth(1)
+            .unwrap();
+        let truncated = entries[..cut].to_vec();
+        journal["entries"] = json!(truncated);
+        blob["journal"] = json!(serde_json::to_vec(&journal).unwrap());
+
+        // The truncated blob replays turn 1 offline and blocks at turn 2's
+        // `input` — ready for a different message down a new path.
+        let mut d2 = Driver::from_blob(&serde_json::to_vec(&blob).unwrap()).unwrap();
+        let status: serde_json::Value =
+            serde_json::from_str(&d2.run_until_blocked().unwrap()).unwrap();
+        assert_eq!(status["status"], json!("blocked"));
+        assert_eq!(status["name"], json!("input"));
+        assert_eq!(d2.console_lines(), vec!["a -> A"]);
+
+        // Continue down the branch: the divergent turn records cleanly.
+        d2.resolve_op(status["opId"].as_f64().unwrap(), &json!("z").to_string())
+            .unwrap();
+        for answer in ["Z", "quit"] {
+            let status: serde_json::Value =
+                serde_json::from_str(&d2.run_until_blocked().unwrap()).unwrap();
+            assert_eq!(status["status"], json!("blocked"));
+            d2.resolve_op(status["opId"].as_f64().unwrap(), &json!(answer).to_string())
+                .unwrap();
+        }
+        let status: serde_json::Value =
+            serde_json::from_str(&d2.run_until_blocked().unwrap()).unwrap();
+        assert_eq!(status["status"], json!("completed"));
+        assert_eq!(d2.console_lines(), vec!["a -> A", "z -> Z"]);
+        assert_eq!(d2.divergence(), None);
+    }
+
     #[test]
     fn reject_op_surfaces_as_js_exception() {
         let mut d = Driver::record(BUNDLE, effects());

--- a/website/app/(home)/playground/page.tsx
+++ b/website/app/(home)/playground/page.tsx
@@ -15,8 +15,8 @@ export default function PlaygroundPage() {
       </h1>
       <p className="mt-3 text-fd-muted-foreground">
         A chidori agent running entirely in this tab — ask it about chidori, or
-        hand it a tool. Reload mid-conversation and it resumes; every effect is
-        journaled.
+        hand it a tool. Every effect is journaled: reload mid-conversation and
+        it resumes, rewind any turn, or branch into an alternate timeline.
       </p>
       <PlaygroundClient />
     </main>

--- a/website/app/(home)/playground/playground-client.tsx
+++ b/website/app/(home)/playground/playground-client.tsx
@@ -27,10 +27,17 @@ import {
 } from './brain';
 import { makeTools } from './tools';
 import { ToolCard } from './cards';
+import {
+  type BranchStore,
+  countTurns,
+  freshBranches,
+  truncateAtTurn,
+} from './timeline';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const ASSETS = `${BASE}/chidori-wasm`;
 const SAVE_KEY = 'chidori-playground-chat-v1';
+const BRANCH_KEY = 'chidori-playground-branches-v1';
 // The exchanged OpenRouter key lives in sessionStorage: it survives the PKCE
 // redirect back to this page, and is gone when the tab closes.
 const OR_KEY = 'chidori-playground-openrouter-key';
@@ -94,6 +101,7 @@ export function PlaygroundClient() {
   const [provider, setProvider] = useState<'mock' | 'openrouter'>('mock');
   const [orKey, setOrKey] = useState<string | null>(null);
   const [model, setModel] = useState('openrouter/auto');
+  const [branchState, setBranchState] = useState<BranchStore>(freshBranches);
 
   const loadedRef = useRef<Loaded | null>(null);
   const loadedPromiseRef = useRef<Promise<Loaded | null> | null>(null);
@@ -108,6 +116,17 @@ export function PlaygroundClient() {
   const modelRef = useRef(model);
   const docsIndexRef = useRef<DocsIndex | null>(null);
   const feedBoxRef = useRef<HTMLDivElement | null>(null);
+  const branchRef = useRef(branchState);
+
+  const updateBranches = useCallback((next: BranchStore) => {
+    branchRef.current = next;
+    setBranchState(next);
+    try {
+      localStorage.setItem(BRANCH_KEY, JSON.stringify(next));
+    } catch {
+      /* storage full/blocked — branches just won't survive a reload */
+    }
+  }, []);
 
   const refreshFeed = useCallback(() => {
     const agent = agentRef.current;
@@ -229,6 +248,18 @@ export function PlaygroundClient() {
 
   useEffect(() => {
     let cancelled = false;
+    try {
+      const raw = localStorage.getItem(BRANCH_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as BranchStore;
+        if (parsed && typeof parsed.activeLabel === 'string' && Array.isArray(parsed.stashed)) {
+          branchRef.current = parsed;
+          setBranchState(parsed);
+        }
+      }
+    } catch {
+      /* corrupted branch store — start fresh */
+    }
     const loading = loadAssets();
     loadedPromiseRef.current = loading.catch(() => null);
     fetch(`${BASE}/playground-docs.json`)
@@ -340,12 +371,145 @@ export function PlaygroundClient() {
     }
   }, []);
 
+  /** The active timeline's durable blob, from the live agent or the save. */
+  const currentBlobText = useCallback((): string | null => {
+    const agent = agentRef.current;
+    if (agent) return new TextDecoder().decode(agent.blob());
+    return localStorage.getItem(SAVE_KEY);
+  }, []);
+
+  /** Orphan the running agent and restore a fresh one from `blobText`. */
+  const startFromBlob = useCallback(
+    (blobText: string, note: string): boolean => {
+      const loaded = loadedRef.current;
+      if (!loaded) return false;
+      tokenRef.current += 1; // orphan the old agent; its host calls hang
+      const token = tokenRef.current;
+      agentRef.current = null;
+      resolveRef.current = null;
+      queueRef.current = [];
+      setBusy(null);
+      try {
+        const agent = loaded.sdk.BrowserAgent.restore(
+          loaded.wasm,
+          new TextEncoder().encode(blobText),
+          buildHost(token),
+        ) as AgentHandle;
+        agentRef.current = agent;
+        localStorage.setItem(SAVE_KEY, blobText);
+        setHasSaved(true);
+        // The feed repaints from the replayed console as soon as the run
+        // reaches its input frontier (onInput → refreshFeed).
+        setStatusLine(note);
+        drive(agent, token);
+        return true;
+      } catch (err) {
+        setStatusLine(`Restore failed: ${String(err)}`);
+        return false;
+      }
+    },
+    [buildHost, drive],
+  );
+
+  /**
+   * Rewind the active timeline to just before user turn `turn`: the journal
+   * is truncated at that turn's `chidori.input()` entry and the shorter blob
+   * restored — the surviving prefix replays offline and the agent waits at
+   * input again, with the removed message queued up in the box for editing.
+   */
+  const rewindTo = useCallback(
+    (turn: number, text: string) => {
+      const current = currentBlobText();
+      if (!current) return;
+      const cut = truncateAtTurn(current, turn);
+      if (cut === null) {
+        setStatusLine('Rewind failed: that turn was not found in the journal.');
+        return;
+      }
+      const dropped = countTurns(current) - turn;
+      const note = `⏪ Rewound to before turn ${turn + 1}: the journal was truncated at that chidori.input() and replayed offline (${dropped} turn${dropped === 1 ? '' : 's'} discarded).`;
+      if (startFromBlob(cut, note)) setDraft(text);
+    },
+    [currentBlobText, startFromBlob],
+  );
+
+  /**
+   * Branch: stash the full-length blob as a switchable timeline, then rewind
+   * this one. Nothing is lost — the discarded future lives on as a branch.
+   */
+  const branchFrom = useCallback(
+    (turn: number, text: string) => {
+      const current = currentBlobText();
+      if (!current) return;
+      const cut = truncateAtTurn(current, turn);
+      if (cut === null) {
+        setStatusLine('Branch failed: that turn was not found in the journal.');
+        return;
+      }
+      const store = branchRef.current;
+      const label = `path ${store.nextId}`;
+      const note = `⑂ Stashed “${store.activeLabel}” as a branch and rewound to before turn ${turn + 1} — you are now on “${label}”.`;
+      if (!startFromBlob(cut, note)) return;
+      updateBranches({
+        activeLabel: label,
+        nextId: store.nextId + 1,
+        stashed: [
+          ...store.stashed,
+          { label: store.activeLabel, blob: current, turns: countTurns(current) },
+        ],
+      });
+      setDraft(text);
+    },
+    [currentBlobText, startFromBlob, updateBranches],
+  );
+
+  /** Switch timelines: stash the active blob, restore the chosen one. */
+  const switchTo = useCallback(
+    (label: string) => {
+      const store = branchRef.current;
+      const target = store.stashed.find((b) => b.label === label);
+      if (!target) return;
+      const current = currentBlobText();
+      const stashed = store.stashed.filter((b) => b.label !== label);
+      if (current) {
+        stashed.push({
+          label: store.activeLabel,
+          blob: current,
+          turns: countTurns(current),
+        });
+      }
+      if (
+        startFromBlob(
+          target.blob,
+          `⑂ Switched to “${target.label}” — restored from its saved blob and replayed offline.`,
+        )
+      ) {
+        updateBranches({ activeLabel: target.label, nextId: store.nextId, stashed });
+      }
+    },
+    [currentBlobText, startFromBlob, updateBranches],
+  );
+
+  const dropBranch = useCallback(
+    (label: string) => {
+      const store = branchRef.current;
+      updateBranches({
+        ...store,
+        stashed: store.stashed.filter((b) => b.label !== label),
+      });
+    },
+    [updateBranches],
+  );
+
   const reset = useCallback(() => {
     tokenRef.current += 1; // orphan the running agent; its host calls hang
     agentRef.current = null;
     resolveRef.current = null;
     queueRef.current = [];
     localStorage.removeItem(SAVE_KEY);
+    localStorage.removeItem(BRANCH_KEY);
+    branchRef.current = freshBranches();
+    setBranchState(branchRef.current);
     setFeed([]);
     setBusy(null);
     setStatusLine('');
@@ -378,6 +542,11 @@ export function PlaygroundClient() {
       </div>
     );
   }
+
+  // The user-turn index of each feed event ('user' events only): turn k in
+  // the feed is the k-th journaled `input` effect, which is where rewind cuts.
+  let userTurns = 0;
+  const turnOf = feed.map((e) => (e.kind === 'user' ? userTurns++ : -1));
 
   const button =
     'rounded-lg border border-fd-border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-fd-accent disabled:pointer-events-none disabled:opacity-40';
@@ -431,7 +600,13 @@ export function PlaygroundClient() {
           <button id="replay" className={button} disabled={!ready || !hasSaved} onClick={replay} title="Re-render this chat from its journal — zero live calls">
             ↺ Replay offline
           </button>
-          <button id="clear" className={button} disabled={!hasSaved && feed.length === 0} onClick={reset}>
+          <button
+            id="clear"
+            className={button}
+            disabled={!hasSaved && feed.length === 0 && branchState.stashed.length === 0}
+            onClick={reset}
+            title="Clear this conversation and every branch"
+          >
             ✕ Reset
           </button>
         </span>
@@ -440,6 +615,37 @@ export function PlaygroundClient() {
         <p className="mt-2 text-xs text-fd-muted-foreground">
           Not connected yet — messages fall back to the offline brain until you connect.
         </p>
+      )}
+      {branchState.stashed.length > 0 && (
+        <div id="branches" className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+          <span className="text-fd-muted-foreground">Timelines:</span>
+          <span className="rounded-full border border-fd-primary/60 bg-fd-primary/10 px-2.5 py-1 font-medium">
+            ⑂ {branchState.activeLabel} · current
+          </span>
+          {branchState.stashed.map((b) => (
+            <span
+              key={b.label}
+              className="flex items-center overflow-hidden rounded-full border border-fd-border"
+            >
+              <button
+                id={`switch-${b.label.replace(/\s+/g, '-')}`}
+                className="px-2.5 py-1 transition-colors hover:bg-fd-accent"
+                title={`Switch to “${b.label}” — the current chat is stashed, this branch's blob is restored and replayed`}
+                onClick={() => switchTo(b.label)}
+              >
+                ⑂ {b.label} · {b.turns} turn{b.turns === 1 ? '' : 's'}
+              </button>
+              <button
+                className="border-l border-fd-border px-1.5 py-1 text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-foreground"
+                title={`Delete branch “${b.label}”`}
+                aria-label={`Delete branch ${b.label}`}
+                onClick={() => dropBranch(b.label)}
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+        </div>
       )}
 
       <div className="mt-3 overflow-hidden rounded-xl border border-fd-border bg-fd-card/50">
@@ -466,11 +672,30 @@ export function PlaygroundClient() {
             <div className="flex flex-col gap-3">
               {feed.map((event, i) => {
                 if (event.kind === 'user') {
+                  const turn = turnOf[i];
                   return (
-                    <div key={i} className="flex justify-end">
+                    <div key={i} className="group flex flex-col items-end">
                       <p className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-fd-primary px-3.5 py-2 text-sm text-fd-primary-foreground">
                         {event.text}
                       </p>
+                      <span className="mt-1 flex gap-1.5 text-[11px] text-fd-muted-foreground opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                        <button
+                          id={`rewind-${turn}`}
+                          className="rounded border border-fd-border px-1.5 py-0.5 transition-colors hover:bg-fd-accent hover:text-fd-foreground"
+                          title="Rewind here: the journal is truncated just before this message and replayed — later turns on this path are discarded"
+                          onClick={() => rewindTo(turn, event.text)}
+                        >
+                          ⏪ Rewind
+                        </button>
+                        <button
+                          id={`branch-${turn}`}
+                          className="rounded border border-fd-border px-1.5 py-0.5 transition-colors hover:bg-fd-accent hover:text-fd-foreground"
+                          title="Branch here: stash this conversation as a switchable timeline, then rewind to try a different path"
+                          onClick={() => branchFrom(turn, event.text)}
+                        >
+                          ⑂ Branch
+                        </button>
+                      </span>
                     </div>
                   );
                 }
@@ -544,6 +769,12 @@ export function PlaygroundClient() {
             Every <code>chidori.prompt / tool / input</code> effect is journaled: the conversation
             auto-saves each turn, survives a reload, and <em>Replay offline</em> repaints it — cards
             and all — with zero live calls.
+          </li>
+          <li>
+            Rewind and branch (hover a message you sent) are journal operations: rewinding
+            truncates the effect journal just before that turn&apos;s <code>chidori.input()</code>{' '}
+            and replays the shorter journal; branching stashes the full blob first, so every
+            timeline is just another durable blob you can switch back to.
           </li>
           <li>
             Docs answers are grounded: these docs are indexed at build time, retrieved into the

--- a/website/app/(home)/playground/timeline.ts
+++ b/website/app/(home)/playground/timeline.ts
@@ -1,0 +1,95 @@
+/**
+ * Journal surgery for the playground's rewind & branch controls.
+ *
+ * A durable blob is self-describing JSON — {bundle, effects, journal} — and
+ * the journal is itself JSON: {bundle_hash, entries: [{site, seq, args,
+ * outcome}]}. Every chat turn begins with exactly one `input` effect (the
+ * agent's `chidori.input()` call), so "rewind to before turn N" is pure data
+ * work: cut the entry list just before the Nth `input` entry. Restoring the
+ * shorter blob replays the surviving prefix offline and blocks at that
+ * `chidori.input()` — the exact suspended state the run was in before the
+ * user sent message N. Branching is the same cut after stashing the
+ * full-length blob, so the discarded future remains a switchable timeline.
+ */
+
+interface JournalEntry {
+  site: string;
+  seq: number;
+  args?: unknown;
+  outcome?: unknown;
+}
+
+interface JournalDoc {
+  bundle_hash: string;
+  entries: JournalEntry[];
+}
+
+interface BlobDoc {
+  bundle: string;
+  effects: string[];
+  /** Journal bytes; serde's Vec<u8> serializes as a JSON number array. */
+  journal: number[];
+}
+
+function decodeJournal(blob: BlobDoc): JournalDoc {
+  return JSON.parse(new TextDecoder().decode(new Uint8Array(blob.journal)));
+}
+
+/** How many user turns (journaled `chidori.input()` results) the blob holds. */
+export function countTurns(blobText: string): number {
+  try {
+    const journal = decodeJournal(JSON.parse(blobText));
+    return journal.entries.filter((e) => e.site === 'input').length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * A copy of the blob rewound to just before user turn `turn` (0-based):
+ * every journal entry from that turn's `input` onward is dropped, everything
+ * else — bundle, effects, bundle_hash, earlier entries — is preserved
+ * verbatim. Returns null when the blob does not parse or has no such turn.
+ */
+export function truncateAtTurn(blobText: string, turn: number): string | null {
+  try {
+    const blob: BlobDoc = JSON.parse(blobText);
+    const journal = decodeJournal(blob);
+    let inputs = 0;
+    let cut = -1;
+    for (let i = 0; i < journal.entries.length; i++) {
+      if (journal.entries[i].site === 'input') {
+        if (inputs === turn) {
+          cut = i;
+          break;
+        }
+        inputs += 1;
+      }
+    }
+    if (cut < 0) return null;
+    journal.entries = journal.entries.slice(0, cut);
+    blob.journal = Array.from(new TextEncoder().encode(JSON.stringify(journal)));
+    return JSON.stringify(blob);
+  } catch {
+    return null;
+  }
+}
+
+/** One stashed (inactive) timeline. */
+export interface Branch {
+  label: string;
+  blob: string;
+  turns: number;
+}
+
+/** The persisted branch set: the active path's label plus stashed timelines. */
+export interface BranchStore {
+  activeLabel: string;
+  /** Monotonic counter for fresh "path N" labels (survives deletes). */
+  nextId: number;
+  stashed: Branch[];
+}
+
+export function freshBranches(): BranchStore {
+  return { activeLabel: 'main', nextId: 2, stashed: [] };
+}


### PR DESCRIPTION
Building on the chat agent playground (#150), every user message now
carries hover controls to rewind and branch the execution — both pure
journal operations, demonstrating the durable-replay model:

- Rewind truncates the effect journal just before that turn's
  chidori.input() entry and restores the shorter blob: the surviving
  prefix replays offline and the agent waits at input again, with the
  removed message prefilled for editing.
- Branch stashes the full-length blob as a switchable timeline first,
  so the discarded future lives on; a "Timelines" pill bar switches
  between paths (each switch is a restore + offline replay) and
  survives reloads via localStorage.
- timeline.ts holds the blob surgery ({bundle, effects, journal} ->
  cut entries before the Nth input) plus the branch-store types.
- A native test in chidori-wasm pins the engine contract the controls
  rely on: a truncated journal restores to the cut turn's input
  frontier and records a divergent continuation cleanly.

Verified end-to-end with a headless-browser run against the wasm
build: branch at turn 2, diverge, switch back (offline replay),
reload persistence, rewind to turn 1, delete branch.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HzFsBWEvRg7MoXiCcs58fS