### PR TITLE
Make the playground agent self-modifiable from the chat

### DIFF
--- a/sdk/browser/index.d.ts
+++ b/sdk/browser/index.d.ts
@@ -111,4 +111,8 @@ export class BrowserAgent {
   run(): Promise<RunResult>;
   console(): string[];
   blob(): Uint8Array;
+  /** Replay divergence message (an edit changed already-executed code), or null. */
+  divergence(): string | null;
+  /** True when restored with a modified bundle — modify-and-resume. */
+  bundleChanged(): boolean;
 }

--- a/sdk/browser/index.js
+++ b/sdk/browser/index.js
@@ -278,6 +278,12 @@ export class BrowserAgent {
     let liveCalls = 0;
     for (;;) {
       const status = JSON.parse(this.runtime.runUntilBlocked());
+      // Divergence detected mid-pump surfaces as a clean completion of the
+      // rejected program — check for it at every exit so replaying a journal
+      // against edited code fails loud (the engine's fail-loud policy), not
+      // as a silently dead run.
+      const diverged = this.runtime.divergence();
+      if (diverged) throw new Error(`replay divergence: ${diverged}`);
       if (status.status === 'completed') {
         return { status: 'completed', console: this.runtime.consoleLines(), liveCalls };
       }
@@ -355,5 +361,23 @@ export class BrowserAgent {
   /** The durable artifact (bundle + effects + journal). Save it anywhere. */
   blob() {
     return this.runtime.toBlob();
+  }
+
+  /**
+   * Replay divergence message, or null. Set when the restored bundle made a
+   * different effect call than the journal recorded — i.e. an edit changed
+   * already-executed code before the resume point.
+   */
+  divergence() {
+    return this.runtime.divergence() ?? null;
+  }
+
+  /**
+   * True when this agent was restored with a bundle whose content hash
+   * differs from the one its journal was recorded against — the
+   * modify-and-resume case: same history, new code.
+   */
+  bundleChanged() {
+    return this.runtime.bundleChanged();
   }
 }

--- a/website/app/(home)/playground/agent-source.ts
+++ b/website/app/(home)/playground/agent-source.ts
@@ -10,8 +10,13 @@
  *
  * Each feed event is one JSON line on the console — the page renders the
  * chat (bubbles, tool cards) purely from the journaled console output.
+ *
+ * This is only the *default* implementation: the chat can rewrite it. The
+ * agent's tool set includes read_source / update_source / reset_source, and
+ * an accepted edit is hot-swapped in at the end of the turn — the journal
+ * replays against the new code (modify-and-resume).
  */
-export const AGENT_SOURCE = `type Decision = { tool?: string; args?: unknown; reply?: string };
+export const DEFAULT_AGENT_SOURCE = `type Decision = { tool?: string; args?: unknown; reply?: string };
 type Message = { role: string; content: string };
 
 const transcript: Message[] = [];

--- a/website/app/(home)/playground/brain.ts
+++ b/website/app/(home)/playground/brain.ts
@@ -159,7 +159,12 @@ const TOOL_SPEC = `Tools you can call (one per decision):
 - calculate {expression: string} — arithmetic with + - * / % ^ ( ), functions sqrt sin cos tan abs ln log exp round floor ceil, constants pi and e.
 - chart {title?: string, kind?: "bar" | "line", series: [{label: string, value: number}, ...]} — renders a chart card in the chat. Provide the data yourself.
 - color_palette {mood: string, colors: [{hex: string, name: string} x5]} — renders five swatches. Pick the hex values yourself.
-- roll_dice {count?: number, sides?: number} — fair dice, rolled by the host.`;
+- roll_dice {count?: number, sides?: number} — fair dice, rolled by the host.
+- read_source {} — your own source code: the chidori agent program currently running this conversation.
+- update_source {find: string, replace: string} or {source: string} — rewrite your own implementation. The find text must occur exactly once in the current source (call read_source first and copy it verbatim). The edit is validated by replaying this conversation's journal against the new code, then hot-swapped in when the turn ends.
+- reset_source {} — go back to the original playground source.`;
+
+const SELF_MOD_GUIDE = `Self-modification: you are allowed — encouraged — to rewrite your own program when asked. Call read_source before editing, and prefer small {find, replace} patches over full rewrites. The runtime enforces modify-and-resume: your journal (every past prompt/tool/input call) is replayed against the new code, so an edit is rejected as divergence if it changes calls that already happened — e.g. altering what past turns pushed into the transcript. Changing only emitted output (the emit(...) lines) or future behavior is safe, and past turns will re-render through the new code.`;
 
 export function buildSystemPrompt(index: DocsIndex | null, latestUser: string): string {
   const hits = searchDocs(index, latestUser, 4);
@@ -173,6 +178,8 @@ export function buildSystemPrompt(index: DocsIndex | null, latestUser: string): 
 About chidori: ${OVERVIEW}
 
 ${TOOL_SPEC}
+
+${SELF_MOD_GUIDE}
 
 Protocol — respond with EXACTLY one JSON object and nothing else:
   {"tool": "<name>", "args": {...}}   to call a tool, or
@@ -262,8 +269,37 @@ export function mockDecide(transcript: ChatMessage[], index: DocsIndex | null): 
   return route(text, index);
 }
 
+/**
+ * The line the offline brain's canned self-edit patches: appending to the
+ * *emitted* reply (not the transcript) keeps every already-journaled
+ * `chidori.prompt` call byte-identical, so the swap replays cleanly and past
+ * turns re-render with the signature.
+ */
+const EMIT_REPLY_LINE = "emit({ kind: 'assistant', text: reply });";
+
 function route(text: string, index: DocsIndex | null): Decision {
   const t = text.toLowerCase();
+
+  // Self-modification: the agent reading, patching, and resetting its own
+  // program. Checked first — "code" and "source" say exactly what is meant.
+  if (/\b(your|its|my) (own )?(source|code|implementation)\b|\byourself\b/.test(t)) {
+    if (/\b(reset|revert|restore)\b/.test(t) || /\b(original|default)\b/.test(t)) {
+      return { tool: 'reset_source', args: {} };
+    }
+    if (/\b(rewrite|modify|change|edit|update|patch|improve|upgrade)\b/.test(t)) {
+      const quoted = /["“”']([^"“”']{1,24})["“”']/.exec(text)?.[1];
+      const emoji = /\p{Extended_Pictographic}/u.exec(text)?.[0];
+      const sig = (quoted ?? emoji ?? '⚡').replace(/[\\'`]/g, '').trim() || '⚡';
+      return {
+        tool: 'update_source',
+        args: {
+          find: EMIT_REPLY_LINE,
+          replace: `emit({ kind: 'assistant', text: reply + ' ${sig}' });`,
+        },
+      };
+    }
+    return { tool: 'read_source', args: {} };
+  }
 
   const dice = /(\d+)\s*d\s*(\d+)/.exec(t);
   if (dice || /\b(roll|dice)\b/.test(t)) {
@@ -338,7 +374,8 @@ function route(text: string, index: DocsIndex | null): Decision {
       '• "How does offline replay work?" (searches these docs)\n' +
       '• "Weather in Tokyo"\n' +
       '• "Chart the first 10 fibonacci numbers"\n' +
-      '• "What is 2^16 / 3?"  • "Roll 3d6"  • "A palette for a storm at dusk"',
+      '• "What is 2^16 / 3?"  • "Roll 3d6"  • "A palette for a storm at dusk"\n' +
+      '• "Show me your own source code"  • "Rewrite your code: add a ⚡ to every reply"',
   };
 }
 
@@ -378,6 +415,26 @@ function composeReply(toolMsg: { name?: string; result?: Json }): Decision {
     }
     case 'color_palette':
       return { reply: `Five swatches for “${String(r.mood)}” — rendered above.` };
+    case 'read_source':
+      return {
+        reply:
+          `That's me — ${String(r.lines)} lines of TypeScript${r.modified ? ' (already rewritten via this chat)' : ''}, ` +
+          'and it really is the program running this conversation on the wasm engine. ' +
+          'Ask me to change it — e.g. "rewrite your code: add a ⚡ to every reply" — and I\'ll hot-swap myself mid-conversation.',
+      };
+    case 'update_source':
+      return {
+        reply:
+          `Done — I ${r.mode === 'patch' ? 'patched' : 'rewrote'} my own source. The edit was validated by replaying ` +
+          'this conversation\'s journal against the new code; when this reply lands, the page hot-swaps it in. ' +
+          'Watch the feed: my past turns re-render through the new implementation.',
+      };
+    case 'reset_source':
+      return {
+        reply: r.unchanged
+          ? 'I\'m already running my original source — nothing to reset.'
+          : 'Back to the original source — the swap lands as this turn ends, and the journal replays against it.',
+      };
     default:
       return { reply: `Done: ${JSON.stringify(r).slice(0, 200)}` };
   }

--- a/website/app/(home)/playground/cards.tsx
+++ b/website/app/(home)/playground/cards.tsx
@@ -38,6 +38,12 @@ export function ToolCard({ name, args, result }: { name: string; args?: Json; re
       return <DiceCard r={r} />;
     case 'color_palette':
       return <PaletteCard r={r} />;
+    case 'read_source':
+      return <SourceCard r={r} />;
+    case 'update_source':
+      return <SourceUpdateCard r={r} args={asObj(args)} />;
+    case 'reset_source':
+      return <SourceUpdateCard r={r} args={{}} reset />;
     default:
       return (
         <div className={card}>
@@ -213,6 +219,60 @@ function DiceCard({ r }: { r: Record<string, Json> }) {
         )}
         <span className="ml-1 text-sm text-fd-muted-foreground">= {String(r.total)}</span>
       </div>
+    </div>
+  );
+}
+
+function SourceCard({ r }: { r: Record<string, Json> }) {
+  return (
+    <div className={card}>
+      <CardTitle
+        name="read_source"
+        extra={`${String(r.lines)} lines${r.modified ? ' · rewritten via chat' : ''}`}
+      />
+      <pre className="mt-2 max-h-56 overflow-auto rounded-lg border border-fd-border bg-fd-background p-2.5 text-[10px] leading-relaxed">
+        {String(r.source ?? '')}
+      </pre>
+    </div>
+  );
+}
+
+function SourceUpdateCard({
+  r,
+  args,
+  reset,
+}: {
+  r: Record<string, Json>;
+  args: Record<string, Json>;
+  reset?: boolean;
+}) {
+  const patch = typeof args.find === 'string';
+  const diffPre =
+    'mt-1 max-h-32 overflow-auto rounded-lg border border-fd-border bg-fd-background p-2 text-[10px] leading-relaxed';
+  return (
+    <div className={card}>
+      <CardTitle
+        name={reset ? 'reset_source' : 'update_source'}
+        extra={reset ? undefined : String(r.mode ?? '')}
+      />
+      {r.unchanged ? (
+        <p className="mt-1 text-sm text-fd-muted-foreground">Already running the original source.</p>
+      ) : (
+        <>
+          {patch && (
+            <div className="mt-2 font-mono">
+              <p className="text-[10px] text-fd-muted-foreground">−</p>
+              <pre className={`${diffPre} line-through opacity-60`}>{String(args.find)}</pre>
+              <p className="mt-1.5 text-[10px] text-fd-muted-foreground">+</p>
+              <pre className={diffPre}>{String(args.replace ?? '')}</pre>
+            </div>
+          )}
+          <p className="mt-2 text-sm text-fd-muted-foreground">
+            🧬 {String(r.note ?? 'hot-swaps in when this turn ends')}
+            {r.lines ? ` · ${String(r.lines)} lines` : ''}
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/website/app/(home)/playground/page.tsx
+++ b/website/app/(home)/playground/page.tsx
@@ -4,7 +4,7 @@ import { PlaygroundClient } from './playground-client';
 export const metadata: Metadata = {
   title: 'Playground — Chidori',
   description:
-    'Chat with a chidori agent running entirely in your browser: the pure-Rust engine compiled to WebAssembly, with tools, generative UI, and docs-grounded answers.',
+    'Chat with a chidori agent running entirely in your browser: the pure-Rust engine compiled to WebAssembly, with tools, generative UI, docs-grounded answers — and the ability to rewrite its own code mid-conversation.',
 };
 
 export default function PlaygroundPage() {
@@ -14,9 +14,11 @@ export default function PlaygroundPage() {
         Playground
       </h1>
       <p className="mt-3 text-fd-muted-foreground">
-        A chidori agent running entirely in this tab — ask it about chidori, or
-        hand it a tool. Every effect is journaled: reload mid-conversation and
-        it resumes, rewind any turn, or branch into an alternate timeline.
+        A chidori agent running entirely in this tab — ask it about chidori,
+        hand it a tool, or ask it to rewrite its own code. Every effect is
+        journaled: reload mid-conversation and it resumes, rewind any turn,
+        branch into an alternate timeline — or hot-swap the agent&apos;s
+        implementation and replay the same history against the new code.
       </p>
       <PlaygroundClient />
     </main>

--- a/website/app/(home)/playground/playground-client.tsx
+++ b/website/app/(home)/playground/playground-client.tsx
@@ -19,6 +19,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { DEFAULT_AGENT_SOURCE } from './agent-source';
 import {
   type ChatMessage,
@@ -38,6 +39,16 @@ import {
   freshBranches,
   truncateAtTurn,
 } from './timeline';
+
+// The CodeMirror editor is a heavy chunk; load it only when the
+// "under the hood" panel is first opened.
+const SourceEditor = dynamic(
+  () => import('./source-editor').then((m) => m.SourceEditor),
+  {
+    ssr: false,
+    loading: () => <p className="mt-2 text-xs text-fd-muted-foreground">Loading editor…</p>,
+  },
+);
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const ASSETS = `${BASE}/chidori-wasm`;
@@ -122,6 +133,8 @@ export function PlaygroundClient() {
   const [model, setModel] = useState('openrouter/auto');
   const [branchState, setBranchState] = useState<BranchStore>(freshBranches);
   const [source, setSource] = useState(DEFAULT_AGENT_SOURCE);
+  /** Latches true the first time "under the hood" opens (mounts the editor). */
+  const [hoodOpened, setHoodOpened] = useState(false);
 
   const loadedRef = useRef<Loaded | null>(null);
   const loadedPromiseRef = useRef<Promise<Loaded | null> | null>(null);
@@ -597,6 +610,37 @@ export function PlaygroundClient() {
   }, [hotSwap]);
 
   /**
+   * Manual edits from the source editor go through the same gate as the
+   * chat's update_source tool — compile, replay-validate, hot-swap — they
+   * just skip the "wait for the turn to end" step, because applying is only
+   * enabled while the agent sits idle at `chidori.input()`.
+   */
+  const applyManualEdit = useCallback(
+    (next: string): string | null => {
+      const loaded = loadedRef.current;
+      if (!loaded) return 'The engine is still loading.';
+      if (!next.includes('chidori.input')) {
+        return 'The source must keep awaiting chidori.input() in a loop, or the chat ends.';
+      }
+      try {
+        if (!agentRef.current) {
+          // Nothing recorded yet: compile-check now, run it on first message.
+          (loaded.wasm as WasmModule).stripTypes(next, 'agent.ts');
+          applySource(next);
+          setStatusLine('🧬 Source updated — your next message starts the agent on the edited code.');
+          return null;
+        }
+        validateSwap(next);
+        hotSwap(next);
+        return null;
+      } catch (err) {
+        return String(err);
+      }
+    },
+    [applySource, validateSwap, hotSwap],
+  );
+
+  /**
    * Rewind the active timeline to just before user turn `turn`: the journal
    * is truncated at that turn's `chidori.input()` entry and the shorter blob
    * restored — the surviving prefix replays offline and the agent waits at
@@ -955,7 +999,12 @@ export function PlaygroundClient() {
         </p>
       )}
 
-      <details className="mt-8 rounded-lg border border-fd-border p-4">
+      <details
+        className="mt-8 rounded-lg border border-fd-border p-4"
+        onToggle={(e) => {
+          if (e.currentTarget.open) setHoodOpened(true);
+        }}
+      >
         <summary className="cursor-pointer text-sm font-medium">Under the hood</summary>
         <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-fd-muted-foreground">
           <li>
@@ -975,10 +1024,10 @@ export function PlaygroundClient() {
           </li>
           <li>
             The agent can rewrite itself: <code>read_source</code> and <code>update_source</code>{' '}
-            are ordinary tools. An accepted edit is validated by replaying this conversation&apos;s
-            journal against the new code, then hot-swapped in at the end of the turn
-            (modify-and-resume: same journal, new program) — an edit that would change
-            already-journaled effect calls is rejected as divergence.
+            are ordinary tools — and the editor below edits the same live program by hand. An
+            accepted edit is validated by replaying this conversation&apos;s journal against the
+            new code, then hot-swapped in (modify-and-resume: same journal, new program) — an
+            edit that would change already-journaled effect calls is rejected as divergence.
           </li>
           <li>
             Docs answers are grounded: these docs are indexed at build time, retrieved into the
@@ -986,12 +1035,21 @@ export function PlaygroundClient() {
           </li>
         </ul>
         <p className="mt-3 text-xs text-fd-muted-foreground" id="source-label">
-          agent.ts — the program running this chat
-          {source !== DEFAULT_AGENT_SOURCE ? ' · rewritten via chat (ask it to "reset your code" to undo)' : ''}
+          agent.ts — the program running this chat, editable
+          {source !== DEFAULT_AGENT_SOURCE ? ' · rewritten (ask the agent to "reset your code" to undo)' : ''}
         </p>
-        <pre className="mt-1 overflow-x-auto rounded-lg border border-fd-border bg-fd-card p-4 text-xs">
-          {source}
-        </pre>
+        {hoodOpened ? (
+          <SourceEditor
+            source={source}
+            defaultSource={DEFAULT_AGENT_SOURCE}
+            busy={busy !== null}
+            onApply={applyManualEdit}
+          />
+        ) : (
+          <pre className="mt-1 overflow-x-auto rounded-lg border border-fd-border bg-fd-card p-4 text-xs">
+            {source}
+          </pre>
+        )}
       </details>
     </div>
   );

--- a/website/app/(home)/playground/playground-client.tsx
+++ b/website/app/(home)/playground/playground-client.tsx
@@ -8,13 +8,18 @@
  * chat box. The feed renders purely from the journaled console, so restored
  * and replayed runs repaint identically — cards included.
  *
+ * The agent's source is itself mutable *from inside the chat*: the
+ * update_source tool stages a replacement, validated by replaying the live
+ * journal against the new bundle, and when the turn ends the page hot-swaps
+ * the code in (modify-and-resume: same journal, new program).
+ *
  * The wasm engine + browser SDK load at runtime from /public (build artifacts
  * of scripts/build-wasm.sh, hence the webpackIgnore'd imports); the docs
  * index loads from /playground-docs.json (scripts/build-playground-context.mjs).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AGENT_SOURCE } from './agent-source';
+import { DEFAULT_AGENT_SOURCE } from './agent-source';
 import {
   type ChatMessage,
   type DocsIndex,
@@ -38,6 +43,7 @@ const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const ASSETS = `${BASE}/chidori-wasm`;
 const SAVE_KEY = 'chidori-playground-chat-v1';
 const BRANCH_KEY = 'chidori-playground-branches-v1';
+const SOURCE_KEY = 'chidori-playground-source-v1';
 // The exchanged OpenRouter key lives in sessionStorage: it survives the PKCE
 // redirect back to this page, and is gone when the tab closes.
 const OR_KEY = 'chidori-playground-openrouter-key';
@@ -45,9 +51,10 @@ const OR_KEY = 'chidori-playground-openrouter-key';
 const SUGGESTIONS = [
   'What is chidori, in one paragraph?',
   'How does offline replay work?',
+  'Show me your own source code',
+  'Rewrite your code: add a ⚡ to every reply',
   'Weather in Tokyo',
   'Chart the first 10 fibonacci numbers',
-  'What is 2^16 / 3?',
   'Roll 3d6',
   'A color palette for a storm at dusk',
 ];
@@ -62,6 +69,18 @@ interface AgentHandle {
   run(): Promise<RunView>;
   console(): string[];
   blob(): Uint8Array;
+}
+
+/** The slice of the wasm module's surface the hot-swap machinery touches. */
+interface WasmModule {
+  stripTypes(source: string, filename: string): string;
+  WasmRuntime: {
+    fromBlob(bytes: Uint8Array): {
+      runUntilBlocked(): string;
+      divergence(): string | undefined;
+      free?: () => void;
+    };
+  };
 }
 
 declare global {
@@ -102,6 +121,7 @@ export function PlaygroundClient() {
   const [orKey, setOrKey] = useState<string | null>(null);
   const [model, setModel] = useState('openrouter/auto');
   const [branchState, setBranchState] = useState<BranchStore>(freshBranches);
+  const [source, setSource] = useState(DEFAULT_AGENT_SOURCE);
 
   const loadedRef = useRef<Loaded | null>(null);
   const loadedPromiseRef = useRef<Promise<Loaded | null> | null>(null);
@@ -117,6 +137,12 @@ export function PlaygroundClient() {
   const docsIndexRef = useRef<DocsIndex | null>(null);
   const feedBoxRef = useRef<HTMLDivElement | null>(null);
   const branchRef = useRef(branchState);
+  const sourceRef = useRef(source);
+  /** An update_source edit accepted this turn, waiting for the turn to end. */
+  const pendingSourceRef = useRef<string | null>(null);
+  /** Reverts an in-flight hot-swap if replaying the full journal fails. */
+  const swapFallbackRef = useRef<((err: string) => void) | null>(null);
+  const hotSwapRef = useRef<((next: string) => void) | null>(null);
 
   const updateBranches = useCallback((next: BranchStore) => {
     branchRef.current = next;
@@ -144,12 +170,73 @@ export function PlaygroundClient() {
     }
   }, []);
 
+  /** Make `next` the displayed + persisted agent source. */
+  const applySource = useCallback((next: string) => {
+    sourceRef.current = next;
+    setSource(next);
+    try {
+      if (next === DEFAULT_AGENT_SOURCE) localStorage.removeItem(SOURCE_KEY);
+      else localStorage.setItem(SOURCE_KEY, next);
+    } catch {
+      /* storage full/blocked — the swap still works, just not durable */
+    }
+  }, []);
+
+  /**
+   * Prove the conversation can move onto `next`: compile it, then restore a
+   * scratch runtime from the live blob with the bundle swapped and pump it to
+   * the journal frontier. An edit that changes any already-executed effect
+   * call fails replay (divergence) and throws here — inside the tool call —
+   * so the model reads the reason and can try a smaller patch.
+   */
+  const validateSwap = useCallback((next: string) => {
+    const loaded = loadedRef.current;
+    if (!loaded) throw new Error('engine not loaded yet');
+    const wasm = loaded.wasm as WasmModule;
+    const bundle = loaded.sdk.PRELUDE + wasm.stripTypes(next, 'agent.ts');
+    const agent = agentRef.current;
+    if (!agent) return; // no history yet — nothing to replay against
+    const blob = JSON.parse(new TextDecoder().decode(agent.blob())) as { bundle: string };
+    blob.bundle = bundle;
+    const scratch = wasm.WasmRuntime.fromBlob(new TextEncoder().encode(JSON.stringify(blob)));
+    try {
+      // Replayed entries resolve internally; one pump reaches the frontier.
+      // Divergence detected mid-pump unwinds the program to a quiet
+      // completion, so ask for it explicitly rather than relying on a throw.
+      const status = JSON.parse(scratch.runUntilBlocked()) as { status: string };
+      const diverged = scratch.divergence();
+      if (diverged) {
+        throw new Error(`the edit changes code that already ran, so the journal cannot replay: ${diverged}`);
+      }
+      if (status.status === 'completed') {
+        throw new Error(
+          'the new source ran to completion instead of waiting at chidori.input() — the chat would end',
+        );
+      }
+    } finally {
+      scratch.free?.();
+    }
+  }, []);
+
+  /** Validate `next` and stage it; the swap happens when the turn ends. */
+  const proposeSource = useCallback(
+    (next: string) => {
+      validateSwap(next);
+      pendingSourceRef.current = next;
+    },
+    [validateSwap],
+  );
+
   /** Host implementations for one agent generation. */
   const buildHost = useCallback(
     (token: number) => {
       const stale = () => token !== tokenRef.current;
       const hang = () => new Promise<never>(() => {});
-      const baseTools = makeTools(() => docsIndexRef.current);
+      const baseTools = makeTools(() => docsIndexRef.current, {
+        getSource: () => pendingSourceRef.current ?? sourceRef.current,
+        defaultSource: DEFAULT_AGENT_SOURCE,
+        propose: proposeSource,
+      });
       const tools: Record<string, (kwargs: Json) => Promise<Json>> = {};
       for (const [name, impl] of Object.entries(baseTools)) {
         tools[name] = async (kwargs) => {
@@ -189,6 +276,18 @@ export function PlaygroundClient() {
         tools,
         onInput: () => {
           if (stale()) return hang();
+          // Reaching input means the journal replayed cleanly — a hot-swap
+          // in flight has succeeded, so disarm its revert.
+          swapFallbackRef.current = null;
+          const staged = pendingSourceRef.current;
+          if (staged !== null) {
+            // The turn that staged an edit just ended: swap now. This agent
+            // is orphaned (its input hangs); the new one restores from the
+            // same journal with the new bundle and waits at input instead.
+            pendingSourceRef.current = null;
+            setTimeout(() => hotSwapRef.current?.(staged), 0);
+            return hang();
+          }
           setBusy(null);
           refreshFeed();
           persist();
@@ -200,7 +299,7 @@ export function PlaygroundClient() {
         },
       };
     },
-    [refreshFeed, persist],
+    [refreshFeed, persist, proposeSource],
   );
 
   const drive = useCallback(
@@ -215,6 +314,13 @@ export function PlaygroundClient() {
         .catch((err) => {
           if (token !== tokenRef.current) return;
           setBusy(null);
+          const fallback = swapFallbackRef.current;
+          if (fallback) {
+            // A hot-swapped journal failed to replay: put the old code back.
+            swapFallbackRef.current = null;
+            fallback(String(err));
+            return;
+          }
           setStatusLine(`Agent error: ${String(err)}`);
         });
     },
@@ -259,6 +365,15 @@ export function PlaygroundClient() {
       }
     } catch {
       /* corrupted branch store — start fresh */
+    }
+    try {
+      const savedSource = localStorage.getItem(SOURCE_KEY);
+      if (savedSource !== null) {
+        sourceRef.current = savedSource;
+        setSource(savedSource);
+      }
+    } catch {
+      /* storage blocked — run the default source */
     }
     const loading = loadAssets();
     loadedPromiseRef.current = loading.catch(() => null);
@@ -317,7 +432,7 @@ export function PlaygroundClient() {
     if (!loaded || agentRef.current) return;
     const token = tokenRef.current;
     const agent = loaded.sdk.BrowserAgent.start(loaded.wasm, {
-      source: AGENT_SOURCE,
+      source: sourceRef.current,
       ...buildHost(token),
     }) as AgentHandle;
     agentRef.current = agent;
@@ -412,6 +527,76 @@ export function PlaygroundClient() {
   );
 
   /**
+   * Move the conversation onto `next`: swap the durable blob's bundle for the
+   * newly compiled source and restore — the whole journal replays against the
+   * new code (modify-and-resume), so the chat keeps its history and even its
+   * feed re-renders through the new implementation. `proposeSource` already
+   * replay-validated up to the accepting tool call; the tail of that turn is
+   * covered by the revert armed in swapFallbackRef.
+   */
+  const hotSwap = useCallback(
+    (next: string) => {
+      const loaded = loadedRef.current;
+      const agent = agentRef.current;
+      if (!loaded || !agent) return;
+      const prevBlobText = new TextDecoder().decode(agent.blob());
+      const prevSource = sourceRef.current;
+      let nextBlobText: string;
+      try {
+        const wasm = loaded.wasm as WasmModule;
+        const blob = JSON.parse(prevBlobText) as { bundle: string };
+        blob.bundle = loaded.sdk.PRELUDE + wasm.stripTypes(next, 'agent.ts');
+        nextBlobText = JSON.stringify(blob);
+      } catch (err) {
+        setStatusLine(`Hot-swap failed: ${String(err)}`);
+        return;
+      }
+      // Unlike rewind/branch, a swap continues the same conversation — carry
+      // any message the user typed while the swapping turn ran.
+      const carried = [...queueRef.current];
+      const deliver = () => {
+        if (!carried.length) return;
+        const resolve = resolveRef.current;
+        if (resolve) {
+          // The restored agent already replayed to its input and is waiting.
+          resolveRef.current = null;
+          queueRef.current.push(...carried.slice(1));
+          resolve(carried[0]);
+        } else {
+          queueRef.current.push(...carried);
+        }
+      };
+      applySource(next);
+      swapFallbackRef.current = (err: string) => {
+        applySource(prevSource);
+        startFromBlob(
+          prevBlobText,
+          `⚠️ Hot-swap reverted — the journal could not replay under the new code: ${err}`,
+        );
+        deliver();
+      };
+      const ok = startFromBlob(
+        nextBlobText,
+        next === DEFAULT_AGENT_SOURCE
+          ? '🧬 Hot-swapped back to the original agent source — the journal replayed against it (modify-and-resume).'
+          : '🧬 Hot-swapped the agent’s source mid-conversation: same journal, new code — every past turn just re-rendered through the new implementation.',
+      );
+      if (!ok) {
+        const fallback = swapFallbackRef.current;
+        swapFallbackRef.current = null;
+        fallback?.('restore failed');
+        return;
+      }
+      deliver();
+    },
+    [applySource, startFromBlob],
+  );
+
+  useEffect(() => {
+    hotSwapRef.current = hotSwap;
+  }, [hotSwap]);
+
+  /**
    * Rewind the active timeline to just before user turn `turn`: the journal
    * is truncated at that turn's `chidori.input()` entry and the shorter blob
    * restored — the surviving prefix replays offline and the agent waits at
@@ -455,7 +640,12 @@ export function PlaygroundClient() {
         nextId: store.nextId + 1,
         stashed: [
           ...store.stashed,
-          { label: store.activeLabel, blob: current, turns: countTurns(current) },
+          {
+            label: store.activeLabel,
+            blob: current,
+            turns: countTurns(current),
+            source: sourceRef.current,
+          },
         ],
       });
       setDraft(text);
@@ -476,6 +666,7 @@ export function PlaygroundClient() {
           label: store.activeLabel,
           blob: current,
           turns: countTurns(current),
+          source: sourceRef.current,
         });
       }
       if (
@@ -484,10 +675,13 @@ export function PlaygroundClient() {
           `⑂ Switched to “${target.label}” — restored from its saved blob and replayed offline.`,
         )
       ) {
+        // Timelines carry their own code: the blob's bundle is what runs, and
+        // the branch's stashed source keeps the display honest.
+        applySource(target.source ?? DEFAULT_AGENT_SOURCE);
         updateBranches({ activeLabel: target.label, nextId: store.nextId, stashed });
       }
     },
-    [currentBlobText, startFromBlob, updateBranches],
+    [currentBlobText, startFromBlob, updateBranches, applySource],
   );
 
   const dropBranch = useCallback(
@@ -506,15 +700,18 @@ export function PlaygroundClient() {
     agentRef.current = null;
     resolveRef.current = null;
     queueRef.current = [];
+    pendingSourceRef.current = null;
+    swapFallbackRef.current = null;
     localStorage.removeItem(SAVE_KEY);
     localStorage.removeItem(BRANCH_KEY);
     branchRef.current = freshBranches();
     setBranchState(branchRef.current);
+    applySource(DEFAULT_AGENT_SOURCE);
     setFeed([]);
     setBusy(null);
     setStatusLine('');
     setHasSaved(false);
-  }, []);
+  }, [applySource]);
 
   const connectOpenRouter = useCallback(() => {
     // Redirects to openrouter.ai's consent page; the redirect back lands on
@@ -777,12 +974,23 @@ export function PlaygroundClient() {
             timeline is just another durable blob you can switch back to.
           </li>
           <li>
+            The agent can rewrite itself: <code>read_source</code> and <code>update_source</code>{' '}
+            are ordinary tools. An accepted edit is validated by replaying this conversation&apos;s
+            journal against the new code, then hot-swapped in at the end of the turn
+            (modify-and-resume: same journal, new program) — an edit that would change
+            already-journaled effect calls is rejected as divergence.
+          </li>
+          <li>
             Docs answers are grounded: these docs are indexed at build time, retrieved into the
             model&apos;s context, and exposed as the <code>search_docs</code> tool.
           </li>
         </ul>
-        <pre className="mt-3 overflow-x-auto rounded-lg border border-fd-border bg-fd-card p-4 text-xs">
-          {AGENT_SOURCE}
+        <p className="mt-3 text-xs text-fd-muted-foreground" id="source-label">
+          agent.ts — the program running this chat
+          {source !== DEFAULT_AGENT_SOURCE ? ' · rewritten via chat (ask it to "reset your code" to undo)' : ''}
+        </p>
+        <pre className="mt-1 overflow-x-auto rounded-lg border border-fd-border bg-fd-card p-4 text-xs">
+          {source}
         </pre>
       </details>
     </div>

--- a/website/app/(home)/playground/source-editor.tsx
+++ b/website/app/(home)/playground/source-editor.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+/**
+ * The editable "under the hood" source view: a CodeMirror editor over the
+ * agent's live source, with an Apply button that funnels manual edits
+ * through the exact same validate → hot-swap path the chat's update_source
+ * tool uses. The heavy editor chunk loads only once the panel is opened
+ * (this component is mounted lazily by the client).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+import { javascript } from '@codemirror/lang-javascript';
+
+/** Tracks fumadocs' theme, which toggles the `dark` class on <html>. */
+function useIsDark(): boolean {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    const el = document.documentElement;
+    const update = () => setDark(el.classList.contains('dark'));
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+  return dark;
+}
+
+const EXTENSIONS = [javascript({ typescript: true })];
+
+export function SourceEditor({
+  source,
+  defaultSource,
+  busy,
+  onApply,
+}: {
+  /** The source the agent is currently running (chat edits move it). */
+  source: string;
+  defaultSource: string;
+  /** True while a turn is in flight — applying mid-turn would race the agent. */
+  busy: boolean;
+  /** Validate + hot-swap; returns an error message to display, or null. */
+  onApply: (next: string) => string | null;
+}) {
+  const [draft, setDraft] = useState(source);
+  const [error, setError] = useState<string | null>(null);
+  const isDark = useIsDark();
+
+  // When the *agent's* source changes under us (a chat-driven swap, a branch
+  // switch, a reset), follow it — unless the user has unsaved edits, which
+  // must not be clobbered by the agent's own rewrite.
+  const [lastSynced, setLastSynced] = useState(source);
+  if (source !== lastSynced) {
+    setLastSynced(source);
+    if (draft === lastSynced) setDraft(source);
+  }
+  const dirty = draft !== source;
+
+  const apply = useCallback(() => {
+    setError(onApply(draft));
+  }, [onApply, draft]);
+
+  const button =
+    'rounded-lg border border-fd-border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-fd-accent disabled:pointer-events-none disabled:opacity-40';
+
+  return (
+    <div className="mt-1">
+      <div className="overflow-hidden rounded-lg border border-fd-border text-xs [&_.cm-editor]:bg-transparent [&_.cm-focused]:outline-none">
+        <CodeMirror
+          value={draft}
+          onChange={setDraft}
+          extensions={EXTENSIONS}
+          theme={isDark ? 'dark' : 'light'}
+          maxHeight="24rem"
+          basicSetup={{ foldGutter: false, searchKeymap: false }}
+          aria-label="Agent source editor"
+        />
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <button id="apply-source" className={button} disabled={!dirty || busy} onClick={apply}>
+          🧬 Apply &amp; hot-swap
+        </button>
+        <button
+          id="discard-source"
+          className={button}
+          disabled={!dirty}
+          onClick={() => {
+            setDraft(source);
+            setError(null);
+          }}
+        >
+          Discard edits
+        </button>
+        {draft !== defaultSource && (
+          <button id="load-default-source" className={button} onClick={() => setDraft(defaultSource)}>
+            Load original
+          </button>
+        )}
+        {dirty && !error && (
+          <span className="text-xs text-fd-muted-foreground">
+            {busy ? 'unsaved edits — waiting for the current turn to finish' : 'unsaved edits'}
+          </span>
+        )}
+      </div>
+      {error && (
+        <p id="apply-error" className="mt-2 text-xs text-red-500 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/website/app/(home)/playground/timeline.ts
+++ b/website/app/(home)/playground/timeline.ts
@@ -80,6 +80,12 @@ export interface Branch {
   label: string;
   blob: string;
   turns: number;
+  /**
+   * The agent source this timeline was running when stashed (its blob's
+   * bundle is the *transpiled* form, so the readable source rides along for
+   * display; absent on branches stashed before self-modification existed).
+   */
+  source?: string;
 }
 
 /** The persisted branch set: the active path's label plus stashed timelines. */

--- a/website/app/(home)/playground/tools.ts
+++ b/website/app/(home)/playground/tools.ts
@@ -169,10 +169,30 @@ const asObj = (kwargs: Json): Record<string, Json> =>
   kwargs && typeof kwargs === 'object' && !Array.isArray(kwargs) ? kwargs : {};
 
 /**
- * Build the tool table for a BrowserAgent host. `getIndex` is read at call
- * time so tools see the docs index even if it loads after the agent starts.
+ * Host hooks behind the self-modification tools. The page owns the running
+ * agent, so reading the live source and staging a replacement go through
+ * these callbacks; `propose` must throw (with a message the model can act
+ * on) when the new source doesn't compile or the conversation's journal
+ * cannot replay against it.
  */
-export function makeTools(getIndex: () => DocsIndex | null): Record<string, (kwargs: Json) => Json | Promise<Json>> {
+export interface SelfHost {
+  /** The source the next turn will run (a staged edit, if one is pending). */
+  getSource(): string;
+  /** The pristine source the playground shipped with. */
+  defaultSource: string;
+  /** Validate `next` and stage it for the end-of-turn hot-swap. */
+  propose(next: string): void;
+}
+
+/**
+ * Build the tool table for a BrowserAgent host. `getIndex` is read at call
+ * time so tools see the docs index even if it loads after the agent starts;
+ * `self` wires the source-editing tools back to the page hosting the agent.
+ */
+export function makeTools(
+  getIndex: () => DocsIndex | null,
+  self: SelfHost,
+): Record<string, (kwargs: Json) => Json | Promise<Json>> {
   return {
     search_docs: (kwargs) => {
       const query = String(asObj(kwargs).query ?? '');
@@ -219,6 +239,63 @@ export function makeTools(getIndex: () => DocsIndex | null): Record<string, (kwa
       // A model may send only a mood; derive swatches deterministically.
       if (!colors.length) colors = paletteFor(mood) as unknown as Json[];
       return { mood, colors: colors.slice(0, 6) };
+    },
+
+    read_source: () => {
+      const source = self.getSource();
+      return {
+        source,
+        lines: source.split('\n').length,
+        modified: source !== self.defaultSource,
+      };
+    },
+
+    update_source: (kwargs) => {
+      const o = asObj(kwargs);
+      const current = self.getSource();
+      let next: string;
+      let mode: 'rewrite' | 'patch';
+      if (typeof o.source === 'string' && o.source.trim()) {
+        next = o.source;
+        mode = 'rewrite';
+      } else if (typeof o.find === 'string' && o.find.length) {
+        const find = o.find;
+        const at = current.indexOf(find);
+        if (at === -1) {
+          throw new Error('find text does not occur in the current source — call read_source and copy it exactly');
+        }
+        if (current.indexOf(find, at + find.length) !== -1) {
+          throw new Error('find text occurs more than once — include more surrounding lines to make it unique');
+        }
+        next = current.slice(0, at) + String(o.replace ?? '') + current.slice(at + find.length);
+        mode = 'patch';
+      } else {
+        throw new Error('update_source needs {source} for a full rewrite or {find, replace} for a patch');
+      }
+      if (!next.includes('chidori.input')) {
+        throw new Error('the new source must keep awaiting chidori.input() in a loop, or the chat ends after this turn');
+      }
+      // Compiles the new source and replays the journal against it; throws
+      // (into this tool call, where the model can read it) on divergence.
+      self.propose(next);
+      return {
+        ok: true,
+        mode,
+        lines: next.split('\n').length,
+        note: 'validated against the journal — hot-swaps in when this turn ends',
+      };
+    },
+
+    reset_source: (): Json => {
+      if (self.getSource() === self.defaultSource) {
+        return { ok: true, unchanged: true, note: 'already running the original source' };
+      }
+      self.propose(self.defaultSource);
+      return {
+        ok: true,
+        lines: self.defaultSource.split('\n').length,
+        note: 'original source staged — hot-swaps in when this turn ends',
+      };
     },
 
     roll_dice: (kwargs) => {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@codemirror/lang-javascript": "^6.2.5",
+        "@uiw/react-codemirror": "^4.25.11",
         "fumadocs-core": "^15.5.1",
         "fumadocs-mdx": "^11.6.9",
         "fumadocs-ui": "^15.5.1",
@@ -40,6 +42,123 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1030,6 +1149,47 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
@@ -2415,6 +2575,59 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.11",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.11.tgz",
+      "integrity": "sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.11",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.11.tgz",
+      "integrity": "sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.11",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
@@ -2591,6 +2804,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -2615,6 +2843,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -5376,6 +5610,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -5696,6 +5936,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,8 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@uiw/react-codemirror": "^4.25.11",
     "fumadocs-core": "^15.5.1",
     "fumadocs-mdx": "^11.6.9",
     "fumadocs-ui": "^15.5.1",


### PR DESCRIPTION
The /playground chat can now rewrite its own implementation while you talk
to it. The agent's source is no longer a fixed string: read_source,
update_source ({find, replace} patch or full {source} rewrite), and
reset_source are ordinary chidori tools, so both the offline brain and an
OpenRouter model can inspect and edit the very program that is running the
conversation.

An accepted edit rides the engine's modify-and-resume contract end to end:

- update_source validates the edit inside the tool call by restoring a
  scratch WasmRuntime from the live durable blob with the bundle swapped
  for the newly compiled source, and pumping it to the journal frontier.
  An edit that changes already-executed effect calls fails replay there
  (fail-loud divergence), so the model reads the reason in the tool error
  and can try a smaller patch — nothing is journaled as "applied" that
  could not actually apply.
- When the staging turn ends (the agent's next chidori.input()), the page
  hot-swaps: same journal, new bundle, restored and replayed. Past turns
  re-render through the new code — the offline brain's canned demo patches
  the emitted reply line, so every earlier reply retroactively picks up
  the new signature while the journaled transcript stays byte-identical.
- A revert hook covers the swap's only unvalidated window (the tail of the
  staging turn): if the full-journal replay diverges after all, the old
  blob and source are restored and the divergence is surfaced.

Timelines compose with this: branches stash the source they were running,
rewind keeps the current code, reset returns to the shipped source, and
the modified source persists in localStorage next to the conversation.

BrowserAgent gains divergence() and bundleChanged(), and run() now checks
for divergence at its exit points — a divergence detected mid-pump unwinds
the program to a quiet completion, so without the explicit check a replay
against edited code would return {status: 'completed'} instead of failing
loud as the engine's replay policy intends.

Verified with a Playwright run against the wasm build: read → patch →
retroactive re-render → new-turn behavior → reload restore → offline
replay of the swapped blob → reset, plus the failure paths (stale patch
rejected with a readable error; past-mutating edits refused as divergence
by both the scratch validator and BrowserAgent.run).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011s6bVZriKKRCcPGinzVHzZ