### PR TITLE
Make the docs site work well on mobile

### DIFF
--- a/website/app/(home)/page.tsx
+++ b/website/app/(home)/page.tsx
@@ -37,12 +37,12 @@ const FEATURES = [
 export default function HomePage() {
   return (
     <main className="flex flex-1 flex-col">
-      <section className="mx-auto w-full max-w-5xl px-6 pt-20 pb-16 md:pt-28">
-        <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-balance md:text-5xl">
+      <section className="mx-auto w-full max-w-5xl px-4 pt-14 pb-16 sm:px-6 sm:pt-20 md:pt-28">
+        <h1 className="max-w-3xl text-3xl font-semibold tracking-tight text-balance sm:text-4xl md:text-5xl">
           The agent framework where every run is durable, replayable, and
           resumable by default.
         </h1>
-        <p className="mt-6 max-w-2xl text-lg text-fd-muted-foreground">
+        <p className="mt-6 max-w-2xl text-base text-fd-muted-foreground sm:text-lg">
           Write agents as plain async TypeScript on a Rust core. Every side
           effect flows through the runtime as a recorded host call, so any run
           can be checkpointed to disk, replayed for byte-identical output with
@@ -72,7 +72,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-5xl px-6 pb-24">
+      <section className="mx-auto w-full max-w-5xl px-4 pb-24 sm:px-6">
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {FEATURES.map((f) => (
             <Link

--- a/website/app/(home)/playground/page.tsx
+++ b/website/app/(home)/playground/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function PlaygroundPage() {
   return (
-    <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-12">
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
       <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
         Playground
       </h1>

--- a/website/app/(home)/playground/playground-client.tsx
+++ b/website/app/(home)/playground/playground-client.tsx
@@ -572,7 +572,7 @@ export function PlaygroundClient() {
         </div>
         {provider === 'openrouter' &&
           (orKey ? (
-            <span className="flex items-center gap-2">
+            <span className="flex flex-wrap items-center gap-2">
               <span id="or-connected" className="text-fd-muted-foreground">
                 ✓ connected
               </span>
@@ -585,7 +585,7 @@ export function PlaygroundClient() {
                   setModel(e.target.value);
                 }}
                 aria-label="OpenRouter model"
-                className="w-52 rounded-lg border border-fd-border bg-fd-background px-2 py-1"
+                className="w-40 min-w-0 rounded-lg border border-fd-border bg-fd-background px-2 py-1 text-base sm:w-52 sm:text-sm"
               />
               <button id="or-disconnect" className={button} onClick={disconnectOpenRouter}>
                 Disconnect
@@ -649,7 +649,7 @@ export function PlaygroundClient() {
       )}
 
       <div className="mt-3 overflow-hidden rounded-xl border border-fd-border bg-fd-card/50">
-        <div ref={feedBoxRef} className="h-[28rem] overflow-y-auto p-4">
+        <div ref={feedBoxRef} className="h-[min(28rem,65dvh)] overflow-y-auto p-3 sm:p-4">
           {feed.length === 0 && !busy ? (
             <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
               <p className="text-sm text-fd-muted-foreground">
@@ -678,10 +678,10 @@ export function PlaygroundClient() {
                       <p className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-fd-primary px-3.5 py-2 text-sm text-fd-primary-foreground">
                         {event.text}
                       </p>
-                      <span className="mt-1 flex gap-1.5 text-[11px] text-fd-muted-foreground opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                      <span className="turn-controls mt-1 flex gap-1.5 text-[11px] text-fd-muted-foreground">
                         <button
                           id={`rewind-${turn}`}
-                          className="rounded border border-fd-border px-1.5 py-0.5 transition-colors hover:bg-fd-accent hover:text-fd-foreground"
+                          className="rounded border border-fd-border px-2 py-1 transition-colors hover:bg-fd-accent hover:text-fd-foreground"
                           title="Rewind here: the journal is truncated just before this message and replayed — later turns on this path are discarded"
                           onClick={() => rewindTo(turn, event.text)}
                         >
@@ -689,7 +689,7 @@ export function PlaygroundClient() {
                         </button>
                         <button
                           id={`branch-${turn}`}
-                          className="rounded border border-fd-border px-1.5 py-0.5 transition-colors hover:bg-fd-accent hover:text-fd-foreground"
+                          className="rounded border border-fd-border px-2 py-1 transition-colors hover:bg-fd-accent hover:text-fd-foreground"
                           title="Branch here: stash this conversation as a switchable timeline, then rewind to try a different path"
                           onClick={() => branchFrom(turn, event.text)}
                         >
@@ -744,7 +744,7 @@ export function PlaygroundClient() {
             placeholder={ready ? 'Message the agent…' : 'Loading…'}
             disabled={!ready}
             autoComplete="off"
-            className="min-w-0 flex-1 rounded-lg border border-fd-border bg-fd-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-fd-primary/40"
+            className="min-w-0 flex-1 rounded-lg border border-fd-border bg-fd-background px-3 py-2 text-base outline-none focus:ring-2 focus:ring-fd-primary/40 sm:text-sm"
           />
           <button id="send" type="submit" className={button} disabled={!ready || !draft.trim()}>
             Send
@@ -771,7 +771,7 @@ export function PlaygroundClient() {
             and all — with zero live calls.
           </li>
           <li>
-            Rewind and branch (hover a message you sent) are journal operations: rewinding
+            Rewind and branch (the controls under any message you sent) are journal operations: rewinding
             truncates the effect journal just before that turn&apos;s <code>chidori.input()</code>{' '}
             and replays the shorter journal; branching stashes the full blob first, so every
             timeline is just another durable blob you can switch back to.

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -15,3 +15,21 @@
 .dark {
   --color-fd-background: hsl(0 0% 4%);
 }
+
+/*
+ * Per-turn controls (rewind/branch) are always visible so touch devices can
+ * reach them; devices with a real hover pointer get the quieter hover-reveal.
+ */
+.turn-controls {
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+@media (hover: hover) and (pointer: fine) {
+  .turn-controls {
+    opacity: 0;
+  }
+  .group:hover .turn-controls,
+  .turn-controls:focus-within {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
The playground's rewind/branch controls were revealed by group-hover,
which never fires on touch devices (Tailwind v4 gates hover variants
behind the hover media feature) — they were unreachable on phones. They
are now always visible, with the quiet hover-reveal kept only for
devices with a real hover pointer via a (hover: hover) and
(pointer: fine) media query, and slightly larger tap targets.

Other mobile fixes:
- Chat and model inputs use 16px font on phones so iOS Safari stops
  auto-zooming on focus.
- The OpenRouter model row wraps instead of overflowing narrow screens.
- The chat feed height caps at 65dvh so the composer stays on screen.
- Home and playground pages get a tightened mobile type scale and
  padding (px-4, smaller hero heading below sm).

Verified: static export builds clean and home, docs, and playground
render with zero horizontal overflow at a 390px viewport.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Y296493rJ2z4cq5hhGZGN