### PR TITLE
Make docs examples runnable in a side panel with a site-wide OpenRouter login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,11 +59,15 @@ node_modules/
 /website/out/
 /website/.source/
 /website/next-env.d.ts
+/website/tsconfig.tsbuildinfo
 # Playground runtime assets, mirrored from the wasm build by scripts/build-wasm.sh
 /website/public/chidori-wasm/
 # Docs index for the /playground chat agent (regenerate with
 # website/scripts/build-playground-context.mjs; runs as part of npm run build)
 /website/public/playground-docs.json
+# Runnable docs-example index for the example-runner panel (regenerate with
+# website/scripts/build-runnable-examples.mjs; runs as part of npm run build)
+/website/public/runnable-examples.json
 
 # Secrets / local env
 .env

--- a/website/app/(home)/playground/playground-client.tsx
+++ b/website/app/(home)/playground/playground-client.tsx
@@ -20,6 +20,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { OPENROUTER_KEY_STORAGE } from '@/lib/openrouter';
 import { DEFAULT_AGENT_SOURCE } from './agent-source';
 import {
   type ChatMessage,
@@ -56,8 +57,10 @@ const SAVE_KEY = 'chidori-playground-chat-v1';
 const BRANCH_KEY = 'chidori-playground-branches-v1';
 const SOURCE_KEY = 'chidori-playground-source-v1';
 // The exchanged OpenRouter key lives in sessionStorage: it survives the PKCE
-// redirect back to this page, and is gone when the tab closes.
-const OR_KEY = 'chidori-playground-openrouter-key';
+// redirect back to this page, and is gone when the tab closes. The storage
+// key is shared site-wide (lib/openrouter.ts), so one login also powers the
+// docs pages' runnable examples — and a login started there works here.
+const OR_KEY = OPENROUTER_KEY_STORAGE;
 
 const SUGGESTIONS = [
   'What is chidori, in one paragraph?',

--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -2,11 +2,17 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
 import { baseOptions } from '@/lib/layout.shared';
 import { source } from '@/lib/source';
+import { RunnerPanel } from './runner/runner-panel';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <DocsLayout tree={source.pageTree} {...baseOptions()}>
       {children}
+      {/* The example-runner side panel: mounted once for all docs pages,
+          opened by the Run button on runnable code blocks. It also finishes
+          the site-wide OpenRouter PKCE login when a page load is the
+          redirect back from openrouter.ai. */}
+      <RunnerPanel />
     </DocsLayout>
   );
 }

--- a/website/app/docs/runner/harness.ts
+++ b/website/app/docs/runner/harness.ts
@@ -1,0 +1,174 @@
+/**
+ * The VM-side harness the docs runner wraps around an example before handing
+ * it to the wasm engine. It recreates enough of the native `chidori:agent`
+ * module surface — `run()`, `defineTool()`, captured `fetch`, the provider
+ * tool-use loop inside `chidori.prompt()` — for the docs' durable-core
+ * examples to execute unmodified in the browser sandbox.
+ *
+ * Every observable step is also emitted as one JSON line on the console
+ * (the playground's trick): the panel renders its feed purely from journaled
+ * console output, so a restored or offline-replayed run repaints
+ * identically with zero live calls.
+ */
+
+/**
+ * Prompt-effect payloads the shim exchanges with the page's host when a
+ * prompt carries tools: the host answers each hop with either tool calls to
+ * make or the final reply.
+ */
+export interface ToolLoopDecision {
+  content?: string;
+  toolCalls?: { id: string; name: string; args: unknown }[];
+  reply?: string;
+}
+
+/** Marks a prompt effect as one hop of the shim's tool-use loop. */
+export const TOOL_LOOP_PROTOCOL = 'docs-tools-v1';
+
+const HARNESS_PRELUDE = `// ---- docs example harness (site-injected) ----
+const __feed = (event) => {
+  try { console.log(JSON.stringify(event)); } catch (err) { console.log(JSON.stringify({ k: 'note', text: 'unserializable event: ' + String(err) })); }
+};
+const __rawPrompt = chidori.prompt;
+const __rawInput = chidori.input;
+const __rawLog = chidori.log;
+const __rawFetch = chidori.fetch;
+const __rawTool = chidori.tool;
+let __runHandler = null;
+function run(handler) { __runHandler = handler; }
+function defineTool(def) {
+  if (!def || typeof def.name !== 'string' || typeof def.run !== 'function') {
+    throw new Error('defineTool needs { name, description, parameters, run }');
+  }
+  return {
+    __tool: true,
+    name: def.name,
+    description: String(def.description ?? ''),
+    parameters: def.parameters ?? { type: 'object', properties: {} },
+    run: def.run,
+  };
+}
+// The captured networking surface: a fetch that flows through the journaled
+// http_fetch effect, so replays never touch the network.
+globalThis.fetch = async (url, init) => {
+  const raw = await __rawFetch(String(url), init ?? null);
+  __feed({ k: 'fetch', url: String(url), status: raw.status, ok: raw.ok, simulated: !!(raw.json && raw.json.__simulated) });
+  return {
+    ok: raw.ok,
+    status: raw.status,
+    text: async () => raw.text,
+    json: async () => (raw.json !== null && raw.json !== undefined ? raw.json : JSON.parse(raw.text)),
+  };
+};
+chidori.log = async (message, fields) => {
+  __feed({ k: 'log', message: String(message), fields: fields === undefined ? null : fields });
+  return __rawLog(String(message), fields);
+};
+chidori.input = async (message, opts) => {
+  const answer = String(await __rawInput(String(message), opts ?? null));
+  __feed({ k: 'input', prompt: String(message), answer });
+  return answer;
+};
+chidori.tool = async (name, kwargs) => {
+  const result = await __rawTool(String(name), kwargs ?? null);
+  __feed({ k: 'tool', name: String(name), args: kwargs ?? {}, result: result === undefined ? null : result });
+  return result;
+};
+// Native signature is step(label, fn); the browser prelude's is step(fn).
+const __rawStep = chidori.step;
+chidori.step = (label, fn) => __rawStep(typeof fn === 'function' ? fn : label);
+chidori.prompt = async (text, opts) => {
+  const o = opts ?? {};
+  const tools = Array.isArray(o.tools) ? o.tools.filter((t) => t && t.__tool) : [];
+  const passthrough = {
+    system: o.system ?? null,
+    maxTokens: o.maxTokens ?? null,
+    temperature: typeof o.temperature === 'number' ? o.temperature : null,
+    kind: o.type ?? null,
+  };
+  if (tools.length === 0) {
+    const reply = String(await __rawPrompt(String(text), passthrough));
+    __feed({ k: 'prompt', text: String(text), reply });
+    return reply;
+  }
+  // The provider tool-use loop, run from inside the VM: each hop is one
+  // journaled prompt effect; tool bodies execute right here, so their
+  // closures (and their captured fetch) work exactly as documented.
+  const messages = [{ role: 'user', content: String(text) }];
+  const specs = tools.map((t) => ({ name: t.name, description: t.description, parameters: t.parameters }));
+  const maxTurns = Math.max(1, Number(o.maxTurns ?? 6));
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const raw = await __rawPrompt(JSON.stringify({ messages, tools: specs }), { ...passthrough, protocol: '${TOOL_LOOP_PROTOCOL}' });
+    let decision;
+    try { decision = JSON.parse(String(raw)); } catch (err) { decision = { reply: String(raw) }; }
+    const calls = Array.isArray(decision.toolCalls) ? decision.toolCalls : [];
+    if (calls.length === 0) {
+      const reply = String(decision.reply ?? '');
+      __feed({ k: 'prompt', text: String(text), reply, toolTurns: turn });
+      return reply;
+    }
+    messages.push({
+      role: 'assistant',
+      content: typeof decision.content === 'string' ? decision.content : '',
+      tool_calls: calls.map((c) => ({
+        id: String(c.id),
+        type: 'function',
+        function: { name: String(c.name), arguments: JSON.stringify(c.args ?? {}) },
+      })),
+    });
+    for (const c of calls) {
+      const tool = tools.find((t) => t.name === c.name);
+      let result;
+      try {
+        result = tool ? await tool.run(c.args ?? {}) : { error: 'no such tool: ' + String(c.name) };
+      } catch (err) {
+        result = { error: String(err) };
+      }
+      if (result === undefined) result = null;
+      __feed({ k: 'tool', name: String(c.name), args: c.args ?? {}, result });
+      messages.push({ role: 'tool', tool_call_id: String(c.id), content: JSON.stringify(result) });
+    }
+  }
+  const bail = '(tool-turn limit of ' + maxTurns + ' reached without a final reply)';
+  __feed({ k: 'prompt', text: String(text), reply: bail });
+  return bail;
+};
+`;
+
+/** JSON is almost a JS literal; escape the two exceptions. */
+function asJsLiteral(value: unknown): string {
+  return JSON.stringify(value ?? {}).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+}
+
+/** Drop `import … from "chidori:agent"` — the harness provides that surface. */
+export function stripAgentImport(code: string): string {
+  return code.replace(/^[ \t]*import[^;]*?from\s*["']chidori:agent["'];?[ \t]*$/gm, '');
+}
+
+/**
+ * Assemble the source handed to BrowserAgent.start: harness + the example
+ * inlined into an async function (legalizing the docs' top-level await and
+ * bare `return`) + a driver that invokes any `run()`-registered handler with
+ * the reader-provided input.
+ */
+export function buildHarnessSource(code: string, input: unknown): string {
+  return `${HARNESS_PRELUDE}
+async function __example() {
+${stripAgentImport(code)}
+}
+async function __main() {
+  // A fragment's bare \`return\` value is its output; a program's output is
+  // whatever its run()-registered handler returns for the reader's input.
+  const fragmentValue = await __example();
+  if (fragmentValue !== undefined) __feed({ k: 'result', value: fragmentValue });
+  if (__runHandler) {
+    const output = await __runHandler(${asJsLiteral(input)});
+    __feed({ k: 'result', value: output === undefined ? null : output });
+  }
+  __feed({ k: 'done' });
+}
+__main().catch((err) => {
+  __feed({ k: 'error', text: String(err && err.message ? err.message : err) });
+});
+`;
+}

--- a/website/app/docs/runner/host.ts
+++ b/website/app/docs/runner/host.ts
@@ -1,0 +1,223 @@
+'use client';
+
+/**
+ * The page-side host for docs example runs: implements the wasm agent's
+ * `chidori.prompt` (OpenRouter when the site-wide login is connected, a
+ * deterministic offline stand-in otherwise), a small `chidori.tool` table,
+ * and a captured-fetch that degrades to a labelled simulated response when
+ * the live network call fails (CORS, offline) — the same trick the
+ * playground's weather tool uses, so examples still demonstrate the
+ * journaling mechanics without a network.
+ */
+
+import { type DocsIndex, type Json, searchDocs } from '../../(home)/playground/brain';
+import { evaluateExpression } from '../../(home)/playground/tools';
+import { getOpenRouterKey, getOpenRouterModel } from '@/lib/openrouter';
+import { TOOL_LOOP_PROTOCOL, type ToolLoopDecision } from './harness';
+
+/**
+ * What every prompt returns when no key is connected — the browser twin of
+ * the CLI's CHIDORI_TEST_LLM_RESPONSE test mode: deterministic, so the
+ * journaling/replay mechanics demo identically, just without a real model.
+ */
+export const OFFLINE_REPLY =
+  '(offline test reply — connect OpenRouter in this panel to run the example against a real model)';
+
+/** One rendered step of a run, parsed from a journaled console line. */
+export type RunEvent =
+  | { k: 'log'; message: string; fields: Json }
+  | { k: 'prompt'; text: string; reply: string; toolTurns?: number }
+  | { k: 'tool'; name: string; args: Json; result: Json }
+  | { k: 'input'; prompt: string; answer: string }
+  | { k: 'fetch'; url: string; status: number; ok: boolean; simulated: boolean }
+  | { k: 'result'; value: Json }
+  | { k: 'error'; text: string }
+  | { k: 'done' }
+  | { k: 'note'; text: string };
+
+const KINDS = new Set(['log', 'prompt', 'tool', 'input', 'fetch', 'result', 'error', 'done', 'note']);
+
+/** Journaled console lines (one JSON event per line) → renderable feed. */
+export function parseRunFeed(lines: string[]): RunEvent[] {
+  return lines.map((line): RunEvent => {
+    try {
+      const ev = JSON.parse(line);
+      if (ev && typeof ev === 'object' && KINDS.has(ev.k)) return ev as RunEvent;
+    } catch {
+      /* a console.log from the example itself — show it verbatim */
+    }
+    return { k: 'note', text: line };
+  });
+}
+
+/**
+ * The offline brain's take on one tool-loop hop: on the first hop it calls
+ * the example's first tool once, with arguments derived deterministically
+ * from the tool's parameter schema (string properties get the user's text),
+ * then replies with the static offline answer. That way a keyless run still
+ * demonstrates the documented loop — model asks, runtime executes the tool,
+ * result feeds back — and replays byte-identically.
+ */
+function offlineToolLoopDecision(hop: {
+  messages: { role: string; content?: string }[];
+  tools: { name: string; description: string; parameters: unknown }[];
+}): ToolLoopDecision {
+  const calledAlready = hop.messages.some((m) => m.role === 'tool');
+  const tool = hop.tools[0];
+  if (calledAlready || !tool) return { reply: OFFLINE_REPLY };
+  const userText = [...hop.messages].reverse().find((m) => m.role === 'user')?.content ?? '';
+  const args: Record<string, unknown> = {};
+  const props = (tool.parameters as { properties?: Record<string, { type?: string }> } | undefined)
+    ?.properties;
+  for (const [name, spec] of Object.entries(props ?? {})) {
+    switch (spec?.type) {
+      case 'number':
+      case 'integer':
+        args[name] = 1;
+        break;
+      case 'boolean':
+        args[name] = false;
+        break;
+      case 'array':
+        args[name] = [];
+        break;
+      case 'object':
+        args[name] = {};
+        break;
+      default:
+        args[name] = userText.slice(0, 120);
+    }
+  }
+  return { content: '', toolCalls: [{ id: 'offline_call_1', name: tool.name, args }] };
+}
+
+interface OpenRouterMessage {
+  content?: string | null;
+  tool_calls?: { id: string; function?: { name?: string; arguments?: string } }[];
+}
+
+async function chatCompletion(apiKey: string, body: Record<string, unknown>): Promise<OpenRouterMessage> {
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+      'HTTP-Referer': typeof location !== 'undefined' ? location.origin : 'https://thousandbirdsinc.github.io',
+      'X-Title': 'Chidori Docs Examples',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`openrouter: ${res.status} ${await res.text()}`);
+  const json = await res.json();
+  const message = json.choices?.[0]?.message;
+  if (!message) throw new Error('openrouter returned no message');
+  return message as OpenRouterMessage;
+}
+
+function systemMessages(opts: Record<string, unknown>): { role: string; content: string }[] {
+  return typeof opts.system === 'string' && opts.system ? [{ role: 'system', content: opts.system }] : [];
+}
+
+/**
+ * Serve one `chidori.prompt` effect. Plain prompts become a single chat
+ * completion; tool-loop hops (marked by the harness protocol) get the
+ * message history + tool schemas and answer with tool calls or a reply.
+ * The model always comes from the site-wide panel setting — docs examples
+ * name native-runtime model aliases that OpenRouter wouldn't resolve.
+ */
+export async function decidePrompt(payload: { text: string; opts?: unknown }): Promise<string> {
+  const opts = (payload.opts ?? {}) as Record<string, unknown>;
+  const key = getOpenRouterKey();
+  if (opts.protocol === TOOL_LOOP_PROTOCOL) {
+    const hop = JSON.parse(payload.text) as {
+      messages: { role: string; content?: string }[];
+      tools: { name: string; description: string; parameters: unknown }[];
+    };
+    if (!key) return JSON.stringify(offlineToolLoopDecision(hop));
+    const message = await chatCompletion(key, {
+      model: getOpenRouterModel(),
+      messages: [...systemMessages(opts), ...hop.messages],
+      tools: hop.tools.map((t) => ({ type: 'function', function: t })),
+    });
+    const calls = message.tool_calls ?? [];
+    if (calls.length > 0) {
+      const decision: ToolLoopDecision = {
+        content: message.content ?? '',
+        toolCalls: calls.map((c, i) => {
+          let args: unknown = {};
+          try {
+            args = JSON.parse(c.function?.arguments || '{}');
+          } catch {
+            /* malformed arguments — hand the tool an empty object */
+          }
+          return { id: c.id || `call_${i}`, name: c.function?.name ?? '', args };
+        }),
+      };
+      return JSON.stringify(decision);
+    }
+    return JSON.stringify({ reply: String(message.content ?? '') } satisfies ToolLoopDecision);
+  }
+  if (!key) return OFFLINE_REPLY;
+  const message = await chatCompletion(key, {
+    model: getOpenRouterModel(),
+    messages: [...systemMessages(opts), { role: 'user', content: payload.text }],
+    ...(opts.maxTokens ? { max_tokens: Number(opts.maxTokens) } : {}),
+    ...(typeof opts.temperature === 'number' ? { temperature: opts.temperature } : {}),
+  });
+  return String(message.content ?? '');
+}
+
+const asObj = (kwargs: Json): Record<string, Json> =>
+  kwargs && typeof kwargs === 'object' && !Array.isArray(kwargs) ? kwargs : {};
+
+/**
+ * The registry behind `chidori.tool()` calls in docs examples. Small on
+ * purpose: docs search (both spellings the docs use), plus the playground's
+ * deterministic calculator.
+ */
+export function makeDocsTools(
+  getIndex: () => DocsIndex | null,
+): Record<string, (kwargs: Json) => Json | Promise<Json>> {
+  const search = (kwargs: Json): Json => {
+    const query = String(asObj(kwargs).query ?? '');
+    const index = getIndex();
+    return {
+      query,
+      hits: searchDocs(index, query, 4) as unknown as Json,
+      ...(index ? {} : { note: 'docs index not loaded' }),
+    };
+  };
+  return {
+    docs_search: search,
+    search_docs: search,
+    calculate: (kwargs) => {
+      const expression = String(asObj(kwargs).expression ?? '');
+      return { expression, value: evaluateExpression(expression) };
+    },
+  };
+}
+
+/**
+ * The captured-network implementation handed to the BrowserAgent host: try
+ * the real fetch; when it fails (CORS, DNS, offline), answer with a clearly
+ * labelled simulated response instead of killing the run, so the journaling
+ * story the example demonstrates still plays out. The `__simulated` marker
+ * is what the harness surfaces in its fetch feed events.
+ */
+export async function fetchWithSimulatedFallback(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetch(input, init);
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        __simulated: true,
+        note: `live request failed in the browser sandbox (${String(err)}) — this is a simulated response`,
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }
+}

--- a/website/app/docs/runner/runnable-pre.tsx
+++ b/website/app/docs/runner/runnable-pre.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+/**
+ * The docs site's code-block renderer: fumadocs' default CodeBlock, plus a
+ * "Run" button on every block that the build-time analysis
+ * (scripts/build-runnable-examples.mjs) proved can execute in the browser
+ * sandbox. Clicking it opens the example-runner side panel with this
+ * block's code.
+ *
+ * The block's text is read from the rendered DOM (shiki preserves the code
+ * verbatim) and matched against the runnable index by content hash — no
+ * per-block annotations in the markdown, which must stay readable on GitHub.
+ */
+
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
+import { type ComponentProps, useEffect, useRef, useState } from 'react';
+import { lookupRunnable, openRunner, type RunnableInfo } from './runner-store';
+
+export function RunnablePre(props: ComponentProps<'pre'>) {
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const codeRef = useRef('');
+  const [runnable, setRunnable] = useState<(RunnableInfo & { id: string }) | null>(null);
+
+  useEffect(() => {
+    const pre = boxRef.current?.querySelector('pre');
+    if (!pre) return;
+    const code = pre.textContent ?? '';
+    codeRef.current = code;
+    let cancelled = false;
+    lookupRunnable(code).then((hit) => {
+      if (hit && !cancelled) setRunnable(hit);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div ref={boxRef} className="relative">
+      <CodeBlock {...props}>
+        <Pre>{props.children}</Pre>
+      </CodeBlock>
+      {runnable && (
+        <button
+          type="button"
+          data-runnable-example={runnable.id}
+          className="absolute bottom-2 right-2 inline-flex h-7 items-center gap-1 rounded-full border border-fd-primary/50 bg-fd-background/90 px-2.5 text-xs font-medium shadow-sm backdrop-blur transition-colors hover:bg-fd-accent"
+          title="Run this example on the wasm chidori engine, right here in your browser"
+          onClick={() =>
+            openRunner({
+              ...runnable,
+              code: codeRef.current,
+              title: document.title.split('|')[0].trim() || 'Docs example',
+            })
+          }
+        >
+          ▶ Run
+        </button>
+      )}
+    </div>
+  );
+}

--- a/website/app/docs/runner/runner-panel.tsx
+++ b/website/app/docs/runner/runner-panel.tsx
@@ -1,0 +1,579 @@
+'use client';
+
+/**
+ * The docs example runner: a right-side panel, mounted once in the docs
+ * layout, that executes the code block the reader clicked "Run" on — for
+ * real, on the wasm build of the chidori engine, in this tab (the same
+ * engine + browser SDK the /playground chat uses).
+ *
+ * The harness (harness.ts) recreates the `chidori:agent` surface the docs'
+ * durable-core examples use; the host half lives in host.ts. Prompts are
+ * served by the site-wide OpenRouter login (lib/openrouter.ts) when
+ * connected — one login covers every example and the playground — and by a
+ * deterministic offline reply otherwise. The feed renders purely from the
+ * run's journaled console, which is what makes "Replay offline" repaint the
+ * whole run with zero live calls.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import {
+  completeOpenRouterLogin,
+  getOpenRouterKey,
+  getOpenRouterModel,
+  setOpenRouterKey,
+  setOpenRouterModel,
+  startOpenRouterLogin,
+  subscribeOpenRouter,
+} from '@/lib/openrouter';
+import { type DocsIndex, type Json, prepareDocsIndex } from '../../(home)/playground/brain';
+import { buildHarnessSource } from './harness';
+import {
+  OFFLINE_REPLY,
+  type RunEvent,
+  decidePrompt,
+  fetchWithSimulatedFallback,
+  makeDocsTools,
+  parseRunFeed,
+} from './host';
+import {
+  type RunnableExample,
+  closeRunner,
+  getRunnerExample,
+  subscribeRunner,
+} from './runner-store';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const ASSETS = `${BASE}/chidori-wasm`;
+
+interface RunResult {
+  status: string;
+  console: string[];
+  liveCalls: number;
+  pendingInput?: { prompt: string; opts?: Json };
+}
+
+interface AgentHandle {
+  run(): Promise<RunResult>;
+  console(): string[];
+  blob(): Uint8Array;
+}
+
+interface Loaded {
+  wasm: unknown;
+  sdk: typeof import('../../../../sdk/browser/index.js');
+}
+
+let assetsPromise: Promise<Loaded> | null = null;
+
+function loadAssets(): Promise<Loaded> {
+  // Runtime imports on purpose (same as the playground): the wasm module and
+  // SDK are static assets built by scripts/build-wasm.sh, not bundle modules.
+  assetsPromise ??= (async () => {
+    const wasm = await import(/* webpackIgnore: true */ `${ASSETS}/chidori_wasm.js`);
+    await wasm.default();
+    const sdk = await import(/* webpackIgnore: true */ `${ASSETS}/chidori-browser.js`);
+    return { wasm, sdk };
+  })();
+  return assetsPromise;
+}
+
+let docsIndexPromise: Promise<DocsIndex | null> | null = null;
+
+function loadDocsIndex(): Promise<DocsIndex | null> {
+  docsIndexPromise ??= fetch(`${BASE}/playground-docs.json`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((json) => (json ? prepareDocsIndex(json) : null))
+    .catch(() => null);
+  return docsIndexPromise;
+}
+
+interface PendingInput {
+  prompt: string;
+  opts: Record<string, Json>;
+  resolve: (answer: string) => void;
+}
+
+type Phase = 'idle' | 'starting' | 'running' | 'done' | 'failed';
+
+const short = (value: Json, max = 2000): string => {
+  const text = JSON.stringify(value, null, 1) ?? 'null';
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+};
+
+function EventCard({ event }: { event: RunEvent }) {
+  const label = 'font-mono text-[10px] uppercase tracking-wide text-fd-muted-foreground';
+  const card = 'rounded-lg border border-fd-border bg-fd-card px-3 py-2 text-xs';
+  switch (event.k) {
+    case 'log':
+      return (
+        <div className={card}>
+          <p className={label}>chidori.log</p>
+          <p className="mt-1">{event.message}</p>
+          {event.fields !== null && event.fields !== undefined && (
+            <pre className="mt-1 max-h-32 overflow-auto font-mono text-[11px] text-fd-muted-foreground">{short(event.fields)}</pre>
+          )}
+        </div>
+      );
+    case 'prompt':
+      return (
+        <div className={card}>
+          <p className={label}>
+            chidori.prompt{event.toolTurns ? ` · ${event.toolTurns} tool turn${event.toolTurns === 1 ? '' : 's'}` : ''}
+          </p>
+          <p className="mt-1 whitespace-pre-wrap text-fd-muted-foreground">{event.text.length > 280 ? `${event.text.slice(0, 280)}…` : event.text}</p>
+          <p className="mt-2 whitespace-pre-wrap border-t border-fd-border pt-2">
+            {event.reply === OFFLINE_REPLY ? <em className="text-fd-muted-foreground">{event.reply}</em> : event.reply}
+          </p>
+        </div>
+      );
+    case 'tool':
+      return (
+        <div className={card}>
+          <p className={label}>tool · {event.name}</p>
+          <pre className="mt-1 max-h-24 overflow-auto font-mono text-[11px] text-fd-muted-foreground">{short(event.args, 600)}</pre>
+          <pre className="mt-1 max-h-32 overflow-auto border-t border-fd-border pt-1 font-mono text-[11px]">{short(event.result)}</pre>
+        </div>
+      );
+    case 'input':
+      return (
+        <div className={card}>
+          <p className={label}>chidori.input · answered</p>
+          <p className="mt-1">{event.prompt}</p>
+          <p className="mt-1 font-medium">→ {event.answer}</p>
+        </div>
+      );
+    case 'fetch':
+      return (
+        <p className="font-mono text-[11px] text-fd-muted-foreground">
+          ⇄ fetch {event.url.length > 64 ? `${event.url.slice(0, 64)}…` : event.url} → {event.status}
+          {event.simulated ? ' · simulated (live request failed)' : ''}
+        </p>
+      );
+    case 'result':
+      return (
+        <div className={`${card} border-fd-primary/40`}>
+          <p className={label}>run output</p>
+          <pre className="mt-1 max-h-48 overflow-auto font-mono text-[11px]">{short(event.value)}</pre>
+        </div>
+      );
+    case 'error':
+      return (
+        <div className={`${card} border-red-500/50`}>
+          <p className={`${label} text-red-500`}>error</p>
+          <p className="mt-1 whitespace-pre-wrap font-mono text-[11px]">{event.text}</p>
+        </div>
+      );
+    case 'done':
+      return <p className="text-center font-mono text-[11px] text-fd-muted-foreground">— run completed —</p>;
+    default:
+      return <p className="font-mono text-[11px] text-fd-muted-foreground">{event.text}</p>;
+  }
+}
+
+export function RunnerPanel() {
+  const example = useSyncExternalStore(subscribeRunner, getRunnerExample, () => null);
+  const orKey = useSyncExternalStore(subscribeOpenRouter, getOpenRouterKey, () => null);
+  const [model, setModel] = useState('openrouter/auto');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [busy, setBusy] = useState<string | null>(null);
+  const [feed, setFeed] = useState<RunEvent[]>([]);
+  const [statusLine, setStatusLine] = useState('');
+  const [inputJson, setInputJson] = useState('{}');
+  const [pending, setPending] = useState<PendingInput | null>(null);
+  const [answerDraft, setAnswerDraft] = useState('');
+  const [hasRecording, setHasRecording] = useState(false);
+
+  // Orphans stale agents: host calls from a superseded run hang forever.
+  const tokenRef = useRef(0);
+  const agentRef = useRef<AgentHandle | null>(null);
+  const feedBoxRef = useRef<HTMLDivElement | null>(null);
+  const exampleIdRef = useRef<string | null>(null);
+
+  // Finish the OpenRouter PKCE login if this page load is the redirect back
+  // from openrouter.ai (no-op otherwise) — docs pages are valid callback
+  // targets, so a login started from any example lands back where it began.
+  useEffect(() => {
+    setModel(getOpenRouterModel());
+    completeOpenRouterLogin().catch((err) => {
+      setStatusLine(`OpenRouter login failed: ${String(err)}`);
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    tokenRef.current += 1;
+    agentRef.current = null;
+    setPhase('idle');
+    setBusy(null);
+    setFeed([]);
+    setPending(null);
+    setAnswerDraft('');
+    setStatusLine('');
+    setHasRecording(false);
+  }, []);
+
+  // A different example was opened: drop any run state and prefill its input.
+  useEffect(() => {
+    const id = example?.id ?? null;
+    if (id === exampleIdRef.current) return;
+    exampleIdRef.current = id;
+    reset();
+    if (example) setInputJson(JSON.stringify(example.input ?? {}, null, 2));
+  }, [example, reset]);
+
+  useEffect(() => {
+    if (!example) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeRunner();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [example]);
+
+  useEffect(() => {
+    const box = feedBoxRef.current;
+    if (box) box.scrollTop = box.scrollHeight;
+  }, [feed, pending, busy]);
+
+  const refreshFeed = useCallback(() => {
+    const agent = agentRef.current;
+    if (agent) setFeed(parseRunFeed(agent.console()));
+  }, []);
+
+  const start = useCallback(async () => {
+    if (!example) return;
+    let input: unknown = {};
+    if (example.mode === 'program') {
+      try {
+        input = JSON.parse(inputJson || '{}');
+      } catch (err) {
+        setStatusLine(`Run input is not valid JSON: ${String(err)}`);
+        return;
+      }
+    }
+    tokenRef.current += 1;
+    const token = tokenRef.current;
+    const stale = () => token !== tokenRef.current;
+    const hang = () => new Promise<never>(() => {});
+    agentRef.current = null;
+    setFeed([]);
+    setPending(null);
+    setStatusLine('');
+    setHasRecording(false);
+    setPhase('starting');
+    setBusy('loading the wasm engine…');
+    let loaded: Loaded;
+    try {
+      loaded = await loadAssets();
+    } catch {
+      setPhase('failed');
+      setBusy(null);
+      setStatusLine('The wasm assets are missing. Build them with scripts/build-wasm.sh, then reload.');
+      return;
+    }
+    const docsIndex = await loadDocsIndex();
+    if (stale()) return;
+
+    const baseTools = makeDocsTools(() => docsIndex);
+    const tools: Record<string, (kwargs: Json) => Promise<Json>> = {};
+    for (const [name, impl] of Object.entries(baseTools)) {
+      tools[name] = async (kwargs) => {
+        if (stale()) return hang();
+        setBusy(`running ${name}…`);
+        refreshFeed();
+        return impl(kwargs);
+      };
+    }
+
+    try {
+      const agent = loaded.sdk.BrowserAgent.start(loaded.wasm, {
+        source: buildHarnessSource(example.code, input),
+        llm: async (payload: { text: string; opts?: unknown }) => {
+          if (stale()) return hang();
+          setBusy(getOpenRouterKey() ? 'calling the model via OpenRouter…' : 'answering with the offline test reply…');
+          refreshFeed();
+          return decidePrompt(payload);
+        },
+        tools,
+        fetchImpl: fetchWithSimulatedFallback as typeof fetch,
+        onInput: (payload: { prompt: string; opts?: Json }) => {
+          if (stale()) return hang();
+          setBusy(null);
+          refreshFeed();
+          const opts = (payload.opts ?? {}) as Record<string, Json>;
+          setAnswerDraft(String(opts.default ?? ''));
+          return new Promise<string>((resolve) => {
+            setPending({ prompt: payload.prompt, opts, resolve });
+          });
+        },
+      }) as AgentHandle;
+      agentRef.current = agent;
+      setPhase('running');
+      setBusy('running…');
+      const result = await agent.run();
+      if (stale()) return;
+      setBusy(null);
+      setPending(null);
+      setFeed(parseRunFeed(result.console));
+      setHasRecording(true);
+      setPhase('done');
+      setStatusLine(
+        `⚡ ${result.console.length} journaled event${result.console.length === 1 ? '' : 's'} — saved as one durable blob; replay it offline below.`,
+      );
+    } catch (err) {
+      if (stale()) return;
+      setBusy(null);
+      setPending(null);
+      refreshFeed();
+      setPhase('failed');
+      setStatusLine(`Run failed: ${String(err)}`);
+    }
+  }, [example, inputJson, refreshFeed]);
+
+  const answer = useCallback(
+    (text: string) => {
+      if (!pending) return;
+      setPending(null);
+      setBusy('running…');
+      pending.resolve(text);
+    },
+    [pending],
+  );
+
+  /** Re-render the whole run from its journal: no model, no network. */
+  const replay = useCallback(async () => {
+    const agent = agentRef.current;
+    if (!agent) return;
+    try {
+      const loaded = await loadAssets();
+      const replayed = loaded.sdk.BrowserAgent.restore(loaded.wasm, agent.blob(), {
+        llm: () => {
+          throw new Error('replay must not call the LLM');
+        },
+        fetchImpl: (() => {
+          throw new Error('replay must not touch the network');
+        }) as unknown as typeof fetch,
+      }) as AgentHandle;
+      const result = await replayed.run();
+      setFeed(parseRunFeed(result.console));
+      setStatusLine(
+        `⚡ Replayed offline: ${result.console.length} journaled events re-rendered with ${result.liveCalls} live calls.`,
+      );
+    } catch (err) {
+      setStatusLine(`Replay error: ${String(err)}`);
+    }
+  }, []);
+
+  if (!example) return null;
+
+  const action =
+    'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-fd-border px-2.5 text-xs font-medium transition-colors hover:bg-fd-accent disabled:pointer-events-none disabled:opacity-40';
+  const choices =
+    pending && Array.isArray(pending.opts.choices)
+      ? (pending.opts.choices as Json[]).map((c) => String(c))
+      : [];
+  const details = pending?.opts.details;
+  const running = phase === 'starting' || phase === 'running';
+
+  return (
+    <aside
+      id="example-runner"
+      aria-label="Runnable example"
+      className="fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-fd-border bg-fd-background shadow-2xl sm:w-[26rem]"
+    >
+      <div className="flex items-center gap-2 border-b border-fd-border px-3 py-2.5">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+          <path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z" />
+        </svg>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">Run this example</p>
+          <p className="truncate text-[11px] text-fd-muted-foreground">
+            {example.title} · live on the wasm engine in this tab
+          </p>
+        </div>
+        <button
+          id="runner-close"
+          className={`${action} ml-auto`}
+          onClick={closeRunner}
+          aria-label="Close the example runner"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* The global OpenRouter connection: one login serves every runnable
+          example on the site (and the /playground chat). */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-fd-border bg-fd-accent/30 px-3 py-2">
+        {orKey ? (
+          <>
+            <span id="runner-or-connected" className="shrink-0 text-xs text-fd-muted-foreground">
+              ✓ OpenRouter
+            </span>
+            <input
+              id="runner-or-model"
+              type="text"
+              value={model}
+              onChange={(e) => {
+                setModel(e.target.value);
+                setOpenRouterModel(e.target.value);
+              }}
+              aria-label="OpenRouter model"
+              className="h-8 w-24 min-w-0 flex-1 rounded-lg border border-fd-border bg-fd-background px-2 text-xs"
+            />
+            <button id="runner-or-disconnect" className={action} onClick={() => setOpenRouterKey(null)}>
+              Disconnect
+            </button>
+          </>
+        ) : (
+          <>
+            <button id="runner-or-connect" className={action} onClick={() => void startOpenRouterLogin()}>
+              Connect OpenRouter
+            </button>
+            <span className="min-w-0 flex-1 text-[11px] leading-tight text-fd-muted-foreground">
+              One login runs every docs example (and the playground). Until then, prompts return a
+              deterministic offline reply.
+            </span>
+          </>
+        )}
+      </div>
+
+      <div ref={feedBoxRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain p-3">
+        <details className="rounded-lg border border-fd-border bg-fd-card/50">
+          <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium">
+            The code this runs{example.mode === 'fragment' ? ' (wrapped in an async run for you)' : ''}
+          </summary>
+          <pre className="max-h-56 overflow-auto border-t border-fd-border p-3 font-mono text-[11px]">{example.code}</pre>
+        </details>
+
+        {example.mode === 'program' && (
+          <div>
+            <label htmlFor="runner-input" className="text-[11px] font-medium text-fd-muted-foreground">
+              Run input — the JSON handed to this agent&apos;s run() handler
+            </label>
+            <textarea
+              id="runner-input"
+              value={inputJson}
+              onChange={(e) => setInputJson(e.target.value)}
+              rows={Math.min(6, inputJson.split('\n').length)}
+              spellCheck={false}
+              className="mt-1 w-full resize-y rounded-lg border border-fd-border bg-fd-background p-2 font-mono text-xs outline-none focus:ring-2 focus:ring-fd-primary/40"
+            />
+          </div>
+        )}
+
+        {feed.length === 0 && !busy && (
+          <p className="text-xs leading-relaxed text-fd-muted-foreground">
+            Press <strong>Run</strong> and this code executes for real — the pure-Rust chidori engine
+            compiled to WebAssembly, right here in this tab. Every <code>chidori.*</code> call is
+            journaled as it happens, so when the run finishes you can replay it offline,
+            byte-identically, with zero live calls.
+          </p>
+        )}
+
+        {feed.map((event, i) => (
+          <EventCard key={i} event={event} />
+        ))}
+
+        {pending && (
+          <div className="rounded-lg border border-fd-primary/50 bg-fd-card px-3 py-2.5 text-xs" id="runner-pending-input">
+            <p className="font-mono text-[10px] uppercase tracking-wide text-fd-muted-foreground">
+              chidori.input · the run is suspended, waiting on you
+            </p>
+            <p className="mt-1.5 text-sm font-medium">{pending.prompt}</p>
+            {details !== null && details !== undefined && (
+              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-fd-border bg-fd-background p-2 font-mono text-[11px]">
+                {typeof details === 'string' ? details : short(details)}
+              </pre>
+            )}
+            {choices.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {choices.map((choice) => (
+                  <button
+                    key={choice}
+                    id={`runner-choice-${choice.replace(/\s+/g, '-')}`}
+                    className={`${action} ${choice === String(pending.opts.default ?? '') ? 'border-fd-primary/60' : ''}`}
+                    onClick={() => answer(choice)}
+                  >
+                    {choice}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <form
+                className="mt-2 flex gap-1.5"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  answer(answerDraft);
+                }}
+              >
+                <input
+                  id="runner-answer"
+                  type="text"
+                  value={answerDraft}
+                  onChange={(e) => setAnswerDraft(e.target.value)}
+                  autoComplete="off"
+                  className="h-8 min-w-0 flex-1 rounded-lg border border-fd-border bg-fd-background px-2 text-xs outline-none focus:ring-2 focus:ring-fd-primary/40"
+                />
+                <button type="submit" className={action}>
+                  Answer
+                </button>
+              </form>
+            )}
+          </div>
+        )}
+
+        {busy && (
+          <p className="flex items-center gap-2 font-mono text-[11px] text-fd-muted-foreground" id="runner-busy">
+            <span aria-hidden className="flex gap-1">
+              <span className="size-1 animate-pulse rounded-full bg-current" />
+              <span className="size-1 animate-pulse rounded-full bg-current [animation-delay:200ms]" />
+              <span className="size-1 animate-pulse rounded-full bg-current [animation-delay:400ms]" />
+            </span>
+            {busy}
+          </p>
+        )}
+      </div>
+
+      {statusLine && (
+        <p
+          id="runner-status"
+          className="border-t border-fd-border bg-fd-accent/30 px-3 py-1.5 font-mono text-[11px] leading-relaxed text-fd-muted-foreground"
+        >
+          {statusLine}
+        </p>
+      )}
+      <div className="flex items-center gap-1.5 border-t border-fd-border p-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))]">
+        <button
+          id="runner-run"
+          className="h-9 shrink-0 rounded-lg bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground transition-opacity hover:opacity-85 disabled:pointer-events-none disabled:opacity-40"
+          disabled={running}
+          onClick={() => void start()}
+        >
+          {phase === 'done' || phase === 'failed' ? '▶ Run again' : '▶ Run'}
+        </button>
+        <button
+          id="runner-replay"
+          className={action}
+          disabled={!hasRecording || running}
+          onClick={() => void replay()}
+          title="Re-render this run from its journal — zero live calls"
+        >
+          ↺ Replay offline
+        </button>
+        <button
+          id="runner-clear"
+          className={`${action} ml-auto`}
+          disabled={running || (feed.length === 0 && !statusLine)}
+          onClick={reset}
+        >
+          Clear
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/website/app/docs/runner/runner-store.ts
+++ b/website/app/docs/runner/runner-store.ts
@@ -1,0 +1,79 @@
+'use client';
+
+/**
+ * The tiny global store connecting docs code blocks to the example-runner
+ * side panel: any RunnablePre on the page can open the panel with its code,
+ * and the panel (mounted once in the docs layout) subscribes here.
+ */
+
+export interface RunnableInfo {
+  mode: 'program' | 'fragment';
+  /** Editable-input template for program-mode examples ({} when absent). */
+  input?: Record<string, unknown>;
+}
+
+export interface RunnableExample extends RunnableInfo {
+  /** Content hash — identifies the example across opens. */
+  id: string;
+  /** The block's exact source text, as displayed. */
+  code: string;
+  /** The docs page the block came from (for the panel header). */
+  title: string;
+}
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+let current: RunnableExample | null = null;
+const listeners = new Set<() => void>();
+
+export function openRunner(example: RunnableExample): void {
+  current = example;
+  for (const l of listeners) l();
+}
+
+export function closeRunner(): void {
+  current = null;
+  for (const l of listeners) l();
+}
+
+export function subscribeRunner(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => listeners.delete(onChange);
+}
+
+export function getRunnerExample(): RunnableExample | null {
+  return current;
+}
+
+// ---------------------------------------------------------------------------
+// Runnable-block lookup: public/runnable-examples.json is built from docs/
+// by scripts/build-runnable-examples.mjs and keyed by an FNV-1a hash of the
+// block's normalized text (same function as the build script).
+
+export function hashCode(code: string): string {
+  const s = code.replace(/\r\n/g, '\n').trim();
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(36);
+}
+
+let indexPromise: Promise<Record<string, RunnableInfo>> | null = null;
+
+function loadIndex(): Promise<Record<string, RunnableInfo>> {
+  indexPromise ??= fetch(`${BASE}/runnable-examples.json`)
+    .then((res) => (res.ok ? res.json() : { examples: {} }))
+    .then((json: { examples?: Record<string, RunnableInfo> }) => json.examples ?? {})
+    .catch(() => ({}));
+  return indexPromise;
+}
+
+/** Resolve a code block to its runnable entry, or null for static blocks. */
+export async function lookupRunnable(code: string): Promise<(RunnableInfo & { id: string }) | null> {
+  const id = hashCode(code);
+  const index = await loadIndex();
+  const info = index[id];
+  return info ? { ...info, id } : null;
+}

--- a/website/lib/openrouter.ts
+++ b/website/lib/openrouter.ts
@@ -1,0 +1,136 @@
+/**
+ * The site-wide OpenRouter connection, shared by every runnable surface: the
+ * /playground chat and the "run this example" panel on docs pages. One PKCE
+ * login connects all of them — the exchanged key lives in sessionStorage
+ * under a single storage key, so it survives the redirect back from
+ * openrouter.ai and is gone when the tab closes.
+ *
+ * The PKCE flow mirrors sdk/browser's startOpenRouterLogin /
+ * completeOpenRouterLogin and shares its sessionStorage verifier key, but is
+ * reimplemented here so a docs page can finish a login callback without
+ * having to load the wasm assets first.
+ */
+
+/** Where the exchanged API key lives (same key the playground has always used). */
+export const OPENROUTER_KEY_STORAGE = 'chidori-playground-openrouter-key';
+/** PKCE verifier storage — identical to sdk/browser so the flows interoperate. */
+const VERIFIER_STORAGE = 'chidori-openrouter-verifier';
+/** The model choice is a durable preference, not a secret — localStorage. */
+const MODEL_STORAGE = 'chidori-openrouter-model';
+
+export const DEFAULT_OPENROUTER_MODEL = 'openrouter/auto';
+
+/** Fired on window whenever the stored key or model changes. */
+const CHANGE_EVENT = 'chidori:openrouter-change';
+
+const hasWindow = () => typeof window !== 'undefined';
+
+function emitChange(): void {
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function getOpenRouterKey(): string | null {
+  if (!hasWindow()) return null;
+  try {
+    return sessionStorage.getItem(OPENROUTER_KEY_STORAGE);
+  } catch {
+    return null;
+  }
+}
+
+export function setOpenRouterKey(key: string | null): void {
+  if (!hasWindow()) return;
+  try {
+    if (key === null) sessionStorage.removeItem(OPENROUTER_KEY_STORAGE);
+    else sessionStorage.setItem(OPENROUTER_KEY_STORAGE, key);
+  } catch {
+    /* storage blocked — the connection just won't persist */
+  }
+  emitChange();
+}
+
+export function getOpenRouterModel(): string {
+  if (!hasWindow()) return DEFAULT_OPENROUTER_MODEL;
+  try {
+    return localStorage.getItem(MODEL_STORAGE) || DEFAULT_OPENROUTER_MODEL;
+  } catch {
+    return DEFAULT_OPENROUTER_MODEL;
+  }
+}
+
+export function setOpenRouterModel(model: string): void {
+  if (!hasWindow()) return;
+  try {
+    const trimmed = model.trim();
+    if (!trimmed || trimmed === DEFAULT_OPENROUTER_MODEL) localStorage.removeItem(MODEL_STORAGE);
+    else localStorage.setItem(MODEL_STORAGE, trimmed);
+  } catch {
+    /* storage blocked */
+  }
+  emitChange();
+}
+
+/** Subscribe to key/model changes (shape matches useSyncExternalStore). */
+export function subscribeOpenRouter(onChange: () => void): () => void {
+  if (!hasWindow()) return () => {};
+  window.addEventListener(CHANGE_EVENT, onChange);
+  // A login finished in another same-origin tab also counts.
+  window.addEventListener('storage', onChange);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onChange);
+    window.removeEventListener('storage', onChange);
+  };
+}
+
+/** RFC 4648 base64url, no padding — the PKCE alphabet. */
+function base64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Begin OpenRouter's PKCE login: store a code verifier and navigate to
+ * openrouter.ai's consent page, which redirects back to the current page
+ * with `?code=`. {@link completeOpenRouterLogin} finishes the exchange.
+ */
+export async function startOpenRouterLogin(): Promise<void> {
+  const verifier = base64url(crypto.getRandomValues(new Uint8Array(32)));
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  const challenge = base64url(new Uint8Array(digest));
+  sessionStorage.setItem(VERIFIER_STORAGE, verifier);
+  const url =
+    'https://openrouter.ai/auth' +
+    `?callback_url=${encodeURIComponent(location.href)}` +
+    `&code_challenge=${challenge}&code_challenge_method=S256`;
+  location.assign(url);
+}
+
+/**
+ * Finish a PKCE login if this page load is the redirect back from
+ * openrouter.ai: exchange `?code=` for an API key, store it globally, and
+ * scrub the one-time code from the address bar. A no-op (returns null)
+ * when the URL carries no code, so call it unconditionally on mount.
+ */
+export async function completeOpenRouterLogin(): Promise<string | null> {
+  if (!hasWindow()) return null;
+  const here = new URL(location.href);
+  const code = here.searchParams.get('code');
+  if (!code) return null;
+  const verifier = sessionStorage.getItem(VERIFIER_STORAGE);
+  const res = await fetch('https://openrouter.ai/api/v1/auth/keys', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      code,
+      ...(verifier ? { code_verifier: verifier, code_challenge_method: 'S256' } : {}),
+    }),
+  });
+  if (!res.ok) throw new Error(`openrouter key exchange: ${res.status} ${await res.text()}`);
+  const { key } = (await res.json()) as { key: string };
+  sessionStorage.removeItem(VERIFIER_STORAGE);
+  here.searchParams.delete('code');
+  history.replaceState(null, '', here);
+  setOpenRouterKey(key);
+  return key;
+}

--- a/website/mdx-components.tsx
+++ b/website/mdx-components.tsx
@@ -1,9 +1,14 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
+import { RunnablePre } from '@/app/docs/runner/runnable-pre';
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    // Code blocks render through the runner-aware wrapper: blocks the
+    // build-time analysis proved executable in the browser sandbox get a
+    // "Run" button that opens the example-runner side panel.
+    pre: RunnablePre,
     ...components,
   };
 }

--- a/website/package.json
+++ b/website/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "node scripts/build-playground-context.mjs && next dev",
-    "build": "node scripts/build-playground-context.mjs && next build",
+    "dev": "node scripts/build-playground-context.mjs && node scripts/build-runnable-examples.mjs && next dev",
+    "build": "node scripts/build-playground-context.mjs && node scripts/build-runnable-examples.mjs && next build",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/website/scripts/build-runnable-examples.mjs
+++ b/website/scripts/build-runnable-examples.mjs
@@ -1,0 +1,284 @@
+// Builds public/runnable-examples.json — an index of the docs' ts/js code
+// blocks that can actually execute on the wasm engine in the reader's
+// browser. Docs pages look their code blocks up in it (by content hash) and
+// offer a "Run" button that opens the example-runner side panel.
+//
+// A block qualifies when, after dropping its `chidori:agent` import, it is
+// syntactically valid, references nothing the runner's sandbox doesn't
+// provide (free-identifier analysis via the TypeScript parser), and touches
+// only the durable-core chidori API the browser host implements
+// (prompt/input/tool/log/step/sleep/now/random + captured fetch). Fragments
+// without a `run(...)` registration are executed as-is inside an async
+// wrapper; programs get their registered handler invoked with a reader-
+// editable input object, whose shape is sniffed from the handler signature.
+//
+// Runs before `next dev`/`next build` (see package.json); the output is
+// gitignored like the wasm assets.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const docsDir = path.resolve(here, '../../docs');
+const outFile = path.resolve(here, '../public/runnable-examples.json');
+
+// Mirror the site's content rules (source.config.ts): every docs/*.md except
+// the GitHub-facing README and the posts thread, which are not site pages.
+const EXCLUDE = new Set(['README.md', 'posts/harness-engineering-thread.md']);
+
+// The slice of `chidori.*` the browser host implements (sdk/browser). A block
+// that touches anything else (context, actors, memory, workspace, signals…)
+// stays a static listing.
+const SUPPORTED_API = new Set([
+  'prompt',
+  'input',
+  'tool',
+  'log',
+  'step',
+  'sleep',
+  'now',
+  'random',
+  'fetch',
+]);
+
+// Globals the runner's VM provides: the harness surface (chidori/run/
+// defineTool/fetch), plus engine built-ins. Deliberately tight — a block
+// referencing anything outside this list is skipped rather than shown with
+// a Run button that throws.
+const ALLOWED_GLOBALS = new Set([
+  'chidori', 'run', 'defineTool', 'fetch', 'console',
+  'JSON', 'Math', 'Object', 'Array', 'String', 'Number', 'Boolean', 'Symbol',
+  'Promise', 'Date', 'RegExp', 'Map', 'Set', 'WeakMap', 'WeakSet',
+  'Error', 'TypeError', 'RangeError', 'SyntaxError',
+  'parseInt', 'parseFloat', 'isNaN', 'isFinite',
+  'encodeURIComponent', 'decodeURIComponent', 'encodeURI', 'decodeURI',
+  'NaN', 'Infinity', 'undefined', 'globalThis', 'arguments',
+]);
+
+/** FNV-1a, matching hashString in the playground's brain.ts and the docs
+ *  runner's client-side lookup. */
+function hashString(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(36);
+}
+
+const normalize = (code) => code.replace(/\r\n/g, '\n').trim();
+
+/** Drop `import … from "chidori:agent"` — the harness provides that surface. */
+function stripAgentImport(code) {
+  return code.replace(/^[ \t]*import[^;]*?from\s*["']chidori:agent["'];?[ \t]*$/gm, '');
+}
+
+/**
+ * Flat free-identifier analysis over the transpiled (type-erased) JS: every
+ * value-position identifier that is neither declared anywhere in the block
+ * nor an allowed global makes the block non-runnable. Flat scoping
+ * over-approximates what's declared, which errs toward showing a Run button;
+ * a genuinely broken block then fails visibly in the panel, which the short
+ * docs examples never do in practice.
+ */
+function freeIdentifiers(sourceFile) {
+  const declared = new Set();
+  const referenced = new Set();
+
+  const declareBinding = (name) => {
+    if (!name) return;
+    if (ts.isIdentifier(name)) declared.add(name.text);
+    else if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+      for (const el of name.elements) {
+        if (ts.isBindingElement(el)) declareBinding(el.name);
+      }
+    }
+  };
+
+  const collectDeclarations = (node) => {
+    if (ts.isVariableDeclaration(node) || ts.isBindingElement(node) || ts.isParameter(node)) {
+      declareBinding(node.name);
+    } else if (
+      (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) || ts.isFunctionExpression(node) || ts.isClassExpression(node)) &&
+      node.name
+    ) {
+      declared.add(node.name.text);
+    } else if (ts.isCatchClause(node) && node.variableDeclaration) {
+      declareBinding(node.variableDeclaration.name);
+    }
+    ts.forEachChild(node, collectDeclarations);
+  };
+
+  const isReference = (node) => {
+    const parent = node.parent;
+    if (!parent) return true;
+    // Property names, member names, and labels are not value references.
+    if (ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+    if (ts.isPropertyAssignment(parent) && parent.name === node) return false;
+    if (
+      (ts.isMethodDeclaration(parent) || ts.isPropertyDeclaration(parent) ||
+        ts.isGetAccessor(parent) || ts.isSetAccessor(parent)) &&
+      parent.name === node
+    ) {
+      return false;
+    }
+    if (ts.isBindingElement(parent) && parent.propertyName === node) return false;
+    // Declaration sites were collected in the first pass.
+    if (ts.isVariableDeclaration(parent) && parent.name === node) return false;
+    if (ts.isBindingElement(parent) && parent.name === node) return false;
+    if (ts.isParameter(parent) && parent.name === node) return false;
+    if ((ts.isFunctionDeclaration(parent) || ts.isFunctionExpression(parent) || ts.isClassDeclaration(parent) || ts.isClassExpression(parent)) && parent.name === node) return false;
+    if (ts.isLabeledStatement(parent) && parent.label === node) return false;
+    if ((ts.isBreakStatement(parent) || ts.isContinueStatement(parent)) && parent.label === node) return false;
+    return true;
+  };
+
+  const collectReferences = (node) => {
+    if (ts.isIdentifier(node) && isReference(node)) referenced.add(node.text);
+    ts.forEachChild(node, collectReferences);
+  };
+
+  collectDeclarations(sourceFile);
+  collectReferences(sourceFile);
+
+  const free = [];
+  for (const name of referenced) {
+    if (!declared.has(name) && !ALLOWED_GLOBALS.has(name)) free.push(name);
+  }
+  return free;
+}
+
+/** Default value for a property, from its (erased-by-then) TS type text. */
+function defaultForType(type) {
+  if (!type) return '';
+  if (ts.isUnionTypeNode(type)) return defaultForType(type.types[0]);
+  switch (type.kind) {
+    case ts.SyntaxKind.NumberKeyword:
+      return 0;
+    case ts.SyntaxKind.BooleanKeyword:
+      return false;
+    case ts.SyntaxKind.ArrayType:
+      return [];
+    case ts.SyntaxKind.TypeLiteral: {
+      const nested = {};
+      for (const m of type.members) {
+        if (ts.isPropertySignature(m) && m.name && ts.isIdentifier(m.name)) {
+          nested[m.name.text] = defaultForType(m.type);
+        }
+      }
+      return nested;
+    }
+    default:
+      return '';
+  }
+}
+
+/**
+ * Sniff the shape of the input object a program-mode example expects, from
+ * the `run(handler)` signature: a typed parameter (`input: { question:
+ * string }`) yields typed defaults, a destructured one yields empty strings.
+ * Returns null when the handler takes no input.
+ */
+function sniffInputShape(tsSourceFile) {
+  let shape = null;
+  const visit = (node) => {
+    if (
+      shape === null &&
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'run' &&
+      node.arguments.length >= 1
+    ) {
+      const handler = node.arguments[0];
+      if ((ts.isArrowFunction(handler) || ts.isFunctionExpression(handler)) && handler.parameters.length >= 1) {
+        const param = handler.parameters[0];
+        if (param.type && ts.isTypeLiteralNode(param.type)) {
+          shape = {};
+          for (const m of param.type.members) {
+            if (ts.isPropertySignature(m) && m.name && ts.isIdentifier(m.name)) {
+              shape[m.name.text] = defaultForType(m.type);
+            }
+          }
+        } else if (ts.isObjectBindingPattern(param.name)) {
+          shape = {};
+          for (const el of param.name.elements) {
+            if (ts.isBindingElement(el) && ts.isIdentifier(el.name)) shape[el.name.text] = '';
+          }
+        } else {
+          shape = {};
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(tsSourceFile);
+  return shape && Object.keys(shape).length ? shape : null;
+}
+
+function* mdFiles(dir, rel = '') {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'media') continue;
+      yield* mdFiles(path.join(dir, entry.name), relPath);
+    } else if (entry.name.endsWith('.md') && !EXCLUDE.has(relPath)) {
+      yield relPath;
+    }
+  }
+}
+
+function analyzeBlock(code) {
+  const stripped = stripAgentImport(code);
+  // Any surviving module syntax means the block needs things the sandbox
+  // doesn't have (other modules, an importer).
+  if (/^[ \t]*(import|export)\b/m.test(stripped)) return null;
+
+  const apiCalls = [...stripped.matchAll(/\bchidori\s*\.\s*(\w+)/g)].map((m) => m[1]);
+  if (apiCalls.some((name) => !SUPPORTED_API.has(name))) return null;
+
+  // Check the exact shape the harness executes: the block inlined into an
+  // async function body (which also legalizes top-level await/return).
+  const wrapped = `async function __example() {\n${stripped}\n}\n`;
+  const transpiled = ts.transpileModule(wrapped, {
+    reportDiagnostics: true,
+    compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.ESNext },
+  });
+  if (transpiled.diagnostics && transpiled.diagnostics.length > 0) return null;
+
+  // Must actually exercise the runtime — bare type/interface blocks erase to
+  // nothing and would "run" vacuously.
+  if (!/\bchidori\s*\.|\bfetch\s*\(|\brun\s*\(/.test(transpiled.outputText)) return null;
+
+  const jsAst = ts.createSourceFile('block.js', transpiled.outputText, ts.ScriptTarget.ES2022, true, ts.ScriptKind.JS);
+  if (freeIdentifiers(jsAst).length > 0) return null;
+
+  const mode = /\brun\s*\(/.test(stripped) ? 'program' : 'fragment';
+  let input = null;
+  if (mode === 'program') {
+    const tsAst = ts.createSourceFile('block.ts', wrapped, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TS);
+    input = sniffInputShape(tsAst);
+  }
+  return { mode, ...(input ? { input } : {}) };
+}
+
+const examples = {};
+let scanned = 0;
+let runnable = 0;
+for (const rel of [...mdFiles(docsDir)].sort()) {
+  const raw = fs.readFileSync(path.join(docsDir, rel), 'utf8');
+  for (const m of raw.matchAll(/```(ts|js|typescript|javascript)[^\n]*\n([\s\S]*?)```/g)) {
+    scanned += 1;
+    const code = m[2];
+    const entry = analyzeBlock(code);
+    if (!entry) continue;
+    runnable += 1;
+    examples[hashString(normalize(code))] = entry;
+  }
+}
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(outFile, JSON.stringify({ examples }));
+console.log(
+  `runnable docs examples: ${runnable} of ${scanned} ts/js blocks → ${path.relative(process.cwd(), outFile)}`,
+);


### PR DESCRIPTION
Reuses the playground's patterns — the wasm engine + browser SDK loaded from
/public, journaled console lines as the render source, and OpenRouter PKCE
auth — to let readers execute the docs' code blocks in the browser:

- scripts/build-runnable-examples.mjs analyzes every ts/js block in docs/ at
  build time (TypeScript parser: syntax check, free-identifier analysis,
  supported-API check) and indexes the runnable ones by content hash, so the
  markdown needs no annotations and stays readable on GitHub. 11 blocks
  across 6 pages qualify today; future self-contained examples qualify
  automatically.
- app/docs/runner/ is the example runner: RunnablePre puts a "Run" button on
  indexed code blocks; RunnerPanel (mounted once in the docs layout) executes
  the block on the wasm engine in a right-side panel. A VM-side harness
  recreates the chidori:agent surface the examples use — run(), defineTool(),
  captured fetch (with a labelled simulated fallback when the live request
  fails), and the provider tool-use loop inside chidori.prompt() — and emits
  each step as a journaled console event, so "Replay offline" repaints the
  whole run with zero live calls. chidori.input() suspends into an interactive
  approval/answer card, choices and details included.
- lib/openrouter.ts makes the OpenRouter login global: one PKCE login (same
  storage keys the playground and sdk/browser already use) now powers every
  docs example and the playground chat; without it, prompts return a
  deterministic offline reply that still exercises one tool turn. The
  playground imports the shared storage-key constant.

Verified end-to-end in headless Chromium against the static export with real
wasm assets: run button rendering, the tutorial agent's log → tool loop →
approval gate → result flow, offline replay (0 live calls), the docs_search
tool, and playground boot.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N2fbc1LfrmnCP2fGxAtsUy